### PR TITLE
Add skill and build dist on dev

### DIFF
--- a/guides/dev-guide.ts
+++ b/guides/dev-guide.ts
@@ -14,7 +14,7 @@ import {
   createTrustedFolders,
   spawnAsync
 } from '../harness/lib/agent-shared.ts';
-import { environmentConfig } from '../harness/config.ts';
+import { environmentConfig, config, Serving } from '../harness/config.ts';
 import { cRed, cGreen, cYellow, cCyan, cBold, cDim } from '../lib/colors.ts';
 import {
   type GuideInventory,
@@ -321,11 +321,18 @@ async function runAgentTest(targetDir: string, guideName: string, taskMap: Map<s
   console.log(`Task: ${taskInfo.taskName} (base_app: ${taskInfo.baseApp})`);
   console.log(`Prompt: ${cDim(taskInfo.prompt.substring(0, 120))}${taskInfo.prompt.length > 120 ? '...' : ''}`);
 
-  // Step d: Build MCP index
-  console.log(`\nBuilding MCP index...`);
-  const buildCode = await spawnAsync('pnpm', ['build:mcp'], { cwd: rootDir, stdio: 'inherit' });
+  // Step d: Build workspace dependencies
+  let buildCode = 0;
+  if (config.suite.serving === Serving.MCP) {
+    console.log(`\nBuilding MCP index...`);
+    buildCode = await spawnAsync('pnpm', ['build:mcp'], { cwd: rootDir, stdio: 'inherit' });
+  } else if (config.suite.serving === Serving.SKILLS_CLI) {
+    console.log(`\nBuilding skills-cli dist...`);
+    buildCode = await spawnAsync('pnpm', ['--filter', 'modern-web-mcp', 'build-dist'], { cwd: rootDir, stdio: 'inherit' });
+  }
+
   if (buildCode !== 0) {
-    console.error(cRed(`Failed to build MCP index (exit code ${buildCode})`));
+    console.error(cRed(`Failed to build workspace dependencies (exit code ${buildCode})`));
     return;
   }
 

--- a/harness/lib/agent-shared.ts
+++ b/harness/lib/agent-shared.ts
@@ -205,7 +205,7 @@ export function copySkills(homeDir: string, agent: string, cli: boolean): boolea
   try {
     fs.mkdirSync(destDir, { recursive: true });
 
-    if (cli) { // Skills-cli mode
+    if (cli) { // Add modern-web-use-cases Skill from skills-cli dist
       const distSource = path.join(rootDir, 'dist/skills-cli/skills/modern-web-use-cases');
       if (!fs.existsSync(distSource)) {
         console.log(`skills-cli distribution not found at ${distSource}. Running 'pnpm --filter modern-web-mcp build-dist' automatically...`);
@@ -240,40 +240,41 @@ export function copySkills(homeDir: string, agent: string, cli: boolean): boolea
         console.error(`Failed to copy standalone skills-cli: ${e.message}`);
         return false;
       }
-    } else { // Skills-discipline mode
-      if (!fs.existsSync(guidesSource)) {
-        console.warn(`Warning: Guides directory not found at ${guidesSource}`);
-        return false;
+    }
+
+    // Skills-discipline mode
+    if (!fs.existsSync(guidesSource)) {
+      console.warn(`Warning: Guides directory not found at ${guidesSource}`);
+      return false;
+    }
+
+    // 1. Scan top-level directories for SKILL.md and copy them
+    const topLevelDirs = fs.readdirSync(guidesSource, { withFileTypes: true })
+      .filter(d => d.isDirectory() && !d.name.startsWith('.') && d.name !== 'node_modules');
+
+    for (const dir of topLevelDirs) {
+      const categorySrc = path.join(guidesSource, dir.name);
+      const categoryDest = path.join(destDir, dir.name);
+      const skillPath = path.join(categorySrc, 'SKILL.md');
+
+      if (fs.existsSync(skillPath)) {
+        fs.mkdirSync(categoryDest, { recursive: true });
+        fs.copyFileSync(skillPath, path.join(categoryDest, 'SKILL.md'));
       }
+    }
 
-      // 1. Scan top-level directories for SKILL.md and copy them
-      const topLevelDirs = fs.readdirSync(guidesSource, { withFileTypes: true })
-        .filter(d => d.isDirectory() && !d.name.startsWith('.') && d.name !== 'node_modules');
+    // 2. Scan and copy guide.md for eval-ready guides
+    const allGuides = scanAllGuides();
 
-      for (const dir of topLevelDirs) {
-        const categorySrc = path.join(guidesSource, dir.name);
-        const categoryDest = path.join(destDir, dir.name);
-        const skillPath = path.join(categorySrc, 'SKILL.md');
+    for (const inv of allGuides) {
+      if (classifyGuide(inv) === 'eval-ready') {
+        const catDest = path.join(destDir, inv.category);
+        const guideDest = path.join(catDest, inv.name);
+        fs.mkdirSync(guideDest, { recursive: true });
 
-        if (fs.existsSync(skillPath)) {
-          fs.mkdirSync(categoryDest, { recursive: true });
-          fs.copyFileSync(skillPath, path.join(categoryDest, 'SKILL.md'));
-        }
-      }
-
-      // 2. Scan and copy guide.md for eval-ready guides
-      const allGuides = scanAllGuides();
-
-      for (const inv of allGuides) {
-        if (classifyGuide(inv) === 'eval-ready') {
-          const catDest = path.join(destDir, inv.category);
-          const guideDest = path.join(catDest, inv.name);
-          fs.mkdirSync(guideDest, { recursive: true });
-
-          const guideFileSrc = path.join(inv.dir, 'guide.md');
-          const guideFileDest = path.join(guideDest, 'guide.md');
-          fs.copyFileSync(guideFileSrc, guideFileDest);
-        }
+        const guideFileSrc = path.join(inv.dir, 'guide.md');
+        const guideFileDest = path.join(guideDest, 'guide.md');
+        fs.copyFileSync(guideFileSrc, guideFileDest);
       }
     }
 


### PR DESCRIPTION
skills cli serving will now take any SKILL files in the disciple level folders and add them to the agent's skills (currently just `guides/forms/SKILL.md`)

rebuild the `dist/skills-cli` when running the agent test in `gd dev` workflow so the latest guides are added to the tool used by the agent