### PR TITLE
Update Dependabot: add 14-day cooldown for npm and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,8 @@ updates:
       interval: "weekly"
       day: "sunday"
     open-pull-requests-limit: 3
+    cooldown:
+      default-days: 14
     groups:
       everything:
         patterns:
@@ -26,3 +28,5 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 1
+    cooldown:
+      default-days: 14


### PR DESCRIPTION
best practice 14 day soak.