### PR TITLE
Setup CODEOWNERS and add rule for /guides

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+/guides/ @philipwalton @rviscomi @malchata


### PR DESCRIPTION
This would autosuggest Phil, Rick and Jeremy to review anything in /guides/ so people don't need to search for the three whenever they create a new PR.