### PR TITLE
fix: avoid random projects.json ENOENT failures during gd dev

### DIFF
--- a/harness/lib/agent-shared.ts
+++ b/harness/lib/agent-shared.ts
@@ -53,6 +53,20 @@ export function createIsolatedHome(prefix: string): string {
   const originalHome = process.env.HOME || process.cwd();
   copyFileIfExists(path.join(originalHome, '.npmrc'), path.join(tempHome, '.npmrc'));
 
+  // Pre-populate projects.json to prevent JetSki concurrent write race conditions
+  try {
+    const geminiDir = path.join(tempHome, '.gemini');
+    fs.mkdirSync(geminiDir, { recursive: true });
+    const mockProjects = {
+      projects: {
+        [path.join(tempHome, 'work')]: 'work'
+      }
+    };
+    fs.writeFileSync(path.join(geminiDir, 'projects.json'), JSON.stringify(mockProjects, null, 2));
+  } catch (err) {
+    console.warn('Warning: Failed to pre-populate projects.json:', err);
+  }
+
   console.log(`Setting up isolated HOME at ${tempHome}...`);
   return tempHome;
 }

--- a/harness/lib/agent-shared.ts
+++ b/harness/lib/agent-shared.ts
@@ -53,7 +53,7 @@ export function createIsolatedHome(prefix: string): string {
   const originalHome = process.env.HOME || process.cwd();
   copyFileIfExists(path.join(originalHome, '.npmrc'), path.join(tempHome, '.npmrc'));
 
-  // Pre-populate projects.json to prevent JetSki concurrent write race conditions
+  // Pre-populate projects.json to prevent concurrent write race conditions in geminicli. https://github.com/GoogleChrome/guidance/pull/479
   try {
     const geminiDir = path.join(tempHome, '.gemini');
     fs.mkdirSync(geminiDir, { recursive: true });


### PR DESCRIPTION
fixes the annoying projects.json ENOENT race condition when running gd dev (specifically inside isolated agent homes). 

before, multiple internal gemini tasks would race to rename the project list tmp file, crashing the dev run:

```txt
Failed to save project registry to /tmp/ghh-grader-gen-ceil8t/.gemini/projects.json: Error: ENOENT: no such file or directory, rename '/tmp/ghh-grader-gen-ceil8t/.gemini/projects.json.tmp' -> '/tmp/ghh-grader-gen-ceil8t/.gemini/projects.json'
    at async Object.rename (node:internal/fs/promises:781:10)
    at async ProjectRegistry.save (.../@google/gemini-cli-core/dist/src/config/projectRegistry.js:73:13)
    at async cleanupToolOutputFiles (.../@google/gemini-cli/dist/src/utils/sessionCleanup.js:268:13)
```

this simply pre-fills the expected json structure inside the isolated space before we boot the cli to prevent it entirely.


---------- 

As far as I can tell, this wasn't creating a problem for us, but it looked bad.  We're actually just fixing a bug in Gemini here.