### PR TITLE
smarter and quieter guide scan and build

### DIFF
--- a/harness/lib/utils.ts
+++ b/harness/lib/utils.ts
@@ -76,7 +76,6 @@ export function inventoryGuide(dir: string, taskMap: Map<string, TaskInfo>): Gui
   const hasExpectations = fs.existsSync(path.join(dir, EXPECTATIONS_FILE));
 
   const guideContent = readFileSafe(path.join(dir, GUIDE_FILE));
-  console.log(dir);
   let hasGuide = false;
   let isStub = false;
 

--- a/serving/scripts/build-guides.ts
+++ b/serving/scripts/build-guides.ts
@@ -31,7 +31,7 @@ async function processGuides() {
 
   const LANCE_DB_DIR = path.join(ROOT_DIR, ".modern-web-data");
 
-  if (!targetGuidePath && !force && fs.existsSync(OUTPUT_FILE) && fs.existsSync(BUILD_GUIDES_DIR) && fs.existsSync(LANCE_DB_DIR)) {
+  if (!targetGuidePath && !force && fs.existsSync(OUTPUT_FILE) && fs.existsSync(BUILD_GUIDES_DIR) && fs.existsSync(LANCE_DB_DIR) && fs.readdirSync(LANCE_DB_DIR).length > 0) {
     const outputFileMTime = fs.statSync(OUTPUT_FILE).mtimeMs;
     let anyGuideNewer = false;
     for (const inv of readyGuides) {

--- a/serving/scripts/build-guides.ts
+++ b/serving/scripts/build-guides.ts
@@ -23,6 +23,28 @@ interface UseCase {
 }
 
 async function processGuides() {
+  const targetGuidePath = process.argv.slice(2).find(arg => !arg.startsWith("--"));
+  const force = process.argv.includes("--force");
+
+  // Scan guides first to see if we even need to run
+  const readyGuides = scanAllGuides().filter(inv => classifyGuide(inv) === 'eval-ready');
+
+  if (!targetGuidePath && !force && fs.existsSync(OUTPUT_FILE)) {
+    const outputFileMTime = fs.statSync(OUTPUT_FILE).mtimeMs;
+    let anyGuideNewer = false;
+    for (const inv of readyGuides) {
+      const guidePath = path.join(inv.dir, "guide.md");
+      if (fs.existsSync(guidePath) && fs.statSync(guidePath).mtimeMs > outputFileMTime) {
+        anyGuideNewer = true;
+        break;
+      }
+    }
+    if (!anyGuideNewer) {
+      console.log("No guides modified since last build. Skipping guide build.");
+      return;
+    }
+  }
+
   // Ensure clean build/guides exists
   if (fs.existsSync(BUILD_GUIDES_DIR)) {
     fs.rmSync(BUILD_GUIDES_DIR, { recursive: true, force: true });
@@ -69,9 +91,6 @@ async function processGuides() {
     await processSingleGuideFile(guidePath, category, id, useCases, storeUseCases);
   } else {
     // Batch process all guides
-    console.log(`Scanning for guides in: ${GUIDES_DIR}`);
-    const readyGuides = scanAllGuides().filter(inv => classifyGuide(inv) === 'eval-ready');
-
     if (readyGuides.length === 0) {
       console.log("No guides found.");
     }

--- a/serving/scripts/build-guides.ts
+++ b/serving/scripts/build-guides.ts
@@ -34,15 +34,22 @@ async function processGuides() {
   if (!targetGuidePath && !force && fs.existsSync(OUTPUT_FILE) && fs.existsSync(BUILD_GUIDES_DIR) && fs.existsSync(LANCE_DB_DIR) && fs.readdirSync(LANCE_DB_DIR).length > 0) {
     const outputFileMTime = fs.statSync(OUTPUT_FILE).mtimeMs;
     let anyGuideNewer = false;
-    for (const inv of readyGuides) {
-      const guidePath = path.join(inv.dir, "guide.md");
-      if (fs.existsSync(guidePath) && fs.statSync(guidePath).mtimeMs > outputFileMTime) {
-        anyGuideNewer = true;
-        break;
+
+    // Also check if the build script itself was modified
+    if (fs.statSync(import.meta.filename).mtimeMs > outputFileMTime) {
+      anyGuideNewer = true;
+    } else {
+      for (const inv of readyGuides) {
+        const guidePath = path.join(inv.dir, "guide.md");
+        if (fs.existsSync(guidePath) && fs.statSync(guidePath).mtimeMs > outputFileMTime) {
+          anyGuideNewer = true;
+          break;
+        }
       }
     }
+
     if (!anyGuideNewer) {
-      console.log("No guides modified since last build. Skipping guide build.");
+      console.log("No guides or script modified since last build. Skipping guide build.");
       return;
     }
   }

--- a/serving/scripts/build-guides.ts
+++ b/serving/scripts/build-guides.ts
@@ -74,8 +74,6 @@ async function processGuides() {
   const store = new Store();
 
   // Check for target guide argument, ignoring flags
-  const targetGuidePath = process.argv.slice(2).find(arg => !arg.startsWith("--"));
-
   if (targetGuidePath) {
     // Single guide mode
     let absoluteTargetPath = path.resolve(ROOT_DIR, "..", targetGuidePath);

--- a/serving/scripts/build-guides.ts
+++ b/serving/scripts/build-guides.ts
@@ -29,7 +29,9 @@ async function processGuides() {
   // Scan guides first to see if we even need to run
   const readyGuides = scanAllGuides().filter(inv => classifyGuide(inv) === 'eval-ready');
 
-  if (!targetGuidePath && !force && fs.existsSync(OUTPUT_FILE) && fs.existsSync(BUILD_GUIDES_DIR)) {
+  const LANCE_DB_DIR = path.join(ROOT_DIR, ".modern-web-data");
+
+  if (!targetGuidePath && !force && fs.existsSync(OUTPUT_FILE) && fs.existsSync(BUILD_GUIDES_DIR) && fs.existsSync(LANCE_DB_DIR)) {
     const outputFileMTime = fs.statSync(OUTPUT_FILE).mtimeMs;
     let anyGuideNewer = false;
     for (const inv of readyGuides) {

--- a/serving/scripts/build-guides.ts
+++ b/serving/scripts/build-guides.ts
@@ -29,7 +29,7 @@ async function processGuides() {
   // Scan guides first to see if we even need to run
   const readyGuides = scanAllGuides().filter(inv => classifyGuide(inv) === 'eval-ready');
 
-  if (!targetGuidePath && !force && fs.existsSync(OUTPUT_FILE)) {
+  if (!targetGuidePath && !force && fs.existsSync(OUTPUT_FILE) && fs.existsSync(BUILD_GUIDES_DIR)) {
     const outputFileMTime = fs.statSync(OUTPUT_FILE).mtimeMs;
     let anyGuideNewer = false;
     for (const inv of readyGuides) {


### PR DESCRIPTION
- **Silence noise**: Dropped the verbose logs dumping every directory while scanning guides.  too many tokens!!
- **Smart builds**: `scripts/build-guides.ts` now exits in milliseconds if nothing changed. It skips the heavy Embedder init unless:
  - You add/edit a `guide.md` file.
  - Generated files (`use-cases.gen.ts`, `build/guides`, or `.modern-web-data`) are missing or empty.
  - you edit build-guides itself

Speeds up `dev`, `test`, and `typecheck` runs quite a bit! 