### PR TITLE
Add a guide for deferring heavy content rendering

### DIFF
--- a/guides/performance/defer-rendering-heavy-content/demo.html
+++ b/guides/performance/defer-rendering-heavy-content/demo.html
@@ -152,7 +152,7 @@
 
     .below-fold-cv {
       content-visibility: auto;
-      contain-intrinsic-size: 1000px;
+      contain-intrinsic-size: auto none auto 1000px;
       /* Estimated height to prevent scrollbar jumping */
     }
 
@@ -221,7 +221,7 @@
         <p><strong>Try it out!</strong> Hit Cmd/Ctrl+F and search for the magic word: <code
             style="font-size:1.2rem; color: #d97706; background: #fffbeb; padding: 2px 6px; border-radius: 4px;">Supercalifragilisticexpialidocious</code>.
           If it is hidden, the browser will automatically reveal this entire section!</p>
-        <button class="btn" id="toggle-btn-3" aria-expanded="true">Show Dashboard</button>
+        <button class="btn" id="toggle-btn-3" aria-expanded="false">Show Dashboard</button>
       </div>
       <div hidden="until-found" id="demo3-container">
         <p class="searchable-text">
@@ -320,7 +320,7 @@
     const demo2Container = document.getElementById('demo2-container');
 
     toggleBtn2.addEventListener('click', () => {
-      // For this one we just use standard display none approach to hide completely 
+      // For this one we just use standard display none approach to hide completely
       // or we can remove it from DOM
       const isHidden = demo2Container.style.display === 'none';
       if (isHidden) {

--- a/guides/performance/defer-rendering-heavy-content/expectations.md
+++ b/guides/performance/defer-rendering-heavy-content/expectations.md
@@ -1,0 +1,12 @@
+# Expectations: `defer-rendering-heavy-content`
+
+- Any content that does not need to be rendered immediately on page load and is outside the initial viewport should use `content-visibility: auto`.
+- If applying `content-visibility: auto` to an element, `contain-intrinsic-size` MUST be applied to the same element.
+
+- Any content that does not need to be rendered immediately on page load and visibility can be toggled should use `content-visibility: hidden`.
+- If applying `content-visibility: hidden` to an element and the users Baseline target is older than Baseline 2025, a fallback strategy must be used. The implementation should include a CSS feature detection check for native support (e.g., `@supports (content-visibility: hidden) { ... }`) and execute a fallback UI strategy for unsupported browsers.
+
+- Any content that does not need to be rendered immediately on page load and visibility can be toggled and is searchable should use `hidden="until-found"`.
+- If applying `hidden="until-found"` to an element, the element should not have any `display` or `visibility` CSS properties applied to it directly.
+- If applying `hidden="until-found"` to an element and the element has related UI state (e.g., updating ARIA attributes, toggling open/close classes, or managing accordion icons), that state should be synchronized using a beforematch event listener.
+- If applying `hidden="until-found"` to an element and the users Baseline target is older than Baseline 2025, a fallback strategy must be used. The implementation must include an explicit JavaScript feature detection check for native support (e.g., `if (!('onbeforematch' in HTMLElement.prototype))`) and execute a fallback UI strategy for unsupported browsers.

--- a/guides/performance/defer-rendering-heavy-content/guide.md
+++ b/guides/performance/defer-rendering-heavy-content/guide.md
@@ -5,3 +5,124 @@ web-feature-ids:
   - hidden-until-found
   - content-visibility
 ---
+
+# Defer rendering heavy content
+
+Web pages with extensive content—such as infinite scrolls, complex dashboards, or dense articles—can suffer from slow initial rendering and sluggish interactions. Modern web technologies allow you to defer the rendering workload for content that is not immediately visible, significantly boosting performance without breaking accessibility or user expectations.
+
+To optimize rendering, you can utilize the CSS `content-visibility` property and the HTML `hidden="until-found"` attribute. While both aid performance, they serve distinct use cases.
+
+## When to use which
+
+| Scenario / Example | Feature Applied | Performance Benefit |
+| :--- | :--- | :--- |
+| **1. Below the fold** (Delay initial load) | **`content-visibility: auto`** | Browser automatically offloads layout/paint workload until the container scrolls close to view, keeping standard page load speed frictionless. |
+| **2. Toggle State** (Fast view switching) | **`content-visibility: hidden`** | Skips layout calculations for hidden divs but preserves style containment state, allowing for instantaneous toggling without structural shifts (superior to `display: none`). |
+| **3. Searchable & Deferred** (Collapsible specs/FAQ) | **`hidden="until-found"`** | Same benefits as previous, defers load-time rendering fully, but remains searchable via native Find-in-page. The browser automatically unhides and scrolls to the target on match. |
+
+## How to implement `content-visibility: auto`
+
+1. **Identify heavy sections:** Locate large, self-contained layout blocks that are initially off-screen (e.g., card items in an infinite feed).
+2. **Apply CSS:** Add `content-visibility: auto` and provide an estimated height or width using `contain-intrinsic-size`.
+
+### Example code
+
+```css
+.heavy-section {
+  /* Skips rendering calculations when off-screen */
+  content-visibility: auto;
+  
+  /* Mandatory: Provide an estimated height to prevent layouts shifts */
+  contain-intrinsic-size: 0px 500px; 
+}
+```
+
+## How to implement `content-visibility: hidden`
+
+1. **Identify heavy sections:** Locate layout blocks that are initially hidden (e.g., extra rows in a large data table).
+2. **Apply CSS:** Add `content-visibility: hidden` to the element.
+3. **Reveal the element:** When the element should be revealed, change the `content-visibility` property to `visible` or `auto`.
+
+### Example code
+
+```css
+.cached-view {
+  /* Hides content but caches rendering state */
+  content-visibility: hidden;
+}
+
+.cached-view.is-active {
+  content-visibility: visible;
+}
+```
+
+Because `content-visibility: hidden` excludes the element and its children from the accessibility tree and find-in-page search, **DO NOT** use it if the content must remain discoverable while hidden. For searchable hidden content, use `hidden="until-found"`.
+
+## How to implement `hidden="until-found"`
+  
+The `hidden="until-found"` attribute forces the browser to apply an internal `content-visibility: hidden` rule. This hides content until a user utilizes "Find in page" or navigates via document fragments directly into the container.
+
+1. **Identify heavy sections:** Locate layout blocks that are initially hidden (e.g., extra rows in a large data table).
+2. **Apply the attribute:** Add `hidden="until-found"` directly onto the collapsible container element.
+3. **Handle state synchronization:** If reveal states require DOM updates (such as toggling an aria-expanded attribute or rotating a chevron icon), use the `beforematch` event listener.
+
+### Example code
+
+```html
+<div class="heavy-section" hidden="until-found">
+  <p>Heavy content.</p>
+</div>
+```
+
+```javascript
+// Optional: Handle state synchronization
+const heavySection = document.querySelector('.heavy-section');
+
+heavySection.addEventListener('beforematch', (event) => {
+  // Logic to execute immediately before the browser reveals the match
+});
+```
+
+## Best Practices
+
+- **DO** use `contain-intrinsic-size` with `content-visibility: auto`. Failure to do so forces height recalculations on scroll, causing viewport layout jumping or visual glitches.
+- **DO NOT** apply `content-visibility: auto` to elements inside the initial fold viewport, as this delays critical page rendering.
+- **DO NOT** apply standard `display: none` or `visibility: hidden` to elements designed to use `hidden="until-found"`, as this permanently excludes them from search discovery.
+- **DO** verify that `hidden="until-found"` handles interactive states gracefully on trigger.
+
+## Browser support and fallback strategies
+
+{{ BASELINE_STATUS("content-visibility") }}
+
+{{ BASELINE_STATUS("hidden-until-found") }}
+
+### `content-visibility` fallback
+
+When `content-visibility` is not supported it will be ignored by the browser. In most cases `content-visibility: auto` will not need a fallback, though without it performance gains will be lost. An unsupported browser will leave `content-visibility: hidden` elements completely visible. Use feature detection to implement a fallback.
+
+```css
+/* Default for everyone */
+.inactive {
+  display: none;
+}
+
+/* Modern Browsers only */
+@supports (content-visibility: hidden) {
+ .inactive {
+    display: block; /* Turn the layout box back on */
+    content-visibility: hidden;
+  }
+}
+```
+
+### `hidden="until-found"` fallback
+When `hidden="until-found` is not supported elements will remain hidden.Use feature detection targeting `onbeforematch` and extract or reveal content accordingly.
+
+```javascript
+if (!('onbeforematch' in HTMLElement.prototype)) {
+  document.querySelectorAll('[hidden="until-found"]').forEach(el => {
+    // Unsupported browsers show content to maintain searchability
+    el.removeAttribute('hidden'); 
+  });
+}
+```

--- a/guides/performance/defer-rendering-heavy-content/guide.md
+++ b/guides/performance/defer-rendering-heavy-content/guide.md
@@ -37,8 +37,16 @@ The `contain-intrinsic-size` CSS shorthand property allows you to provide an est
   /* Skips rendering calculations when off-screen */
   content-visibility: auto;
   
-  /* Mandatory: Provide an estimated height to prevent layouts shifts */
-  contain-intrinsic-size: auto none auto 500px; 
+  /* Mandatory: Provide an estimated size to prevent layouts shifts.
+    - 'auto' is optional and enables the browser to remember the actual size
+      once rendered. It must be paired with a <length> value to be used for
+      the first render.
+    - 'none' tells the browser not to apply any intrinsic width to this element.
+      It can be used for either the height or the width value.
+    - '150px' is the estimated height of this element. This can be any valid
+      CSS <length> value.
+   */
+  contain-intrinsic-size: auto none auto 150px; 
 }
 ```
 
@@ -97,13 +105,9 @@ heavySection.addEventListener('beforematch', (event) => {
 
 ## Browser support and fallback strategies
 
-{{ BASELINE_STATUS("content-visibility") }}
-
-{{ BASELINE_STATUS("hidden-until-found") }}
-
 ### `content-visibility` fallback
 
-When `content-visibility` is not supported it will be ignored by the browser. In most cases `content-visibility: auto` will not need a fallback, though without it performance gains will be lost. An unsupported browser will leave `content-visibility: hidden` elements completely visible. Use feature detection to implement a fallback.
+{{ BASELINE_STATUS("content-visibility") }} When `content-visibility` is not supported it will be ignored by the browser. In most cases `content-visibility: auto` will not need a fallback, though without it performance gains will be lost. An unsupported browser will leave `content-visibility: hidden` elements completely visible. Use feature detection to implement a fallback.
 
 ```css
 /* Default for everyone */
@@ -121,7 +125,7 @@ When `content-visibility` is not supported it will be ignored by the browser. In
 ```
 
 ### `hidden="until-found"` fallback
-When `hidden="until-found"` is not supported elements will remain hidden. Use feature detection targeting `onbeforematch` and extract or reveal content accordingly.
+{{ BASELINE_STATUS("hidden-until-found") }} When `hidden="until-found"` is not supported elements will remain hidden. Use feature detection targeting `onbeforematch` and extract or reveal content accordingly.
 
 ```javascript
 if (!('onbeforematch' in HTMLElement.prototype)) {

--- a/guides/performance/defer-rendering-heavy-content/guide.md
+++ b/guides/performance/defer-rendering-heavy-content/guide.md
@@ -121,7 +121,7 @@ When `content-visibility` is not supported it will be ignored by the browser. In
 ```
 
 ### `hidden="until-found"` fallback
-When `hidden="until-found` is not supported elements will remain hidden. Use feature detection targeting `onbeforematch` and extract or reveal content accordingly.
+When `hidden="until-found"` is not supported elements will remain hidden. Use feature detection targeting `onbeforematch` and extract or reveal content accordingly.
 
 ```javascript
 if (!('onbeforematch' in HTMLElement.prototype)) {

--- a/guides/performance/defer-rendering-heavy-content/guide.md
+++ b/guides/performance/defer-rendering-heavy-content/guide.md
@@ -8,7 +8,7 @@ web-feature-ids:
 
 # Defer rendering heavy content
 
-Web pages with extensive content—such as infinite scrolls, complex dashboards, or dense articles—can suffer from slow initial rendering and sluggish interactions. Modern web technologies allow you to defer the rendering workload for content that is not immediately visible, significantly boosting performance without breaking accessibility or user expectations.
+Web pages with extensive content—such as infinite scrolls, complex dashboards, or dense articles can suffer from slow initial rendering and sluggish interactions. Modern web technologies allow you to defer the rendering workload for content that is not immediately visible, significantly boosting performance without breaking accessibility or user expectations.
 
 To optimize rendering, you can utilize the CSS `content-visibility` property and the HTML `hidden="until-found"` attribute. While both aid performance, they serve distinct use cases.
 
@@ -23,7 +23,12 @@ To optimize rendering, you can utilize the CSS `content-visibility` property and
 ## How to implement `content-visibility: auto`
 
 1. **Identify heavy sections:** Locate large, self-contained layout blocks that are initially off-screen (e.g., card items in an infinite feed).
-2. **Apply CSS:** Add `content-visibility: auto` and provide an estimated height or width using `contain-intrinsic-size`.
+2. **Apply CSS:** Add `content-visibility: auto` to each off-screen element.
+3. **Provide an estimated height or width:** Add `contain-intrinsic-size` to each off-screen element.
+
+### How to use `contain-intrinsic-size`
+
+The `contain-intrinsic-size` CSS shorthand property allows you to provide an estimated height and/or width for an element. This can be used to prevent layout shifts and visual glitches when the user scrolls to the element. The `auto` keyword can be paired with a length value for the browser to remember the size of the element when it is rendered and use the "remembered" size on the next render.
 
 ### Example code
 
@@ -33,7 +38,7 @@ To optimize rendering, you can utilize the CSS `content-visibility` property and
   content-visibility: auto;
   
   /* Mandatory: Provide an estimated height to prevent layouts shifts */
-  contain-intrinsic-size: 0px 500px; 
+  contain-intrinsic-size: auto none auto 500px; 
 }
 ```
 
@@ -116,7 +121,7 @@ When `content-visibility` is not supported it will be ignored by the browser. In
 ```
 
 ### `hidden="until-found"` fallback
-When `hidden="until-found` is not supported elements will remain hidden.Use feature detection targeting `onbeforematch` and extract or reveal content accordingly.
+When `hidden="until-found` is not supported elements will remain hidden. Use feature detection targeting `onbeforematch` and extract or reveal content accordingly.
 
 ```javascript
 if (!('onbeforematch' in HTMLElement.prototype)) {

--- a/guides/performance/defer-rendering-heavy-content/prompts.md
+++ b/guides/performance/defer-rendering-heavy-content/prompts.md
@@ -1,0 +1,3 @@
+- Implement a product listing page with 1000 products and infinite scroll, optimise the rendering so the page loads quickly and remains responsive.
+- Implement a complex dashboard with 100 widgets, the dashboard should be hidden on page load and revealed when the user clicks a button to view it, the dashboard should load quickly when visible.
+- Create a page with a long article that is split into sections, the sections should be hidden on page load and revealed when the user clicks a button to view them, the sections should load quickly when visible.


### PR DESCRIPTION
Guides for https://github.com/GoogleChrome/guidance/issues/208. Also explaining when to choose between `content-visibility` and `hidden="until-found"` to achieve this use case.