### PR TITLE
Gemini CLI custom policy

### DIFF
--- a/serving/skills-cli/template/policies/modern-web-use-cases.toml
+++ b/serving/skills-cli/template/policies/modern-web-use-cases.toml
@@ -1,0 +1,20 @@
+[[rule]]
+toolName = "run_shell_command"
+commandRegex = "setup.sh"
+decision = "allow"
+priority = 100
+modes = ["plan"]
+
+[[rule]]
+toolName = "run_shell_command"
+commandPrefix = ["npm install", "npm i"]
+decision = "allow"
+priority = 100
+modes = ["plan"]
+
+[[rule]]
+toolName = "run_shell_command"
+commandRegex = "modern-web"
+decision = "allow"
+priority = 100
+modes = ["plan"]


### PR DESCRIPTION
Adding a policy file for Gemini CLI so that it allows agents to execute commands needed by our skill while in Plan Mode, which is restricted to read-only tools by default.

https://geminicli.com/docs/cli/plan-mode/#custom-policies
https://github.com/gemini-cli-extensions/conductor/blob/main/policies/conductor.toml