### PR TITLE
Move before usecases

### DIFF
--- a/guides/user-experience/keep-an-animation-running-while-moving-the-element/guide.md
+++ b/guides/user-experience/keep-an-animation-running-while-moving-the-element/guide.md
@@ -1,0 +1,6 @@
+---
+name: keep-an-animation-running-while-moving-the-element
+description: Move or reparent an element and keep in-flight CSS transitions and Web Animations API animations running.
+web-feature-ids:
+- move-before
+---

--- a/guides/user-experience/keep-an-animation-running-while-moving-the-element/guide.md
+++ b/guides/user-experience/keep-an-animation-running-while-moving-the-element/guide.md
@@ -1,6 +1,0 @@
----
-name: keep-an-animation-running-while-moving-the-element
-description: Move or reparent an element and keep in-flight CSS transitions and Web Animations API animations running.
-web-feature-ids:
-- move-before
----

--- a/guides/user-experience/keep-focus-while-moving-element/guide.md
+++ b/guides/user-experience/keep-focus-while-moving-element/guide.md
@@ -1,6 +1,0 @@
----
-name: keep-focus-while-moving-element
-description: Maintain the active element's visual and programmatic focus when moving elements around or reparenting them in the DOM (for example when dragging and dropping elements or reordering a list).
-web-feature-ids:
-- move-before
----

--- a/guides/user-experience/keep-focus-while-moving-element/guide.md
+++ b/guides/user-experience/keep-focus-while-moving-element/guide.md
@@ -1,0 +1,6 @@
+---
+name: keep-focus-while-moving-element
+description: Maintain the active element's visual and programmatic focus when moving elements around or reparenting them in the DOM (for example when dragging and dropping elements or reordering a list).
+web-feature-ids:
+- move-before
+---

--- a/guides/user-experience/keep-iframe-active-while-moving/guide.md
+++ b/guides/user-experience/keep-iframe-active-while-moving/guide.md
@@ -1,0 +1,6 @@
+---
+name: keep-iframe-active-while-moving
+description: Relocate an iframe containing heavy state (such as a video player like YouTube or a WebGL context) between different layout containers without triggering a document reload or media reset.
+web-feature-ids:
+- move-before
+---

--- a/guides/user-experience/keep-iframe-active-while-moving/guide.md
+++ b/guides/user-experience/keep-iframe-active-while-moving/guide.md
@@ -1,6 +1,0 @@
----
-name: keep-iframe-active-while-moving
-description: Relocate an iframe containing heavy state (such as a video player like YouTube or a WebGL context) between different layout containers without triggering a document reload or media reset.
-web-feature-ids:
-- move-before
----

--- a/guides/user-experience/move-dom-element-without-losing-state/guide.md
+++ b/guides/user-experience/move-dom-element-without-losing-state/guide.md
@@ -1,0 +1,6 @@
+---
+name: move-dom-element-without-losing-state
+description: Move or reparent a DOM element without losing important element state, such as interactivity states (:focus/:active), <iframe> loading state, animation/transition state, etc
+web-feature-ids:
+- move-before
+---

--- a/guides/user-experience/persistent-top-layer/guide.md
+++ b/guides/user-experience/persistent-top-layer/guide.md
@@ -1,0 +1,6 @@
+---
+name: persistent-top-layer-ui
+description: Keep a modal dialog, fullscreen element, or native popover visibly open and functionally active when its underlying DOM node is moved or reparented in the DOM.
+web-feature-ids:
+- move-before
+---


### PR DESCRIPTION
Fixes #66 

Open question. Should we have one use-case per type of element that isn't now no-longer impacted by a re-parenting?