### PR TITLE
Set the default agent to Gemini CLI

### DIFF
--- a/harness/config.ts
+++ b/harness/config.ts
@@ -46,7 +46,7 @@ export const suiteConfig: SuiteConfig = {
   tasks: [], // Empty = discover all tasks in harness/tasks/. Set explicitly to run a subset.
   mcpServersToEnable: ['modern-web'], // Available servers: 'modern-web', 'google-developer-knowledge'
   enableSkills: false,
-  agent: Agents.JETSKI,
+  agent: Agents.GEMINI_CLI,
   negative: false, // When `true`, runs the suite on all tasks in `tasks/negative/`
 };
 


### PR DESCRIPTION
I think it might still be useful to have a way to configure agents via CLI args, but for now I pretty much always prefer Gemini CLI as my default agent for quick tests, and I assume most other people do too