### PR TITLE
Add filters to the dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,18 +54,16 @@ pnpm suite
 pnpm task <task_name>
 # Example: pnpm task batch-analytics-events-task
 
-# To generate reports from results
-pnpm report
-
-# To view local results (`harness/results/`) in the dashboard
-pnpm dashboard --local
-
 # To upload results to GCS (Project: chrome-kiwi-air-force-dev, Bucket: guidance-evals)
 pnpm upload <suite-name>
 # Example: pnpm upload analytics-suite
 
-# To view uploaded results in the dashboard
+# To view results in the dashboard
 pnpm dashboard
+
+# To re-generate evaluation reports for a suite
+pnpm report <suite-name>
+# Example: pnpm report analytics-suite
 ```
 
 ## Configuration
@@ -74,7 +72,6 @@ All configuration is centralized in [`harness/config.ts`](./harness/config.ts). 
 
 -   **Environment**: Paths to binaries (Jetski, Gemini CLI, Claude Code), API keys, and server locations.
 -   **Suite**: Agent selection, number of runs, tasks to run, enabled MCP servers, and skills.
--   **Evaluation**: Name of suite to evaluate.
 
 All settings must be adjusted in `harness/config.ts` or via environment variables in `.env` at the `guidance/` root.
 

--- a/eval-view/dashboard.html
+++ b/eval-view/dashboard.html
@@ -32,6 +32,8 @@
 
     <footer class="dashboard-footer">
       <a href="./" class="secondary-btn" style="margin-right: 10px;">← Back to Results</a>
+      <button id="view-gcs-artifacts-btn" class="secondary-btn" style="display: none; margin-right: 10px;">View GCS
+        Artifacts</button>
       <button id="view-log-btn" class="secondary-btn">View Full Run Log</button>
     </footer>
   </div>

--- a/eval-view/dashboard.html
+++ b/eval-view/dashboard.html
@@ -32,8 +32,8 @@
 
     <footer class="dashboard-footer">
       <a href="./" class="secondary-btn" style="margin-right: 10px;">← Back to Results</a>
-      <button id="view-gcs-artifacts-btn" class="secondary-btn" style="display: none; margin-right: 10px;">View GCS
-        Artifacts</button>
+      <button id="view-gcs-artifacts-btn" class="secondary-btn" style="display: none; margin-right: 10px;">View
+        Source</button>
       <button id="view-log-btn" class="secondary-btn">View Full Run Log</button>
     </footer>
   </div>

--- a/eval-view/dashboard.js
+++ b/eval-view/dashboard.js
@@ -13,7 +13,8 @@ document.addEventListener('DOMContentLoaded', async () => {
             throw new Error('No testID provided in query string');
         }
 
-        const evalsPath = `results/${testID}/evals.json?t=${Date.now()}`;
+        const source = params.get('source') || 'local';
+        const evalsPath = `results/${testID}/evals.json?source=${source}&t=${Date.now()}`;
         const response = await fetch(evalsPath);
         if (!response.ok) throw new Error(`Failed to load data from ${evalsPath}`);
         const data = await response.json();
@@ -25,7 +26,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         // Fetch jetski info (optional)
         let jetskiVersion = null;
         try {
-            const jetskiRes = await fetch(`results/${testID}/jetski_info.json`);
+            const jetskiRes = await fetch(`results/${testID}/jetski_info.json?source=${source}`);
             if (jetskiRes.ok) {
                 const jetskiData = await jetskiRes.json();
                 jetskiVersion = jetskiData['Jetski Version'];
@@ -37,10 +38,14 @@ document.addEventListener('DOMContentLoaded', async () => {
         // Fetch timestamp from manifest
         let timestamp = null;
         try {
-            const evalsRes = await fetch(`results/${testID}/evals.json?t=${Date.now()}`);
-            if (evalsRes.ok) {
-                const evals = await evalsRes.json();
-                timestamp = evals.timestamp;
+            if (data.timestamp) {
+                timestamp = data.timestamp;
+            } else {
+                const evalsRes = await fetch(evalsPath);
+                if (evalsRes.ok) {
+                    const evals = await evalsRes.json();
+                    timestamp = evals.timestamp;
+                }
             }
         } catch (e) {
             console.log('Failed to fetch evals.json for timestamp:', e);
@@ -140,12 +145,25 @@ document.addEventListener('DOMContentLoaded', async () => {
     // We no longer need popstate for modal state because we use replaceState exclusively.
     // Full page deep links are handled via DOMContentLoaded.
 
+    // View GCS Artifacts
+    const gcsBtn = document.getElementById('view-gcs-artifacts-btn');
+    if (gcsBtn) {
+        const params = new URLSearchParams(window.location.search);
+        const source = params.get('source');
+        const testID = params.get('testID');
+        if (source === 'remote') {
+            gcsBtn.style.display = 'inline-block';
+            gcsBtn.onclick = () => window.open(`https://console.cloud.google.com/storage/browser/guidance-evals/${testID}?project=chrome-kiwi-air-force-dev`, '_blank');
+        }
+    }
+
     // View Log Handler
     const viewLogBtn = document.getElementById('view-log-btn');
     if (viewLogBtn) {
         const params = new URLSearchParams(window.location.search);
         const testID = params.get('testID');
-        const logPath = `results/${testID}/test_suite.log`;
+        const source = params.get('source') || 'local';
+        const logPath = `results/${testID}/test_suite.log?source=${source}`;
 
         // Check if log file exists
         try {
@@ -242,9 +260,16 @@ function renderTestHeader(testID, jetskiVersion, timestamp) {
         if (timestamp) {
             let timeStr = timestamp;
             try {
-                timeStr = new Date(timestamp).toLocaleString();
+                const _date = new Date(timestamp);
+                timeStr = _date.toLocaleString('en-US', {
+                    month: 'long',
+                    day: 'numeric',
+                    hour: 'numeric',
+                    minute: '2-digit',
+                    hour12: true
+                });
             } catch { }
-            html += ` — Run at ${timeStr}`;
+            html += ` — ${timeStr}`;
         }
 
         if (jetskiVersion) {
@@ -469,7 +494,8 @@ async function showDetails(testName, runs, stats, testID) {
         if (viewResourcesLink) {
             viewResourcesLink.onclick = (e) => {
                 e.preventDefault();
-                const resourcesPath = `${usedBasePath}/${MCP_LOG_FILE}`;
+                const source = new URLSearchParams(window.location.search).get('source') || 'local';
+                const resourcesPath = `${usedBasePath}/${MCP_LOG_FILE}?source=${source}`;
                 viewContent(resourcesPath, resourcesPath);
             };
         }
@@ -480,7 +506,8 @@ async function showDetails(testName, runs, stats, testID) {
         diffButton.style.cssText = 'margin-left: 10px; font-size: 0.8em; padding: 2px 8px;';
         diffButton.onclick = () => viewDiff(setupPath, resultPath, testName, run.runNumber);
 
-        const rawResultsPath = `${usedBasePath}/${guide}_results.json`;
+        const sourceParam = new URLSearchParams(window.location.search).get('source') || 'local';
+        const rawResultsPath = `${usedBasePath}/${guide}_results.json?source=${sourceParam}`;
         let showRawResults = false;
         try {
             const rawRes = await fetch(rawResultsPath, { method: 'HEAD' });
@@ -778,13 +805,13 @@ async function getResultPaths(testID, run, testName) {
         `results/${testID}/${run.runNumber}/${appName}/${guide}/${runType}`
     ];
 
-    const resultPath = await findBestEntryPoint(basePaths);
+    const resultPathBase = await findBestEntryPoint(basePaths);
 
     // Determine which base path was used
-    const usedBasePath = basePaths.find(bp => resultPath.startsWith(bp)) || basePaths[0];
+    const usedBasePath = basePaths.find(bp => resultPathBase.startsWith(bp)) || basePaths[0];
 
     // Calculate relative path (e.g., "src/App.jsx" or "index.html")
-    const relativePath = resultPath.replace(usedBasePath + '/', '');
+    const relativePath = resultPathBase.replace(usedBasePath + '/', '');
     
     // Check old style path and new style path
     const candidateSetupPaths = [
@@ -802,6 +829,9 @@ async function getResultPaths(testID, run, testName) {
             }
         } catch {}
     }
+
+    const source = new URLSearchParams(window.location.search).get('source') || 'local';
+    const resultPath = `${resultPathBase}?source=${source}`;
 
     return { setupPath, resultPath, usedBasePath };
 }
@@ -821,9 +851,11 @@ async function findBestEntryPoint(basePaths) {
         'index.html'
     ];
 
+    const source = new URLSearchParams(window.location.search).get('source') || 'local';
+
     for (const basePath of pathsToCheck) {
         const checks = candidates.map(candidate =>
-            fetch(`${basePath}/${candidate}`, { method: 'HEAD' })
+            fetch(`${basePath}/${candidate}?source=${source}`, { method: 'HEAD' })
                 .then(res => res.ok ? `${basePath}/${candidate}` : null)
                 .catch(() => null)
         );

--- a/eval-view/dashboard.js
+++ b/eval-view/dashboard.js
@@ -267,7 +267,7 @@ function renderTestHeader(testID, jetskiVersion, timestamp) {
                     hour: 'numeric',
                     minute: '2-digit',
                     hour12: true
-                });
+                }).replace(' at ', ', ');
             } catch { }
             html += ` — ${timeStr}`;
         }
@@ -463,7 +463,7 @@ async function showDetails(testName, runs, stats, testID) {
                         <strong style="font-size: 0.9em; font-weight: 600;">${guide} used by agent</strong>
                     </div>
                     <div>
-                        <a href="#" class="view-resources-link" style="font-size: 0.8em; color: var(--text-secondary); text-decoration: underline; opacity: 0.7;">View ${MCP_LOG_FILE}</a>
+                        <a href="#" class="view-resources-link" style="font-size: 0.8em; color: var(--text-secondary); text-decoration: underline; opacity: 0.7;">${MCP_LOG_FILE}</a>
                     </div>
                 </div>
             `;
@@ -476,7 +476,6 @@ async function showDetails(testName, runs, stats, testID) {
                 <strong>Run ${run.runNumber}</strong>
                 <span style="color: ${getColor(s.rate)}">${s.rate}% Pass (${s.passed}/${s.total})</span>
                 <div class="run-actions">
-                    <a href="${resultPath}" target="_blank">View Source ↗</a>
                 </div>
             </div>
             <ul class="check-list">
@@ -500,32 +499,66 @@ async function showDetails(testName, runs, stats, testID) {
             };
         }
 
-        const diffButton = document.createElement('button');
-        diffButton.className = 'secondary-btn small-btn';
-        diffButton.textContent = 'View Diff';
-        diffButton.style.cssText = 'margin-left: 10px; font-size: 0.8em; padding: 2px 8px;';
-        diffButton.onclick = () => viewDiff(setupPath, resultPath, testName, run.runNumber);
-
         const sourceParam = new URLSearchParams(window.location.search).get('source') || 'local';
-        const rawResultsPath = `${usedBasePath}/${guide}_results.json?source=${sourceParam}`;
-        let showRawResults = false;
+        const relativeDir = usedBasePath.replace('results/', '');
+
+        const dropdown = document.createElement('select');
+        dropdown.className = 'run-actions-dropdown';
+        dropdown.style.cssText = 'padding: 4px; font-size: 0.9em; border-radius: 4px; border: 1px solid var(--border-color); background: var(--bg-secondary); color: var(--text-primary); cursor: pointer;';
+        dropdown.innerHTML = '<option value="" disabled selected>Artifacts</option>';
+
+        const sourceOpt = document.createElement('option');
+        sourceOpt.value = 'source';
+        sourceOpt.textContent = 'App';
+        dropdown.appendChild(sourceOpt);
+
+        const diffOpt = document.createElement('option');
+        diffOpt.value = 'diff';
+        diffOpt.textContent = 'Diff';
+        dropdown.appendChild(diffOpt);
+
+        let sessionFile = null;
         try {
-            const rawRes = await fetch(rawResultsPath, { method: 'HEAD' });
-            if (rawRes.ok) showRawResults = true;
+            const filesRes = await fetch(`/api/run-files?dir=${encodeURIComponent(relativeDir)}&source=${sourceParam}`);
+            if (filesRes.ok) {
+                const { files } = await filesRes.json();
+
+                const rawJson = files.find(f => f === `${guide}_results.json`);
+                if (rawJson) {
+                    const rawOpt = document.createElement('option');
+                    rawOpt.value = 'raw';
+                    rawOpt.textContent = 'Raw Test Results';
+                    dropdown.appendChild(rawOpt);
+                }
+
+                sessionFile = files.find(f => f.startsWith('session-') && f.endsWith('.html'));
+                if (sessionFile) {
+                    const trajOpt = document.createElement('option');
+                    trajOpt.value = 'trajectory';
+                    trajOpt.textContent = 'Trajectory';
+                    dropdown.appendChild(trajOpt);
+                }
+            }
         } catch (e) {
-            console.log('Error checking raw results:', e);
+            console.log('Error checking run files:', e);
         }
 
-        if (showRawResults) {
-            const rawResultsBtn = document.createElement('button');
-            rawResultsBtn.className = 'secondary-btn small-btn';
-            rawResultsBtn.textContent = 'View Raw Results';
-            rawResultsBtn.style.cssText = 'margin-left: 10px; font-size: 0.8em; padding: 2px 8px;';
-            rawResultsBtn.onclick = () => viewContent(rawResultsPath, rawResultsPath);
-            runDetail.querySelector('.run-actions').appendChild(rawResultsBtn);
-        }
+        dropdown.onchange = (e) => {
+            const val = e.target.value;
+            e.target.value = ''; // reset selection
+            if (val === 'source') {
+                window.open(resultPath, '_blank');
+            } else if (val === 'diff') {
+                viewDiff(setupPath, resultPath, testName, run.runNumber);
+            } else if (val === 'trajectory' && sessionFile) {
+                window.open(`${usedBasePath}/${sessionFile}?source=${sourceParam}`, '_blank');
+            } else if (val === 'raw') {
+                const rawPath = `${usedBasePath}/${guide}_results.json?source=${sourceParam}`;
+                viewContent(rawPath, rawPath);
+            }
+        };
 
-        runDetail.querySelector('.run-actions').appendChild(diffButton);
+        runDetail.querySelector('.run-actions').appendChild(dropdown);
         return runDetail;
     });
 

--- a/eval-view/dashboard.spec.js
+++ b/eval-view/dashboard.spec.js
@@ -13,7 +13,7 @@ test.describe('Eval View Dashboard', () => {
     await expect(page.locator('.tab-button[data-tab="trends"]')).toBeVisible();
 
     // Check suites content
-    await expect(page.locator('.suite-item-container').first()).toBeVisible();
+    await expect(page.locator('.suite-table-row').first()).toBeVisible();
   });
 
   test('should load suites from API', async ({ page }) => {
@@ -28,7 +28,7 @@ test.describe('Eval View Dashboard', () => {
   test('should navigate to explorer tab', async ({ page }) => {
     await page.goto('/');
     // Wait for data to be loaded (suites appear)
-    await expect(page.locator('.suite-item-container').first()).toBeVisible();
+    await expect(page.locator('.suite-table-row').first()).toBeVisible();
     
     await page.click('.tab-button[data-tab="explorer"]');
     
@@ -67,10 +67,10 @@ test.describe('Eval View Dashboard', () => {
     const modal = page.locator('#modal');
     await expect(modal).toBeVisible();
 
-    // Verify "View Diff" button exists and click it
-    const diffButton = page.locator('button:has-text("View Diff")').first();
-    await expect(diffButton).toBeVisible();
-    await diffButton.click();
+    // Verify dropdown exists and select "Diff"
+    const dropdown = page.locator('.run-actions-dropdown').first();
+    await expect(dropdown).toBeVisible();
+    await dropdown.selectOption('diff');
 
     // Verify diff content is displayed
     // The title changes to "Diff: ..."

--- a/eval-view/index.html
+++ b/eval-view/index.html
@@ -32,6 +32,10 @@
               <button id="deselect-all-btn" class="text-btn">None</button>
             </div>
           </div>
+          <div style="padding: 10px; border-bottom: 1px solid var(--border-color);">
+            <input type="text" id="filter-search" placeholder="Search tests..."
+              style="width: 100%; box-sizing: border-box; padding: 6px; border-radius: 4px; border: 1px solid var(--border-color); background: var(--bg-secondary); color: var(--text-primary); font-size: 0.9em; outline: none;">
+          </div>
           <div id="filter-list" class="filter-list">
             <!-- Checkboxes injected by JS -->
           </div>
@@ -47,8 +51,42 @@
 
     <!-- Suites Tab -->
     <div id="suites-tab" class="tab-content active">
-      <div id="suites-list" class="suites-list-container">
-        <!-- populated by JS -->
+      <div class="suites-table-container">
+        <table class="suites-table">
+          <thead>
+            <tr>
+              <th style="padding-left:15px; text-align: left;">Suite ID</th>
+              <th>Source
+                <select id="filter-source" class="header-filter-select">
+                  <option value="all">All</option>
+                  <option value="local">Local</option>
+                  <option value="remote">Remote</option>
+                </select>
+              </th>
+              <th>Agent
+                <select id="filter-agent" class="header-filter-select">
+                  <option value="all">All</option>
+                  <option value="jetski">jetski</option>
+                  <option value="gemini_cli">gemini_cli</option>
+                  <option value="claude_code">claude_code</option>
+                </select>
+              </th>
+              <th>Serving
+                <select id="filter-skills" class="header-filter-select">
+                  <option value="all">All</option>
+                  <option value="skills">Skills</option>
+                  <option value="mcp">MCP</option>
+                </select>
+              </th>
+              <th>Guided</th>
+              <th>Unguided</th>
+              <th style="padding-right:15px; text-align: right;">Date</th>
+            </tr>
+          </thead>
+          <tbody id="suites-list">
+            <!-- populated by JS -->
+          </tbody>
+          </table>
       </div>
     </div>
 

--- a/eval-view/landing.css
+++ b/eval-view/landing.css
@@ -1,4 +1,55 @@
 /* Base Layout */
+.suites-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.suites-table th {
+  padding: 12px 10px;
+  background-color: var(--bg-tertiary);
+  border-bottom: 2px solid var(--border-color);
+  color: var(--text-secondary);
+  font-weight: 600;
+  text-align: center;
+}
+
+.suites-table td {
+  padding: 16px 10px;
+  border-bottom: 1px solid var(--border-color);
+  text-align: center;
+}
+
+.suite-table-row:hover {
+  background-color: var(--bg-tertiary);
+  transition: background-color 0.2s;
+}
+
+.header-filter-select {
+  margin-left: 8px;
+  font-size: 0.85em;
+  padding: 4px 8px;
+  border-radius: 6px;
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  color: var(--text-primary);
+  cursor: pointer;
+  outline: none;
+  transition: all 0.2s;
+  /* Appearance for custom dropdown arrow spacing */
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6 9 12 15 18 9'%3e%3c/polyline%3e%3c/svg%3e");
+  background-repeat: no-repeat;
+  background-position: right 8px center;
+  background-size: 1em;
+  padding-right: 28px;
+}
+
+.header-filter-select:hover {
+  background-color: var(--bg-tertiary);
+  border-color: var(--text-secondary);
+}
 .landing-container {
   max-width: 1400px;
   margin: 0 auto;

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -4,7 +4,9 @@ let allTestData = {}; // Cache all test data by testID
 let currentTab = 'suites';
 let currentScenarioFilter = 'all';
 let selectedTestIds = new Set(); // Set of test IDs to show
-let isLocalServer = false;
+let currentSourceFilter = 'all';
+let currentAgentFilter = 'all';
+let currentSkillsFilter = 'all';
 
 
 document.addEventListener('DOMContentLoaded', async () => {
@@ -15,23 +17,31 @@ document.addEventListener('DOMContentLoaded', async () => {
         setupTabs();
         setupFilters();
         setupTestFilters(); // New filter setup
+        setupTableFilters();
 
         const params = new URLSearchParams(window.location.search);
 
-        // Handle 'tests' param - if present, filter selectedTestIds
-        const testsParam = params.get('tests');
-        if (testsParam) {
-            const requestedIds = new Set(testsParam.split(','));
-            // Only keep IDs that actually exist
-            selectedTestIds = new Set(
-                [...requestedIds].filter(id => allTestData[id])
-            );
-            // If none of the requested IDs exist, fallback to all?
-            // Better to show none or empty state if user requested specific ones that don't exist?
-            // Let's stick to what we found.
-        } else {
-            // Default: Select All
-            selectedTestIds = new Set(Object.keys(allTestData));
+        // Initialize with default states relative to compoundKeys instead of simple testIDs
+        selectedTestIds = new Set(Object.keys(allTestData));
+
+        let initialTests = params.get('tests');
+        if (initialTests && initialTests.trim() !== '') {
+            const requestedIds = initialTests.split(',').filter(id => id.trim() !== '');
+            // Map requested IDs (which might just be testIDs from old links) to the new compound keys if possible
+            const matchIds = new Set();
+            requestedIds.forEach(req => {
+                if (allTestData[req]) { matchIds.add(req); }
+                else {
+                    // try finding a match by bare testID
+                    Object.keys(allTestData).forEach(ck => {
+                        if (ck.startsWith(req + '|||')) matchIds.add(ck);
+                    });
+                }
+            });
+
+            if (matchIds.size > 0) {
+                selectedTestIds = matchIds;
+            }
         }
 
         // Update filter UI to match initial state
@@ -65,12 +75,22 @@ window.addEventListener('popstate', () => {
     // Ideally we re-init selectedTestIds but that might be heavy?
     // Let's just reload for now if tests param changes drastically, or re-render.
     // For simplicity, we can reload or just re-read params.
+    selectedTestIds = new Set(Object.keys(allTestData)); // Default to all
     const testsParam = params.get('tests');
-    if (testsParam) {
-        const requestedIds = new Set(testsParam.split(','));
-        selectedTestIds = new Set([...requestedIds].filter(id => allTestData[id]));
-    } else {
-        selectedTestIds = new Set(Object.keys(allTestData));
+    if (testsParam && testsParam.trim() !== '') {
+        const requestedIds = testsParam.split(',').filter(id => id.trim() !== '');
+        const matchIds = new Set();
+        requestedIds.forEach(req => {
+            if (allTestData[req]) { matchIds.add(req); }
+            else {
+                Object.keys(allTestData).forEach(ck => {
+                    if (ck.startsWith(req + '|||')) matchIds.add(ck);
+                });
+            }
+        });
+        if (matchIds.size > 0) {
+            selectedTestIds = matchIds;
+        }
     }
     renderFilterMenuItems();
     renderAll();
@@ -139,6 +159,12 @@ function setupTestFilters() {
     const filterMenu = document.getElementById('filter-menu');
     const selectAllBtn = document.getElementById('select-all-btn');
     const deselectAllBtn = document.getElementById('deselect-all-btn');
+    const list = document.getElementById('filter-list');
+    const searchInput = document.getElementById('filter-search');
+
+    // Make list scrollable
+    list.style.maxHeight = '300px';
+    list.style.overflowY = 'auto';
 
     // Toggle Menu
     filterBtn.addEventListener('click', (e) => {
@@ -168,31 +194,54 @@ function setupTestFilters() {
         renderFilterMenuItems();
         renderAll();
     });
+
+    // Search functionality
+    searchInput.addEventListener('input', (e) => {
+        const term = e.target.value.toLowerCase();
+        const items = list.querySelectorAll('.filter-item');
+        items.forEach(item => {
+            const label = item.querySelector('.filter-item-label').textContent.toLowerCase();
+            item.style.display = label.includes(term) ? 'flex' : 'none';
+        });
+    });
+
+    renderFilterMenuItems();
 }
+
+function setupTableFilters() {
+    const filterSource = document.getElementById('filter-source');
+    const filterAgent = document.getElementById('filter-agent');
+    const filterSkills = document.getElementById('filter-skills');
+
+    if (filterSource) filterSource.addEventListener('change', (e) => { currentSourceFilter = e.target.value; renderSuites(); });
+    if (filterAgent) filterAgent.addEventListener('change', (e) => { currentAgentFilter = e.target.value; renderSuites(); });
+    if (filterSkills) filterSkills.addEventListener('change', (e) => { currentSkillsFilter = e.target.value; renderSuites(); });
+}
+
 
 function renderFilterMenuItems() {
     const list = document.getElementById('filter-list');
     list.innerHTML = '';
 
     // Get all tests sorted by date
-    const allIds = Object.keys(allTestData).sort((a, b) => {
+    const sortedIds = Object.keys(allTestData).sort((a, b) => {
         return new Date(allTestData[b].timestamp) - new Date(allTestData[a].timestamp);
     });
 
-    allIds.forEach(testID => {
+    sortedIds.forEach(compoundKey => {
         const item = document.createElement('label');
         item.className = 'filter-item';
 
         const checkbox = document.createElement('input');
         checkbox.type = 'checkbox';
-        checkbox.checked = selectedTestIds.has(testID);
-        checkbox.value = testID;
+        checkbox.checked = selectedTestIds.has(compoundKey);
+        checkbox.value = compoundKey;
 
         checkbox.addEventListener('change', (e) => {
             if (e.target.checked) {
-                selectedTestIds.add(testID);
+                selectedTestIds.add(compoundKey);
             } else {
-                selectedTestIds.delete(testID);
+                selectedTestIds.delete(compoundKey);
             }
             updateUrlParams();
             renderAll();
@@ -201,12 +250,22 @@ function renderFilterMenuItems() {
         const labelContent = document.createElement('div');
         labelContent.className = 'filter-item-label';
 
+        const testInfo = allTestData[compoundKey];
+
         const idSpan = document.createElement('span');
-        idSpan.textContent = testID.replace('test_', '');
+        idSpan.textContent = testInfo.testID.replace('test_', '') + ` (${testInfo.source})`;
 
         const dateSpan = document.createElement('span');
         dateSpan.className = 'filter-item-date';
-        dateSpan.textContent = new Date(allTestData[testID].timestamp).toLocaleString();
+
+        const _d = new Date(testInfo.timestamp);
+        dateSpan.textContent = _d.toLocaleString('en-US', {
+            month: 'long',
+            day: 'numeric',
+            hour: 'numeric',
+            minute: '2-digit',
+            hour12: true
+        });
 
         labelContent.appendChild(idSpan);
         labelContent.appendChild(dateSpan);
@@ -244,8 +303,6 @@ async function loadAllTests() {
         if (!response.ok) throw new Error('Failed to fetch suites');
         const manifest = await response.json();
 
-        isLocalServer = manifest.isLocal || false;
-
         if (!manifest.suites || manifest.suites.length === 0) {
             document.getElementById('empty-state').style.display = 'block';
             return;
@@ -254,14 +311,30 @@ async function loadAllTests() {
         document.getElementById('empty-state').style.display = 'none';
 
         // Load all test data
-        for (const testID of manifest.suites) {
+        for (const suite of manifest.suites) {
+            const isObj = typeof suite === 'object';
+            const testID = isObj ? suite.id : suite;
+            const source = isObj ? suite.source : (manifest.isLocal ? 'local' : 'remote');
+
             try {
-                const response = await fetch(`results/${testID}/evals.json?t=${Date.now()}`);
+                const response = await fetch(`results/${testID}/evals.json?source=${source}&t=${Date.now()}`);
                 if (response.ok) {
                     const parsed = await response.json();
-                    allTestData[testID] = {
+
+                    let servingArch = 'unknown';
+                    if (parsed.enableSkills !== undefined) {
+                        servingArch = parsed.enableSkills ? 'skills' : 'mcp';
+                    }
+
+                    const compoundKey = `${testID}|||${source}`;
+
+                    allTestData[compoundKey] = {
+                        testID: testID,
                         timestamp: parsed.timestamp || new Date().toISOString(), // Fallback
-                        data: parsed
+                        data: parsed,
+                        source: source,
+                        agent: parsed.agent || 'unknown',
+                        servingArch: servingArch
                     };
                 }
             } catch (e) {
@@ -285,13 +358,28 @@ function renderSuites() {
 
     const container = document.getElementById('suites-list');
 
-    container.innerHTML = testIds.map(testID => {
-        const testInfo = allTestData[testID];
+    let html = '';
+
+    testIds.forEach(compoundKey => {
+        const testInfo = allTestData[compoundKey];
+        const testID = testInfo.testID;
+
+        // Apply filters
+        if (currentSourceFilter !== 'all' && testInfo.source !== currentSourceFilter) return;
+        if (currentAgentFilter !== 'all' && testInfo.agent !== currentAgentFilter) return;
+        if (currentSkillsFilter !== 'all' && testInfo.servingArch !== currentSkillsFilter) return;
+
         const data = testInfo.data;
         const _date = new Date(testInfo.timestamp);
 
-        // Custom format to add time into the label:
-        const prettyTimestampStr = `${_date.toLocaleDateString()} at ${_date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
+        // Custom format to match "March 5, 2:25PM"
+        const prettyTimestampStr = _date.toLocaleString('en-US', {
+            month: 'long',
+            day: 'numeric',
+            hour: 'numeric',
+            minute: '2-digit',
+            hour12: true
+        });
 
         const gStats = calculateGroupTotalStats(data.results, 'guided');
         const uStats = calculateGroupTotalStats(data.results, 'unguided');
@@ -299,35 +387,22 @@ function renderSuites() {
         const gRate = gStats.total > 0 ? Math.round((gStats.passed / gStats.total) * 100) : 0;
         const uRate = uStats.total > 0 ? Math.round((uStats.passed / uStats.total) * 100) : 0;
 
-        const gcpLink = `https://console.cloud.google.com/storage/browser/guidance-evals/${testID}?project=chrome-kiwi-air-force-dev`;
-        const localLink = `dashboard.html?testID=${testID}`;
+        const localLink = `dashboard.html?testID=${testID}&source=${testInfo.source}`;
 
-        const gcpButtonHtml = !isLocalServer ?
-            `<button onclick="event.stopPropagation(); window.open('${gcpLink}', '_blank');" class="secondary-btn" style="font-size: 0.8rem; padding: 6px 10px;">View Result Artifacts</button>` : '';
-
-        return `
-            <div onclick="window.location.href='${localLink}'" class="suite-item-container" style="cursor: pointer; border: 1px solid var(--border-color); border-radius: var(--radius-lg); padding: 20px; margin-bottom: 20px; transition: all 0.2s;" onmouseover="this.style.borderColor='var(--primary-color)'; this.style.transform='translateY(-2px)';" onmouseout="this.style.borderColor='var(--border-color)'; this.style.transform='none';">
-                <div style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 16px;">
-                    <div style="flex: 1; min-width: 250px;">
-                        <h3 style="margin: 0; font-size: 1.25rem; color: var(--text-primary); pointer-events: none;">${testID}</h3>
-                        <div style="font-size: 0.85rem; color: var(--text-tertiary); margin-top: 4px; pointer-events: none;">${prettyTimestampStr}</div>
-                    </div>
-
-                    <div style="display: flex; gap: 32px; align-items: center; justify-content: flex-end;">
-                        <div style="text-align: right;">
-                            <div style="font-size: 0.85rem; color: var(--text-secondary); margin-bottom: 4px;">Guided Pass Rate</div>
-                            <div style="font-size: 2rem; font-weight: 700; color: ${getColor(gRate)};">${gRate}%</div>
-                        </div>
-                        <div style="text-align: right;">
-                            <div style="font-size: 0.85rem; color: var(--text-secondary); margin-bottom: 4px;">Unguided Pass Rate</div>
-                            <div style="font-size: 2rem; font-weight: 700; color: ${getColor(uRate)};">${uRate}%</div>
-                        </div>
-                        ${!isLocalServer ? `<div style="margin-left: 16px;">${gcpButtonHtml}</div>` : ''}
-                    </div>
-                </div>
-            </div>
+        html += `
+            <tr class="suite-table-row" onclick="window.location.href='${localLink}'" style="cursor: pointer;">
+                <td style="padding-left:15px; text-align: left; font-weight: 600;">${testID}</td>
+                <td style="text-transform: capitalize;">${testInfo.source}</td>
+                <td>${testInfo.agent}</td>
+                <td style="text-transform: capitalize;">${testInfo.servingArch.replace('mcp', 'MCP')}</td>
+                <td><span style="font-weight: 700; color: ${getColor(gRate)};">${gRate}%</span></td>
+                <td><span style="font-weight: 700; color: ${getColor(uRate)};">${uRate}%</span></td>
+                <td style="padding-right:15px; text-align: right; color: var(--text-tertiary); font-size: 0.85rem;">${prettyTimestampStr}</td>
+            </tr>
         `;
-    }).join('');
+    });
+
+    container.innerHTML = html;
 }
 
 

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -475,8 +475,8 @@ function renderGridRow(testName) {
     const cellsHtml = [];
     let hasData = false;
 
-    testIds.forEach(testID => {
-        const data = allTestData[testID].data;
+    testIds.forEach(compoundTestId => {
+        const data = allTestData[compoundTestId].data;
         const results = data.results;
 
         const runData = results[testName];
@@ -495,12 +495,14 @@ function renderGridRow(testName) {
 
             const avgRate = totalChecks > 0 ? Math.round((totalPassed / totalChecks) * 100) : 0;
 
+            const testId = allTestData[compoundTestId].testID;
+            const source = allTestData[compoundTestId].source;
+            const dateStr = new Date(allTestData[compoundTestId].timestamp).toLocaleString('en-US', { month: 'long', day: 'numeric', hour: 'numeric', minute: '2-digit', hour12: true }).replace(' at ', ', ');
             cellsHtml.push(`
-                const dateStr = new Date(allTestData[testID].timestamp).toLocaleString('en-US', { month: 'long', day: 'numeric', hour: 'numeric', minute: '2-digit', hour12: true }).replace(' at ', ', ');
                 <a class="test-grid-cell"
-                     href="dashboard.html?testID=${testID}"
+                     href="dashboard.html?testID=${testId}&source=${source}"
                      style="background-color: ${getColor(avgRate)}"
-                     title="${testID} - ${dateStr}: ${avgRate}% (${totalPassed}/${totalChecks})">
+                     title="${testId} - ${dateStr}: ${avgRate}% (${totalPassed}/${totalChecks})">
                     ${avgRate}%
                 </a>
             `);
@@ -524,8 +526,8 @@ function renderComparisonHistory(scenario, prompt) {
     // Gather all checks from BOTH agents for this prompt
     agents.forEach(agent => {
         const testName = `${scenario} - ${prompt} - ${agent}`;
-        testIds.forEach(testID => {
-            const data = allTestData[testID].data;
+        testIds.forEach(compoundTestId => {
+            const data = allTestData[compoundTestId].data;
             const results = data.results;
             if (results && results[testName]) {
                 results[testName].forEach(run => {
@@ -569,11 +571,13 @@ function renderComparisonHistory(scenario, prompt) {
 
             // Generate sparklines for this check/agent
             let sparklinesHtml = '';
-            testIds.forEach(testID => {
-                const data = allTestData[testID].data;
+            testIds.forEach(compoundTestId => {
+                const data = allTestData[compoundTestId].data;
                 const results = data.results;
 
                 let hasRuns = false;
+                const testId = allTestData[compoundTestId].testID;
+                const source = allTestData[compoundTestId].source;
 
                 if (results && results[testName]) {
                     const runs = results[testName];
@@ -583,12 +587,12 @@ function renderComparisonHistory(scenario, prompt) {
                         // logic in evaluate.js suggests they are pushed in runDirs sort order (ascending)
                         [...runs].reverse().forEach(run => {
                             let status = 'missing';
-                            let tooltip = `Test ${testID.replace('test_', '')} (Run ${run.runNumber}): Not Run`;
+                            let tooltip = `Test ${testId.replace('test_', '')} (Run ${run.runNumber}): Not Run`;
 
                             const check = run.results.find(c => c.id === checkId);
                             if (check) {
                                 status = check.passed ? 'pass' : 'fail';
-                                tooltip = `Test ${testID.replace('test_', '')} (Run ${run.runNumber}): ${check.passed ? 'PASS' : 'FAIL'}\n${check.message}`;
+                                tooltip = `Test ${testId.replace('test_', '')} (Run ${run.runNumber}): ${check.passed ? 'PASS' : 'FAIL'}\\n${check.message}`;
                             }
 
                             let color = 'var(--bg-tertiary)';
@@ -600,8 +604,8 @@ function renderComparisonHistory(scenario, prompt) {
                             const encodedCheckId = encodeURIComponent(checkId);
 
                             sparklinesHtml += `
-                                <a href="dashboard.html?testID=${testID}&testName=${encodedTestName}&checkId=${encodedCheckId}"
-                                   class="sparkline-dot"
+                                <a href="dashboard.html?testID=${testId}&source=${source}&testName=${encodedTestName}&checkId=${encodedCheckId}"
+                                   class="history-sparkline-item"
                                    style="background-color: ${color}; border: ${border};"
                                    title="${escapeHtml(tooltip)}"></a>
                             `;
@@ -610,7 +614,7 @@ function renderComparisonHistory(scenario, prompt) {
                 }
 
                 if (!hasRuns) {
-                    let tooltip = `Test ${testID.replace('test_', '')}: Not Run`;
+                    let tooltip = `Test ${testId.replace('test_', '')}: Not Run`;
 
                     let color = 'var(--bg-tertiary)';
                     const border = '1px solid var(--border-color)';
@@ -619,8 +623,8 @@ function renderComparisonHistory(scenario, prompt) {
                     const encodedCheckId = encodeURIComponent(checkId);
 
                     sparklinesHtml += `
-                        <a href="dashboard.html?testID=${testID}&testName=${encodedTestName}&checkId=${encodedCheckId}"
-                           class="sparkline-dot"
+                        <a href="dashboard.html?testID=${testId}&source=${source}&testName=${encodedTestName}&checkId=${encodedCheckId}"
+                           class="history-sparkline-item"
                            style="background-color: ${color}; border: ${border};"
                            title="${escapeHtml(tooltip)}"></a>
                     `;
@@ -652,14 +656,17 @@ function renderTrends() {
 
     // Helper to render bars
     const renderBars = (groupType) => {
-        return testIds.map(testID => {
-            const data = allTestData[testID].data;
+        return testIds.map(compoundTestId => {
+            const testInfo = allTestData[compoundTestId];
+            const testId = testInfo.testID;
+            const source = testInfo.source;
+            const data = testInfo.data;
             const stats = calculateGroupTotalStats(data.results, groupType);
             const value = stats.total > 0 ? Math.round((stats.passed / stats.total) * 100) : 0;
-            const timestamp = new Date(allTestData[testID].timestamp).toLocaleString('en-US', { month: 'long', day: 'numeric', hour: 'numeric', minute: '2-digit', hour12: true }).replace(' at ', ', ');
+            const timestamp = new Date(testInfo.timestamp).toLocaleString('en-US', { month: 'long', day: 'numeric', hour: 'numeric', minute: '2-digit', hour12: true }).replace(' at ', ', ');
 
             return `
-                <a class="timeline-bar" href="dashboard.html?testID=${testID}" title="${testID} - ${timestamp}: ${value}%">
+                <a class="timeline-bar" href="dashboard.html?testID=${testId}&source=${source}" title="${testId} - ${timestamp}: ${value}%">
                     <div class="timeline-bar-fill" style="height: ${Math.max(value * 2, 10)}px; background-color: ${getColor(value)}"></div>
                     <div class="timeline-bar-label">${value}%</div>
                 </a>

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -265,7 +265,7 @@ function renderFilterMenuItems() {
             hour: 'numeric',
             minute: '2-digit',
             hour12: true
-        });
+        }).replace(' at ', ', ');
 
         labelContent.appendChild(idSpan);
         labelContent.appendChild(dateSpan);
@@ -379,7 +379,7 @@ function renderSuites() {
             hour: 'numeric',
             minute: '2-digit',
             hour12: true
-        });
+        }).replace(' at ', ', ');
 
         const gStats = calculateGroupTotalStats(data.results, 'guided');
         const uStats = calculateGroupTotalStats(data.results, 'unguided');
