### PR TITLE
add dependabot with noise reduction

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,58 @@
+# Noise reduction strategy:
+# 1. Weekly updates on Mondays to avoid daily interruptions.
+# 2. Group all minor and patch updates into a single PR per project.
+# 3. Limit total open PRs to prevent backlog accumulation.
+
+version: 2
+updates:
+  # Main Workspace (serving, harness, eval-view)
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Content Visibility evaluation project
+  - package-ecosystem: "npm"
+    directory: "/expect-to-eval/content-visibility"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 2
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Harness project
+  - package-ecosystem: "npm"
+    directory: "/harness"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 2
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # Keep GitHub Actions up to date
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 2


### PR DESCRIPTION
Setting up dependabot for the workspace, harness, and actions. Grouping minor/patch updates and running weekly to keep things quiet. 

Holding on merge until harness pnpm transition is settled.  aka waiting on #116