### PR TITLE
Force actions to run on Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   basics:
     runs-on: ubuntu-latest

--- a/.github/workflows/guide-sync.yml
+++ b/.github/workflows/guide-sync.yml
@@ -23,6 +23,9 @@ permissions:
   contents: read
   issues: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   sync:
     runs-on: ubuntu-latest


### PR DESCRIPTION
While running the `guide-sync` action, I noticed this warning:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: pnpm/action-setup@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

This PR resolves it by setting the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env variable.