### PR TITLE
isolatedhome hardening

### DIFF
--- a/guides/performance/identify-heavy-scripts/grader.ts
+++ b/guides/performance/identify-heavy-scripts/grader.ts
@@ -61,7 +61,7 @@ test.describe(`Identify Heavy Scripts Expectations: ${demoName}`, () => {
             // version doesn't support the specific type yet.
             try {
               return originalObserve.apply(this, arguments as any);
-            } catch (e) {
+            } catch {
               // Swallow errors from the real API to keep the script running for the grader
             }
           };

--- a/harness/lib/agent-shared.ts
+++ b/harness/lib/agent-shared.ts
@@ -26,6 +26,11 @@ export function createIsolatedHome(prefix: string): string {
   // too long for valid Unix socket paths, which causes issues for some JetSki/VS Code components.
   const tempHome = `/tmp/${prefix}-${Math.random().toString(36).substring(7)}`;
   fs.mkdirSync(tempHome, { recursive: true });
+
+  // Provide authentication to the isolated environment so npm tasks work
+  const originalHome = process.env.HOME || process.cwd();
+  copyFileIfExists(path.join(originalHome, '.npmrc'), path.join(tempHome, '.npmrc'));
+
   console.log(`Setting up isolated HOME at ${tempHome}...`);
   return tempHome;
 }

--- a/harness/run_suite.ts
+++ b/harness/run_suite.ts
@@ -190,7 +190,7 @@ const args = [
     templateDir
   ])}
 ];
-const result = spawnSync('node', args, { stdio: 'inherit', cwd: ${JSON.stringify(process.cwd())} });
+const result = spawnSync(process.execPath, args, { stdio: 'inherit', cwd: ${JSON.stringify(process.cwd())} });
 process.exit(result.status ?? 0);
           `.trim();
           


### PR DESCRIPTION
two small things.

1. npmrc should get copied in to avoid npm registry issues (which i experience because google corp things)

2. use process.execPath instead of 'node' to harden against non-primary node versions being used in subprocesses.