### PR TITLE
add upload suite option (to GCS), dashboard can pull remote results

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,19 @@ pnpm suite
 
 # To run a single isolated task
 pnpm task <task_name>
-# Example: pnpm task cards-render
+# Example: pnpm task batch-analytics-events-task
 
 # To generate reports from results
 pnpm report
 
-# To view the results in the dashboard
+# To view local results (`harness/results/`) in the dashboard
+pnpm dashboard --local
+
+# To upload results to GCS (Project: chrome-kiwi-air-force-dev, Bucket: guidance-evals)
+pnpm upload <suite-name>
+# Example: pnpm upload analytics-suite
+
+# To view uploaded results in the dashboard
 pnpm dashboard
 ```
 

--- a/eval-view/dashboard.html
+++ b/eval-view/dashboard.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Spike Test Eval Dashboard</title>
+  <title>Suite Results</title>
   <link rel="stylesheet" href="dashboard.css">
   <script src="diff.min.js"></script>
 
@@ -13,7 +13,7 @@
 <body>
   <div class="container">
     <header>
-      <h1>Spike Test Eval Dashboard</h1>
+      <h1>Suite Results</h1>
       <div id="test-header" style="font-size: 0.9em; color: var(--text-secondary); margin-top: 8px;">
         <!-- Test ID and timestamp will be injected here -->
       </div>

--- a/eval-view/dashboard.js
+++ b/eval-view/dashboard.js
@@ -37,16 +37,13 @@ document.addEventListener('DOMContentLoaded', async () => {
         // Fetch timestamp from manifest
         let timestamp = null;
         try {
-            const manifestRes = await fetch(`results/tests.json?t=${Date.now()}`);
-            if (manifestRes.ok) {
-                const manifest = await manifestRes.json();
-                const testEntry = manifest.tests.find(t => t.id === testID);
-                if (testEntry && testEntry.timestamp) {
-                    timestamp = testEntry.timestamp;
-                }
+            const evalsRes = await fetch(`results/${testID}/evals.json?t=${Date.now()}`);
+            if (evalsRes.ok) {
+                const evals = await evalsRes.json();
+                timestamp = evals.timestamp;
             }
         } catch (e) {
-            console.log('Could not load test manifest:', e);
+            console.log('Failed to fetch evals.json for timestamp:', e);
         }
 
         renderTestHeader(testID, jetskiVersion, timestamp);

--- a/eval-view/dashboard.spec.js
+++ b/eval-view/dashboard.spec.js
@@ -5,16 +5,15 @@ test.describe('Eval View Dashboard', () => {
     await page.goto('/');
 
     // Check title
-    await expect(page.locator('.landing-title')).toContainText('Results');
+    await expect(page.locator('.landing-title')).toContainText('Guidance Evals');
 
     // Check tabs exist
-    await expect(page.locator('.tab-button[data-tab="overview"]')).toBeVisible();
+    await expect(page.locator('.tab-button[data-tab="suites"]')).toBeVisible();
     await expect(page.locator('.tab-button[data-tab="explorer"]')).toBeVisible();
     await expect(page.locator('.tab-button[data-tab="trends"]')).toBeVisible();
 
-    // Check overview content
-    await expect(page.locator('#latest-guided-metric')).toBeVisible();
-    await expect(page.locator('#latest-unguided-metric')).toBeVisible();
+    // Check suites content
+    await expect(page.locator('.suite-item-container').first()).toBeVisible();
   });
 
   test('should load suites from API', async ({ page }) => {
@@ -28,8 +27,8 @@ test.describe('Eval View Dashboard', () => {
 
   test('should navigate to explorer tab', async ({ page }) => {
     await page.goto('/');
-    // Wait for data to be loaded (overview cards appear)
-    await expect(page.locator('#latest-guided-metric')).not.toContainText('-');
+    // Wait for data to be loaded (suites appear)
+    await expect(page.locator('.suite-item-container').first()).toBeVisible();
     
     await page.click('.tab-button[data-tab="explorer"]');
     

--- a/eval-view/dashboard.spec.js
+++ b/eval-view/dashboard.spec.js
@@ -17,13 +17,13 @@ test.describe('Eval View Dashboard', () => {
     await expect(page.locator('#latest-unguided-metric')).toBeVisible();
   });
 
-  test('should load results from harness directory', async ({ page }) => {
-    // Attempt to fetch results/tests.json through the server
-    const response = await page.request.get('/results/tests.json');
+  test('should load suites from API', async ({ page }) => {
+    // Attempt to fetch /api/suites through the server
+    const response = await page.request.get('/api/suites');
     expect(response.ok()).toBe(true);
     
     const data = await response.json();
-    expect(data).toHaveProperty('tests');
+    expect(data).toHaveProperty('suites');
   });
 
   test('should navigate to explorer tab', async ({ page }) => {
@@ -41,7 +41,7 @@ test.describe('Eval View Dashboard', () => {
     await page.goto('/dashboard.html?testID=example-result');
 
     // Check title
-    await expect(page.locator('h1')).toContainText('Eval Dashboard');
+    await expect(page.locator('h1')).toContainText('Suite Results');
 
     // Check header info
     await expect(page.locator('#test-header')).toContainText('example-result');

--- a/eval-view/index.html
+++ b/eval-view/index.html
@@ -12,8 +12,8 @@
   <div class="landing-container">
     <header class="header-nav">
       <div>
-        <h1 class="landing-title">Results</h1>
-        <p class="landing-subtitle">All test runs and performance over time</p>
+        <h1 class="landing-title">Guidance Evals</h1>
+        <p class="landing-subtitle">All suite runs and performance over time</p>
       </div>
       <div class="filter-container-nav">
         <button id="filter-btn" class="secondary-btn">
@@ -40,28 +40,15 @@
     </header>
 
     <nav class="dashboard-tabs">
-      <button class="tab-button active" data-tab="overview">Overview</button>
+      <button class="tab-button active" data-tab="suites">Suites</button>
       <button class="tab-button" data-tab="explorer">Explorer</button>
       <button class="tab-button" data-tab="trends">Trends</button>
     </nav>
 
-    <!-- Overview Tab -->
-    <div id="overview-tab" class="tab-content active">
-      <div class="overview-grid">
-        <div class="overview-card">
-          <h3>Latest Guided Pass Rate</h3>
-          <div class="metric-huge" id="latest-guided-metric">-</div>
-          <div class="metric-sub">Across all checks</div>
-        </div>
-        <div class="overview-card">
-          <h3>Latest Unguided Pass Rate</h3>
-          <div class="metric-huge" id="latest-unguided-metric">-</div>
-          <div class="metric-sub">Across all checks</div>
-        </div>
-        <div class="overview-card">
-          <h3>Recent Runs</h3>
-          <div id="overview-recent-tests" class="recent-tests-compact"></div>
-        </div>
+    <!-- Suites Tab -->
+    <div id="suites-tab" class="tab-content active">
+      <div id="suites-list" class="suites-list-container">
+        <!-- populated by JS -->
       </div>
     </div>
 

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -1,9 +1,10 @@
 import { getRunStats, getColor, escapeHtml, capitalize } from './utils.js';
 
 let allTestData = {}; // Cache all test data by testID
-let currentTab = 'overview';
+let currentTab = 'suites';
 let currentScenarioFilter = 'all';
 let selectedTestIds = new Set(); // Set of test IDs to show
+let isLocalServer = false;
 
 
 document.addEventListener('DOMContentLoaded', async () => {
@@ -42,7 +43,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         }
 
         // Initial Render
-        renderOverview();
+        renderSuites();
         renderExplorer();
         renderTrends();
 
@@ -55,8 +56,8 @@ document.addEventListener('DOMContentLoaded', async () => {
 // Handle browser back/forward
 window.addEventListener('popstate', () => {
     const params = new URLSearchParams(window.location.search);
-    const view = params.get('view') || 'overview';
-    if (['overview', 'explorer', 'trends'].includes(view)) {
+    const view = params.get('view') || 'suites';
+    if (['suites', 'explorer', 'trends'].includes(view)) {
         activateTab(view, false);
     }
 
@@ -201,7 +202,7 @@ function renderFilterMenuItems() {
         labelContent.className = 'filter-item-label';
 
         const idSpan = document.createElement('span');
-        idSpan.textContent = `Test ${testID.replace('test_', '')}`;
+        idSpan.textContent = testID.replace('test_', '');
 
         const dateSpan = document.createElement('span');
         dateSpan.className = 'filter-item-date';
@@ -232,18 +233,20 @@ function updateUrlParams() {
 }
 
 function renderAll() {
-    renderOverview();
+    renderSuites();
     renderExplorer();
     renderTrends();
 }
 
 async function loadAllTests() {
     try {
-        const response = await fetch(`results/tests.json?t=${Date.now()}`);
-        if (!response.ok) throw new Error('Manifest not found');
+        const response = await fetch(`/api/suites?t=${Date.now()}`);
+        if (!response.ok) throw new Error('Failed to fetch suites');
         const manifest = await response.json();
 
-        if (!manifest.tests || manifest.tests.length === 0) {
+        isLocalServer = manifest.isLocal || false;
+
+        if (!manifest.suites || manifest.suites.length === 0) {
             document.getElementById('empty-state').style.display = 'block';
             return;
         }
@@ -251,21 +254,22 @@ async function loadAllTests() {
         document.getElementById('empty-state').style.display = 'none';
 
         // Load all test data
-        for (const testEntry of manifest.tests) {
+        for (const testID of manifest.suites) {
             try {
-                const response = await fetch(`results/${testEntry.id}/evals.json?t=${Date.now()}`);
+                const response = await fetch(`results/${testID}/evals.json?t=${Date.now()}`);
                 if (response.ok) {
-                    allTestData[testEntry.id] = {
-                        timestamp: testEntry.timestamp,
-                        data: await response.json()
+                    const parsed = await response.json();
+                    allTestData[testID] = {
+                        timestamp: parsed.timestamp || new Date().toISOString(), // Fallback
+                        data: parsed
                     };
                 }
             } catch (e) {
-                console.warn(`Failed to load test ${testEntry.id}:`, e);
+                console.warn(`Failed to load test ${testID}:`, e);
             }
         }
     } catch (error) {
-        console.warn('No manifest found:', error);
+        console.warn('Error loading suites:', error);
         document.getElementById('empty-state').style.display = 'block';
         throw error;
     }
@@ -275,37 +279,19 @@ async function loadAllTests() {
 // RENDERERS
 // ==========================================
 
-function renderOverview() {
+function renderSuites() {
     const testIds = getSortedTestIds();
     if (testIds.length === 0) return;
 
-    const latestTestId = testIds[0];
-    const latestData = allTestData[latestTestId].data;
+    const container = document.getElementById('suites-list');
 
-    // 1. Render Metrics
-    const guidedMetric = document.getElementById('latest-guided-metric');
-    const unguidedMetric = document.getElementById('latest-unguided-metric');
-
-    const guidedStats = calculateGroupTotalStats(latestData.results, 'guided');
-    const unguidedStats = calculateGroupTotalStats(latestData.results, 'unguided');
-
-    const guidedRate = guidedStats.total > 0 ? Math.round((guidedStats.passed / guidedStats.total) * 100) : 0;
-    const unguidedRate = unguidedStats.total > 0 ? Math.round((unguidedStats.passed / unguidedStats.total) * 100) : 0;
-
-    guidedMetric.textContent = `${guidedRate}%`;
-    guidedMetric.style.color = getColor(guidedRate);
-
-    unguidedMetric.textContent = `${unguidedRate}%`;
-    unguidedMetric.style.color = getColor(unguidedRate);
-
-    // 2. Render Recent Tests List
-    const container = document.getElementById('overview-recent-tests');
-    const recentTests = testIds.slice(0, 5);
-
-    container.innerHTML = recentTests.map(testID => {
+    container.innerHTML = testIds.map(testID => {
         const testInfo = allTestData[testID];
         const data = testInfo.data;
-        const timestamp = new Date(testInfo.timestamp).toLocaleString();
+        const _date = new Date(testInfo.timestamp);
+
+        // Custom format to add time into the label:
+        const prettyTimestampStr = `${_date.toLocaleDateString()} at ${_date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
 
         const gStats = calculateGroupTotalStats(data.results, 'guided');
         const uStats = calculateGroupTotalStats(data.results, 'unguided');
@@ -313,23 +299,33 @@ function renderOverview() {
         const gRate = gStats.total > 0 ? Math.round((gStats.passed / gStats.total) * 100) : 0;
         const uRate = uStats.total > 0 ? Math.round((uStats.passed / uStats.total) * 100) : 0;
 
+        const gcpLink = `https://console.cloud.google.com/storage/browser/guidance-evals/${testID}?project=chrome-kiwi-air-force-dev`;
+        const localLink = `dashboard.html?testID=${testID}`;
+
+        const gcpButtonHtml = !isLocalServer ?
+            `<button onclick="event.stopPropagation(); window.open('${gcpLink}', '_blank');" class="secondary-btn" style="font-size: 0.8rem; padding: 6px 10px;">View Result Artifacts</button>` : '';
+
         return `
-            <a class="recent-test-item" href="dashboard.html?testID=${testID}">
-                <div>
-                    <div class="test-id">Test ${testID.replace('test_', '')}</div>
-                    <div class="test-timestamp">${timestamp}</div>
-                </div>
-                <div class="test-stats">
-                    <div>
-                        <div class="stat-label">Guided</div>
-                        <div class="stat-value" style="color: ${getColor(gRate)}">${gRate}%</div>
+            <div onclick="window.location.href='${localLink}'" class="suite-item-container" style="cursor: pointer; border: 1px solid var(--border-color); border-radius: var(--radius-lg); padding: 20px; margin-bottom: 20px; transition: all 0.2s;" onmouseover="this.style.borderColor='var(--primary-color)'; this.style.transform='translateY(-2px)';" onmouseout="this.style.borderColor='var(--border-color)'; this.style.transform='none';">
+                <div style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 16px;">
+                    <div style="flex: 1; min-width: 250px;">
+                        <h3 style="margin: 0; font-size: 1.25rem; color: var(--text-primary); pointer-events: none;">${testID}</h3>
+                        <div style="font-size: 0.85rem; color: var(--text-tertiary); margin-top: 4px; pointer-events: none;">${prettyTimestampStr}</div>
                     </div>
-                    <div>
-                        <div class="stat-label">Unguided</div>
-                        <div class="stat-value" style="color: ${getColor(uRate)}">${uRate}%</div>
+
+                    <div style="display: flex; gap: 32px; align-items: center; justify-content: flex-end;">
+                        <div style="text-align: right;">
+                            <div style="font-size: 0.85rem; color: var(--text-secondary); margin-bottom: 4px;">Guided Pass Rate</div>
+                            <div style="font-size: 2rem; font-weight: 700; color: ${getColor(gRate)};">${gRate}%</div>
+                        </div>
+                        <div style="text-align: right;">
+                            <div style="font-size: 0.85rem; color: var(--text-secondary); margin-bottom: 4px;">Unguided Pass Rate</div>
+                            <div style="font-size: 2rem; font-weight: 700; color: ${getColor(uRate)};">${uRate}%</div>
+                        </div>
+                        ${!isLocalServer ? `<div style="margin-left: 16px;">${gcpButtonHtml}</div>` : ''}
                     </div>
                 </div>
-            </a>
+            </div>
         `;
     }).join('');
 }