@@ -496,10 +496,11 @@ function renderGridRow(testName) {
             const avgRate = totalChecks > 0 ? Math.round((totalPassed / totalChecks) * 100) : 0;
 
             cellsHtml.push(`
+                const dateStr = new Date(allTestData[testID].timestamp).toLocaleString('en-US', { month: 'long', day: 'numeric', hour: 'numeric', minute: '2-digit', hour12: true }).replace(' at ', ', ');
                 <a class="test-grid-cell"
                      href="dashboard.html?testID=${testID}"
                      style="background-color: ${getColor(avgRate)}"
-                     title="${testID} - ${new Date(allTestData[testID].timestamp).toLocaleDateString()}: ${avgRate}% (${totalPassed}/${totalChecks})">
+                     title="${testID} - ${dateStr}: ${avgRate}% (${totalPassed}/${totalChecks})">
                     ${avgRate}%
                 </a>
             `);
@@ -655,7 +656,7 @@ function renderTrends() {
             const data = allTestData[testID].data;
             const stats = calculateGroupTotalStats(data.results, groupType);
             const value = stats.total > 0 ? Math.round((stats.passed / stats.total) * 100) : 0;
-            const timestamp = new Date(allTestData[testID].timestamp).toLocaleDateString();
+            const timestamp = new Date(allTestData[testID].timestamp).toLocaleString('en-US', { month: 'long', day: 'numeric', hour: 'numeric', minute: '2-digit', hour12: true }).replace(' at ', ', ');
 
             return `
                 <a class="timeline-bar" href="dashboard.html?testID=${testID}" title="${testID} - ${timestamp}: ${value}%">

--- a/eval-view/server.js
+++ b/eval-view/server.js
@@ -91,6 +91,44 @@ const server = http.createServer(async (req, res) => {
     return;
   }
 
+  if (decodedPath === '/api/run-files') {
+    const parsedUrl = new URL(req.url, `http://${req.headers.host}`);
+    const relativePath = parsedUrl.searchParams.get('dir');
+    const source = parsedUrl.searchParams.get('source') || 'local';
+
+    if (!relativePath) {
+      res.writeHead(400);
+      res.end('Missing dir parameter');
+      return;
+    }
+
+    let files = [];
+    if (source === 'local') {
+      const resultsDir = process.env.USE_MOCK_RESULTS === 'true' ? './mock-results' : '../harness/results';
+      const targetDir = path.join(resultsDir, relativePath);
+      try {
+        if (fs.existsSync(targetDir)) {
+          files = fs.readdirSync(targetDir, { withFileTypes: true })
+            .filter(d => !d.isDirectory())
+            .map(d => d.name);
+        }
+      } catch (e) {
+        console.error('Error reading local dir:', e.message);
+      }
+    } else {
+      try {
+        const [gcsFiles] = await bucket.getFiles({ prefix: relativePath });
+        files = gcsFiles.map(f => path.basename(f.name));
+      } catch (e) {
+        console.error('Error reading remote dir:', e.message);
+      }
+    }
+
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ files }));
+    return;
+  }
+
   let filePath;
   // Map results and setup to the harness directory
   if (decodedPath.startsWith('/results/')) {

--- a/eval-view/server.js
+++ b/eval-view/server.js
@@ -5,7 +5,6 @@ import { exec } from 'child_process';
 import { Storage } from '@google-cloud/storage';
 
 const PORT = process.env.PORT || 8081;
-const USE_LOCAL = process.argv.includes('--local');
 const PROJECT_ID = 'chrome-kiwi-air-force-dev';
 const BUCKET_NAME = 'guidance-evals';
 
@@ -59,30 +58,36 @@ const server = http.createServer(async (req, res) => {
 
   // Handle /api/suites endpoint
   if (decodedPath === '/api/suites') {
-    if (USE_LOCAL) {
-      const resultsDir = process.env.USE_MOCK_RESULTS === 'true' ? './mock-results' : '../harness/results';
-      try {
+    let suitesList = [];
+
+    // Local
+    const resultsDir = process.env.USE_MOCK_RESULTS === 'true' ? './mock-results' : '../harness/results';
+    try {
+      if (fs.existsSync(resultsDir)) {
         const dirs = fs.readdirSync(resultsDir, { withFileTypes: true })
           .filter(dirent => dirent.isDirectory() && dirent.name !== 'single_task')
           .map(dirent => dirent.name);
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ suites: dirs, isLocal: true }));
-      } catch (e) {
-        res.writeHead(500);
-        res.end(JSON.stringify({ error: e.message }));
+        dirs.forEach(d => suitesList.push({ id: d, source: 'local' }));
       }
-    } else {
-      try {
-        const [_, __, apiResponse] = await bucket.getFiles({ delimiter: '/' });
-        const prefixes = apiResponse.prefixes || [];
-        const suites = prefixes.map(p => p.slice(0, -1)); // Remove trailing slash
-        res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ suites, isLocal: false }));
-      } catch (e) {
-        res.writeHead(500);
-        res.end(JSON.stringify({ error: e.message }));
-      }
+    } catch (e) {
+      console.error('Error reading local suites:', e.message);
     }
