### PR TITLE
Updates optimize tasks to use empty app

### DIFF
--- a/harness/tasks/optimize-image-priority-task.md
+++ b/harness/tasks/optimize-image-priority-task.md
@@ -1,5 +1,5 @@
 ---
-base_app: daily-grind
+base_app: empty-app
 grader: optimize-image-priority
 ---
-Add the "Rewards" page to this site. The new page features a main hero image 'hero-lcp.jpg' which is the largest contentful element. The page also contains a product image gallery where the first image is visible but the second image 'gallery-alt.jpg' is currently hidden behind a toggle. There is also a secondary 'mega-menu-promo.jpg' image that is part of a navigation menu and initially hidden. Finally, include a 'footer-logo.png' much further down the page below the fold.
+Create an extremely minimal product landing page that features a main hero image 'hero-lcp.jpg' which is the largest contentful element. The page also contains a product image gallery where the first image is visible but the second image 'gallery-alt.jpg' is currently hidden behind a toggle. There is also a secondary 'mega-menu-promo.jpg' image that is part of a navigation menu and initially hidden. Finally, include a 'footer-logo.png' much further down the page below the fold.

--- a/harness/tasks/optimize-preload-priority-task.md
+++ b/harness/tasks/optimize-preload-priority-task.md
@@ -1,5 +1,5 @@
 ---
-base_app: daily-grind
+base_app: empty-app
 grader: optimize-preload-priority
 ---
-Add the "Rewards" page to this site. It should be a minimal video landing page that optimizes for LCP. This includes a video poster image 'poster.jpg' (the LCP element), a custom web font 'brand-font.woff2' that is critical for the header rendering, and a secondary font 'secondary-font.woff2' for less critical UI elements.
+Create an extremely minimal video landing page that optimizes for LCP. This includes a video poster image 'poster.jpg' (the LCP element), a custom web font 'brand-font.woff2' that is critical for the header rendering, and a secondary font 'secondary-font.woff2' for less critical UI elements.

--- a/harness/tasks/optimize-script-priority-task.md
+++ b/harness/tasks/optimize-script-priority-task.md
@@ -1,5 +1,5 @@
 ---
-base_app: daily-grind
+base_app: empty-app
 grader: optimize-script-priority
 ---
-Add the "Locations" page to this site. It requires a critical interactivity script at '/js/app.js' that should be loaded asynchronously. It also includes an older '/js/legacy-widgets.js' script that is normally parser-blocking. Finally, include an analytics script '/js/tracker.js'.
+Create an extremely minimal web page for a dashboard. It requires a critical interactivity script at '/js/app.js' that should be loaded asynchronously. It also includes an older '/js/legacy-widgets.js' script that is normally parser-blocking. Finally, include an analytics script '/js/tracker.js'.


### PR DESCRIPTION
In previous runs, the optimize tasks told the agent to create new pages, which the grader did not pick up.

This PR updates the tasks so that they use the original prompts from the guides, but also uses an "empty" app to be compatible with those prompts.

Results: https://googlechrome.github.io/guidance/dashboard.html?testId=optimize-suite&source=remote