### PR TITLE
Include feature names in seach results

### DIFF
--- a/serving/mcp-server/data/baseline.ts
+++ b/serving/mcp-server/data/baseline.ts
@@ -176,6 +176,16 @@ export function resolveFeatureId(featureId: string): string[] {
 }
 
 /**
+ * Gets the human-readable name for a feature ID.
+ * @param featureId - The feature ID to look up
+ * @returns The feature name
+ */
+export function getFeatureName(featureId: string): string {
+  const feature = features[featureId] as Feature;
+  return feature.name;
+}
+
+/**
  * Validates a feature ID.
  */
 export function validateFeature(id: string): FeatureValidationResult {

--- a/serving/mcp-server/lib/store.ts
+++ b/serving/mcp-server/lib/store.ts
@@ -13,6 +13,7 @@ export interface UseCase {
   id: string;
   description: string;
   category: string;
+  featuresUsed: string[];
   chunkContent?: string;
   vector?: number[];
   distance?: number;
@@ -77,6 +78,7 @@ export class Store {
         id: r.id as string,
         description: r.description as string,
         category: r.category as string,
+        featuresUsed: Array.from(r.featuresUsed as Iterable<string>),
         distance: dist.toFixed(2),
       });
 

--- a/serving/scripts/build-guides.ts
+++ b/serving/scripts/build-guides.ts
@@ -7,6 +7,7 @@ import { Embedder } from "../mcp-server/lib/embedder.ts";
 import { Store, type UseCase as StoreUseCase } from "../mcp-server/lib/store.ts";
 import { replaceMacros } from "../mcp-server/lib/macros.ts";
 import { classifyGuide, scanAllGuides } from "../../harness/lib/utils.ts";
+import { getFeatureName } from "../mcp-server/data/baseline.ts";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -21,6 +22,7 @@ interface UseCase {
   id: string;
   description: string;
   category: string;
+  featuresUsed: string[];
 }
 
 async function processGuides() {
@@ -81,6 +83,7 @@ export interface UseCase {
   id: string;
   description: string;
   category: string;
+  featuresUsed: string[];
 }
 
 export const USE_CASES: UseCase[] = ${JSON.stringify(useCases, null, 2)};
@@ -140,10 +143,14 @@ async function processSingleGuideFile(
 
   const processedMarkdown = replaceMacros(markdownBody, filePath);
 
+  const featureIds: string[] = data['web-feature-ids'] || [];
+  const featuresUsed = featureIds.map(getFeatureName);
+
   useCases.push({
     id,
     description: data.description,
     category,
+    featuresUsed,
   });
 
   const chunks = chunkMarkdown(processedMarkdown);
@@ -159,6 +166,7 @@ async function processSingleGuideFile(
       id,
       description: data.description,
       category,
+      featuresUsed,
       chunkContent: chunk,
       vector
     });

--- a/serving/scripts/demo-search.ts
+++ b/serving/scripts/demo-search.ts
@@ -23,11 +23,7 @@ async function main() {
   console.log(`  ↳ Took ${(endSearch - startSearch).toFixed(2)}ms`);
 
   // 3. Display
-  console.log("\nTop Results:");
-  results.forEach((r, i) => {
-    console.log(`\n${i + 1}. [${r.id}] (${r.category}) - Distance: ${r.distance}`);
-    console.log(`   ${r.description}`);
-  });
+  console.log(JSON.stringify(results, null, 2));
 }
 
 main().catch(console.error);


### PR DESCRIPTION
Feature info could be useful for a coding agent when trying to understand if a use case is appropriate for a given task. Use case descriptions are more focused on the problem statement, so this adds the names of the web features directly to the search results.

Example result (what an agent would see):

```json
{
  "id": "optimize-preload-priority",
  "description": "Optimize the relative priority of preloaded content to reduce critical resource load delays.",
  "category": "performance",
  "featuresUsed": [
    "Fetch priority",
    "<link rel=\"preload\">"
  ],
  "distance": "1.08"
}
```