+
+    // Remote
+    try {
+      const [_, __, apiResponse] = await bucket.getFiles({ delimiter: '/' });
+      const prefixes = apiResponse.prefixes || [];
+      const remoteDirs = prefixes.map(p => p.slice(0, -1)); // Remove trailing slash
+
+      remoteDirs.forEach(d => {
+        suitesList.push({ id: d, source: 'remote' });
+      });
+    } catch (e) {
+      console.error('Error reading remote suites:', e.message);
+    }
+
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ suites: suitesList }));
     return;
   }
 
@@ -90,8 +95,9 @@ const server = http.createServer(async (req, res) => {
   // Map results and setup to the harness directory
   if (decodedPath.startsWith('/results/')) {
     const relativeResultPath = decodedPath.substring(9);
+    const useLocal = req.url.includes('source=local');
 
-    if (!USE_LOCAL) {
+    if (!useLocal) {
       // Stream from GCS
       const extname = path.extname(relativeResultPath) || '';
       let contentType = MIME_TYPES[extname] || 'application/octet-stream';
@@ -194,7 +200,7 @@ const server = http.createServer(async (req, res) => {
 
 server.listen(PORT, () => {
   const url = `http://localhost:${PORT}/`;
-  console.log(`Server running at ${url} (${USE_LOCAL ? 'LOCAL MODE' : 'GCP MODE'})`);
+  console.log(`Server running at ${url}`);
 
   // Try to open the browser if not disabled
   if (process.env.NO_OPEN !== 'true') {

--- a/harness/config.ts
+++ b/harness/config.ts
@@ -45,8 +45,8 @@ export const environmentConfig: EnvironmentConfig = {
 // *** Run with: `pnpm suite`         ***
 // **************************************
 export const suiteConfig: SuiteConfig = {
-  name: 'analytics-suite-1',
-  numRuns: 1,
+  name: 'local-suite',
+  numRuns: 2,
   tasks: ['batch-analytics-events-task'],
   mcpServersToEnable: ['modern-web'], // Available servers: 'modern-web', 'google-developer-knowledge'
   enableSkills: false,

--- a/harness/config.ts
+++ b/harness/config.ts
@@ -40,25 +40,17 @@ export const environmentConfig: EnvironmentConfig = {
   mcpApiKey: process.env.MCP_API_KEY || '', // For google-developer-knowledge MCP server
 };
 
-// *******************************
-// *** Set suite configuration ***
-// *** Run with: `pnpm suite`  ***
-// *******************************
+// **************************************
+// *** Set suite & eval configuration ***
+// *** Run with: `pnpm suite`         ***
+// **************************************
 export const suiteConfig: SuiteConfig = {
-  name: 'analytics-suite',
+  name: 'analytics-suite-1',
   numRuns: 1,
-  tasks: ['batch-analytics-events-task', 'full-session-analytics-task'],
+  tasks: ['batch-analytics-events-task'],
   mcpServersToEnable: ['modern-web'], // Available servers: 'modern-web', 'google-developer-knowledge'
   enableSkills: false,
   agent: Agents.GEMINI_CLI,
-};
-
-// ************************************
-// *** Set evaluation configuration ***
-// *** Run with: `pnpm report`      ***
-// ************************************
-export const evalConfig: EvalConfig = {
-  suiteName: 'analytics-suite'
 };
 
 export interface EnvironmentConfig {
@@ -83,14 +75,9 @@ export interface SuiteConfig {
   agent: string;
 }
 
-export interface EvalConfig {
-  suiteName: string | null;
-}
-
 export const config = {
   environment: environmentConfig,
   suite: suiteConfig,
-  eval: evalConfig,
 };
 
 // Validate critical paths exist during configuration

--- a/harness/evaluate.ts
+++ b/harness/evaluate.ts
@@ -16,7 +16,7 @@ async function main() {
   console.log('Starting Evaluation...'.cyan.bold);
 
   const resultsDirBase = path.join(__dirname, 'results');
-  let suiteName = config.eval.suiteName;
+  let suiteName = process.argv[2] || config.suite.name;
   if (!suiteName) {
     console.error('❌ No suite name provided! Please specify a suite to evaluate.'.red);
     process.exit(1);
@@ -38,7 +38,7 @@ async function main() {
     const metrics = calculateMetrics(allResults, numRuns);
     const mdReport = generateMarkdownReport(metrics, allResults);
     const timestamp = new Date().toISOString();
-    const jsonReport = generateJsonReport(metrics, allResults, timestamp, numRuns);
+    const jsonReport = generateJsonReport(metrics, allResults, timestamp, numRuns, config.suite.agent, config.suite.enableSkills);
 
     saveReports(resultsDir, mdReport, jsonReport);
 

--- a/harness/lib/reporting.ts
+++ b/harness/lib/reporting.ts
@@ -57,13 +57,15 @@ export function generateMarkdownReport(metrics: Metrics, allResults: Record<stri
   return md;
 }
 
-export function generateJsonReport(metrics: Metrics, allResults: Record<string, RunResult[]>, timestamp: string, runCount: number) {
+export function generateJsonReport(metrics: Metrics, allResults: Record<string, RunResult[]>, timestamp: string, runCount: number, agent: string, enableSkills: boolean) {
   return {
     summary: metrics.summary,
     results: allResults,
     stats: metrics.testPassRates,
     timestamp,
-    runCount
+    runCount,
+    agent,
+    enableSkills
   };
 }
 

--- a/harness/run_suite.ts
+++ b/harness/run_suite.ts
@@ -204,9 +204,14 @@ async function main() {
       }
     }
 
-
-
     console.log(`\n✅ Test suite complete! Results saved to: results/${testID}`);
+
+    console.log(`\n=== Running Evaluation for ${testID} ===`);
+    try {
+      await runCommand('node', [path.join(__dirname, 'evaluate.ts'), testID]);
+    } catch (evalError) {
+      console.error('❌ Evaluation failed:', evalError);
+    }
   } catch (e) {
     console.error('❌ Error during suite execution:', e);
   } finally {

--- a/harness/upload_suite.ts
+++ b/harness/upload_suite.ts
@@ -21,6 +21,8 @@ async function uploadDirectory(bucket: any, dirPath: string, gcsPrefix: string) 
     if (file.isDirectory()) {
       await uploadDirectory(bucket, fullPath, destinationPath);
     } else {
+      if (file.name === '.DS_Store') continue;
+
       console.log(`Uploading ${fullPath} to gs://${BUCKET_NAME}/${destinationPath}...`);
       await bucket.upload(fullPath, {
         destination: destinationPath,


### PR DESCRIPTION
Add filters for agent, local/remote, serving architecture.

Also includes evaluation in the `pnpm suite` cmd. `pnpm report <suite-name>` can still be run if results need to regenerated.

Also adds the newly added trajectory HTML to the dashboard in the test run window.

<img width="1422" height="386" alt="Screenshot 2026-03-05 at 5 48 17 PM" src="https://github.com/user-attachments/assets/8d0f9639-5fde-406d-b092-e4a31255ffff" />