### PR TITLE
dashboard polish: inline bars, radar tooltip, continuous color

### DIFF
--- a/eval-view/dashboard-layout.css
+++ b/eval-view/dashboard-layout.css
@@ -12,53 +12,9 @@
   --accent-warning: #d29922;
 }
 
-/* Tabs Navigation */
-.dashboard-tabs {
-  display: flex;
-  gap: 8px;
-  margin-bottom: 24px;
-  border-bottom: 1px solid var(--border-color);
-  padding-bottom: 0;
-}
-
-.tab-button {
-  background: transparent;
-  border: none;
-  color: var(--text-secondary);
-  padding: 12px 16px;
-  cursor: pointer;
-  font-size: 14px;
-  font-weight: 500;
-  position: relative;
-  transition: color 0.2s;
-}
-
-.tab-button:hover {
-  color: var(--text-primary);
-}
-
-.tab-button.active {
-  color: var(--text-primary);
-}
-
-.tab-button.active::after {
-  content: '';
-  position: absolute;
-  bottom: -1px;
-  left: 0;
-  width: 100%;
-  height: 2px;
-  background-color: var(--accent-orange, #f78166);
-}
-
 /* Tab Content Areas */
 .tab-content {
-  display: none;
   animation: fadeIn 0.2s ease-out;
-}
-
-.tab-content.active {
-  display: block;
 }
 
 @keyframes fadeIn {

--- a/eval-view/dashboard.js
+++ b/eval-view/dashboard.js
@@ -1,4 +1,4 @@
-import { getRunStats, getColor, escapeHtml, formatTestName, initGoogleAuth } from './utils.js';
+import { getRunStats, getColor, escapeHtml, formatTestName, initGoogleAuth, calculateRadarData } from './utils.js';
 import { ApiClient } from './api.js';
 import { RadarChart } from './radar.js';
 
@@ -822,48 +822,14 @@ async function viewDiff(setupPath, resultPath, testName, runNumber) {
 }
 
 function renderRadarChart(data, testId) {
-    const results = data.results;
-    const apps = {};
-
-    Object.keys(results).forEach(key => {
-        const parts = key.split(' - ');
-        if (parts.length !== 3) return;
-
-        const [appName, guide, runType] = parts;
-        const scenarioName = `${appName} (${guide})`;
-
-        if (!apps[scenarioName]) {
-            apps[scenarioName] = { guided: [], unguided: [] };
-        }
-
-        const runData = results[key];
-        const totalPassed = runData.reduce((acc, run) => acc + getRunStats(run.results).passed, 0);
-        const totalChecks = runData.reduce((acc, run) => acc + run.results.length, 0);
-        const avgRate = totalChecks > 0 ? (totalPassed / totalChecks) * 100 : 0;
-
-        if (runType === 'guided') {
-            apps[scenarioName].guided.push(avgRate);
-        } else if (runType === 'unguided') {
-            apps[scenarioName].unguided.push(avgRate);
-        }
-    });
-
-    const labels = Object.keys(apps).sort();
+    const { labels, guided, unguided } = calculateRadarData(data.results);
+    
     if (labels.length < 3) {
         document.getElementById('chart-section').classList.add('hidden');
         return;
     }
 
     document.getElementById('chart-section').classList.remove('hidden');
-
-    const guidedData = labels.map(label => {
-        const scores = apps[label].guided;
-        return scores.length > 0 ? Math.round(scores.reduce((a, b) => a + b, 0) / scores.length) : 0;
-    });
-    const unguidedData = labels.map(label => {
-        const scores = apps[label].unguided;
-        return scores.length > 0 ? Math.round(scores.reduce((a, b) => a + b, 0) / scores.length) : 0;
-    });
 
     const chart = new RadarChart('radar-chart', {
         size: 600,
@@ -876,14 +842,14 @@ function renderRadarChart(data, testId) {
         const runType = type.toLowerCase(); // "guided" or "unguided"
 
         // Find the original key in the results
-        const originalKey = Object.keys(results).find(key => {
+        const originalKey = Object.keys(data.results).find(key => {
             const parts = key.split(' - ');
             return `${parts[0]} (${parts[1]})` === scenarioName && parts[2] === runType;
         });
 
         if (originalKey) {
             const testName = originalKey;
-            const runData = results[testName];
+            const runData = data.results[testName];
             const testStats = data.stats[testName];
             showDetails(testName, runData, testStats, testId);
         }
@@ -894,14 +860,14 @@ function renderRadarChart(data, testId) {
         datasets: [
             {
                 label: 'Unguided',
-                data: unguidedData,
+                data: unguided,
                 backgroundColor: 'rgba(218, 54, 51, 0.2)',
                 borderColor: '#da3633',
                 onClick: handlePointClick
             },
             {
                 label: 'Guided',
-                data: guidedData,
+                data: guided,
                 backgroundColor: 'rgba(35, 134, 54, 0.2)',
                 borderColor: '#238636',
                 onClick: handlePointClick

--- a/eval-view/dashboard.js
+++ b/eval-view/dashboard.js
@@ -165,11 +165,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (closeBtn) closeBtn.onclick = closeModal;
 
     // Close on backdrop click
-    modal.addEventListener('click', (event) => {
-        if (event.target === modal) {
-            closeModal();
-        }
-    });
+    modal.addEventListener('click', (event) => event.target === modal && closeModal());
 
     // Handle Esc key or dialog close API
     modal.addEventListener('close', () => {

--- a/eval-view/dashboard.spec.js
+++ b/eval-view/dashboard.spec.js
@@ -7,10 +7,6 @@ test.describe('Eval View Dashboard', () => {
     // Check title
     await expect(page.locator('.landing-title')).toContainText('Guidance Evals');
 
-    // Check tabs exist
-    await expect(page.locator('.tab-button[data-tab="suites"]')).toBeVisible();
-    await expect(page.locator('.tab-button[data-tab="trends"]')).toBeVisible();
-
     // Check suites content
     await expect(page.locator('.suite-table-row').first()).toBeVisible();
   });

--- a/eval-view/index.html
+++ b/eval-view/index.html
@@ -60,37 +60,34 @@
               <th style="padding-left:15px; text-align: left;">Suite ID</th>
               <th style="padding-left:15px; text-align: left;">Date</th>
               <th>
-                <div class="header-cell-content">
-                  <span class="header-label">Agent</span>
-                  <select id="filter-agent" class="header-filter-select">
-                    <option value="all">All</option>
+                <select id="filter-agent" class="header-filter-select">
+                  <option value="all">Agent</option>
+                  <optgroup label="Select Agent">
                     <option value="jetski">jetski</option>
                     <option value="gemini_cli">gemini_cli</option>
                     <option value="claude_code">claude_code</option>
-                  </select>
-                </div>
+                  </optgroup>
+                </select>
               </th>
               <th>
-                <div class="header-cell-content">
-                  <span class="header-label">Serving</span>
-                  <select id="filter-skills" class="header-filter-select">
-                    <option value="all">All</option>
+                <select id="filter-skills" class="header-filter-select">
+                  <option value="all">Serving</option>
+                  <optgroup label="Select Architecture">
                     <option value="skills">Skills</option>
                     <option value="mcp">MCP</option>
-                  </select>
-                </div>
+                  </optgroup>
+                </select>
               </th>
               <th style="text-align: right; padding-right: 15px;">Guided</th>
               <th style="text-align: right; padding-right: 15px;">Unguided</th>
               <th>
-                <div class="header-cell-content">
-                  <span class="header-label">Source</span>
-                  <select id="filter-source" class="header-filter-select">
-                    <option value="all">All</option>
+                <select id="filter-source" class="header-filter-select">
+                  <option value="all">Source</option>
+                  <optgroup label="Select Source">
                     <option value="local">Local</option>
                     <option value="remote">Remote</option>
-                  </select>
-                </div>
+                  </optgroup>
+                </select>
               </th>
             </tr>
           </thead>

--- a/eval-view/index.html
+++ b/eval-view/index.html
@@ -58,16 +58,7 @@
           <thead>
             <tr>
               <th style="padding-left:15px; text-align: left;">Suite ID</th>
-              <th>
-                <div class="header-cell-content">
-                  <span class="header-label">Source</span>
-                  <select id="filter-source" class="header-filter-select">
-                    <option value="all">All</option>
-                    <option value="local">Local</option>
-                    <option value="remote">Remote</option>
-                  </select>
-                </div>
-              </th>
+              <th style="padding-left:15px; text-align: left;">Date</th>
               <th>
                 <div class="header-cell-content">
                   <span class="header-label">Agent</span>
@@ -91,7 +82,16 @@
               </th>
               <th style="text-align: right; padding-right: 15px;">Guided</th>
               <th style="text-align: right; padding-right: 15px;">Unguided</th>
-              <th style="padding-right:15px; text-align: right;">Date</th>
+              <th>
+                <div class="header-cell-content">
+                  <span class="header-label">Source</span>
+                  <select id="filter-source" class="header-filter-select">
+                    <option value="all">All</option>
+                    <option value="local">Local</option>
+                    <option value="remote">Remote</option>
+                  </select>
+                </div>
+              </th>
             </tr>
           </thead>
           <tbody id="suites-list">

--- a/eval-view/index.html
+++ b/eval-view/index.html
@@ -107,6 +107,7 @@
   </div>
 
   <div id="radar-tooltip-container" class="radar-tooltip-container hidden">
+    <div id="radar-tooltip-header"></div>
     <div id="radar-tooltip-chart" style="width: 300px; height: 300px;"></div>
   </div>
 

--- a/eval-view/index.html
+++ b/eval-view/index.html
@@ -47,10 +47,6 @@
       </div>
     </header>
 
-    <nav class="dashboard-tabs">
-      <button class="tab-button active" data-tab="suites">Suites</button>
-    </nav>
-
     <!-- Suites Tab -->
     <div id="suites-tab" class="tab-content active">
       <div class="suites-table-container">

--- a/eval-view/index.html
+++ b/eval-view/index.html
@@ -49,7 +49,6 @@
 
     <nav class="dashboard-tabs">
       <button class="tab-button active" data-tab="suites">Suites</button>
-      <button class="tab-button" data-tab="trends">Trends</button>
     </nav>
 
     <!-- Suites Tab -->
@@ -59,27 +58,36 @@
           <thead>
             <tr>
               <th style="padding-left:15px; text-align: left;">Suite ID</th>
-              <th>Source
-                <select id="filter-source" class="header-filter-select">
-                  <option value="all">All</option>
-                  <option value="local">Local</option>
-                  <option value="remote">Remote</option>
-                </select>
+              <th>
+                <div class="header-cell-content">
+                  <span class="header-label">Source</span>
+                  <select id="filter-source" class="header-filter-select">
+                    <option value="all">All</option>
+                    <option value="local">Local</option>
+                    <option value="remote">Remote</option>
+                  </select>
+                </div>
               </th>
-              <th>Agent
-                <select id="filter-agent" class="header-filter-select">
-                  <option value="all">All</option>
-                  <option value="jetski">jetski</option>
-                  <option value="gemini_cli">gemini_cli</option>
-                  <option value="claude_code">claude_code</option>
-                </select>
+              <th>
+                <div class="header-cell-content">
+                  <span class="header-label">Agent</span>
+                  <select id="filter-agent" class="header-filter-select">
+                    <option value="all">All</option>
+                    <option value="jetski">jetski</option>
+                    <option value="gemini_cli">gemini_cli</option>
+                    <option value="claude_code">claude_code</option>
+                  </select>
+                </div>
               </th>
-              <th>Serving
-                <select id="filter-skills" class="header-filter-select">
-                  <option value="all">All</option>
-                  <option value="skills">Skills</option>
-                  <option value="mcp">MCP</option>
-                </select>
+              <th>
+                <div class="header-cell-content">
+                  <span class="header-label">Serving</span>
+                  <select id="filter-skills" class="header-filter-select">
+                    <option value="all">All</option>
+                    <option value="skills">Skills</option>
+                    <option value="mcp">MCP</option>
+                  </select>
+                </div>
               </th>
               <th style="text-align: right; padding-right: 15px;">Guided</th>
               <th style="text-align: right; padding-right: 15px;">Unguided</th>
@@ -90,25 +98,6 @@
             <!-- populated by JS -->
           </tbody>
           </table>
-      </div>
-    </div>
-
-    <!-- Trends Tab -->
-    <div id="trends-tab" class="tab-content">
-      <div id="timeline-section" class="timeline-section">
-        <div class="timeline-header">
-          <h2>Overall Pass Rate Timeline</h2>
-          <span class="timeline-subtitle">(Latest First)</span>
-          </div>
-        <div class="timeline-group">
-          <div class="test-grid-label">Guided Pass Rate</div>
-          <div id="guided-timeline" class="timeline-chart"></div>
-        </div>
-
-        <div class="timeline-group">
-          <div class="test-grid-label">Unguided Pass Rate</div>
-          <div id="unguided-timeline" class="timeline-chart"></div>
-        </div>
       </div>
     </div>
 

--- a/eval-view/index.html
+++ b/eval-view/index.html
@@ -117,6 +117,10 @@
     </div>
   </div>
 
+  <div id="radar-tooltip-container" class="radar-tooltip-container hidden">
+    <div id="radar-tooltip-chart" style="width: 300px; height: 300px;"></div>
+  </div>
+
   <script type="module" src="landing.js"></script>
 </body>
 </html>

--- a/eval-view/index.html
+++ b/eval-view/index.html
@@ -81,8 +81,8 @@
                   <option value="mcp">MCP</option>
                 </select>
               </th>
-              <th>Guided</th>
-              <th>Unguided</th>
+              <th style="text-align: right; padding-right: 15px;">Guided</th>
+              <th style="text-align: right; padding-right: 15px;">Unguided</th>
               <th style="padding-right:15px; text-align: right;">Date</th>
             </tr>
           </thead>

--- a/eval-view/landing.css
+++ b/eval-view/landing.css
@@ -28,7 +28,7 @@
 }
 
 .suites-table td {
-  padding: 16px 10px;
+  padding: 0 10px;
   border-bottom: 1px solid var(--border-color);
   text-align: center;
 }

--- a/eval-view/landing.css
+++ b/eval-view/landing.css
@@ -523,3 +523,29 @@
   background: var(--bg-tertiary);
   border-color: var(--text-secondary);
 }
+
+.rate-cell {
+  position: relative;
+  z-index: 1;
+  padding: 0 !important;
+  vertical-align: middle;
+}
+
+.rate-bar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  background-color: var(--text-secondary);
+  opacity: 0.12;
+  z-index: -1;
+}
+
+.rate-value {
+  position: relative;
+  display: block;
+  padding: 16px 10px;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+}

--- a/eval-view/landing.css
+++ b/eval-view/landing.css
@@ -534,7 +534,7 @@
 .rate-bar {
   position: absolute;
   top: 0;
-  left: 0;
+  right: 0;
   height: 100%;
   background-color: var(--text-secondary);
   opacity: 0.12;

--- a/eval-view/landing.css
+++ b/eval-view/landing.css
@@ -13,6 +13,20 @@
   text-align: center;
 }
 
+.header-cell-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+.header-label {
+  font-size: 0.85em;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-secondary);
+}
+
 .suites-table td {
   padding: 16px 10px;
   border-bottom: 1px solid var(--border-color);
@@ -25,7 +39,6 @@
 }
 
 .header-filter-select {
-  margin-left: 8px;
   font-size: 0.85em;
   padding: 4px 8px;
   border-radius: 6px;
@@ -44,6 +57,8 @@
   background-position: right 8px center;
   background-size: 1em;
   padding-right: 28px;
+  width: 100%;
+  max-width: 120px;
 }
 
 .header-filter-select:hover {

--- a/eval-view/landing.css
+++ b/eval-view/landing.css
@@ -564,6 +564,26 @@
   display: block;
 }
 
+.radar-tooltip-title {
+  font-size: 0.9em;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 300px;
+}
+
+.radar-tooltip-subtitle {
+  font-size: 0.75em;
+  color: var(--text-secondary);
+  margin-bottom: 10px;
+  border-bottom: 1px solid var(--border-color);
+  padding-bottom: 8px;
+  text-transform: capitalize;
+}
+
 .rate-cell {
   position: relative;
   z-index: 1;

--- a/eval-view/landing.css
+++ b/eval-view/landing.css
@@ -544,8 +544,9 @@
 .rate-value {
   position: relative;
   display: block;
-  padding: 16px 10px;
+  padding: 16px 15px;
   width: 100%;
   height: 100%;
   box-sizing: border-box;
+  text-align: right;
 }

--- a/eval-view/landing.css
+++ b/eval-view/landing.css
@@ -13,20 +13,6 @@
   text-align: center;
 }
 
-.header-cell-content {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 6px;
-}
-
-.header-label {
-  font-size: 0.85em;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  color: var(--text-secondary);
-}
-
 .suites-table td {
   padding: 0 10px;
   border-bottom: 1px solid var(--border-color);
@@ -44,10 +30,13 @@
   border-radius: 6px;
   background-color: var(--bg-secondary);
   border: 1px solid var(--border-color);
-  color: var(--text-primary);
+  color: var(--text-secondary);
   cursor: pointer;
   outline: none;
   transition: all 0.2s;
+  font-weight: 600;
+  text-transform: uppercase;
+  text-align: center;
   /* Appearance for custom dropdown arrow spacing */
   -webkit-appearance: none;
   -moz-appearance: none;
@@ -58,12 +47,25 @@
   background-size: 1em;
   padding-right: 28px;
   width: 100%;
-  max-width: 120px;
+  max-width: 130px;
+}
+
+.header-filter-select optgroup {
+  text-transform: none;
+  font-weight: normal;
+  text-align: left;
+}
+
+.header-filter-select option {
+  text-transform: none;
+  font-weight: normal;
+  text-align: left;
 }
 
 .header-filter-select:hover {
   background-color: var(--bg-tertiary);
   border-color: var(--text-secondary);
+  color: var(--text-primary);
 }
 .landing-container {
   max-width: 1400px;

--- a/eval-view/landing.css
+++ b/eval-view/landing.css
@@ -524,6 +524,31 @@
   border-color: var(--text-secondary);
 }
 
+.radar-tooltip-container {
+  position: fixed;
+  z-index: 2000;
+  background: rgba(13, 17, 23, 0.95);
+  backdrop-filter: blur(8px);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+  pointer-events: none;
+  padding: 15px;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  transform: translateY(10px);
+}
+
+.radar-tooltip-container.hidden {
+  opacity: 0;
+  display: none;
+}
+
+.radar-tooltip-container:not(.hidden) {
+  opacity: 1;
+  transform: translateY(0);
+  display: block;
+}
+
 .rate-cell {
   position: relative;
   z-index: 1;

--- a/eval-view/landing.css
+++ b/eval-view/landing.css
@@ -581,7 +581,6 @@
   margin-bottom: 10px;
   border-bottom: 1px solid var(--border-color);
   padding-bottom: 8px;
-  text-transform: capitalize;
 }
 
 .rate-cell {

--- a/eval-view/landing.css
+++ b/eval-view/landing.css
@@ -35,7 +35,6 @@
   outline: none;
   transition: all 0.2s;
   font-weight: 600;
-  text-transform: uppercase;
   text-align: center;
   /* Appearance for custom dropdown arrow spacing */
   -webkit-appearance: none;
@@ -47,7 +46,7 @@
   background-size: 1em;
   padding-right: 28px;
   width: auto;
-  min-width: 80px;
+  min-width: 90px;
 }
 
 .header-filter-select.is-filtered {
@@ -57,13 +56,11 @@
 }
 
 .header-filter-select optgroup {
-  text-transform: none;
   font-weight: normal;
   text-align: left;
 }
 
 .header-filter-select option {
-  text-transform: none;
   font-weight: normal;
   text-align: left;
 }

--- a/eval-view/landing.css
+++ b/eval-view/landing.css
@@ -28,8 +28,8 @@
   font-size: 0.85em;
   padding: 4px 8px;
   border-radius: 6px;
-  background-color: var(--bg-secondary);
-  border: 1px solid var(--border-color);
+  background-color: transparent;
+  border: 1px solid transparent;
   color: var(--text-secondary);
   cursor: pointer;
   outline: none;
@@ -46,8 +46,14 @@
   background-position: right 8px center;
   background-size: 1em;
   padding-right: 28px;
-  width: 100%;
-  max-width: 130px;
+  width: auto;
+  min-width: 80px;
+}
+
+.header-filter-select.is-filtered {
+  background-color: var(--bg-secondary);
+  border-color: var(--accent-color);
+  color: var(--text-primary);
 }
 
 .header-filter-select optgroup {
@@ -63,9 +69,14 @@
 }
 
 .header-filter-select:hover {
-  background-color: var(--bg-tertiary);
-  border-color: var(--text-secondary);
+  background-color: var(--bg-secondary);
+  border-color: var(--border-color);
   color: var(--text-primary);
+}
+
+.header-filter-select.is-filtered:hover {
+  border-color: var(--accent-color);
+  filter: brightness(1.1);
 }
 .landing-container {
   max-width: 1400px;

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -87,9 +87,7 @@ window.addEventListener('popstate', () => {
 function setupTabs() {
     const tabs = document.querySelectorAll('.tab-button');
     tabs.forEach(tab => {
-        tab.addEventListener('click', () => {
-            activateTab(tab.dataset.tab);
-        });
+        tab.addEventListener('click', () => activateTab(tab.dataset.tab));
     });
 }
 
@@ -454,9 +452,7 @@ function setupRateCellHovers() {
 
         cell.addEventListener('mousemove', (e) => updateTooltipPosition(e.clientX, e.clientY));
 
-        cell.addEventListener('mouseleave', () => {
-            hideRadarTooltip();
-        });
+        cell.addEventListener('mouseleave', () => hideRadarTooltip());
     });
 }
 

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -1,4 +1,5 @@
 import { getRunStats, getColor, initGoogleAuth, authenticatedFetch, getAccessToken } from './utils.js';
+import { RadarChart } from './radar.js';
 
 let allTestData = {}; // Cache all test data by testId
 let currentTab = 'suites';
@@ -412,11 +413,11 @@ function renderSuites() {
                 <td style="text-transform: capitalize;">${testInfo.source}</td>
                 <td>${testInfo.agent}</td>
                 <td style="text-transform: capitalize;">${testInfo.servingArch.replace('mcp', 'MCP')}</td>
-                <td class="rate-cell">
+                <td class="rate-cell" data-compound-key="${compoundKey}">
                     <div class="rate-bar" style="width: ${gRate}%;"></div>
                     <div class="rate-value"><span style="font-weight: 700; color: ${getColor(gRate)};">${gRate}%</span></div>
                 </td>
-                <td class="rate-cell">
+                <td class="rate-cell" data-compound-key="${compoundKey}">
                     <div class="rate-bar" style="width: ${uRate}%;"></div>
                     <div class="rate-value"><span style="font-weight: 700; color: ${getColor(uRate)};">${uRate}%</span></div>
                 </td>
@@ -426,6 +427,120 @@ function renderSuites() {
     });
 
     container.innerHTML = html;
+    setupRateCellHovers();
+}
+
+let radarChartInstance = null;
+const tooltipContainer = document.getElementById('radar-tooltip-container');
+const tooltipChart = document.getElementById('radar-tooltip-chart');
+
+function setupRateCellHovers() {
+    const rateCells = document.querySelectorAll('.rate-cell');
+    rateCells.forEach(cell => {
+        cell.addEventListener('mouseenter', (e) => {
+            const compoundKey = cell.dataset.compoundKey;
+            const testInfo = allTestData[compoundKey];
+            if (!testInfo) return;
+
+            showRadarTooltip(testInfo, e.clientX, e.clientY);
+        });
+
+        cell.addEventListener('mousemove', (e) => {
+            updateTooltipPosition(e.clientX, e.clientY);
+        });
+
+        cell.addEventListener('mouseleave', () => {
+            hideRadarTooltip();
+        });
+    });
+}
+
+function showRadarTooltip(testInfo, x, y) {
+    const data = testInfo.data;
+    const results = data.results;
+    
+    // Extract scenarios (app + guide)
+    const apps = {};
+    Object.keys(results).forEach(key => {
+        const parts = key.split(' - ');
+        if (parts.length !== 3) return;
+        const [appName, guide, runType] = parts;
+        const scenarioName = `${appName} (${guide})`;
+        if (!apps[scenarioName]) apps[scenarioName] = { guided: [], unguided: [] };
+        
+        const runData = results[key];
+        const totalPassed = runData.reduce((acc, run) => acc + getRunStats(run.results).passed, 0);
+        const totalChecks = runData.reduce((acc, run) => acc + run.results.length, 0);
+        const avgRate = totalChecks > 0 ? (totalPassed / totalChecks) * 100 : 0;
+        
+        if (runType === 'guided') apps[scenarioName].guided.push(avgRate);
+        else if (runType === 'unguided') apps[scenarioName].unguided.push(avgRate);
+    });
+
+    const labels = Object.keys(apps).sort();
+    if (labels.length < 3) return; // Radar chart needs at least 3 axes
+
+    const guidedData = labels.map(l => {
+        const s = apps[l].guided;
+        return s.length > 0 ? Math.round(s.reduce((a, b) => a + b, 0) / s.length) : 0;
+    });
+    const unguidedData = labels.map(l => {
+        const s = apps[l].unguided;
+        return s.length > 0 ? Math.round(s.reduce((a, b) => a + b, 0) / s.length) : 0;
+    });
+
+    tooltipContainer.classList.remove('hidden');
+    updateTooltipPosition(x, y);
+
+    if (!radarChartInstance) {
+        radarChartInstance = new RadarChart('radar-tooltip-chart', {
+            size: 300,
+            padding: 40,
+            levels: 5
+        });
+    }
+
+    radarChartInstance.render({
+        labels: labels,
+        datasets: [
+            {
+                label: 'Unguided',
+                data: unguidedData,
+                backgroundColor: 'rgba(218, 54, 51, 0.2)',
+                borderColor: '#da3633'
+            },
+            {
+                label: 'Guided',
+                data: guidedData,
+                backgroundColor: 'rgba(35, 134, 54, 0.2)',
+                borderColor: '#238636'
+            }
+        ]
+    });
+}
+
+function updateTooltipPosition(x, y) {
+    const offset = 20;
+    let finalX = x + offset;
+    let finalY = y + offset;
+
+    // Boundary check
+    const tooltipWidth = 330; // 300px chart + padding
+    const tooltipHeight = 330;
+    
+    if (finalX + tooltipWidth > window.innerWidth) {
+        finalX = x - tooltipWidth - offset;
+    }
+    if (finalY + tooltipHeight > window.innerHeight) {
+        finalY = y - tooltipHeight - offset;
+    }
+
+    tooltipContainer.style.left = `${finalX}px`;
+    tooltipContainer.style.top = `${finalY}px`;
+}
+
+function hideRadarTooltip() {
+    tooltipContainer.classList.add('hidden');
 }
 
 

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -1,4 +1,4 @@
-import { getRunStats, getColor, initGoogleAuth, authenticatedFetch, getAccessToken, escapeHtml } from './utils.js';
+import { getRunStats, getColor, initGoogleAuth, authenticatedFetch, getAccessToken, escapeHtml, timeAgo } from './utils.js';
 import { RadarChart } from './radar.js';
 
 let allTestData = {}; // Cache all test data by testId
@@ -402,6 +402,7 @@ function renderSuites() {
         const uRate = uStats.total > 0 ? Math.round((uStats.passed / uStats.total) * 100) : 0;
 
         const localLink = `dashboard.html?testId=${testId}&source=${testInfo.source}`;
+        const timeAgoStr = timeAgo(_date);
 
         html += `
             <tr class="suite-table-row" onclick="window.location.href='${localLink}'" style="cursor: pointer;">
@@ -417,7 +418,10 @@ function renderSuites() {
                     <div class="rate-bar" style="width: ${uRate}%;"></div>
                     <div class="rate-value"><span style="font-weight: 700; color: ${getColor(uRate)};">${uRate}%</span></div>
                 </td>
-                <td style="padding-right:15px; text-align: right; color: var(--text-secondary); font-size: 0.85rem;">${prettyTimestampStr}</td>
+                <td style="padding-right:15px; text-align: right; font-size: 0.85rem;">
+                    <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 2px;">${timeAgoStr}</div>
+                    <div style="color: var(--text-secondary); font-size: 0.8em;">${prettyTimestampStr}</div>
+                </td>
             </tr>
         `;
     });

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -1,4 +1,4 @@
-import { getRunStats, getColor, initGoogleAuth, authenticatedFetch, getAccessToken, escapeHtml, timeAgo } from './utils.js';
+import { getRunStats, getColor, initGoogleAuth, authenticatedFetch, getAccessToken, escapeHtml, timeAgo, calculateRadarData } from './utils.js';
 import { RadarChart } from './radar.js';
 
 let allTestData = {}; // Cache all test data by testId
@@ -474,71 +474,27 @@ function showRadarTooltip(testInfo, x, y, compoundKey) {
     if (headerDiv) {
         headerDiv.innerHTML = `
             <div class="radar-tooltip-title">${escapeHtml(testInfo.testId)}</div>
-            <div class="radar-tooltip-subtitle">${escapeHtml(testInfo.agent)} • ${escapeHtml(testInfo.servingArch)}</div>
+            <div class="radar-tooltip-subtitle">${escapeHtml(testInfo.agent)} • ${escapeHtml(testInfo.servingArch.replace('mcp', 'MCP'))}</div>
         `;
     }
 
-    const data = testInfo.data;
-    const results = data.results;
-    
-    // Extract scenarios (app + guide)
-    const apps = {};
-    Object.keys(results).forEach(key => {
-        const parts = key.split(' - ');
-        if (parts.length !== 3) return;
-        const [appName, guide, runType] = parts;
-        const scenarioName = `${appName} (${guide})`;
-        if (!apps[scenarioName]) apps[scenarioName] = { guided: [], unguided: [] };
-        
-        const runData = results[key];
-        const totalPassed = runData.reduce((acc, run) => acc + getRunStats(run.results).passed, 0);
-        const totalChecks = runData.reduce((acc, run) => acc + run.results.length, 0);
-        const avgRate = totalChecks > 0 ? (totalPassed / totalChecks) * 100 : 0;
-        
-        if (runType === 'guided') apps[scenarioName].guided.push(avgRate);
-        else if (runType === 'unguided') apps[scenarioName].unguided.push(avgRate);
-    });
-
-    const labels = Object.keys(apps).sort();
-    if (labels.length < 3) return; // Radar chart needs at least 3 axes
-
-    const guidedData = labels.map(l => {
-        const s = apps[l].guided;
-        return s.length > 0 ? Math.round(s.reduce((a, b) => a + b, 0) / s.length) : 0;
-    });
-    const unguidedData = labels.map(l => {
-        const s = apps[l].unguided;
-        return s.length > 0 ? Math.round(s.reduce((a, b) => a + b, 0) / s.length) : 0;
-    });
+    const { labels, guided, unguided } = calculateRadarData(testInfo.data.results);
+    if (labels.length < 3) return;
 
     tooltipContainer.classList.remove('hidden');
     updateTooltipPosition(x, y);
 
     if (!radarChartInstance) {
         radarChartInstance = new RadarChart('radar-tooltip-chart', {
-            size: 300,
-            padding: 20,
-            levels: 5,
-            hideLabels: true,
-            hideLegend: true
+            size: 300, padding: 20, levels: 5, hideLabels: true, hideLegend: true
         });
     }
 
     radarChartInstance.render({
-        labels: labels,
+        labels,
         datasets: [
-            {
-                label: 'Unguided',
-                data: unguidedData,
-                backgroundColor: 'rgba(218, 54, 51, 0.2)',
-                borderColor: '#da3633'
-            },
-            {
-                label: 'Guided',
-                data: guidedData,
-                backgroundColor: 'rgba(35, 134, 54, 0.2)',
-                borderColor: '#238636'
-            }
+            { label: 'Unguided', data: unguided, backgroundColor: 'rgba(218, 54, 51, 0.2)', borderColor: '#da3633' },
+            { label: 'Guided', data: guided, backgroundColor: 'rgba(35, 134, 54, 0.2)', borderColor: '#238636' }
         ]
     });
 }

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -406,7 +406,10 @@ function renderSuites() {
         html += `
             <tr class="suite-table-row" onclick="window.location.href='${localLink}'" style="cursor: pointer;">
                 <td style="padding-left:15px; text-align: left; font-weight: 600;">${testId}</td>
-                <td style="text-transform: capitalize;">${testInfo.source}</td>
+                <td style="padding-left:15px; text-align: left; font-size: 0.85rem;">
+                    <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 2px;">${timeAgoStr}</div>
+                    <div style="color: var(--text-secondary); font-size: 0.8em;">${prettyTimestampStr}</div>
+                </td>
                 <td>${testInfo.agent}</td>
                 <td style="text-transform: capitalize;">${testInfo.servingArch.replace('mcp', 'MCP')}</td>
                 <td class="rate-cell" data-compound-key="${compoundKey}">
@@ -417,10 +420,7 @@ function renderSuites() {
                     <div class="rate-bar" style="width: ${uRate}%;"></div>
                     <div class="rate-value"><span style="font-weight: 700; color: ${getColor(uRate)};">${uRate}%</span></div>
                 </td>
-                <td style="padding-right:15px; text-align: right; font-size: 0.85rem;">
-                    <div style="font-weight: 600; color: var(--text-primary); margin-bottom: 2px;">${timeAgoStr}</div>
-                    <div style="color: var(--text-secondary); font-size: 0.8em;">${prettyTimestampStr}</div>
-                </td>
+                <td style="text-transform: capitalize;">${testInfo.source}</td>
             </tr>
         `;
     });

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -180,22 +180,26 @@ function setupTestFilters() {
 }
 
 function setupTableFilters() {
-    const filterSource = document.getElementById('filter-source');
-    const filterAgent = document.getElementById('filter-agent');
-    const filterSkills = document.getElementById('filter-skills');
+    const filters = {
+        'filter-source': (val) => currentSourceFilter = val,
+        'filter-agent': (val) => currentAgentFilter = val,
+        'filter-skills': (val) => currentSkillsFilter = val
+    };
 
-    if (filterSource) filterSource.addEventListener('change', (e) => {
-        currentSourceFilter = e.target.value;
-        renderSuites();
+    Object.entries(filters).forEach(([id, updateFn]) => {
+        const el = document.getElementById(id);
+        if (!el) return;
+        el.addEventListener('change', (e) => {
+            updateFn(e.target.value);
+            syncSelectStyles(e.target);
+            renderSuites();
+        });
+        syncSelectStyles(el);
     });
-    if (filterAgent) filterAgent.addEventListener('change', (e) => {
-        currentAgentFilter = e.target.value;
-        renderSuites();
-    });
-    if (filterSkills) filterSkills.addEventListener('change', (e) => {
-        currentSkillsFilter = e.target.value;
-        renderSuites();
-    });
+}
+
+function syncSelectStyles(el) {
+    el.classList.toggle('is-filtered', el.value !== 'all');
 }
 
 

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -472,7 +472,7 @@ function showRadarTooltip(testInfo, x, y, compoundKey) {
     if (headerDiv) {
         headerDiv.innerHTML = `
             <div class="radar-tooltip-title">${escapeHtml(testInfo.testId)}</div>
-            <div class="radar-tooltip-subtitle">${escapeHtml(testInfo.agent)} • ${escapeHtml(testInfo.servingArch.replace('mcp', 'MCP'))}</div>
+            <div class="radar-tooltip-subtitle">${escapeHtml(testInfo.agent)} • ${escapeHtml(testInfo.servingArch)}</div>
         `;
     }
 

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -287,11 +287,12 @@ async function loadLocalTests() {
             if (suite.source !== 'local') continue;
             
             const testId = suite.id;
+            const suiteTimestamp = suite.timestamp;
             try {
                 const response = await fetch(`${testId}/evals.json?source=local&t=${Date.now()}`);
                 if (response.ok) {
                     const parsed = await response.json();
-                    registerTestData(testId, 'local', parsed);
+                    registerTestData(testId, 'local', parsed, suiteTimestamp);
                 }
             } catch (e) {
                 console.warn(`Failed to load local test ${testId}:`, e);
@@ -344,7 +345,7 @@ async function loadRemoteTests() {
     }
 }
 
-function registerTestData(testId, source, parsed) {
+function registerTestData(testId, source, parsed, forcedTimestamp) {
     let servingArch = 'unknown';
     if (parsed.enableSkills !== undefined) {
         servingArch = parsed.enableSkills ? 'skills' : 'mcp';
@@ -354,7 +355,7 @@ function registerTestData(testId, source, parsed) {
 
     allTestData[compoundKey] = {
         testId: testId,
-        timestamp: parsed.timestamp || new Date().toISOString(), // Fallback
+        timestamp: forcedTimestamp || parsed.timestamp || new Date().toISOString(),
         data: parsed,
         source: source,
         agent: parsed.agent || 'unknown',

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -429,6 +429,8 @@ function renderSuites() {
 }
 
 let radarChartInstance = null;
+let currentRadarKey = null;
+let hideTimeout = null;
 const tooltipContainer = document.getElementById('radar-tooltip-container');
 const tooltipChart = document.getElementById('radar-tooltip-chart');
 
@@ -440,7 +442,12 @@ function setupRateCellHovers() {
             const testInfo = allTestData[compoundKey];
             if (!testInfo) return;
 
-            showRadarTooltip(testInfo, e.clientX, e.clientY);
+            if (hideTimeout) {
+                clearTimeout(hideTimeout);
+                hideTimeout = null;
+            }
+
+            showRadarTooltip(testInfo, e.clientX, e.clientY, compoundKey);
         });
 
         cell.addEventListener('mousemove', (e) => {
@@ -453,7 +460,13 @@ function setupRateCellHovers() {
     });
 }
 
-function showRadarTooltip(testInfo, x, y) {
+function showRadarTooltip(testInfo, x, y, compoundKey) {
+    if (currentRadarKey === compoundKey && !tooltipContainer.classList.contains('hidden')) {
+        updateTooltipPosition(x, y);
+        return;
+    }
+
+    currentRadarKey = compoundKey;
     const data = testInfo.data;
     const results = data.results;
     
@@ -540,7 +553,12 @@ function updateTooltipPosition(x, y) {
 }
 
 function hideRadarTooltip() {
-    tooltipContainer.classList.add('hidden');
+    if (hideTimeout) clearTimeout(hideTimeout);
+    hideTimeout = setTimeout(() => {
+        currentRadarKey = null;
+        tooltipContainer.classList.add('hidden');
+        hideTimeout = null;
+    }, 50);
 }
 
 

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -495,8 +495,10 @@ function showRadarTooltip(testInfo, x, y) {
     if (!radarChartInstance) {
         radarChartInstance = new RadarChart('radar-tooltip-chart', {
             size: 300,
-            padding: 40,
-            levels: 5
+            padding: 20,
+            levels: 5,
+            hideLabels: true,
+            hideLegend: true
         });
     }
 

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -47,13 +47,12 @@ document.addEventListener('DOMContentLoaded', async () => {
         renderFilterMenuItems();
 
         const view = params.get('view');
-        if (view && ['overview', 'trends'].includes(view)) {
+        if (view && ['suites'].includes(view)) {
             activateTab(view, false);
         }
 
         // Initial Render
         renderSuites();
-        renderTrends();
 
     } catch (error) {
         console.error('Error:', error);
@@ -65,7 +64,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 window.addEventListener('popstate', () => {
     const params = new URLSearchParams(window.location.search);
     const view = params.get('view') || 'suites';
-    if (['suites', 'trends'].includes(view)) {
+    if (['suites'].includes(view)) {
         activateTab(view, false);
     }
 
@@ -267,7 +266,6 @@ function updateUrlParams() {
 
 function renderAll() {
     renderSuites();
-    renderTrends();
 }
 
 async function loadLocalTests() {
@@ -545,37 +543,6 @@ function hideRadarTooltip() {
     tooltipContainer.classList.add('hidden');
 }
 
-
-function renderTrends() {
-    const testIds = getSortedTestIds();
-    const guidedTimeline = document.getElementById('guided-timeline');
-    const unguidedTimeline = document.getElementById('unguided-timeline');
-
-    if (!guidedTimeline || !unguidedTimeline) return;
-
-    // Helper to render bars
-    const renderBars = (groupType) => {
-        return testIds.map(compoundTestId => {
-            const testInfo = allTestData[compoundTestId];
-            const testId = testInfo.testId;
-            const source = testInfo.source;
-            const data = testInfo.data;
-            const stats = calculateGroupTotalStats(data.results, groupType);
-            const value = stats.total > 0 ? Math.round((stats.passed / stats.total) * 100) : 0;
-            const timestamp = new Date(testInfo.timestamp).toLocaleString('en-US', { month: 'long', day: 'numeric', hour: 'numeric', minute: '2-digit', hour12: true }).replace(' at ', ', ');
-
-            return `
-                <a class="timeline-bar" href="dashboard.html?testId=${testId}&source=${source}" title="${testId} - ${timestamp}: ${value}%">
-                    <div class="timeline-bar-fill" style="height: ${Math.max(value * 2, 10)}px; background-color: ${getColor(value)}"></div>
-                    <div class="timeline-bar-label">${value}%</div>
-                </a>
-            `;
-        }).join('');
-    };
-
-    guidedTimeline.innerHTML = renderBars('guided');
-    unguidedTimeline.innerHTML = renderBars('unguided');
-}
 
 // ==========================================
 // HELPERS

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -1,4 +1,4 @@
-import { getRunStats, getColor, initGoogleAuth, authenticatedFetch, getAccessToken } from './utils.js';
+import { getRunStats, getColor, initGoogleAuth, authenticatedFetch, getAccessToken, escapeHtml } from './utils.js';
 import { RadarChart } from './radar.js';
 
 let allTestData = {}; // Cache all test data by testId
@@ -467,6 +467,15 @@ function showRadarTooltip(testInfo, x, y, compoundKey) {
     }
 
     currentRadarKey = compoundKey;
+
+    const headerDiv = document.getElementById('radar-tooltip-header');
+    if (headerDiv) {
+        headerDiv.innerHTML = `
+            <div class="radar-tooltip-title">${escapeHtml(testInfo.testId)}</div>
+            <div class="radar-tooltip-subtitle">${escapeHtml(testInfo.agent)} • ${escapeHtml(testInfo.servingArch.replace('mcp', 'MCP'))}</div>
+        `;
+    }
+
     const data = testInfo.data;
     const results = data.results;
     

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -184,9 +184,18 @@ function setupTableFilters() {
     const filterAgent = document.getElementById('filter-agent');
     const filterSkills = document.getElementById('filter-skills');
 
-    if (filterSource) filterSource.addEventListener('change', (e) => { currentSourceFilter = e.target.value; renderSuites(); });
-    if (filterAgent) filterAgent.addEventListener('change', (e) => { currentAgentFilter = e.target.value; renderSuites(); });
-    if (filterSkills) filterSkills.addEventListener('change', (e) => { currentSkillsFilter = e.target.value; renderSuites(); });
+    if (filterSource) filterSource.addEventListener('change', (e) => {
+        currentSourceFilter = e.target.value;
+        renderSuites();
+    });
+    if (filterAgent) filterAgent.addEventListener('change', (e) => {
+        currentAgentFilter = e.target.value;
+        renderSuites();
+    });
+    if (filterSkills) filterSkills.addEventListener('change', (e) => {
+        currentSkillsFilter = e.target.value;
+        renderSuites();
+    });
 }
 
 

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -435,7 +435,6 @@ let radarChartInstance = null;
 let currentRadarKey = null;
 let hideTimeout = null;
 const tooltipContainer = document.getElementById('radar-tooltip-container');
-const tooltipChart = document.getElementById('radar-tooltip-chart');
 
 function setupRateCellHovers() {
     const rateCells = document.querySelectorAll('.rate-cell');

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -412,9 +412,15 @@ function renderSuites() {
                 <td style="text-transform: capitalize;">${testInfo.source}</td>
                 <td>${testInfo.agent}</td>
                 <td style="text-transform: capitalize;">${testInfo.servingArch.replace('mcp', 'MCP')}</td>
-                <td><span style="font-weight: 700; color: ${getColor(gRate)};">${gRate}%</span></td>
-                <td><span style="font-weight: 700; color: ${getColor(uRate)};">${uRate}%</span></td>
-                <td style="padding-right:15px; text-align: right; color: var(--text-tertiary); font-size: 0.85rem;">${prettyTimestampStr}</td>
+                <td class="rate-cell">
+                    <div class="rate-bar" style="width: ${gRate}%;"></div>
+                    <div class="rate-value"><span style="font-weight: 700; color: ${getColor(gRate)};">${gRate}%</span></div>
+                </td>
+                <td class="rate-cell">
+                    <div class="rate-bar" style="width: ${uRate}%;"></div>
+                    <div class="rate-value"><span style="font-weight: 700; color: ${getColor(uRate)};">${uRate}%</span></div>
+                </td>
+                <td style="padding-right:15px; text-align: right; color: var(--text-secondary); font-size: 0.85rem;">${prettyTimestampStr}</td>
             </tr>
         `;
     });

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -315,13 +315,11 @@ async function loadRemoteTests() {
              document.getElementById('empty-state').style.display = 'none';
         }
 
-        // Load remote test data
-        for (const prefix of prefixes) {
+        // Load remote test data in parallel
+        await Promise.all(prefixes.map(async (prefix) => {
             const testId = prefix.slice(0, -1); // Remove trailing slash
-            
             try {
                 const fileUrl = `https://storage.googleapis.com/storage/v1/b/guidance-evals/o/${encodeURIComponent(prefix + 'evals.json')}?alt=media`;
-                
                 const response = await authenticatedFetch(fileUrl);
                 if (response.ok) {
                     const parsed = await response.json();
@@ -330,7 +328,7 @@ async function loadRemoteTests() {
             } catch (e) {
                 console.warn(`Failed to load remote test ${testId}:`, e);
             }
-        }
+        }));
         
         // Re-render UI now that we have remote data
         const params = new URLSearchParams(window.location.search);

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -452,9 +452,7 @@ function setupRateCellHovers() {
             showRadarTooltip(testInfo, e.clientX, e.clientY, compoundKey);
         });
 
-        cell.addEventListener('mousemove', (e) => {
-            updateTooltipPosition(e.clientX, e.clientY);
-        });
+        cell.addEventListener('mousemove', (e) => updateTooltipPosition(e.clientX, e.clientY));
 
         cell.addEventListener('mouseleave', () => {
             hideRadarTooltip();

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -11,7 +11,6 @@ let currentSkillsFilter = 'all';
 document.addEventListener('DOMContentLoaded', async () => {
     try {
         // Initialize UI
-        setupTabs();
         setupTestFilters(); // New filter setup
         setupTableFilters();
 
@@ -46,11 +45,6 @@ document.addEventListener('DOMContentLoaded', async () => {
         // Update filter UI to match initial state
         renderFilterMenuItems();
 
-        const view = params.get('view');
-        if (view && ['suites'].includes(view)) {
-            activateTab(view, false);
-        }
-
         // Initial Render
         renderSuites();
 
@@ -63,10 +57,6 @@ document.addEventListener('DOMContentLoaded', async () => {
 // Handle browser back/forward
 window.addEventListener('popstate', () => {
     const params = new URLSearchParams(window.location.search);
-    const view = params.get('view') || 'suites';
-    if (['suites'].includes(view)) {
-        activateTab(view, false);
-    }
 
     selectedTestIds = new Set(Object.keys(allTestData)); // Default to all
     const testsParam = params.get('tests');
@@ -83,47 +73,6 @@ window.addEventListener('popstate', () => {
     renderFilterMenuItems();
     renderAll();
 });
-
-function setupTabs() {
-    const tabs = document.querySelectorAll('.tab-button');
-    tabs.forEach(tab => {
-        tab.addEventListener('click', () => activateTab(tab.dataset.tab));
-    });
-}
-
-function activateTab(tabName, updateUrl = true) {
-    if (updateUrl && currentTab === tabName) return;
-
-    const tabs = document.querySelectorAll('.tab-button');
-
-    // Update active tab state
-    tabs.forEach(t => {
-        if (t.dataset.tab === tabName) {
-            t.classList.add('active');
-        } else {
-            t.classList.remove('active');
-        }
-    });
-
-    // Hide all content
-    document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
-
-    // Show selected content
-    const targetId = `${tabName}-tab`;
-    const targetContent = document.getElementById(targetId);
-    if (targetContent) {
-        targetContent.classList.add('active');
-    }
-
-    currentTab = tabName;
-
-    if (updateUrl) {
-        const url = new URL(window.location);
-        url.searchParams.set('view', tabName);
-        window.history.replaceState({}, '', url);
-    }
-}
-
 
 function setupTestFilters() {
     const filterBtn = document.getElementById('filter-btn');

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -2,7 +2,6 @@ import { getRunStats, getColor, initGoogleAuth, authenticatedFetch, getAccessTok
 import { RadarChart } from './radar.js';
 
 let allTestData = {}; // Cache all test data by testId
-let currentTab = 'suites';
 let selectedTestIds = new Set(); // Set of test IDs to show
 let currentSourceFilter = 'all';
 let currentAgentFilter = 'all';

--- a/eval-view/radar.js
+++ b/eval-view/radar.js
@@ -107,21 +107,8 @@ export class RadarChart {
         const cos = Math.cos(angle);
         const sin = Math.sin(angle);
 
-        if (Math.abs(cos) < 0.1) {
-          text.setAttribute("text-anchor", "middle");
-        } else if (cos > 0) {
-          text.setAttribute("text-anchor", "start");
-        } else {
-          text.setAttribute("text-anchor", "end");
-        }
-
-        if (Math.abs(sin) < 0.1) {
-          text.setAttribute("alignment-baseline", "middle");
-        } else if (sin > 0) {
-          text.setAttribute("alignment-baseline", "hanging");
-        } else {
-          text.setAttribute("alignment-baseline", "baseline");
-        }
+        text.setAttribute("text-anchor", Math.abs(cos) < 0.1 ? "middle" : (cos > 0 ? "start" : "end"));
+        text.setAttribute("alignment-baseline", Math.abs(sin) < 0.1 ? "middle" : (sin > 0 ? "hanging" : "baseline"));
 
         text.setAttribute("fill", "#c9d1d9");
         text.setAttribute("font-size", "11"); // Slightly smaller

--- a/eval-view/radar.js
+++ b/eval-view/radar.js
@@ -10,6 +10,8 @@ export class RadarChart {
       padding: options.padding || 60,
       levels: options.levels || 5,
       maxValue: options.maxValue || 100,
+      hideLabels: options.hideLabels || false,
+      hideLegend: options.hideLegend || false,
       ...options
     };
 
@@ -65,13 +67,15 @@ export class RadarChart {
       this.svg.appendChild(polygon);
 
       // Level labels
-      const labelText = document.createElementNS("http://www.w3.org/2000/svg", "text");
-      labelText.setAttribute("x", this.center + 5);
-      labelText.setAttribute("y", this.centerY - levelRadius + 4);
-      labelText.setAttribute("fill", "rgba(255, 255, 255, 0.3)");
-      labelText.setAttribute("font-size", "10");
-      labelText.textContent = Math.round((this.options.maxValue / this.options.levels) * level);
-      this.svg.appendChild(labelText);
+      if (!this.options.hideLabels) {
+        const labelText = document.createElementNS("http://www.w3.org/2000/svg", "text");
+        labelText.setAttribute("x", this.center + 5);
+        labelText.setAttribute("y", this.centerY - levelRadius + 4);
+        labelText.setAttribute("fill", "rgba(255, 255, 255, 0.3)");
+        labelText.setAttribute("font-size", "10");
+        labelText.textContent = Math.round((this.options.maxValue / this.options.levels) * level);
+        this.svg.appendChild(labelText);
+      }
     }
 
     // 2. Draw Axes
@@ -90,64 +94,66 @@ export class RadarChart {
       this.svg.appendChild(line);
 
       // Axis labels with smart positioning
-      const labelOffset = 30; // Slightly reduced to avoid edges
-      const labelX = this.center + (this.radius + labelOffset) * Math.cos(angle);
-      const labelY = this.centerY + (this.radius + labelOffset) * Math.sin(angle);
+      if (!this.options.hideLabels) {
+        const labelOffset = 30; // Slightly reduced to avoid edges
+        const labelX = this.center + (this.radius + labelOffset) * Math.cos(angle);
+        const labelY = this.centerY + (this.radius + labelOffset) * Math.sin(angle);
 
-      const text = document.createElementNS("http://www.w3.org/2000/svg", "text");
-      text.setAttribute("x", labelX);
-      text.setAttribute("y", labelY);
+        const text = document.createElementNS("http://www.w3.org/2000/svg", "text");
+        text.setAttribute("x", labelX);
+        text.setAttribute("y", labelY);
 
-      // Smart alignment based on angle
-      const cos = Math.cos(angle);
-      const sin = Math.sin(angle);
+        // Smart alignment based on angle
+        const cos = Math.cos(angle);
+        const sin = Math.sin(angle);
 
-      if (Math.abs(cos) < 0.1) {
-        text.setAttribute("text-anchor", "middle");
-      } else if (cos > 0) {
-        text.setAttribute("text-anchor", "start");
-      } else {
-        text.setAttribute("text-anchor", "end");
-      }
-
-      if (Math.abs(sin) < 0.1) {
-        text.setAttribute("alignment-baseline", "middle");
-      } else if (sin > 0) {
-        text.setAttribute("alignment-baseline", "hanging");
-      } else {
-        text.setAttribute("alignment-baseline", "baseline");
-      }
-
-      text.setAttribute("fill", "#c9d1d9");
-      text.setAttribute("font-size", "11"); // Slightly smaller
-      text.setAttribute("font-weight", "500");
-
-      // Extract use case ID from format "appName (useCaseId)", or use label as-is
-      let useCaseId = label;
-      const match = label.match(/\(([^)]+)\)$/);
-      if (match) {
-        useCaseId = match[1];
-      }
-
-      text.textContent = useCaseId;
-
-      text.onmouseover = () => {
-        text.setAttribute("fill", "#fff");
-        text.style.filter = "drop-shadow(0 0 4px rgba(255,255,255,0.4))";
-      };
-      text.onmouseout = () => {
-        text.setAttribute("fill", "#c9d1d9");
-        text.style.filter = "none";
-      };
-
-      text.onclick = () => {
-        const guidedSet = datasets.find(d => d.label === 'Guided');
-        if (guidedSet && guidedSet.onClick) {
-          guidedSet.onClick(i, 'Guided');
+        if (Math.abs(cos) < 0.1) {
+          text.setAttribute("text-anchor", "middle");
+        } else if (cos > 0) {
+          text.setAttribute("text-anchor", "start");
+        } else {
+          text.setAttribute("text-anchor", "end");
         }
-      };
 
-      this.svg.appendChild(text);
+        if (Math.abs(sin) < 0.1) {
+          text.setAttribute("alignment-baseline", "middle");
+        } else if (sin > 0) {
+          text.setAttribute("alignment-baseline", "hanging");
+        } else {
+          text.setAttribute("alignment-baseline", "baseline");
+        }
+
+        text.setAttribute("fill", "#c9d1d9");
+        text.setAttribute("font-size", "11"); // Slightly smaller
+        text.setAttribute("font-weight", "500");
+
+        // Extract use case ID from format "appName (useCaseId)", or use label as-is
+        let useCaseId = label;
+        const match = label.match(/\(([^)]+)\)$/);
+        if (match) {
+          useCaseId = match[1];
+        }
+
+        text.textContent = useCaseId;
+
+        text.onmouseover = () => {
+          text.setAttribute("fill", "#fff");
+          text.style.filter = "drop-shadow(0 0 4px rgba(255,255,255,0.4))";
+        };
+        text.onmouseout = () => {
+          text.setAttribute("fill", "#c9d1d9");
+          text.style.filter = "none";
+        };
+
+        text.onclick = () => {
+          const guidedSet = datasets.find(d => d.label === 'Guided');
+          if (guidedSet && guidedSet.onClick) {
+            guidedSet.onClick(i, 'Guided');
+          }
+        };
+
+        this.svg.appendChild(text);
+      }
     });
 
     // 3. Draw All Polygons First
@@ -265,7 +271,9 @@ export class RadarChart {
     this.svg.onmousemove = handleInteraction;
     this.svg.onmouseleave = hideTooltip;
 
-    this.renderLegend(datasets);
+    if (!this.options.hideLegend) {
+      this.renderLegend(datasets);
+    }
   }
 
   renderLegend(datasets) {

--- a/eval-view/server.js
+++ b/eval-view/server.js
@@ -62,7 +62,22 @@ const server = http.createServer(async (req, res) => {
         const dirs = fs.readdirSync(resultsDir, { withFileTypes: true })
           .filter(dirent => dirent.isDirectory() && dirent.name !== 'single_task')
           .map(dirent => dirent.name);
-        dirs.forEach(d => suitesList.push({ id: d, source: 'local' }));
+        
+        dirs.forEach(d => {
+          const suiteDir = path.join(resultsDir, d);
+          const evalsJsonPath = path.join(suiteDir, 'evals.json');
+          let timestamp = null;
+          try {
+            if (fs.existsSync(evalsJsonPath)) {
+              timestamp = fs.statSync(evalsJsonPath).mtime.toISOString();
+            } else {
+              timestamp = fs.statSync(suiteDir).mtime.toISOString();
+            }
+          } catch (e) {
+            timestamp = new Date().toISOString();
+          }
+          suitesList.push({ id: d, source: 'local', timestamp });
+        });
       }
     } catch (e) {
       console.error('Error reading local suites:', e.message);

--- a/eval-view/server.js
+++ b/eval-view/server.js
@@ -73,7 +73,7 @@ const server = http.createServer(async (req, res) => {
             } else {
               timestamp = fs.statSync(suiteDir).mtime.toISOString();
             }
-          } catch (e) {
+          } catch {
             timestamp = new Date().toISOString();
           }
           suitesList.push({ id: d, source: 'local', timestamp });

--- a/eval-view/utils.js
+++ b/eval-view/utils.js
@@ -44,6 +44,29 @@ export function capitalize(s) {
     return s.charAt(0).toUpperCase() + s.slice(1);
 }
 
+export function timeAgo(date) {
+    const now = new Date();
+    const diffInSeconds = Math.floor((now - new Date(date)) / 1000);
+    const rtf = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+
+    const units = [
+        { name: 'year', seconds: 31536000 },
+        { name: 'month', seconds: 2592000 },
+        { name: 'day', seconds: 86400 },
+        { name: 'hour', seconds: 3600 },
+        { name: 'minute', seconds: 60 },
+        { name: 'second', seconds: 1 }
+    ];
+
+    for (const unit of units) {
+        if (Math.abs(diffInSeconds) >= unit.seconds || unit.name === 'second') {
+            const value = Math.floor(diffInSeconds / unit.seconds);
+            return rtf.format(-value, unit.name);
+        }
+    }
+    return 'just now';
+}
+
 export function formatTestName(name) {
     if (!name) return name;
     return name.split(' - ').join(' / ');

--- a/eval-view/utils.js
+++ b/eval-view/utils.js
@@ -45,26 +45,35 @@ export function capitalize(s) {
 }
 
 export function timeAgo(date) {
-    const now = new Date();
-    const diffInSeconds = Math.floor((now - new Date(date)) / 1000);
+    const diff = Math.floor((new Date() - new Date(date)) / 1000);
     const rtf = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
-
     const units = [
-        { name: 'year', seconds: 31536000 },
-        { name: 'month', seconds: 2592000 },
-        { name: 'day', seconds: 86400 },
-        { name: 'hour', seconds: 3600 },
-        { name: 'minute', seconds: 60 },
-        { name: 'second', seconds: 1 }
+        { name: 'year', s: 31536000 }, { name: 'month', s: 2592000 },
+        { name: 'day', s: 86400 }, { name: 'hour', s: 3600 },
+        { name: 'minute', s: 60 }, { name: 'second', s: 1 }
     ];
+    const u = units.find(u => Math.abs(diff) >= u.s) || units[units.length - 1];
+    return rtf.format(-Math.floor(diff / u.s), u.name);
+}
 
-    for (const unit of units) {
-        if (Math.abs(diffInSeconds) >= unit.seconds || unit.name === 'second') {
-            const value = Math.floor(diffInSeconds / unit.seconds);
-            return rtf.format(-value, unit.name);
-        }
-    }
-    return 'just now';
+export function calculateRadarData(results) {
+    const apps = {};
+    Object.keys(results).forEach(key => {
+        const [appName, guide, runType] = key.split(' - ');
+        if (!runType) return;
+        const scenario = `${appName} (${guide})`;
+        if (!apps[scenario]) apps[scenario] = { guided: [], unguided: [] };
+        const runs = results[key];
+        const passed = runs.reduce((acc, r) => acc + getRunStats(r.results).passed, 0);
+        const total = runs.reduce((acc, r) => acc + r.results.length, 0);
+        apps[scenario][runType].push(total > 0 ? (passed / total) * 100 : 0);
+    });
+    const labels = Object.keys(apps).sort();
+    const getAvg = (l, type) => {
+        const s = apps[l][type];
+        return s.length > 0 ? Math.round(s.reduce((a, b) => a + b, 0) / s.length) : 0;
+    };
+    return { labels, guided: labels.map(l => getAvg(l, 'guided')), unguided: labels.map(l => getAvg(l, 'unguided')) };
 }
 
 export function formatTestName(name) {

--- a/eval-view/utils.js
+++ b/eval-view/utils.js
@@ -14,21 +14,21 @@ export function getColor(percentage) {
     const p = Math.max(0, Math.min(100, percentage));
     let l, c, h;
 
-    if (p <= 50) {
+    if (p <= 30) {
         // Constant Red
         l = 0.53; c = 0.18; h = 26;
     } else if (p >= 90) {
         // Constant Green
         l = 0.52; c = 0.13; h = 145;
-    } else if (p < 70) {
-        // 50% to 70%: Red to Yellow
-        const t = (p - 50) / 20;
+    } else if (p < 60) {
+        // 30% to 60%: Red to Yellow
+        const t = (p - 30) / 30;
         l = 0.53 + (0.72 - 0.53) * t;
         c = 0.18 + (0.15 - 0.18) * t;
         h = 26 + (74 - 26) * t;
     } else {
-        // 70% to 90%: Yellow to Green
-        const t = (p - 70) / 20;
+        // 60% to 90%: Yellow to Green
+        const t = (p - 60) / 30;
         l = 0.72 + (0.52 - 0.72) * t;
         c = 0.15 + (0.13 - 0.15) * t;
         h = 74 + (145 - 74) * t;

--- a/eval-view/utils.js
+++ b/eval-view/utils.js
@@ -12,28 +12,21 @@ export function getRunStats(checks) {
 
 export function getColor(percentage) {
     const p = Math.max(0, Math.min(100, percentage));
-    let l, c, h;
+    
+    const RED = 'oklch(53% 0.18 26)';
+    const YELLOW = 'oklch(72% 0.15 74)';
+    const GREEN = 'oklch(52% 0.13 145)';
 
-    if (p <= 30) {
-        // Constant Red
-        l = 0.53; c = 0.18; h = 26;
-    } else if (p >= 90) {
-        // Constant Green
-        l = 0.52; c = 0.13; h = 145;
-    } else if (p < 60) {
-        // 30% to 60%: Red to Yellow
-        const t = (p - 30) / 30;
-        l = 0.53 + (0.72 - 0.53) * t;
-        c = 0.18 + (0.15 - 0.18) * t;
-        h = 26 + (74 - 26) * t;
-    } else {
-        // 60% to 90%: Yellow to Green
-        const t = (p - 60) / 30;
-        l = 0.72 + (0.52 - 0.72) * t;
-        c = 0.15 + (0.13 - 0.15) * t;
-        h = 74 + (145 - 74) * t;
+    if (p <= 30) return RED;
+    if (p >= 90) return GREEN;
+    
+    if (p < 60) {
+        const mix = Math.round((p - 30) / 30 * 100);
+        return `color-mix(in oklch, ${RED}, ${YELLOW} ${mix}%)`;
     }
-    return `oklch(${Math.round(l * 100)}% ${c.toFixed(3)} ${Math.round(h)})`;
+    
+    const mix = Math.round((p - 60) / 30 * 100);
+    return `color-mix(in oklch, ${YELLOW}, ${GREEN} ${mix}%)`;
 }
 
 export function escapeHtml(text) {

--- a/eval-view/utils.js
+++ b/eval-view/utils.js
@@ -12,7 +12,7 @@ export function getRunStats(checks) {
 
 export function getColor(percentage) {
     if (percentage >= 90) return 'var(--accent-success)';
-    if (percentage >= 50) return '#dbab09';
+    if (percentage >= 50) return 'var(--accent-warning)';
     return 'var(--accent-failure)';
 }
 

--- a/eval-view/utils.js
+++ b/eval-view/utils.js
@@ -132,10 +132,7 @@ export function initGoogleAuth(onAuthSuccess) {
         });
 
         if (authBtn) {
-            authBtn.addEventListener('click', () => {
-                // Request an access token
-                tokenClient.requestAccessToken();
-            });
+            authBtn.addEventListener('click', () => tokenClient.requestAccessToken());
         }
     };
     init();

--- a/eval-view/utils.js
+++ b/eval-view/utils.js
@@ -11,9 +11,23 @@ export function getRunStats(checks) {
 }
 
 export function getColor(percentage) {
-    if (percentage >= 90) return 'var(--accent-success)';
-    if (percentage >= 50) return 'var(--accent-warning)';
-    return 'var(--accent-failure)';
+    const p = Math.max(0, Math.min(100, percentage)) / 100;
+    let l, c, h;
+
+    if (p < 0.5) {
+        // Red (oklch(55% 0.2 25)) to Yellow (oklch(85% 0.2 85))
+        const t = p / 0.5;
+        l = 0.55 + (0.85 - 0.55) * t;
+        c = 0.2;
+        h = 25 + (85 - 25) * t;
+    } else {
+        // Yellow (oklch(85% 0.2 85)) to Green (oklch(65% 0.2 145))
+        const t = (p - 0.5) / 0.5;
+        l = 0.85 + (0.65 - 0.85) * t;
+        c = 0.2;
+        h = 85 + (145 - 85) * t;
+    }
+    return `oklch(${Math.round(l * 100)}% ${c} ${Math.round(h)})`;
 }
 
 export function escapeHtml(text) {

--- a/eval-view/utils.js
+++ b/eval-view/utils.js
@@ -11,23 +11,28 @@ export function getRunStats(checks) {
 }
 
 export function getColor(percentage) {
-    const p = Math.max(0, Math.min(100, percentage)) / 100;
+    const p = Math.max(0, Math.min(100, percentage));
     let l, c, h;
 
-    if (p < 0.5) {
-        // Red (oklch(55% 0.2 25)) to Yellow (oklch(85% 0.2 85))
-        const t = p / 0.5;
-        l = 0.55 + (0.85 - 0.55) * t;
-        c = 0.2;
-        h = 25 + (85 - 25) * t;
+    if (p < 50) {
+        // 0% to 50%: Red to Yellow
+        const t = p / 50;
+        l = 0.53 + (0.72 - 0.53) * t;
+        c = 0.18 + (0.15 - 0.18) * t;
+        h = 26 + (74 - 26) * t;
+    } else if (p < 90) {
+        // 50% to 90%: Yellow to Green
+        const t = (p - 50) / 40;
+        l = 0.72 + (0.52 - 0.72) * t;
+        c = 0.15 + (0.13 - 0.15) * t;
+        h = 74 + (145 - 74) * t;
     } else {
-        // Yellow (oklch(85% 0.2 85)) to Green (oklch(65% 0.2 145))
-        const t = (p - 0.5) / 0.5;
-        l = 0.85 + (0.65 - 0.85) * t;
-        c = 0.2;
-        h = 85 + (145 - 85) * t;
+        // 90% to 100%: Green
+        l = 0.52;
+        c = 0.13;
+        h = 145;
     }
-    return `oklch(${Math.round(l * 100)}% ${c} ${Math.round(h)})`;
+    return `oklch(${Math.round(l * 100)}% ${c.toFixed(3)} ${Math.round(h)})`;
 }
 
 export function escapeHtml(text) {

--- a/eval-view/utils.js
+++ b/eval-view/utils.js
@@ -14,23 +14,24 @@ export function getColor(percentage) {
     const p = Math.max(0, Math.min(100, percentage));
     let l, c, h;
 
-    if (p < 50) {
-        // 0% to 50%: Red to Yellow
-        const t = p / 50;
+    if (p <= 50) {
+        // Constant Red
+        l = 0.53; c = 0.18; h = 26;
+    } else if (p >= 90) {
+        // Constant Green
+        l = 0.52; c = 0.13; h = 145;
+    } else if (p < 70) {
+        // 50% to 70%: Red to Yellow
+        const t = (p - 50) / 20;
         l = 0.53 + (0.72 - 0.53) * t;
         c = 0.18 + (0.15 - 0.18) * t;
         h = 26 + (74 - 26) * t;
-    } else if (p < 90) {
-        // 50% to 90%: Yellow to Green
-        const t = (p - 50) / 40;
+    } else {
+        // 70% to 90%: Yellow to Green
+        const t = (p - 70) / 20;
         l = 0.72 + (0.52 - 0.72) * t;
         c = 0.15 + (0.13 - 0.15) * t;
         h = 74 + (145 - 74) * t;
-    } else {
-        // 90% to 100%: Green
-        l = 0.52;
-        c = 0.13;
-        h = 145;
     }
     return `oklch(${Math.round(l * 100)}% ${c.toFixed(3)} ${Math.round(h)})`;
 }


### PR DESCRIPTION
Polished up the suites landing page with some fresh visual upgrades and UX tweaks:

<img width="1520" height="883" alt="image" src="https://github.com/user-attachments/assets/774f31f7-4217-4db1-a1a7-16d4744cb263" />


 - Visuals: Added subtle background "cell bars" barcharts to the Guided/Unguided cells and right-aligned the values/headers for a cleaner look.
 - Radar Tooltips: Hovering over pass rates now pops a simplified radar chart (labels/legend omitted) showing a scenario overview for that run.
 - Continuous Colors: Replaced hard thresholds with a smooth oklch scale via CSS color-mix. It's solid red below 30%, hits yellow at 60%, and turns solid green at 90%.    continuous so you get credit for going from 60 to 70%. 
 - UI Cleanup:
   - Added a modern "time ago" string above the detailed timestamps.
   - Ditched the "Trends" tab to keep the focus on the suites list.  the cell bars communicate the exst same thing
 - Perf & Fixes:
   - Remote suites now load in parallel via Promise.all. (SO MUCH faster)
   - Local tests now use actual file modification times instead of defaulting to Date.now().