### PR TITLE
Shorter radar labels

### DIFF
--- a/eval-view/radar.js
+++ b/eval-view/radar.js
@@ -121,7 +121,15 @@ export class RadarChart {
       text.setAttribute("fill", "#c9d1d9");
       text.setAttribute("font-size", "11"); // Slightly smaller
       text.setAttribute("font-weight", "500");
-      text.textContent = label;
+
+      // Extract use case ID from format "appName (useCaseId)", or use label as-is
+      let useCaseId = label;
+      const match = label.match(/\(([^)]+)\)$/);
+      if (match) {
+        useCaseId = match[1];
+      }
+
+      text.textContent = useCaseId;
 
       text.onmouseover = () => {
         text.setAttribute("fill", "#fff");


### PR DESCRIPTION
Before:

<img width="941" height="701" alt="image" src="https://github.com/user-attachments/assets/718cfb7e-073d-42b4-b4f1-72ebd2258abd" />

After:

<img width="882" height="628" alt="image" src="https://github.com/user-attachments/assets/f88765ca-4149-48b9-ba50-85dd76d5aea9" />


(I don't expect the radar chart to last much longer, given how many more use cases we'll have)