### PR TITLE
Better handling of old use case issues

### DIFF
--- a/guides/sync-use-cases.ts
+++ b/guides/sync-use-cases.ts
@@ -412,20 +412,30 @@ async function run() {
   }
 
   if (GITHUB_TOKEN) {
-    // 4. Cleanup: Close issues for use cases that no longer exist
-    console.log('🧹 Checking for orphaned issues to close...');
+    // 4. Cleanup: Close issues and remove labels for use cases that no longer exist
+    console.log('🧹 Checking for orphaned issues to cleanup...');
     for (const issue of allUseCases) {
-      if (issue.state === 'open' && !activeIssueNumbers.has(issue.number)) {
-        console.log(`${IS_DRY_RUN ? '[DRY RUN] Would close' : 'Closing'} orphaned issue #${issue.number} ("${issue.title}")...`);
+      if (!activeIssueNumbers.has(issue.number)) {
+        if (issue.state === 'open') {
+          console.log(`${IS_DRY_RUN ? '[DRY RUN] Would close' : 'Closing'} orphaned issue #${issue.number} ("${issue.title}")...`);
+          if (!IS_DRY_RUN) {
+            try {
+              await octokit.rest.issues.update({
+                owner: ORG,
+                repo: REPO,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'not_planned'
+              });
+            } catch (err: any) {
+              console.warn(`⚠️ Could not close orphaned issue #${issue.number}: ${err.message}`);
+            }
+          }
+        }
+
+        console.log(`${IS_DRY_RUN ? '[DRY RUN] Would remove label' : 'Removing label'} from orphaned issue #${issue.number} ("${issue.title}")...`);
         if (!IS_DRY_RUN) {
           try {
-            await octokit.rest.issues.update({
-              owner: ORG,
-              repo: REPO,
-              issue_number: issue.number,
-              state: 'closed',
-              state_reason: 'not_planned'
-            });
             await octokit.rest.issues.removeLabel({
               owner: ORG,
               repo: REPO,
@@ -433,7 +443,7 @@ async function run() {
               name: 'new-use-case'
             });
           } catch (err: any) {
-            console.warn(`⚠️ Could not close orphaned issue #${issue.number}: ${err.message}`);
+            console.warn(`⚠️ Could not remove label from orphaned issue #${issue.number}: ${err.message}`);
           }
         }
       }


### PR DESCRIPTION
A use case issue is created when a new subdir is added under `guides/*/`. That subdir is encoded into the issue description.

When the `sync-use-cases` script runs, it checks to make sure that the subdir for that issue still exists. If not, the issue is considered orphaned, and closed. While closing, it also removes the `new-use-case` label, which takes it off of our project tracking board.

The problem is that issues that are already closed weren't having their labels removed. I've fixed that in this PR. So now, the project board should perfectly match the use cases that are actively supported.

Issues affected by this change:

- #268 
- #140