### PR TITLE
replace manual frontmatter parsing with gray-matter

### DIFF
--- a/guides/guide-features-diagram.mjs
+++ b/guides/guide-features-diagram.mjs
@@ -1,6 +1,12 @@
 import fs from 'fs';
 import path from 'path';
+import matter from 'gray-matter';
 
+/**
+ * @param {string} dir
+ * @param {string[]} [fileList=[]]
+ * @returns {string[]}
+ */
 function findGuides(dir, fileList = []) {
   if (!fs.existsSync(dir)) return fileList;
   const files = fs.readdirSync(dir);
@@ -18,34 +24,25 @@ function findGuides(dir, fileList = []) {
 const guidesDir = new URL('.', import.meta.url).pathname;
 const guidesPaths = findGuides(guidesDir);
 
+/** @type {Array<{name: string, features: string[]}>} */
 const guides = [];
 
 for (const p of guidesPaths) {
   const content = fs.readFileSync(p, 'utf-8');
-  // Simple regex parser for YAML frontmatter
-  const match = content.match(/^---\n([\s\S]*?)\n---/);
-  if (!match) continue;
-  
-  const frontmatter = match[1];
-  
-  let name = '';
-  const nameMatch = frontmatter.match(/^name:\s*(.+)$/m);
-  if (nameMatch) {
-    name = nameMatch[1].trim();
-  } else {
+
+  if (!content.startsWith('---\n')) continue;
+
+  const parsed = matter(content);
+
+  let name = parsed.data.name;
+  if (!name) {
     // fallback if no name in yaml, use directory name
     name = path.basename(path.dirname(p));
   }
-  
-  let features = [];
-  const featureSectionMatch = frontmatter.match(/web-feature-ids:\s*\n((?:\s*-\s*.+\n?)*)/);
-  if (featureSectionMatch) {
-    const featureLines = featureSectionMatch[1].trim().split('\n');
-    features = featureLines
-      .map(line => line.replace(/^\s*-\s*/, '').trim())
-      .filter(f => f);
-  }
-  
+
+  /** @type {string[]} */
+  let features = parsed.data['web-feature-ids'] || [];
+
   guides.push({ name, features });
 }
 
@@ -69,7 +66,12 @@ let output = '<!-- Note: This diagram is generated automatically by guides/guide
 output += '# Mapping: Web feature : Use cases\n\n';
 output += '```\n';
 
-const featureKeys = Array.from(featureToGuides.keys()).sort((a,b) => {
+const featureKeys = Array.from(featureToGuides.keys()).sort(
+  /**
+   * @param {string} a
+   * @param {string} b
+   */
+  (a,b) => {
   if (a.includes('No web features')) return 1;
   if (b.includes('No web features')) return -1;
   return a.localeCompare(b);
@@ -77,19 +79,25 @@ const featureKeys = Array.from(featureToGuides.keys()).sort((a,b) => {
 
 for (let i = 0; i < featureKeys.length; i++) {
   const feature = featureKeys[i];
-  const list = featureToGuides.get(feature).sort((a, b) => a.localeCompare(b));
-  
+  const list = featureToGuides.get(feature).sort(
+    /**
+     * @param {string} a
+     * @param {string} b
+     */
+    (a, b) => a.localeCompare(b)
+  );
+
   const isLastFeature = (i === featureKeys.length - 1);
   const featurePrefix = isLastFeature ? '└──' : '├──';
-  
+
   output += `${featurePrefix} ${feature}\n`;
-  
+
   for (let j = 0; j < list.length; j++) {
     const guideName = list[j];
     const isLastGuide = (j === list.length - 1);
     const guidePrefix = isLastFeature ? '    ' : '│   ';
     const guideBullet = isLastGuide ? '└──' : '├──';
-    
+
     output += `${guidePrefix}${guideBullet} ${guideName}\n`;
   }
 }

--- a/guides/package.json
+++ b/guides/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "test": "DRY_RUN=true node --experimental-strip-types ./sync-use-cases.ts"
+    "test": "DRY_RUN=true node --experimental-strip-types ./sync-use-cases.ts",
+    "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
     "@octokit/rest": "^21.1.1",

--- a/guides/performance/batch-analytics-events/grader.ts
+++ b/guides/performance/batch-analytics-events/grader.ts
@@ -2,6 +2,12 @@ import { test, expect } from '@playwright/test';
 import * as fs from 'fs';
 import * as path from 'path';
 
+declare global {
+  interface Window {
+    abortCallCount: number;
+  }
+}
+
 // Setup
 const targetFile = process.env.TARGET_FILE;
 if (!targetFile) {

--- a/guides/tsconfig.json
+++ b/guides/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "nodenext",
+
+    "erasableSyntaxOnly": true,
+    "verbatimModuleSyntax": true,
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+
+    "noEmit": true,
+    "allowJs": true,
+    "checkJs": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "exclude": [
+    "**/test-app-results/**",
+    "**/node_modules/**",
+    "**/grade-report/**",
+    "**/dist/**"
+  ]
+}

--- a/harness/lib/collection.ts
+++ b/harness/lib/collection.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import fs from 'fs';
 import { guideUsed } from './guide_validation.ts';
 import { fileURLToPath } from 'url';
+import matter from 'gray-matter';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -52,17 +53,16 @@ export async function collectResults(resultsDir: string) {
       }
 
       const fileContent = fs.readFileSync(taskPath, 'utf8');
-      const frontmatterMatch = fileContent.match(/^---\n(?:[\s\S]*?)grader:\s*(.+)\n(?:[\s\S]*?)---\n([\s\S]*)$/m);
+      const { data } = matter(fileContent);
 
-      if (!frontmatterMatch) {
+      if (!data || !data.grader) {
          console.warn(`Skipping grading: No 'grader:' found in frontmatter for task ${taskName}`);
          continue;
       }
 
-      const guide = frontmatterMatch[1].trim();
+      const guide = data.grader.trim();
 
-      const baseAppMatch = fileContent.match(/^base_app:\s*(.+)$/m);
-      const actualBaseApp = baseAppMatch ? baseAppMatch[1].trim() : taskName;
+      const actualBaseApp = data.base_app ? data.base_app.trim() : taskName;
 
       const testName = `${taskName} - ${guide} - ${runType}`;
 

--- a/harness/lib/guide_validation.ts
+++ b/harness/lib/guide_validation.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { MCP_LOG_FILE } from '../../constants.ts';
+import matter from 'gray-matter';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -36,14 +37,14 @@ export async function guideUsed(dirPath: string, taskName: string): Promise<bool
   }
 
   const fileContent = fs.readFileSync(taskPath, 'utf8');
-  const frontmatterMatch = fileContent.match(/^---\n(?:[\s\S]*?)grader:\s*(.+)\n(?:[\s\S]*?)---\n([\s\S]*)$/m);
+  const { data } = matter(fileContent);
 
-  if (!frontmatterMatch) {
+  if (!data || !data.grader) {
     console.error(`No 'grader:' found in frontmatter for task ${taskName}`);
     return false;
   }
 
-  const guide = frontmatterMatch[1].trim();
+  const guide = data.grader.trim();
 
   // Extract all use case IDs requested via get_best_practices
   const requestedGuides = toolCalls

--- a/harness/package.json
+++ b/harness/package.json
@@ -22,6 +22,7 @@
     "colors": "^1.4.0",
     "dotenv": "^16.6.1",
     "glob": "^10.5.0",
+    "gray-matter": "^4.0.3",
     "puppeteer-core": "^24.37.5"
   }
 }

--- a/harness/run_suite.ts
+++ b/harness/run_suite.ts
@@ -6,6 +6,7 @@ import fs from 'fs';
 import path from 'path';
 import { spawn } from 'child_process';
 import { config, Agents } from './config.ts';
+import matter from 'gray-matter';
 
 const RUN_TYPES = ['guided', 'unguided'];
 
@@ -56,23 +57,22 @@ async function main() {
       }
 
       const fileContent = fs.readFileSync(taskPath, 'utf8');
-      const frontmatterMatch = fileContent.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+      const { data, content } = matter(fileContent);
 
-      if (!frontmatterMatch) {
+      if (!data || Object.keys(data).length === 0) {
         console.error(`❌ Invalid frontmatter format in ${taskPath}`);
         return;
       }
 
-      const baseAppMatch = frontmatterMatch[1].match(/^base_app:\s*(.+)$/m);
-      if (!baseAppMatch) {
+      if (!data.base_app) {
         console.error(`❌ Missing base_app in frontmatter in ${taskPath}`);
         return;
       }
 
-      const baseApp = baseAppMatch[1].trim();
+      const baseApp = data.base_app.trim();
       templateDir = path.join(baseAppsDir, baseApp);
       targetDir = path.join(resultsDir, 'single_task', task);
-      promptContent = frontmatterMatch[2].trim();
+      promptContent = content.trim();
     }
 
     if (!fs.existsSync(templateDir)) {
@@ -151,21 +151,20 @@ async function main() {
         }
 
         const fileContent = fs.readFileSync(taskPath, 'utf8');
-        const frontmatterMatch = fileContent.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+        const { data, content } = matter(fileContent);
         
-        if (!frontmatterMatch) {
+        if (!data || Object.keys(data).length === 0) {
           console.warn(`Skipping task ${task}: Invalid frontmatter format in ${taskPath}`);
           continue;
         }
 
-        const baseAppMatch = frontmatterMatch[1].match(/^base_app:\s*(.+)$/m);
-        if (!baseAppMatch) {
+        if (!data.base_app) {
           console.warn(`Skipping task ${task}: Missing base_app in frontmatter in ${taskPath}`);
           continue;
         }
 
-        const baseApp = baseAppMatch[1].trim();
-        let promptContent = frontmatterMatch[2].trim();
+        const baseApp = data.base_app.trim();
+        let promptContent = content.trim();
 
         promptContent += COMMON_APPEND_PROMPT;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       glob:
         specifier: ^10.5.0
         version: 10.5.0
+      gray-matter:
+        specifier: ^4.0.3
+        version: 4.0.3
       puppeteer-core:
         specifier: ^24.37.5
         version: 24.37.5

--- a/serving/scripts/build-megaskill.ts
+++ b/serving/scripts/build-megaskill.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {fileURLToPath} from 'node:url';
+import matter from 'gray-matter';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -53,9 +54,10 @@ function buildTaxonomyMarkdown(guidesDir: string, distRefsDir: string): string {
       if (!fs.existsSync(guidePath)) continue;
 
       const guideContent = fs.readFileSync(guidePath, 'utf-8');
+      const { content: parsedContent } = matter(guideContent);
 
       // Skip if there's no content beyond frontmatter
-      const contentWithoutFrontmatter = guideContent.replace(/^---[\s\S]*?---\n*/, '').trim();
+      const contentWithoutFrontmatter = parsedContent.trim();
       if (contentWithoutFrontmatter.length === 0) continue;
 
       // Extract title from first H1 or fall back


### PR DESCRIPTION
we already used it in serving/scripts/build-guides.ts and  guides/sync-use-cases.ts but...   
this certainly gives some cleaner code.


also turns out we werent running typecheck correctly within `guides/`!    The guides/ directory lacked a typecheck script in its package.json. Because pnpm -r only executes scripts that actually exist in a sub-project, the entire guides/ folder was being silently skipped! whoopsies.  now fixed.
      
      
