### PR TITLE
oxlint: ignore unused catch variables

### DIFF
--- a/.agents/skills/project-skills-research/scripts/deep_research.js
+++ b/.agents/skills/project-skills-research/scripts/deep_research.js
@@ -11,7 +11,7 @@ if (!GEMINI_API_KEY) {
 const GEMINI_MODEL_DEEP_RESEARCH = 'deep-research-pro-preview-12-2025';
 const url = 'https://generativelanguage.googleapis.com/v1beta/interactions';
 
-const { values, positionals } = parseArgs({
+const { values } = parseArgs({
   options: {
     discipline: { type: 'string' },
     'interaction-id': { type: 'string' },

--- a/.agents/skills/project-skills-research/scripts/resolve_sources.js
+++ b/.agents/skills/project-skills-research/scripts/resolve_sources.js
@@ -43,7 +43,7 @@ async function main() {
 
   let text = fs.readFileSync(researchPath, 'utf8');
 
-  const regex = /(https:\/\/vertexaisearch\.cloud\.google\.com\/grounding-api-redirect\/[^\s\)]+)/g;
+  const regex = /(https:\/\/vertexaisearch\.cloud\.google\.com\/grounding-api-redirect\/[^\s)]+)/g;
   const matches = [...new Set(text.match(regex))]; // unique
 
   if (!matches.length) {

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -10,7 +10,8 @@
   },
   "rules": {
     "eslint(no-unused-vars)": ["error", {
-      "argsIgnorePattern": "^_"
+      "argsIgnorePattern": "^_",
+      "caughtErrors": "none"
     }],
     "eslint(no-undef)": "error",
     "no-undef": "error"

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -9,8 +9,9 @@
     "Diff": "readonly"
   },
   "rules": {
-    "no-unused-vars": ["warn", {
+    "no-unused-vars": ["error", {
       "argsIgnorePattern": "^_",
+      "varsIgnorePattern": "^_",
       "caughtErrorsIgnorePattern": "^.*$"
     }],
     "eslint(no-undef)": "error",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -9,9 +9,9 @@
     "Diff": "readonly"
   },
   "rules": {
-    "eslint(no-unused-vars)": ["error", {
+    "no-unused-vars": ["warn", {
       "argsIgnorePattern": "^_",
-      "caughtErrors": "none"
+      "caughtErrorsIgnorePattern": "^.*$"
     }],
     "eslint(no-undef)": "error",
     "no-undef": "error"


### PR DESCRIPTION
we're all annoyed by those lint errors. and honestly there's no diff between the before/after when this guy is addressed:

```js
} catch (e) { }
```

so.. we'll avoid getting those errors anymore. 

driveby fixing the remaining errors on main