### PR TITLE
Only run guide-sync in non-dry mode on main push

### DIFF
--- a/.github/workflows/guide-sync.yml
+++ b/.github/workflows/guide-sync.yml
@@ -2,6 +2,8 @@ name: Sync Use Cases
 
 on:
   push:
+    branches:
+      - main
     paths:
       - 'guides/**/guide.md'
       - 'guides/**/grader.ts'


### PR DESCRIPTION
Restricts the push event trigger for the Sync Use Cases workflow to the main branch.