### PR TITLE
Add ability to specify which MCP servers to enable for guided runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ Flags for the report reside in [`harness/evaluate.ts`](./harness/evaluate.ts).
 pnpm report --test_dir=my_test_run
 ```
 
+### Agents
+
+Jetski is the default agent that will be used. When running, be sure to update the settings of the Jetski automation window so that the "Review Policy" is set to "Always Proceed".
+
+When using Gemini CLI, set the `GEMINI_API_KEY` environment variable with your API key.
+
 ## Quality Control
 
 Run the full preflight suite (typechecking, linting, and tests) from the root:

--- a/harness/GEMINI.md
+++ b/harness/GEMINI.md
@@ -1,6 +1,6 @@
 # Agent Instructions
 
-You may have access to an MCP server called "Modern Web" which provides access to guides in Markdown format.
+You may have access to an MCP server called "modern-web".
 
 If you have access to this server and use a guide from it to help you with the task, you MUST record the filename of the guide and the timestamp when you accessed it.
 After completing the task, if you used any guides, create a file named `guides_used.json` in the root of the project directory.

--- a/harness/agents/gemini-cli-agent.ts
+++ b/harness/agents/gemini-cli-agent.ts
@@ -2,22 +2,13 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { spawn } from 'child_process';
-import { fileURLToPath } from 'url';
+
 import config from '../config.ts';
 
-import { updateMcpConfig, createIsolatedHome, cleanupIsolatedHome, copyFileIfExists, createTrustedFolders, copyGeminiContext } from '../lib/agent-shared.ts';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const projectRoot = path.resolve(__dirname, '../..');
+import { updateMcpConfig, createIsolatedHome, cleanupIsolatedHome, copyFileIfExists, createTrustedFolders, copyGeminiContext, parseAgentArgs } from '../lib/agent-shared.ts';
 
 // Usage: node gemini-cli-agent.ts <directory> <prompt> [runType]
-const args = process.argv.slice(2);
-if (args.length < 2) {
-  console.error("Usage: node gemini-cli-agent.ts <directory> <prompt> [runType]");
-  process.exit(1);
-}
-const [targetDirectory, userPrompt, runType] = args;
-const absoluteTargetDir = path.resolve(targetDirectory);
+const { userPrompt, runType, absoluteTargetDir, projectRoot } = parseAgentArgs('gemini-cli-agent.ts');
 
 /**
  * Sets up an isolated HOME directory to ensure test isolation while preserving authentication.
@@ -35,8 +26,7 @@ function setupIsolatedHome(): string {
   const filesToCopy = [
     'oauth_creds.json',
     'google_accounts.json',
-    'installation_id',
-    'settings.json'
+    'installation_id'
   ];
 
   for (const file of filesToCopy) {
@@ -49,8 +39,18 @@ function setupIsolatedHome(): string {
   // Set environment variables for the current process (and children)
   process.env.HOME = tempHome;
 
-  // Point config to the isolated .gemini
-  config.geminiDir = geminiDest;
+  // Add GEMINI context and MCP servers for guided runs
+  if (runType === 'guided') {
+    copyGeminiContext(projectRoot, tempHome);
+
+    updateMcpConfig(
+      path.join(geminiDest, 'settings.json'),
+      config.mcpServersToEnable,
+      config.modernWebServerPath,
+      config.mcpApiKey,
+      'gemini_cli'
+    );
+  }
 
   return tempHome;
 }
@@ -70,13 +70,6 @@ async function run() {
     if (!fs.existsSync(absoluteTargetDir)) {
       fs.mkdirSync(absoluteTargetDir, { recursive: true });
     }
-
-    // Copy GEMINI.md to the target directory
-    if (runType === 'guided') {
-      copyGeminiContext(projectRoot, absoluteTargetDir);
-    }
-
-    updateMcpConfig(path.join(config.geminiDir, 'settings.json'), runType, config.mcpApiKey, 'gemini_cli');
 
     const command = config.geminiCliBin;
     const commandArgs = [

--- a/harness/agents/jetski-agent.ts
+++ b/harness/agents/jetski-agent.ts
@@ -5,20 +5,11 @@ import puppeteer from 'puppeteer-core';
 import type { Page } from 'puppeteer-core';
 import { spawn, execSync } from 'child_process';
 import { config } from '../config.ts';
-import { fileURLToPath } from 'url';
-import { createIsolatedHome, cleanupIsolatedHome, updateMcpConfig, createTrustedFolders, copyGeminiContext } from '../lib/agent-shared.ts';
+
+import { createIsolatedHome, cleanupIsolatedHome, updateMcpConfig, createTrustedFolders, copyGeminiContext, sleep, killProcessOnPort, parseAgentArgs } from '../lib/agent-shared.ts';
 
 // Parse arguments
-// Usage: node jetski-agent.ts <directory> <prompt> [agentType]
-const args = process.argv.slice(2);
-if (args.length < 2) {
-  console.error("Usage: node jetski-agent.ts <directory> <prompt> [agentType]");
-  process.exit(1);
-}
-const [targetDirectory, userPrompt, agentType] = args;
-const absoluteTargetDir = path.resolve(targetDirectory);
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const projectRoot = path.resolve(__dirname, '../..');
+const { userPrompt, runType, absoluteTargetDir, projectRoot } = parseAgentArgs('jetski-agent.ts');
 
 /**
  * Sets up an isolated HOME directory to ensure test isolation while preserving authentication.
@@ -72,7 +63,7 @@ function setupIsolatedHome(): string {
   }
 
   // Copy essential .gemini state
-  const geminiFiles = ['installation_id', 'user_settings.pb', 'mcp_config.json'];
+  const geminiFiles = ['installation_id', 'user_settings.pb'];
   for (const file of geminiFiles) {
     const src = path.join(geminiSource, file);
     if (fs.existsSync(src)) {
@@ -84,16 +75,23 @@ function setupIsolatedHome(): string {
   process.env.HOME = tempHome;
   process.env.JETSKI_DIR = geminiDest;
 
-  // Re-sync config's jetskiDir now that environment variables are set
-  // (In TS we import it so we update the object)
-  config.jetskiDir = geminiDest;
+  // Add GEMINI context and MCP servers for guided runs
+  if (runType === 'guided') {
+    copyGeminiContext(projectRoot, tempHome);
+
+    updateMcpConfig(
+      path.join(geminiDest, 'mcp_config.json'),
+      config.mcpServersToEnable,
+      config.modernWebServerPath,
+      config.mcpApiKey,
+      'jetski'
+    );
+  }
 
   return tempHome;
 }
 
-async function sleep(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
+
 
 async function extractJetskiVersionInfo(page: Page, outputPath: string): Promise<any> {
   try {
@@ -169,17 +167,7 @@ async function extractJetskiVersionInfo(page: Page, outputPath: string): Promise
   }
 }
 
-function killProcessOnPort(port: number | string): void {
-  try {
-    const pid = execSync(`lsof -t -i :${port}`).toString().trim();
-    if (pid) {
-      console.log(`Killing process ${pid} on port ${port}...`);
-      execSync(`kill -9 ${pid}`);
-    }
-  } catch {
-    // Ignore error if no process found (grep/lsof returns exit code 1 if empty)
-  }
-}
+
 
 async function startJetski(directory: string, profileDir: string): Promise<void> {
   // Kill anything on the debug port first
@@ -221,18 +209,11 @@ async function run(): Promise<void> {
   try {
     // Setup isolated environment and MCP config
     testHomeDir = setupIsolatedHome();
-    const mcpConfigPath = path.join(config.jetskiDir, 'mcp_config.json');
-    updateMcpConfig(mcpConfigPath, agentType, config.mcpApiKey, 'jetski');
 
     // Use stable user data dir to persist state (welcome screen, etc.)
     const profileDir = config.jetskiProfileDir;
     if (!fs.existsSync(profileDir)) {
       fs.mkdirSync(profileDir, { recursive: true });
-    }
-
-    // Copy GEMINI.md to the target directory
-    if (agentType === 'guided') {
-      copyGeminiContext(projectRoot, absoluteTargetDir);
     }
 
     await startJetski(absoluteTargetDir, profileDir);

--- a/harness/config.ts
+++ b/harness/config.ts
@@ -19,7 +19,8 @@ interface Config {
   jetskiProfileDir: string;
   geminiCliBin: string;
   geminiDir: string;
-  mcpServerPath: string;
+  mcpServersToEnable: string[];
+  modernWebServerPath: string;
   mcpApiKey: string;
   numRuns: number;
   scenarios: string[];
@@ -38,7 +39,9 @@ const config: Config = {
   geminiDir: process.env.GEMINI_DIR || path.join(os.homedir(), '.gemini'),
 
   // MCP Server Configuration
-  mcpServerPath: path.join(__dirname, '../serving/mcp-server/index.ts'),
+  // Available servers: 'modern-web', 'google-developer-knowledge-mcp'
+  mcpServersToEnable: ['modern-web'],
+  modernWebServerPath: path.join(__dirname, '../serving/mcp-server/index.ts'),
   mcpApiKey: process.env.MCP_API_KEY || '',
 
   // Suite Configuration

--- a/harness/lib/agent-shared.ts
+++ b/harness/lib/agent-shared.ts
@@ -1,5 +1,7 @@
 import fs from 'fs';
 import path from 'path';
+import { execSync } from 'child_process';
+import { fileURLToPath } from 'url';
 
 /**
  * Creates a unique isolated HOME directory in /tmp.
@@ -70,75 +72,140 @@ export function createTrustedFolders(contentsDir: string, folders: string[]): vo
 }
 
 /**
- * Updates the MCP configuration file to enable or disable the Google Developer Knowledge MCP server.
- * @param configFullPath Full path to the MCP configuration file
- * @param runType 'guided' or 'unguided'
+ * Updates the MCP configuration file to enable MCP servers.
+ * 
+ * @param configPath Full path to the MCP configuration file
+ * @param serversToEnable List of enabled MCP server names
+ * @param modernWebServerPath Path to the Modern Web MCP server
  * @param apiKey The API key for the MCP server
+ * @param agent The agent type
+ * @returns True if the config was written successfully, false otherwise.
  */
-export function updateMcpConfig(configFullPath: string, runType: string, apiKey: string, agent: string): void {
-  let mcpConfig: { mcpServers?: Record<string, any> } = { mcpServers: {} };
+export function updateMcpConfig(
+  configPath: string,
+  serversToEnable: string[],
+  modernWebServerPath: string,
+  apiKey: string,
+  agent: string
+): boolean {
+  const mcpConfig: { mcpServers: Record<string, any> } = { mcpServers: {} };
 
-  try {
-    if (fs.existsSync(configFullPath)) {
-      const content = fs.readFileSync(configFullPath, 'utf8');
-      if (content.trim()) {
-        mcpConfig = JSON.parse(content);
+  for (const serverName of serversToEnable) {
+    if (serverName === 'modern-web') {
+      if (!modernWebServerPath || !fs.existsSync(modernWebServerPath)) {
+        throw new Error(`Example MCP server path not found: ${modernWebServerPath}`);
       }
-    }
-  } catch (e) {
-    console.error(`Failed to read MCP config at ${configFullPath}:`, e);
-  }
+      mcpConfig.mcpServers['modern-web'] = {
+        command: 'node',
+        args: [modernWebServerPath]
+      };
+    } else if (serverName === 'google-developer-knowledge-mcp') {
+      if (!apiKey) {
+        throw new Error('MCP_API_KEY is required for google-developer-knowledge-mcp but was not provided.');
+      }
+      const url = 'https://developerknowledge.googleapis.com/mcp';
 
-  if (!mcpConfig.mcpServers) mcpConfig.mcpServers = {};
+      // Jetski requires 'serverUrl' for the urlKey header
+      const urlKey = agent === 'jetski' ? 'serverUrl' : 'url';
 
-  const serverName = 'google-developer-knowledge-mcp';
-  // Note: 'guided' enables the server, anything else (like 'unguided') disables it.
-  if (runType === 'guided') {
-    if (agent === 'gemini_cli') {
-      mcpConfig.mcpServers[serverName] = {
-        "url": "https://developerknowledge.googleapis.com/mcp",
-        "headers": {
-          "X-Goog-Api-Key": apiKey
+      mcpConfig.mcpServers['google-developer-knowledge-mcp'] = {
+        [urlKey]: url,
+        headers: {
+          'X-Goog-Api-Key': apiKey
         }
       };
-    } else if (agent === 'jetski') {
-      mcpConfig.mcpServers[serverName] = {
-        "serverUrl": "https://developerknowledge.googleapis.com/mcp",
-        "headers": {
-          "X-Goog-Api-Key": apiKey
-        }
-      };
+    } else {
+      console.warn(`Warning: Unknown MCP server name '${serverName}' in config. Skipping.`);
     }
-    console.log(`Enabled ${serverName} MCP server in ${configFullPath}`);
-  } else {
-    // For unguided runs (or any other type), clear all MCP servers to ensure a clean slate.
-    mcpConfig.mcpServers = {};
-    console.log(`Cleared all MCP servers in ${configFullPath} (runType: ${runType})`);
   }
 
   try {
-    fs.writeFileSync(configFullPath, JSON.stringify(mcpConfig, null, 2));
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, JSON.stringify(mcpConfig, null, 2));
+    console.log(`Enabled MCP servers in ${configPath}: ${Object.keys(mcpConfig.mcpServers).join(', ')}`);
+    return true;
   } catch (e) {
-    console.error(`Failed to write MCP config to ${configFullPath}:`, e);
+    console.error(`Failed to write MCP config to ${configPath}:`, e);
+    return false;
   }
 }
 
-export function copyGeminiContext(projectRoot: string, targetDir: string): void {
+export function copyGeminiContext(projectRoot: string, homeDir: string): boolean {
   const geminiMdSource = path.join(projectRoot, 'harness', 'GEMINI.md');
-  const agentDir = path.join(targetDir, '.agent');
-  const geminiMdDest = path.join(agentDir, 'GEMINI.md');
+  const geminiDir = path.join(homeDir, '.gemini');
+  const geminiMdDest = path.join(geminiDir, 'GEMINI.md');
 
-  if (fs.existsSync(geminiMdSource)) {
-    try {
-      if (!fs.existsSync(agentDir)) {
-        fs.mkdirSync(agentDir, { recursive: true });
-      }
-      fs.copyFileSync(geminiMdSource, geminiMdDest);
-      console.log(`Copied GEMINI.md to ${geminiMdDest}`);
-    } catch (e: any) {
-      console.warn(`Warning: Failed to copy GEMINI.md: ${e.message}`);
-    }
-  } else {
+  if (!fs.existsSync(geminiMdSource)) {
     console.warn(`Warning: GEMINI.md not found at ${geminiMdSource}`);
+    return false;
   }
+
+  try {
+    if (!fs.existsSync(geminiDir)) {
+      fs.mkdirSync(geminiDir, { recursive: true });
+    }
+    fs.copyFileSync(geminiMdSource, geminiMdDest);
+    console.log(`Copied GEMINI.md to ${geminiMdDest}`);
+    return true;
+  } catch (e: any) {
+    console.warn(`Warning: Failed to copy GEMINI.md: ${e.message}`);
+    return false;
+  }
+}
+
+/**
+ * Sleeps for the specified number of milliseconds.
+ * @param ms Number of milliseconds to sleep
+ */
+export async function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Kills any process running on the specified port.
+ * @param port The port number to check and kill processes on
+ */
+export function killProcessOnPort(port: number | string): void {
+  try {
+    const pid = execSync(`lsof -t -i :${port}`).toString().trim();
+    if (pid) {
+      console.log(`Killing process ${pid} on port ${port}...`);
+      execSync(`kill -9 ${pid}`);
+    }
+  } catch {
+    // Ignore error if no process found (grep/lsof returns exit code 1 if empty)
+  }
+}
+
+export interface AgentArgs {
+  userPrompt: string;
+  runType: string; // 'guided' or 'unguided'
+  absoluteTargetDir: string;
+  projectRoot: string;
+}
+
+/**
+ * Parses command line arguments for agents.
+ * Usage: node <agent-script> <directory> <prompt> [runType]
+ * 
+ * @param scriptName Name of the script for usage message
+ * @returns Parsed arguments
+ */
+export function parseAgentArgs(scriptName: string): AgentArgs {
+  const args = process.argv.slice(2);
+  if (args.length < 2) {
+    console.error(`Usage: node ${scriptName} <directory> <prompt> [runType]`);
+    process.exit(1);
+  }
+  const [targetDirectory, userPrompt, runType] = args;
+  const absoluteTargetDir = path.resolve(targetDirectory);
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const projectRoot = path.resolve(__dirname, '../..');
+
+  return {
+    userPrompt,
+    runType,
+    absoluteTargetDir,
+    projectRoot
+  };
 }

--- a/harness/run_suite.ts
+++ b/harness/run_suite.ts
@@ -57,20 +57,6 @@ async function main() {
     process.exit(1);
   }
 
-  // Generate a unique testID with timestamp or use custom name
-  const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, -5);
-  const testID = customTestName ? `test_${customTestName}` : `test_${timestamp}`;
-  const testDir = path.join(resultsDir, testID);
-  fs.mkdirSync(testDir, { recursive: true });
-
-  // Setup logging to file
-  const logFilePath = path.join(testDir, 'test_suite.log');
-  const originalConsoleMethods = setupLogging(logFilePath);
-
-  console.log(`\n=== Test Suite Starting with ID: ${testID} ===
-`);
-  console.log(`Results will be saved to: ${testDir}\n`);
-  console.log(`Log file: ${logFilePath}\n`);
 
   // Single task mode check
   const [argDir, argPrompt] = positionalArgs;
@@ -80,6 +66,11 @@ async function main() {
     console.log(`Agent: ${agent}`);
     console.log(`Directory: ${argDir}`);
     console.log(`Prompt: ${argPrompt}\n`);
+
+    if (!fs.existsSync(argDir)) {
+      console.log(`Creating directory: ${argDir}`);
+      fs.mkdirSync(argDir, { recursive: true });
+    }
 
     try {
       // Dispatch based on agent
@@ -91,12 +82,24 @@ async function main() {
       }
       console.log(`\n✅ Single task complete!`);
     } catch (error) {
-      console.error(`
-❌ Single task failed:`, error);
+      console.error(`❌ Single task failed:`, error);
     }
-    restoreLogging(originalConsoleMethods);
     return;
   }
+
+  // Generate a unique testID with timestamp or use custom name
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, -5);
+  const testID = customTestName ? `test_${customTestName}` : `test_${timestamp}`;
+  const testDir = path.join(resultsDir, testID);
+  fs.mkdirSync(testDir, { recursive: true });
+
+  // Setup logging to file
+  const logFilePath = path.join(testDir, 'test_suite.log');
+  const originalConsoleMethods = setupLogging(logFilePath);
+
+  console.log(`\n=== Test Suite Starting with ID: ${testID} ===`);
+  console.log(`Results will be saved to: ${testDir}\n`);
+  console.log(`Log file: ${logFilePath}\n`);
 
   try {
     const endRun = 1 + numRuns;

--- a/serving/mcp-server/README.md
+++ b/serving/mcp-server/README.md
@@ -36,32 +36,7 @@ pnpm run dev
 
 ## Usage
 
-Configure your MCP client to use the local server.
-
-> [!IMPORTANT]
-> The location of your MCP configuration depends on which agent you are testing. These paths are determined by [`harness/config.ts`](../../harness/config.ts).
-
-- **Jetski**: `[JETSKI_DIR]/mcp_config.json`
-- **Gemini CLI**: `[GEMINI_DIR]/settings.json`
-
-Example configuration:
-
-> [!WARNING]
-> Update the path below to match your local setup
-
-```json
-{
-  "mcpServers": {
-    "Modern Web": {
-      "command": "node",
-      "args": [
-        "$HOME/code/guidance/serving/mcp-server/index.ts"
-      ]
-    }
-  }
-}
-```
-
+The MCP config is automatically configured using variables in [`harness/config.ts`](../../harness/config.ts).
 
 ## Testing Semantic Search
 


### PR DESCRIPTION
Several updates:

- Add `mcpServersToEnable` to the config, which allows you to specify which servers to enable for the `guided` runs
- Add `modernWebServerPath` to the config, to specify the filepath where the Modern Web server lives
- Create new MCP configs in the test projects' isolated home dirs instead of copying from global config
- Update "Modern Web" in MCP config definition to "modern-web" (Jetski agent could not use the MCP server properly without this change)
- Fix `pnpm task <directory> <prompt>` cmd so that directory is created if it doesn't exist, and automated directory in `results` is not created
- Move more shared code to agent-shared.ts
- Update relevant READMEs