--- a/eval-view/mock-results/tests.json
+++ b/eval-view/mock-results/tests.json
@@ -1,9 +1,0 @@
-{
-  "tests": [
-    {
-      "id": "example-result",
-      "timestamp": "2026-01-16T14:36:47.531Z",
-      "runCount": 1
-    }
-  ]
-}

--- a/eval-view/package.json
+++ b/eval-view/package.json
@@ -9,5 +9,8 @@
   "devDependencies": {
     "@playwright/test": "^1.58.2",
     "playwright": "^1.58.2"
+  },
+  "dependencies": {
+    "@google-cloud/storage": "^7.19.0"
   }
 }

--- a/eval-view/playwright.config.js
+++ b/eval-view/playwright.config.js
@@ -19,7 +19,7 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: 'PORT=11432 NO_OPEN=true USE_MOCK_RESULTS=true node server.js',
+    command: 'PORT=11432 NO_OPEN=true USE_MOCK_RESULTS=true node server.js --local',
     url: 'http://localhost:11432',
     reuseExistingServer: !process.env.CI,
     stdout: 'pipe',

--- a/eval-view/server.js
+++ b/eval-view/server.js
@@ -2,8 +2,16 @@ import * as http from "http";
 import fs from 'fs';
 import path from 'path';
 import { exec } from 'child_process';
