### PR TITLE
Handle new project status "Needs investigation"

### DIFF
--- a/guides/sync-use-cases.test.ts
+++ b/guides/sync-use-cases.test.ts
@@ -280,6 +280,18 @@ describe('getIssueStateChanges', () => {
     assert.strictEqual(result.needsClose, false);
     assert.strictEqual(result.needsReopen, false);
   });
+
+  test('open issue stays open when complete but status is Needs investigation', () => {
+    const result = getIssueStateChanges('open', null, 'Needs investigation');
+    assert.strictEqual(result.needsClose, false);
+    assert.strictEqual(result.needsReopen, false);
+  });
+
+  test('closed issue reopens when complete but status is Needs investigation', () => {
+    const result = getIssueStateChanges('closed', null, 'Needs investigation');
+    assert.strictEqual(result.needsClose, false);
+    assert.strictEqual(result.needsReopen, true);
+  });
 });
 
 describe('getDesiredLabels', () => {

--- a/guides/sync-use-cases.test.ts
+++ b/guides/sync-use-cases.test.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import fs from 'fs';
 import os from 'os';
-import { validateGuide, getStatusName, getIssueStateChanges, getDesiredLabels, buildIssueContent, buildFeatureToIssueMap, buildUseCaseMaps, getFeaturesNeedingSync, buildUseCaseChecklist, updateFeatureIssueBody, processGuideInventory, USE_CASES_START, USE_CASES_END } from './sync-use-cases.ts';
+import { ProjectStatus, validateGuide, getStatusName, getIssueStateChanges, getDesiredLabels, buildIssueContent, buildFeatureToIssueMap, buildUseCaseMaps, getFeaturesNeedingSync, buildUseCaseChecklist, updateFeatureIssueBody, processGuideInventory, USE_CASES_START, USE_CASES_END } from './sync-use-cases.ts';
 import type { GuideInventory } from '../harness/lib/utils.ts';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -228,23 +228,23 @@ Body content.
 
 describe('getStatusName', () => {
   test('returns "Needs guidance" when guide body is empty', () => {
-    assert.strictEqual(getStatusName('', true, true), 'Needs guidance');
+    assert.strictEqual(getStatusName('', true, true), ProjectStatus.NeedsGuidance);
   });
 
   test('returns "Needs guidance" when guide body is only whitespace', () => {
-    assert.strictEqual(getStatusName('   \n\t  ', true, true), 'Needs guidance');
+    assert.strictEqual(getStatusName('   \n\t  ', true, true), ProjectStatus.NeedsGuidance);
   });
 
   test('returns "Needs evals" when grader is missing', () => {
-    assert.strictEqual(getStatusName('Some content.', false, true), 'Needs evals');
+    assert.strictEqual(getStatusName('Some content.', false, true), ProjectStatus.NeedsEvals);
   });
 
   test('returns "Needs evals" when prompts are missing', () => {
-    assert.strictEqual(getStatusName('Some content.', true, false), 'Needs evals');
+    assert.strictEqual(getStatusName('Some content.', true, false), ProjectStatus.NeedsEvals);
   });
 
   test('returns "Needs evals" when both grader and prompts are missing', () => {
-    assert.strictEqual(getStatusName('Some content.', false, false), 'Needs evals');
+    assert.strictEqual(getStatusName('Some content.', false, false), ProjectStatus.NeedsEvals);
   });
 
   test('returns null when guide is complete', () => {
@@ -252,13 +252,13 @@ describe('getStatusName', () => {
   });
 
   test('returns "Needs guidance" before "Needs evals" since guidance must come first', () => {
-    assert.strictEqual(getStatusName('', false, false), 'Needs guidance');
+    assert.strictEqual(getStatusName('', false, false), ProjectStatus.NeedsGuidance);
   });
 });
 
 describe('getIssueStateChanges', () => {
   test('open issue stays open when incomplete', () => {
-    const result = getIssueStateChanges('open', 'Needs guidance');
+    const result = getIssueStateChanges('open', ProjectStatus.NeedsGuidance);
     assert.strictEqual(result.needsClose, false);
     assert.strictEqual(result.needsReopen, false);
   });
@@ -270,7 +270,7 @@ describe('getIssueStateChanges', () => {
   });
 
   test('closed issue is reopened when incomplete', () => {
-    const result = getIssueStateChanges('closed', 'Needs evals');
+    const result = getIssueStateChanges('closed', ProjectStatus.NeedsEvals);
     assert.strictEqual(result.needsClose, false);
     assert.strictEqual(result.needsReopen, true);
   });
@@ -282,13 +282,13 @@ describe('getIssueStateChanges', () => {
   });
 
   test('open issue stays open when complete but status is Needs investigation', () => {
-    const result = getIssueStateChanges('open', null, 'Needs investigation');
+    const result = getIssueStateChanges('open', null, ProjectStatus.NeedsInvestigation);
     assert.strictEqual(result.needsClose, false);
     assert.strictEqual(result.needsReopen, false);
   });
 
   test('closed issue reopens when complete but status is Needs investigation', () => {
-    const result = getIssueStateChanges('closed', null, 'Needs investigation');
+    const result = getIssueStateChanges('closed', null, ProjectStatus.NeedsInvestigation);
     assert.strictEqual(result.needsClose, false);
     assert.strictEqual(result.needsReopen, true);
   });

--- a/guides/sync-use-cases.ts
+++ b/guides/sync-use-cases.ts
@@ -10,6 +10,15 @@ import { scanAllGuides, type GuideInventory } from '../harness/lib/utils.ts';
 
 // --- Types ---
 
+export const ProjectStatus = {
+  NeedsGuidance: 'Needs guidance',
+  NeedsEvals: 'Needs evals',
+  NeedsUseCases: 'Needs use cases',
+  NeedsInvestigation: 'Needs investigation',
+} as const;
+
+export type ProjectStatus = typeof ProjectStatus[keyof typeof ProjectStatus];
+
 interface GuideData {
   name?: string;
   description?: string;
@@ -50,7 +59,7 @@ export interface FeatureToSync {
   issueNumber: number;
   needsReopen: boolean;
   closeReason: 'completed' | null;
-  targetStatus: 'Needs use cases' | 'Needs evals' | null;
+  targetStatus: ProjectStatus | null;
 }
 
 interface ProjectDetails {
@@ -119,12 +128,12 @@ const projectOctokit: any = new Octokit({ auth: PROJECT_GITHUB_TOKEN });
  * Determines the project status name for a use case based on its completeness.
  * Returns null when the use case is complete.
  */
-export function getStatusName(guideBody: string, hasGrader: boolean, hasPrompts: boolean): string | null {
+export function getStatusName(guideBody: string, hasGrader: boolean, hasPrompts: boolean): ProjectStatus | null {
   if (guideBody.trim().length === 0) {
-    return 'Needs guidance';
+    return ProjectStatus.NeedsGuidance;
   }
   if (!hasGrader || !hasPrompts) {
-    return 'Needs evals';
+    return ProjectStatus.NeedsEvals;
   }
   return null;
 }
@@ -132,8 +141,8 @@ export function getStatusName(guideBody: string, hasGrader: boolean, hasPrompts:
 /**
  * Determines whether an existing issue needs to be closed or reopened.
  */
-export function getIssueStateChanges(currentState: 'open' | 'closed', statusName: string | null, currentProjectStatus?: string): { needsClose: boolean; needsReopen: boolean } {
-  const shouldBeOpen = statusName !== null || currentProjectStatus === 'Needs investigation';
+export function getIssueStateChanges(currentState: 'open' | 'closed', statusName: ProjectStatus | null, currentProjectStatus?: string): { needsClose: boolean; needsReopen: boolean } {
+  const shouldBeOpen = statusName !== null || currentProjectStatus === ProjectStatus.NeedsInvestigation;
   return {
     needsClose: !shouldBeOpen && currentState === 'open',
     needsReopen: shouldBeOpen && currentState === 'closed',
@@ -258,7 +267,7 @@ export function getFeaturesNeedingSync(
         issueNumber: featureData.number,
         needsReopen: featureData.state === 'closed',
         closeReason: null,
-        targetStatus: 'Needs evals',
+        targetStatus: ProjectStatus.NeedsEvals,
       });
     } else if (hasCompletedUseCases && featureData.state === 'open') {
       result.push({
@@ -274,7 +283,7 @@ export function getFeaturesNeedingSync(
         issueNumber: featureData.number,
         needsReopen: false,
         closeReason: null,
-        targetStatus: 'Needs use cases',
+        targetStatus: ProjectStatus.NeedsUseCases,
       });
     }
   }
@@ -736,6 +745,12 @@ async function processUseCases(
     const currentProjectStatus = existingIssueNumber ? projectDetails?.issueStatusMap.get(existingIssueNumber) : undefined;
 
     const { issueNumber, changed } = await syncIssue(name, existingIssue, issueTitle, issueBody, priorityLabel, milestoneNumber, statusName, activeIssueNumbers, currentProjectStatus);
+
+    if (currentProjectStatus === ProjectStatus.NeedsInvestigation) {
+      for (const id of featureIds) {
+        featuresWithActiveUseCases.add(id);
+      }
+    }
 
     for (const id of featureIds) {
       if (!featureUseCaseMap.has(id)) featureUseCaseMap.set(id, []);

--- a/guides/sync-use-cases.ts
+++ b/guides/sync-use-cases.ts
@@ -82,7 +82,7 @@ export interface PreparedGuide {
   description: string;
   featureIds: string[];
   relativeSubdir: string;
-  statusName: string | null;
+  statusName: ProjectStatus | null;
 }
 
 export interface GuideInventoryResult {
@@ -551,7 +551,7 @@ async function syncIssue(
   issueBody: string,
   priorityLabel: string | null,
   milestoneNumber: number | null,
-  statusName: string | null,
+  statusName: ProjectStatus | null,
   activeIssueNumbers: Set<number>,
   currentProjectStatus?: string
 ): Promise<{ issueNumber: number; changed: boolean }> {

--- a/guides/sync-use-cases.ts
+++ b/guides/sync-use-cases.ts
@@ -132,8 +132,8 @@ export function getStatusName(guideBody: string, hasGrader: boolean, hasPrompts:
 /**
  * Determines whether an existing issue needs to be closed or reopened.
  */
-export function getIssueStateChanges(currentState: 'open' | 'closed', statusName: string | null): { needsClose: boolean; needsReopen: boolean } {
-  const shouldBeOpen = statusName !== null;
+export function getIssueStateChanges(currentState: 'open' | 'closed', statusName: string | null, currentProjectStatus?: string): { needsClose: boolean; needsReopen: boolean } {
+  const shouldBeOpen = statusName !== null || currentProjectStatus === 'Needs investigation';
   return {
     needsClose: !shouldBeOpen && currentState === 'open',
     needsReopen: shouldBeOpen && currentState === 'closed',
@@ -543,10 +543,11 @@ async function syncIssue(
   priorityLabel: string | null,
   milestoneNumber: number | null,
   statusName: string | null,
-  activeIssueNumbers: Set<number>
+  activeIssueNumbers: Set<number>,
+  currentProjectStatus?: string
 ): Promise<{ issueNumber: number; changed: boolean }> {
   if (existingIssue) {
-    const { needsClose, needsReopen } = getIssueStateChanges(existingIssue.state, statusName);
+    const { needsClose, needsReopen } = getIssueStateChanges(existingIssue.state, statusName, currentProjectStatus);
     const currentLabels = (existingIssue.labels as any[]).map(l => typeof l === 'string' ? l : l.name);
     const desiredLabels = getDesiredLabels(currentLabels, priorityLabel);
     const labelsChanged = desiredLabels.length !== currentLabels.length || desiredLabels.some(l => !currentLabels.includes(l));
@@ -731,8 +732,10 @@ async function processUseCases(
   for (const { name, description, featureIds, relativeSubdir, statusName } of preparedGuides) {
     const { issueTitle, issueBody, priorityLabel, milestoneNumber } = buildIssueContent(name, description, featureIds, relativeSubdir, featureToIssueMap);
     const existingIssue = nameToIssueMap.get(name) || subdirToIssueMap.get(relativeSubdir);
+    const existingIssueNumber = existingIssue?.number;
+    const currentProjectStatus = existingIssueNumber ? projectDetails?.issueStatusMap.get(existingIssueNumber) : undefined;
 
-    const { issueNumber, changed } = await syncIssue(name, existingIssue, issueTitle, issueBody, priorityLabel, milestoneNumber, statusName, activeIssueNumbers);
+    const { issueNumber, changed } = await syncIssue(name, existingIssue, issueTitle, issueBody, priorityLabel, milestoneNumber, statusName, activeIssueNumbers, currentProjectStatus);
 
     for (const id of featureIds) {
       if (!featureUseCaseMap.has(id)) featureUseCaseMap.set(id, []);


### PR DESCRIPTION
1. **Don't Close:** If a use case would normally be closed by the script (because the files are all there and valid), the script will skip closing it if it sees the `Needs investigation` project status.
2. **Reopen:** If a use case issue was previously closed, but someone has set the project status to `Needs investigation`, the script will automatically **reopen** the issue on GitHub.

Same logic applies to feature issues. If a feature has a use case that is being investigated, it'll be considered active and the feature issue will stay open accordingly.

This clears the way for the eval pipeline to reopen use case issues if they're not performing well

cc @paulirish 