### PR TITLE
Fix guides with incorrect feature ID data

### DIFF
--- a/guides/AGENTS.md
+++ b/guides/AGENTS.md
@@ -45,7 +45,7 @@ You MUST start `guide.md` with EXACTLY this YAML frontmatter structure:
 ---
 name: slugified-use-case-name
 description: <do thing> <with feature> (e.g., "Create dynamic color systems using modern color syntax")
-web-features:
+web-feature-ids:
   - webstatus-feature-id
 sources:
   - https://developer.mozilla.org/en-US/docs/Web/API/Feature

--- a/guides/sync-use-cases.ts
+++ b/guides/sync-use-cases.ts
@@ -80,8 +80,12 @@ function validateGuide(filePath: string): ValidationResult {
     errors.push(`Missing "description" in frontmatter for ${relativePath}.`);
   }
 
-  const featureIds = data['web-feature-ids'] || [];
-  if (!Array.isArray(featureIds)) {
+  const featureIds = data['web-feature-ids'];
+  if (featureIds === undefined) {
+    errors.push(
+      `Missing "web-feature-ids" in frontmatter for ${relativePath}.`,
+    );
+  } else if (!Array.isArray(featureIds)) {
     errors.push(`"web-feature-ids" must be an array in ${relativePath}.`);
   } else {
     for (const id of featureIds) {

--- a/guides/user-experience/adapt-scrollbar-to-contrast-preferences/guide.md
+++ b/guides/user-experience/adapt-scrollbar-to-contrast-preferences/guide.md
@@ -1,7 +1,7 @@
 ---
 name: adapt-scrollbar-to-contrast-preferences
 description: Enhance scrollbar visibility for users who prefer high-contrast interfaces
-web-features:
+web-feature-ids:
   - scrollbar-color
   - prefers-contrast
 sources:

--- a/guides/user-experience/adapt-scrollbar-to-light-dark-preferences/guide.md
+++ b/guides/user-experience/adapt-scrollbar-to-light-dark-preferences/guide.md
@@ -1,7 +1,7 @@
 ---
 name: adapt-scrollbar-to-light-dark-preferences
 description: Ensure the scrollbar visually matches the user's operating system light/dark mode preference
-web-features:
+web-feature-ids:
   - scrollbar-color
   - color-scheme
   - prefers-color-scheme

--- a/guides/user-experience/animate-scrollbar-color-on-scroll/guide.md
+++ b/guides/user-experience/animate-scrollbar-color-on-scroll/guide.md
@@ -1,7 +1,7 @@
 ---
 name: animate-scrollbar-color-on-scroll
 description: Animate the scrollbar color dynamically as the user scrolls down the page
-web-features:
+web-feature-ids:
   - scrollbar-color
   - scroll-driven-animations
   - registered-custom-properties
@@ -9,7 +9,6 @@ sources:
   - https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-color
   - https://developer.mozilla.org/en-US/docs/Web/CSS/animation-timeline
   - https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Properties_and_values_API/Registering_properties
-  
   - https://developer.chrome.com/docs/css-ui/scroll-driven-animations
 ---
 

--- a/guides/user-experience/customize-scrollbar-color-and-thickness/guide.md
+++ b/guides/user-experience/customize-scrollbar-color-and-thickness/guide.md
@@ -1,7 +1,7 @@
 ---
 name: customize-scrollbar-color-and-thickness
 description: Customize the color or thickness of a scrollbar
-web-features:
+web-feature-ids:
   - scrollbar-color
   - scrollbar-width
 sources:

--- a/guides/user-experience/design-token-reactivity/guide.md
+++ b/guides/user-experience/design-token-reactivity/guide.md
@@ -1,6 +1,6 @@
 ---
 name: design-token-reactivity
 description: Define higher-order design tokens, like density modes (compact, comfortable, spacious) or themes and have descendant components react to changes directly and in component-appropriate ways.
-web-features-id:
+web-feature-ids:
   - container-style-queries
 ---

--- a/guides/user-experience/fluid-scaling/guide.md
+++ b/guides/user-experience/fluid-scaling/guide.md
@@ -1,6 +1,6 @@
 ---
 name: fluid-scaling
 description: Scale items like font size, spacing, and media sizes smoothly based on the parent container's size rather than using fixed breakpoints
-web-features-id:
+web-feature-ids:
   - container-queries
 ---

--- a/guides/user-experience/size-aware-adaptations/guide.md
+++ b/guides/user-experience/size-aware-adaptations/guide.md
@@ -1,6 +1,6 @@
 ---
 name: size-aware-styling
 description: Build a component whose styles can be conditionally dependent on its own width or height, rather than the width or height of the viewport. For example a card component that can change its layouts depending on how large it is, or a call-to-action button that can conditionally display helper text based on its width.
-web-features-id:
+web-feature-ids:
   - container-queries
 ---

--- a/guides/user-experience/state-driven-component-variations/guide.md
+++ b/guides/user-experience/state-driven-component-variations/guide.md
@@ -1,6 +1,6 @@
 ---
 name: usage-aware-component-variations
 description: Build a component that can adapt its styles conditionally based on where it appears in the DOM (via CSS custom property inheritance) rather than available size. For example, a table of contents components that is expanded in the sidebar but collapsed in a single-column layout.
-web-features-id:
+web-feature-ids:
   - container-style-queries
 ---


### PR DESCRIPTION
I notice several of the guides had incorrect `web-feature-ids` YAML front matter, and as a result the generate use case issues were missing information (e.g. #172, see edits).

This PR updates fixes the YAML front matter and updates the sync script. *(Note: I've also already run the `sync-use-cases.ts`, so the issues should already be up to date.)*