+import { Storage } from '@google-cloud/storage';
 
 const PORT = process.env.PORT || 8081;
+const USE_LOCAL = process.argv.includes('--local');
+const PROJECT_ID = 'chrome-kiwi-air-force-dev';
+const BUCKET_NAME = 'guidance-evals';
+
+const storage = new Storage({ projectId: PROJECT_ID });
+const bucket = storage.bucket(BUCKET_NAME);
+
 const MIME_TYPES = {
   '.html': 'text/html',
   '.js': 'text/javascript',
@@ -18,7 +26,7 @@ const MIME_TYPES = {
   '.log': 'text/plain',
 };
 
-const server = http.createServer((req, res) => {
+const server = http.createServer(async (req, res) => {
   // Ultra-strict raw URL check
   if (req.url.includes('..') || req.url.toLowerCase().includes('%2e')) {
     console.log(`403 Forbidden: Traversal/Encoded attempt - ${req.method} ${req.url}`);
@@ -49,11 +57,76 @@ const server = http.createServer((req, res) => {
     return;
   }
 
+  // Handle /api/suites endpoint
+  if (decodedPath === '/api/suites') {
+    if (USE_LOCAL) {
+      const resultsDir = process.env.USE_MOCK_RESULTS === 'true' ? './mock-results' : '../harness/results';
+      try {
+        const dirs = fs.readdirSync(resultsDir, { withFileTypes: true })
+          .filter(dirent => dirent.isDirectory() && dirent.name !== 'single_task')
+          .map(dirent => dirent.name);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ suites: dirs, isLocal: true }));
+      } catch (e) {
+        res.writeHead(500);
+        res.end(JSON.stringify({ error: e.message }));
+      }
+    } else {
+      try {
+        const [_, __, apiResponse] = await bucket.getFiles({ delimiter: '/' });
+        const prefixes = apiResponse.prefixes || [];
+        const suites = prefixes.map(p => p.slice(0, -1)); // Remove trailing slash
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ suites, isLocal: false }));
+      } catch (e) {
+        res.writeHead(500);
+        res.end(JSON.stringify({ error: e.message }));
+      }
+    }
+    return;
+  }
+
   let filePath;
   // Map results and setup to the harness directory
   if (decodedPath.startsWith('/results/')) {
+    const relativeResultPath = decodedPath.substring(9);
+
+    if (!USE_LOCAL) {
+      // Stream from GCS
+      const extname = path.extname(relativeResultPath) || '';
+      let contentType = MIME_TYPES[extname] || 'application/octet-stream';
+      // If fetching the suite root instead of a file
+      if (relativeResultPath === '' || relativeResultPath.endsWith('/')) {
+        contentType = 'text/html';
+        // Serve an index.html equivalent or 404
+      }
+
+      const file = bucket.file(relativeResultPath);
+      file.exists().then(([exists]) => {
+        if (!exists) {
+          res.writeHead(404);
+          res.end('404 Not Found');
+          return;
+        }
+
+        res.writeHead(200, { 'Content-Type': contentType });
+        file.createReadStream()
+          .on('error', (err) => {
+            console.error('Error streaming from GCS:', err);
+            // We can't write head here if we already wrote 200, but we can end
+            res.end();
+          })
+          .pipe(res);
+      }).catch(err => {
+        console.error('GCS exists check failed:', err);
+        res.writeHead(500);
+        res.end(`Server Error: ${err.message}`);
+      });
+      return;
+    }
+
     const resultsDir = process.env.USE_MOCK_RESULTS === 'true' ? './mock-results' : '../harness/results';
-    filePath = path.join(resultsDir, decodedPath.substring(9));
+    filePath = path.join(resultsDir, relativeResultPath);
   } else if (decodedPath.startsWith('/base_apps/')) {
     filePath = path.join('../harness/base_apps', decodedPath.substring(11));
   } else {
@@ -121,7 +194,7 @@ const server = http.createServer((req, res) => {
 
 server.listen(PORT, () => {
   const url = `http://localhost:${PORT}/`;
-  console.log(`Server running at ${url}`);
+  console.log(`Server running at ${url} (${USE_LOCAL ? 'LOCAL MODE' : 'GCP MODE'})`);
 
   // Try to open the browser if not disabled
   if (process.env.NO_OPEN !== 'true') {

--- a/guides/run-grader.ts
+++ b/guides/run-grader.ts
@@ -70,7 +70,7 @@ async function gradeFile(targetFileAbs: string) {
     stdio: 'inherit'
   });
 
-  return new Promise<void>((resolve, reject) => {
+  return new Promise<void>((_resolve, _reject) => {
     child.on('close', (code) => {
       // Automatically show the report if tests completed or failed
       console.log(`\nTests finished with code ${code}. Opening HTML report...`);

--- a/harness/evaluate.ts
+++ b/harness/evaluate.ts
@@ -15,34 +15,11 @@ import { config } from './config.ts';
 async function main() {
   console.log('Starting Evaluation...'.cyan.bold);
 
-  // Read manifest to find the latest test
   const resultsDirBase = path.join(__dirname, 'results');
-  const manifestPath = path.join(resultsDirBase, 'tests.json');
-  if (!fs.existsSync(manifestPath)) {
-    console.error('Manifest file not found at results/tests.json!'.red);
-    return;
-  }
-
-  let manifest;
-  try {
-    manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
-  } catch {
-    console.error('Failed to parse manifest!'.red);
-    return;
-  }
-
-  if (!manifest.tests || manifest.tests.length === 0) {
-    console.error('No tests found in manifest!'.red);
-    return;
-  }
-
-  let suiteName;
-  if (config.eval.suiteName) {
-    suiteName = config.eval.suiteName;
-  } else {
-    // Get the latest test if no specific test ID is provided
-    const latestTest = manifest.tests[manifest.tests.length - 1];
-    suiteName = latestTest.id;
+  let suiteName = config.eval.suiteName;
+  if (!suiteName) {
+    console.error('❌ No suite name provided! Please specify a suite to evaluate.'.red);
+    process.exit(1);
   }
   const resultsDir = path.join(resultsDirBase, suiteName);
 
@@ -60,7 +37,8 @@ async function main() {
 
     const metrics = calculateMetrics(allResults, numRuns);
     const mdReport = generateMarkdownReport(metrics, allResults);
-    const jsonReport = generateJsonReport(metrics, allResults);
+    const timestamp = new Date().toISOString();
+    const jsonReport = generateJsonReport(metrics, allResults, timestamp, numRuns);
 
     saveReports(resultsDir, mdReport, jsonReport);
 

--- a/harness/lib/reporting.ts
+++ b/harness/lib/reporting.ts
@@ -57,11 +57,13 @@ export function generateMarkdownReport(metrics: Metrics, allResults: Record<stri
   return md;
 }
 
-export function generateJsonReport(metrics: Metrics, allResults: Record<string, RunResult[]>) {
+export function generateJsonReport(metrics: Metrics, allResults: Record<string, RunResult[]>, timestamp: string, runCount: number) {
   return {
     summary: metrics.summary,
     results: allResults,
-    stats: metrics.testPassRates
+    stats: metrics.testPassRates,
+    timestamp,
+    runCount
   };
 }
 

--- a/harness/package.json
+++ b/harness/package.json
@@ -8,6 +8,7 @@
     "suite": "node run_suite.ts",
     "qsmoke": "node quick-smoke.ts",
     "task": "node run_suite.ts",
+    "upload": "node --experimental-strip-types upload_suite.ts",
     "typecheck": "tsc --noEmit",
     "full-run": "npm run suite && npm run report"
   },
@@ -15,6 +16,7 @@
   "dependencies": {
     "@anthropic-ai/claude-code": "^2.1.56",
     "@anthropic-ai/vertex-sdk": "^0.14.4",
+    "@google-cloud/storage": "^7.19.0",
     "@google/gemini-cli": "^0.30.0",
     "cheerio": "^1.2.0",
     "colors": "^1.4.0",

--- a/harness/run_suite.ts
+++ b/harness/run_suite.ts
@@ -204,18 +204,7 @@ async function main() {
       }
     }
 
-    const manifestPath = path.join(resultsDir, 'tests.json');
-    let manifest: { tests: any[] } = { tests: [] };
-    if (fs.existsSync(manifestPath)) {
-      try {
-        manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
-      } catch { }
-    }
 
-    if (!manifest.tests.some(t => t.id === testID)) {
-      manifest.tests.push({ id: testID, timestamp: new Date().toISOString(), runCount: config.suite.numRuns });
-      fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
-    }
 
     console.log(`\n✅ Test suite complete! Results saved to: results/${testID}`);
   } catch (e) {

--- a/harness/upload_suite.ts
+++ b/harness/upload_suite.ts
@@ -1,0 +1,67 @@
+import { Storage } from '@google-cloud/storage';
+import path from 'path';
+import fs from 'fs';
+import 'colors';
+
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const PROJECT_ID = 'chrome-kiwi-air-force-dev';
+const BUCKET_NAME = 'guidance-evals';
+
+async function uploadDirectory(bucket: any, dirPath: string, gcsPrefix: string) {
+  const files = fs.readdirSync(dirPath, { withFileTypes: true });
+
+  for (const file of files) {
+    const fullPath = path.join(dirPath, file.name);
+    const destinationPath = path.join(gcsPrefix, file.name);
+
+    if (file.isDirectory()) {
+      await uploadDirectory(bucket, fullPath, destinationPath);
+    } else {
+      console.log(`Uploading ${fullPath} to gs://${BUCKET_NAME}/${destinationPath}...`);
+      await bucket.upload(fullPath, {
+        destination: destinationPath,
+      });
+    }
+  }
+}
+
+async function main() {
+  const suiteName = process.argv[2];
+
+  if (!suiteName) {
+    console.error('❌ Please provide a suite name as an argument. e.g. pnpm upload <suite-name>');
+    process.exit(1);
+  }
+
+  const resultsDir = path.join(__dirname, 'results', suiteName);
+  const evalsJsonPath = path.join(resultsDir, 'evals.json');
+
+  if (!fs.existsSync(resultsDir)) {
+    console.error(`❌ Results directory not found: ${resultsDir}`.red);
+    process.exit(1);
+  }
+
+  if (!fs.existsSync(evalsJsonPath)) {
+    console.error(`❌ evals.json not found in ${resultsDir}. Cannot upload incomplete or un-evaluated suite.`.red);
+    process.exit(1);
+  }
+
+  console.log(`Starting upload for suite: ${suiteName}`.cyan.bold);
+
+  const storage = new Storage({ projectId: PROJECT_ID });
+  const bucket = storage.bucket(BUCKET_NAME);
+
+  try {
+    await uploadDirectory(bucket, resultsDir, suiteName);
+    console.log(`\n✅ Successfully uploaded suite '${suiteName}' to gs://${BUCKET_NAME}/${suiteName}`.green.bold);
+  } catch (error: any) {
+    console.error(`❌ Upload failed: ${error.message}`.red);
+    process.exit(1);
+  }
+}
+
+main().catch(console.error);

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "task": "pnpm --filter harness task",
     "run-agent": "node harness/run_suite.ts --with-template",
     "report": "pnpm --filter harness report",
+    "upload": "pnpm --filter harness upload",
     "dashboard": "pnpm --filter eval-view start",
     "build:mcp": "pnpm --filter modern-web-mcp build",
     "test:mcp": "pnpm --filter modern-web-mcp test",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,10 @@ importers:
         version: 5.9.3
 
   eval-view:
+    dependencies:
+      '@google-cloud/storage':
+        specifier: ^7.19.0
+        version: 7.19.0
     devDependencies:
       '@playwright/test':
         specifier: ^1.58.2
@@ -59,6 +63,9 @@ importers:
       '@anthropic-ai/vertex-sdk':
         specifier: ^0.14.4
         version: 0.14.4(zod@3.25.76)
+      '@google-cloud/storage':
+        specifier: ^7.19.0
+        version: 7.19.0
       '@google/gemini-cli':
         specifier: ^0.30.0
         version: 0.30.0(@grpc/grpc-js@1.14.3)(express@5.2.1)
@@ -379,6 +386,10 @@ packages:
 
   '@google-cloud/promisify@4.0.0':
     resolution: {integrity: sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==}
+    engines: {node: '>=14'}
+
+  '@google-cloud/storage@7.19.0':
+    resolution: {integrity: sha512-n2FjE7NAOYyshogdc7KQOl/VZb4sneqPjWouSyia9CMDdMhRX5+RIbqalNmC7LOLzuLAN89VlF2HvG8na9G+zQ==}
     engines: {node: '>=14'}
 
   '@google/gemini-cli-core@0.30.0':
@@ -1474,6 +1485,9 @@ packages:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
     engines: {node: '>=4'}
 
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
+
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
@@ -2056,6 +2070,13 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
+  fast-xml-builder@1.0.0:
+    resolution: {integrity: sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==}
+
+  fast-xml-parser@5.4.2:
+    resolution: {integrity: sha512-pw/6pIl4k0CSpElPEJhDppLzaixDEuWui2CUQQBH/ECDf7+y6YwA4Gf7Tyb0Rfe4DIMuZipYj4AEL0nACKglvQ==}
+    hasBin: true
+
   fd-slicer@1.1.0:
     resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
@@ -2633,6 +2654,11 @@ packages:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
 
+  mime@3.0.0:
+    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+
   mime@4.0.7:
     resolution: {integrity: sha512-2OfDPL+e03E0LrXaGYOtTFIYhiuzep94NSsuhrNULq+stylcJedcHdzHtz0atMUuGwJfFYs0YL5xeC/Ca2x0eQ==}
     engines: {node: '>=16'}
@@ -2821,6 +2847,10 @@ packages:
   p-cancelable@4.0.1:
     resolution: {integrity: sha512-wBowNApzd45EIKdO1LaU+LrMBwAcjfPaYtVzV3lmfM3gf8Z4CHZsiIqlM8TZZ8okYvh5A1cP6gTfCRQtwUpaUg==}
     engines: {node: '>=14.16'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
 
   pac-proxy-agent@7.2.0:
     resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
@@ -3079,6 +3109,10 @@ packages:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
 
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
   rimraf@5.0.10:
     resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
     hasBin: true
@@ -3312,6 +3346,9 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strnum@2.2.0:
+    resolution: {integrity: sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==}
 
   stubs@3.0.0:
     resolution: {integrity: sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==}
@@ -3690,6 +3727,10 @@ packages:
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
 
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
+
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
@@ -3928,6 +3969,27 @@ snapshots:
   '@google-cloud/projectify@4.0.0': {}
 
   '@google-cloud/promisify@4.0.0': {}
+
+  '@google-cloud/storage@7.19.0':
+    dependencies:
+      '@google-cloud/paginator': 5.0.2
+      '@google-cloud/projectify': 4.0.0
+      '@google-cloud/promisify': 4.0.0
+      abort-controller: 3.0.0
+      async-retry: 1.3.3
+      duplexify: 4.1.3
+      fast-xml-parser: 5.4.2
+      gaxios: 6.7.1
+      google-auth-library: 9.15.1
+      html-entities: 2.6.0
+      mime: 3.0.0
+      p-limit: 3.1.0
+      retry-request: 7.0.2
+      teeny-request: 9.0.0
+      uuid: 8.3.2
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   '@google/gemini-cli-core@0.30.0(@grpc/grpc-js@1.14.3)(express@5.2.1)':
     dependencies:
@@ -5100,6 +5162,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
+
   asynckit@0.4.0: {}
 
   auto-bind@5.0.1: {}
@@ -5717,6 +5783,13 @@ snapshots:
   fast-levenshtein@2.0.6: {}
 
   fast-uri@3.1.0: {}
+
+  fast-xml-builder@1.0.0: {}
+
+  fast-xml-parser@5.4.2:
+    dependencies:
+      fast-xml-builder: 1.0.0
+      strnum: 2.2.0
 
   fd-slicer@1.1.0:
     dependencies:
@@ -6349,6 +6422,8 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
+  mime@3.0.0: {}
+
   mime@4.0.7: {}
 
   mimic-fn@2.1.0: {}
@@ -6522,6 +6597,10 @@ snapshots:
       '@oxlint/binding-win32-x64-msvc': 1.50.0
 
   p-cancelable@4.0.1: {}
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
 
   pac-proxy-agent@7.2.0:
     dependencies:
@@ -6847,6 +6926,8 @@ snapshots:
 
   retry@0.12.0: {}
 
+  retry@0.13.1: {}
+
   rimraf@5.0.10:
     dependencies:
       glob: 10.5.0
@@ -7170,6 +7251,8 @@ snapshots:
   strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
+
+  strnum@2.2.0: {}
 
   stubs@3.0.0: {}
 
@@ -7498,6 +7581,8 @@ snapshots:
     dependencies:
       buffer-crc32: 0.2.13
       fd-slicer: 1.1.0
+
+  yocto-queue@0.1.0: {}
 
   yoctocolors@2.1.2: {}
 


### PR DESCRIPTION
Preserve local dashboard results (to validate results before uploading) with `pnpm dashboard --local`.

Add `pnpm upload <suite-name>` option, to upload to GCS (Project: `chrome-kiwi-air-force-dev`, Bucket: `guidance-evals`.

Removes the need for `tests.json` and just uses the suite result folders to display in the. dashboard.

`pnpm dashboard` now displays the results from the GCS bucket.

Fix lint errors.

Dashboard homepage updated to look like:

<img width="1420" height="489" alt="Screenshot 2026-03-04 at 6 11 04 PM" src="https://github.com/user-attachments/assets/cc586a31-0610-4a60-9839-5596f3aa2fe4" />