### PR TITLE
add `ResourceUsed interface` avoiding an `any`

### DIFF
--- a/harness/lib/guide_validation.ts
+++ b/harness/lib/guide_validation.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { config } from '../config.ts';
+import { ResourceUsed } from './metrics.ts';
 
 export interface GuideCheck {
   id: string;
@@ -10,7 +11,7 @@ export interface GuideCheck {
 
 export interface GuideValidationResult {
   checks: GuideCheck[];
-  resourcesUsed: any[] | null;
+  resourcesUsed: ResourceUsed[] | null;
 }
 
 export async function checkGuides(dirPath: string, appName: string): Promise<GuideValidationResult> {
@@ -27,7 +28,7 @@ export async function checkGuides(dirPath: string, appName: string): Promise<Gui
     };
   }
 
-  let resources: any[];
+  let resources: ResourceUsed[];
   try {
     resources = JSON.parse(fs.readFileSync(resourcesPath, 'utf8'));
   } catch (e) {

--- a/harness/lib/metrics.ts
+++ b/harness/lib/metrics.ts
@@ -4,12 +4,18 @@ export interface ScenarioCheck {
   message: string;
 }
 
+export interface ResourceUsed {
+  name: string;
+  source?: string;
+  timestamp?: string;
+}
+
 export interface RunResult {
   runNumber: number;
   results: ScenarioCheck[];
   guideResults?: {
     checks: { id: string; passed: boolean; message: string; }[];
-    resourcesUsed: any[] | null;
+    resourcesUsed: ResourceUsed[] | null;
   };
 }
 


### PR DESCRIPTION
Improved code health by replacing loose typing (`any[]`) for `resourcesUsed` with a structured `ResourceUsed` interface in `harness/lib/metrics.ts` and `harness/lib/guide_validation.ts`. This change enhances maintainability and provides better type checking for consumers of these interfaces. Verification was performed by running existing metrics tests.

---
*PR created automatically by Jules for task [5675146243988479456](https://jules.google.com/task/5675146243988479456) started by @paulirish*