### PR TITLE
Fix MCP logging for Jetski, enable trajectories in dashboard

### DIFF
--- a/harness/agents/jetski-agent.ts
+++ b/harness/agents/jetski-agent.ts
@@ -101,7 +101,7 @@ function setupIsolatedWorkDir(): string {
  */
 async function bypassInitialDialogs(page: Page): Promise<void> {
   console.log('Bypassing initial dialogs...');
-  
+
   // 1. Handle "Trust the authors" dialog persistently
   try {
     console.log('Checking for Trust dialog...');
@@ -151,7 +151,7 @@ async function bypassInitialDialogs(page: Page): Promise<void> {
   } catch (e: any) {
     console.log('Error bypassing Welcome Wizard:', e.message);
   }
-  
+
   console.log('UI stabilization wait...');
   await sleep(3000);
 }
@@ -364,12 +364,12 @@ async function run(): Promise<void> {
     console.log(`Typing prompt: "${userPrompt}"`);
     const lines = userPrompt.split('\n');
     for (let i = 0; i < lines.length; i++) {
-        await targetInputBox.type(lines[i]);
-        if (i < lines.length - 1) {
-            await page.keyboard.down('Shift');
-            await page.keyboard.press('Enter');
-            await page.keyboard.up('Shift');
-        }
+      await targetInputBox.type(lines[i]);
+      if (i < lines.length - 1) {
+        await page.keyboard.down('Shift');
+        await page.keyboard.press('Enter');
+        await page.keyboard.up('Shift');
+      }
     }
 
     try {
@@ -394,7 +394,7 @@ async function run(): Promise<void> {
         console.log("Agent Panel disappeared, assuming finished or closed.");
         break;
       }
-      
+
       const cancelButton = await currentPanel.$(cancelButtonSelector);
       if (!cancelButton) {
         console.log("Agent finished.");
@@ -406,11 +406,11 @@ async function run(): Promise<void> {
         const allowButton = await page.evaluateHandle(() => {
           const buttons = Array.from(document.querySelectorAll('button'));
           return buttons.find(b => {
-             const t = b.innerText?.toLowerCase() || '';
-             return t.includes('allow this conversation') || t.includes('allow once');
+            const t = b.innerText?.toLowerCase() || '';
+            return t.includes('allow this conversation') || t.includes('allow once');
           });
         });
-        
+
         if (allowButton && (allowButton as any).asElement()) {
           console.log("Found 'Allow' button, clicking...");
           await (allowButton as any).click();
@@ -452,6 +452,7 @@ async function run(): Promise<void> {
     console.log("Disconnected.");
 
     copyResultsToTarget(workDir, targetDir);
+
     // Extract trajectory pb from isolated home
     const conversationsDir = path.join(path.dirname(workDir), '.gemini', 'jetski', 'conversations');
     exportTrajectories(conversationsDir, '*.pb', targetDir);

--- a/harness/agents/jetski-agent.ts
+++ b/harness/agents/jetski-agent.ts
@@ -77,6 +77,7 @@ function setupIsolatedWorkDir(): string {
   // Set environment variables
   process.env.HOME = tempHome;
   process.env.JETSKI_DIR = jetskiDest;
+  process.env.MCP_LOG_DIR = targetDir;
 
   // Add GEMINI context and MCP servers for guided runs
   if (runType === 'guided') {
@@ -266,6 +267,7 @@ async function startJetski(directory: string, profileDir: string): Promise<void>
 
 async function run(): Promise<void> {
   const workDir = setupIsolatedWorkDir();
+  let stopWatchingMcpLog = () => {};
 
   if (!workDir || !fs.existsSync(workDir)) {
     throw new Error(`Failed to initialize working directory: ${workDir}`);
@@ -325,8 +327,7 @@ async function run(): Promise<void> {
       console.log(`Jetski info already exists at: ${jetskiInfoPath}`);
     }
 
-    process.env.MCP_LOG_DIR = targetDir;
-    const stopWatchingMcpLog = watchLogFile(path.join(targetDir, MCP_LOG_FILE));
+    stopWatchingMcpLog = watchLogFile(path.join(targetDir, MCP_LOG_FILE));
 
     const inputSelector = '[contenteditable="true"][role="textbox"]';
     const sendButtonSelector = '[data-tooltip-id="input-send-button-send-tooltip"]';
@@ -461,6 +462,7 @@ async function run(): Promise<void> {
     console.error("Error during execution:", err);
     process.exit(1);
   } finally {
+    stopWatchingMcpLog();
     killProcessOnPort(config.environment.jetskiDebugPort);
     cleanupIsolatedHome(path.dirname(workDir));
   }

--- a/harness/lib/agent-shared.ts
+++ b/harness/lib/agent-shared.ts
@@ -344,9 +344,10 @@ export function exportTrajectories(sourceDir: string, pattern: string, targetDir
       const trajectoryId = fileName.replace(/\.(json|pb)$/, '');
       const fileBuffer = fs.readFileSync(srcFile);
       const htmlContent = generateExportHtml(new Uint8Array(fileBuffer), fileName);
-      const htmlDest = path.join(targetDir, `${trajectoryId}.html`);
+      const htmlFileName = trajectoryId.startsWith('session-') ? `${trajectoryId}.html` : `session-${trajectoryId}.html`;
+      const htmlDest = path.join(targetDir, htmlFileName);
       fs.writeFileSync(htmlDest, htmlContent, 'utf8');
-      console.log(`Generated HTML export: ${trajectoryId}.html`);
+      console.log(`Generated HTML export: ${htmlFileName}`);
     } catch (e) {
       console.error(`Failed to export trajectory ${fileName}:`, e);
     }


### PR DESCRIPTION
Jetski needed some updates after the structural changes we've made recently.

The MCP logging was updated to be configured properly, and we rename the trajectory file to prepend it with "session-" so that the dashboard knows which HTML file to use as the trajectory.

To be merge after/with https://github.com/GoogleChrome/guidance/pull/96.