### PR TITLE
update guide validation to get all guides and display in dashboard

### DIFF
--- a/eval-view/dashboard.js
+++ b/eval-view/dashboard.js
@@ -484,18 +484,36 @@ async function showDetails(testName, runs, stats, testId) {
         }
 
         let guideSection = '';
-        if (run.guideUsed !== undefined) {
-            const passed = run.guideUsed;
+        const guidesUsed = run.guidesUsed || (run.guideUsed !== undefined ? (typeof run.guideUsed === 'object' && run.guideUsed !== null ? run.guideUsed.guidesUsed : []) : []);
+        const oldPassed = run.guideUsed !== undefined ? (typeof run.guideUsed === 'object' && run.guideUsed !== null ? run.guideUsed.expectedGuideUsed : run.guideUsed) : undefined;
+
+        const hasData = run.guidesUsed !== undefined || run.guideUsed !== undefined;
+
+        if (hasData) {
+            const passed = run.guidesUsed !== undefined ? run.guidesUsed.includes(guide) : oldPassed;
+
+            let guidesHtml = '';
+            const otherGuides = guidesUsed.filter(g => g !== guide);
+            if (otherGuides.length > 0) {
+                guidesHtml = `
+                    <div style="margin-top: 8px; font-size: 0.85em; color: var(--text-secondary);">
+                        <strong style="color: var(--text-primary);">Other Guides Used:</strong> ${otherGuides.map(g => `<code style="background: rgba(255,b255,255,0.05); padding: 2px 4px; border-radius: 3px; font-size: 0.9em;">${escapeHtml(g)}</code>`).join(', ')}
+                    </div>
+                `;
+            }
 
             guideSection = `
-                <div class="guide-section" style="margin-top: 15px; padding: 10px 15px; background: rgba(255,255,255,0.03); border-radius: 6px; border: 1px solid var(--border-color); display: flex; justify-content: space-between; align-items: center;">
-                    <div style="display: flex; align-items: center; gap: 8px;">
-                        <span style="font-size: 1rem;">${passed ? '✅' : '❌'}</span>
-                        <strong style="font-size: 0.9em; font-weight: 600;">${guide} used by agent</strong>
+                <div class="guide-section" style="margin-top: 15px; padding: 12px 15px; background: rgba(255,255,255,0.03); border-radius: 6px; border: 1px solid var(--border-color);">
+                    <div style="display: flex; justify-content: space-between; align-items: center;">
+                        <div style="display: flex; align-items: center; gap: 8px;">
+                            <span style="font-size: 1rem;">${passed ? '✅' : '❌'}</span>
+                            <strong style="font-size: 0.9em; font-weight: 600;">${guide} used by agent</strong>
+                        </div>
+                        <div>
+                            <a href="#" class="view-resources-link" style="font-size: 0.8em; color: var(--text-secondary); text-decoration: underline; opacity: 0.7;">${MCP_LOG_FILE}</a>
+                        </div>
                     </div>
-                    <div>
-                        <a href="#" class="view-resources-link" style="font-size: 0.8em; color: var(--text-secondary); text-decoration: underline; opacity: 0.7;">${MCP_LOG_FILE}</a>
-                    </div>
+                    ${guidesHtml}
                 </div>
             `;
         }

--- a/harness/lib/collection.ts
+++ b/harness/lib/collection.ts
@@ -1,7 +1,7 @@
 import { glob } from "glob";
 import path from 'path';
 import fs from 'fs';
-import { guideUsed } from './guide_validation.ts';
+import { collectGuidesUsed } from './guide_validation.ts';
 import { fileURLToPath } from 'url';
 import matter from 'gray-matter';
 
@@ -132,9 +132,9 @@ run();
 
       const [taskName, runType] = parts;
 
-      let guideUsedResult = undefined;
+      let guidesUsedResult: string[] = [];
       if (runType === 'guided') {
-        guideUsedResult = await guideUsed(dir, taskName);
+        guidesUsedResult = await collectGuidesUsed(dir);
       }
 
       const targetFile = path.join(dir, 'index.html');
@@ -215,7 +215,7 @@ run();
       allResults[testName].push({
         runNumber: parseInt(runDir),
         results: scenarioResults,
-        guideUsed: guideUsedResult,
+        guidesUsed: guidesUsedResult,
         baseApp: actualBaseApp,
         taskName: taskName
       });

--- a/harness/lib/guide_validation.ts
+++ b/harness/lib/guide_validation.ts
@@ -2,16 +2,14 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { MCP_LOG_FILE } from '../../constants.ts';
-import matter from 'gray-matter';
 
 const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
 
-export async function guideUsed(dirPath: string, taskName: string): Promise<boolean> {
+export async function collectGuidesUsed(dirPath: string): Promise<string[]> {
   const logPath = path.join(dirPath, MCP_LOG_FILE);
   
   if (!fs.existsSync(logPath)) {
-    return false;
+    return [];
   }
 
   const logContent = fs.readFileSync(logPath, 'utf8').trim();
@@ -30,27 +28,13 @@ export async function guideUsed(dirPath: string, taskName: string): Promise<bool
     }
   }
 
-  const taskPath = path.resolve(__dirname, `../tasks/${taskName}.md`);
-  if (!fs.existsSync(taskPath)) {
-    console.error(`Task ${taskName} not found at ${taskPath}`);
-    return false;
-  }
-
-  const fileContent = fs.readFileSync(taskPath, 'utf8');
-  const { data } = matter(fileContent);
-
-  if (!data || !data.grader) {
-    console.error(`No 'grader:' found in frontmatter for task ${taskName}`);
-    return false;
-  }
-
-  const guide = data.grader.trim();
-
   // Extract all use case IDs requested via get_best_practices
   const requestedGuides = toolCalls
     .filter(call => call.tool === 'get_best_practices' && Array.isArray(call.result))
     .flatMap(call => call.result.map((r: any) => r.id || ''))
     .filter(Boolean);
 
-  return requestedGuides.some(id => id === guide);
+  const uniqueGuides = [...new Set(requestedGuides)];
+
+  return uniqueGuides;
 }

--- a/harness/lib/metrics.ts
+++ b/harness/lib/metrics.ts
@@ -7,7 +7,7 @@ export interface ScenarioCheck {
 export interface RunResult {
   runNumber: number;
   results: ScenarioCheck[];
-  guideUsed?: boolean;
+  guidesUsed?: string[];
 }
 
 export interface Metrics {


### PR DESCRIPTION
Now the dashboard will show any other guides returned by `get_best_practices` in the MCP server log.

<img width="426" height="64" alt="Screenshot 2026-03-10 at 3 04 30 PM" src="https://github.com/user-attachments/assets/683b85b0-83eb-4fbd-b4ca-57b6383aba53" />