### PR TITLE
Set lower default Playwright timeouts

### DIFF
--- a/guides/playwright.config.ts
+++ b/guides/playwright.config.ts
@@ -3,6 +3,8 @@ import * as path from 'path';
 import * as os from 'os';
 
 export default defineConfig({
+  timeout: 10000,
+  expect: { timeout: 3000 },
   testDir: '.',
   testMatch: '**/grader.ts',
   fullyParallel: false,


### PR DESCRIPTION
Make Playwright fail faster to speed up evals:

- 10s total timeout (was 30s)
- 3s for each `expect` timeout (was 5s)