### PR TITLE
🎨 Palette: Improve keyboard accessibility for Eval Dashboard

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-03-21 - [Keyboard Accessibility for Interactive Grid/Table Elements]
+**Learning:** In the Guidance Eval-View dashboard, interactive elements like `test-card` (divs) and `suite-table-row` (tr) were missing keyboard navigation support. These elements use custom click handlers but weren't focusable or responsive to the 'Enter' key.
+**Action:** Always add `tabindex="0"`, a relevant ARIA `role` (`button` for modals, `link` for navigation), and an `onkeydown` listener for 'Enter' and 'Space' to custom interactive components. Pair this with `:focus-visible` styles using `var(--accent-color)` to provide a clear focus indicator.

--- a/eval-view/dashboard.css
+++ b/eval-view/dashboard.css
@@ -106,6 +106,12 @@ h1 {
   background: var(--hover-bg);
 }
 
+.test-card:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 2px;
+  background: var(--hover-bg);
+}
+
 .test-card h3 {
   margin-top: 0;
   color: var(--text-primary);

--- a/eval-view/dashboard.js
+++ b/eval-view/dashboard.js
@@ -416,6 +416,15 @@ function renderGrid(data, testId) {
                 }
 
                 card.onclick = () => showDetails(testName, runData, testStats, testId);
+                card.tabIndex = 0;
+                card.role = 'button';
+                card.ariaLabel = `View details for ${formatTestName(testName)}`;
+                card.onkeydown = (e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        showDetails(testName, runData, testStats, testId);
+                    }
+                };
                 card.innerHTML = `
                     <h3>${formatTestName(testName)}</h3>
                     <div class="pass-rate-bar">

--- a/eval-view/landing.css
+++ b/eval-view/landing.css
@@ -24,6 +24,12 @@
   transition: background-color 0.2s;
 }
 
+.suite-table-row:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: -2px;
+  background-color: var(--bg-tertiary);
+}
+
 .header-filter-select {
   margin-left: 8px;
   font-size: 0.85em;

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -407,7 +407,7 @@ function renderSuites() {
         const localLink = `dashboard.html?testId=${testId}&source=${testInfo.source}`;
 
         html += `
-            <tr class="suite-table-row" onclick="window.location.href='${localLink}'" style="cursor: pointer;">
+            <tr class="suite-table-row" onclick="window.location.href='${localLink}'" onkeydown="if(event.key === 'Enter' || event.key === ' ') { event.preventDefault(); window.location.href='${localLink}'; }" tabindex="0" role="link" aria-label="View results for suite ${testId}" style="cursor: pointer;">
                 <td style="padding-left:15px; text-align: left; font-weight: 600;">${testId}</td>
                 <td style="text-transform: capitalize;">${testInfo.source}</td>
                 <td>${testInfo.agent}</td>


### PR DESCRIPTION
This PR implements a micro-UX improvement by adding keyboard accessibility to the core interactive elements of the Guidance Eval Dashboard (`eval-view`).

### 💡 What
- **Landing Page:** `suite-table-row` elements (which navigate to specific suite results) are now focusable via Tab, have `role="link"`, and respond to Enter/Space keys.
- **Dashboard Page:** `test-card` elements (which open the detailed results modal) are now focusable, have `role="button"`, and respond to Enter/Space keys.
- **Visual Feedback:** Added `:focus-visible` CSS rules to provide a clear, high-contrast focus indicator using the existing `--accent-color`.
- **Screen Reader Support:** Added descriptive `aria-label` attributes to these interactive elements.

### 🎯 Why
Previously, the dashboard relied exclusively on `onclick` handlers on non-semantic elements (`div`, `tr`). This made the interface inaccessible to keyboard users and screen reader users, who could not focus or interact with the test results.

### ♿ Accessibility
- Full keyboard navigation support (Tab, Enter, Space).
- Semantic roles and descriptive labels for assistive technologies.
- Clear visual focus states.

### ✅ Verification
- Verified with a Playwright script that elements are focusable and triggered by the keyboard.
- Ran `pnpm lint` and existing E2E tests (`pnpm test:e2e` in `eval-view`).
- Captured screenshots and video of the keyboard interactions.


---
*PR created automatically by Jules for task [6481822963771224982](https://jules.google.com/task/6481822963771224982) started by @pattishin*