### PR TITLE
Use case research skill (again)

### DIFF
--- a/.agents/skills/project-use-cases-research/SKILL.md
+++ b/.agents/skills/project-use-cases-research/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: project-use-cases-research
+description: Best practices and instructions for researching and authoring use-case level guidance (stage 1) for web platform features. Use this skill when you need to identify real-world developer problems solved by a specific web platform feature.
+---
+
+# Use Case Research: Identifying Use Cases for a Web Feature
+
+The primary goal of this skill is to define the process for researching a specific web platform feature and translating it into a carefully selected set of its most common and important developer use cases (Stage 1 of the Guidance Pipeline).
+
+## 1. Research
+
+When tasked with researching a web feature to identify use cases, you must execute a sequence combining standard agent-driven research and automated deep research (if needed).
+
+### Step 1: Gather Inputs
+Identify the target feature and any seed sources. Inputs typically come from a GitHub issue or explicit arguments.
+
+- **Feature ID**: Check the issue or arguments for the `web-features` ID (e.g., `fetch-later`, `bfcache`).
+- **Seed URLs**: Extract any URLs provided in the issue or arguments. These are your starting points.
+- **GitHub Issues**: If the feature ID is not clear, use the `gh` CLI to search for issues labeled `new-feature` to find context and seed URLs:
+  ```bash
+  gh issue list --repo GoogleChrome/guidance --label "new-feature"
+  ```
+
+### Step 2: Standard Agent Research
+Use your tools to find authoritative documentation and real-world implementations.
+
+1.  **MDN Web Docs**: Understand the API surface and technical constraints.
+2.  **Chrome Authoritative Guidance**: Search `developer.chrome.com` or `web.dev` for implementation articles.
+3.  **Specs/Explainers**: Check W3C specs or WICG explainers for architectural context.
+
+Save your research findings to `guides/.research/<feature-id>.md` (create the directory if it doesn't exist). Use this file to track your findings.
+
+### Step 3: Overlay Deep Research Enrichment (Optional)
+If standard research is insufficient or if specifically requested by the user, run the automated deep research tool to identify complex edge cases or emerging patterns.
+
+1.  **Run Deep Research**:
+    ```bash
+    node .agents/skills/project-use-cases-research/scripts/deep_research.js --feature-id <id>
+    ```
+2.  **Save Research Artifact**: The script will automatically save the output to `guides/.research/<feature-id>.md` (or similar).
+
+---
+
+## 2. Synthesis
+
+Once research is complete, synthesize the findings into distinct developer use cases.
+
+- **Apply the `project-use-cases` constraints**: Refer to `project-use-cases` skill for the authoritative rules on what constitutes a good use case (verb-first, WHAT-not-HOW).
+- **Generic and Common**: Ensure your use cases are generic enough to fit common developer needs, avoiding overly specific or contrived examples (e.g., prefer concepts like "Expose complex UI forms" over overly specific apps like a "Flight Search").
+- **Distinct Value Proposition**: Propose 2-5 distinct use cases. Do not duplicate existing guides. Check `guides/` for similar descriptions.
+- **Save Representative Sources**: For each usecase, select at least one implementation-focused source (not just API reference).
+
+---
+
+## 3. Scaffolding
+
+Automatically scaffold the initial files for the chosen use cases.
+
+### Step 1: Create `guide.md`
+Create a `guide.md` file in `guides/<category>/<slug>/` folder. Category should be one of `performance`, `accessibility`, `user-experience`, `security`, or a new category if it fits better. Slug must be a short kebab-case summary of the use case (not an action verb).
+
+Required frontmatter:
+```yaml
+---
+name: <slug>
+description: <Short, action-oriented WHAT-not-HOW description>
+web-feature-ids:
+  - <feature-id>
+sources:
+  - <source-url>
+---
+```
+
+### Step 2: Create `demo.html`
+Create a `demo.html` file in the same directory. This should be a minimal, self-contained reference implementation with inline styles and scripts.
+
+---
+
+## 4. Validation
+
+Before finalizing, conduct a quality pass.
+
+- **Cross-Checking Subagent**: Invoke a subagent to compare the proposed use cases against the raw research data (`guides/.research/<feature-id>.md`). Ask it to verify that no important implementation details or edge cases were lost during synthesis.
+- **Run Tests**: Run `pnpm test` or `pnpm --filter guides test` to ensure structural validity of the scaffolded files.
+
+---
+
+## Finalization
+
+Once validated, present the proposed use cases and stubs to the user for approval.

--- a/.agents/skills/project-use-cases-research/scripts/deep_research.js
+++ b/.agents/skills/project-use-cases-research/scripts/deep_research.js
@@ -1,0 +1,133 @@
+import fs from 'fs';
+import path from 'path';
+import { parseArgs } from 'util';
+
+const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
+if (!GEMINI_API_KEY) {
+  console.error("GEMINI_API_KEY is missing. Please set it in your .env file.");
+  process.exit(1);
+}
+
+const GEMINI_MODEL_DEEP_RESEARCH = 'deep-research-pro-preview-12-2025';
+const url = 'https://generativelanguage.googleapis.com/v1beta/interactions';
+
+const { values, positionals } = parseArgs({
+  options: {
+    'feature-id': { type: 'string' },
+    'interaction-id': { type: 'string' },
+    help: { type: 'boolean', short: 'h' },
+  },
+  strict: true,
+});
+
+if (values.help || !values['feature-id']) {
+  console.log(`
+Usage:
+  node deep_research.js --feature-id <id> [options]
+
+Options:
+  --feature-id       Name of the web feature to research (e.g. fetchlater, bfcache)
+  --interaction-id   Interaction ID to resume polling for (if a run was interrupted)
+  -h, --help         Show this help
+`);
+  process.exit(0);
+}
+
+const featureId = values['feature-id'];
+const outputDir = path.resolve('guides/.research');
+const outputPath = path.join(outputDir, `${featureId}.md`);
+
+const prompt = `Thoroughly research the web platform feature '${featureId}'. 
+
+Your goal is to provide a comprehensive research report on how developers use this feature in the real world. 
+- Identify 2-5 distinct developer use cases (problems solved by this feature).
+- Detail common implementation patterns, architectural trade-offs, and technical caveats.
+- Provide clear code examples where applicable.
+- Aim for rich data collection over tight editing; your output will be synthesized by another agent later.
+
+**Source Prioritization Rules**:
+Prioritize sources in the following sequence:
+1. Chrome Authoritative Guidance: web.dev, developer.chrome.com.
+2. Standard-Setting Technical Documentation: MDN Web Docs.
+3. Reputable community standards (W3C Specs, WICG Proposals, reputable blogs).
+
+Break the report down into logical sections including Overview, Use Cases, Implementation Patterns, Caveats, and Sources.`;
+
+async function main() {
+  try {
+    console.log(`Creating directory: ${outputDir}`);
+    fs.mkdirSync(outputDir, { recursive: true });
+
+    let id = values['interaction-id'];
+
+    if (id) {
+      console.log(`Resuming existing interaction ID: ${id}`);
+    } else {
+      console.log(`Starting Deep Research interaction using ${GEMINI_MODEL_DEEP_RESEARCH} for feature: ${featureId}...`);
+      const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-goog-api-key': GEMINI_API_KEY
+        },
+        body: JSON.stringify({
+          agent: GEMINI_MODEL_DEEP_RESEARCH,
+          input: prompt,
+          background: true,
+        }),
+      });
+
+      if (!res.ok) {
+        const errText = await res.text().catch(() => '');
+        throw new Error(`Gemini Interactions API error: ${res.status} ${res.statusText}\n${errText}`);
+      }
+
+      const { id: newId } = await res.json();
+      id = newId;
+    }
+
+    console.log(`Interaction ID: ${id} — polling for completion...`);
+
+    const POLL_INTERVAL_MS = 15_000;
+    const MAX_WAIT_MS = 60 * 60 * 1000; // 60 minutes
+    const start = Date.now();
+
+    while (Date.now() - start < MAX_WAIT_MS) {
+      await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+
+      const pollRes = await fetch(`${url}/${id}`, {
+        headers: { 'x-goog-api-key': GEMINI_API_KEY },
+      });
+      if (!pollRes.ok) {
+        const errText = await pollRes.text().catch(() => '');
+        throw new Error(`Polling error: ${pollRes.status} ${pollRes.statusText}\n${errText}`);
+      }
+
+      const interaction = await pollRes.json();
+      const status = interaction.status.toLowerCase();
+
+      if (status === 'failed' || status === 'cancelled') {
+        throw new Error(`Deep research interaction ${status}.`);
+      }
+
+      const elapsedMin = ((Date.now() - start) / 60_000).toFixed(1);
+      if (status === 'completed') {
+        console.log(`\nCompleted in ${elapsedMin}m`);
+        const text = (interaction.outputs ?? []).map((o) => o.text ?? '').join('');
+        
+        fs.writeFileSync(outputPath, text, 'utf8');
+        console.log(`Research report saved to ${outputPath}`);
+        return;
+      }
+
+      process.stdout.write(`\rStill running… ${elapsedMin}m elapsed`);
+    }
+
+    throw new Error('Deep research timed out after 60 minutes.');
+  } catch (error) {
+    console.error("\nError in Deep Research script:", error.message);
+    process.exit(1);
+  }
+}
+
+main();

--- a/.agents/skills/project-use-cases-research/scripts/deep_research.js
+++ b/.agents/skills/project-use-cases-research/scripts/deep_research.js
@@ -11,7 +11,7 @@ if (!GEMINI_API_KEY) {
 const GEMINI_MODEL_DEEP_RESEARCH = 'deep-research-pro-preview-12-2025';
 const url = 'https://generativelanguage.googleapis.com/v1beta/interactions';
 
-const { values, positionals } = parseArgs({
+const { values } = parseArgs({
   options: {
     'feature-id': { type: 'string' },
     'interaction-id': { type: 'string' },

--- a/.agents/skills/project-use-cases/SKILL.md
+++ b/.agents/skills/project-use-cases/SKILL.md
@@ -11,42 +11,21 @@ The primary goal of this stage is to translate a technical web platform feature 
 2. Stage 2: Authoring guidance for a use case
 3. Stage 3: Evaluating guidance for a use case
 
-## Manual research and discovery
+## Research and discovery
 
-Instead of relying on your (the agent's) general knowledge to come up with a proposed list of use cases yourself, suggest that the user use [Deep Research in NotebookLM](https://notebooklm.google.com/) to discover sources and real-world implementations they might not be aware of. This tool will help them find complex edge cases, performance implications, and emerging best practices.
+Instead of relying on your (the agent's) general knowledge to come up with a proposed list of use cases yourself, use the `project-use-cases-research` skill to perform grounded research. This skill guides you through using your own tools and optional automated deep research to surface authoritative sources and real-world implementations.
 
-Here is an example process for using NotebookLM with Deep Research:
+### Using `project-use-cases-research`
 
-**Step 1: Research the feature**
+Refer to the `project-use-cases-research` skill file for detailed instructions on how to:
+1.  **Gather inputs** from GitHub issues or arguments.
+2.  **Conduct standard research** using `search_web` and `read_url_content`.
+3.  **Run optional automated deep research** using the `deep_research.js` script.
 
-Go to https://notebooklm.google.com/ and create a new notebook. In the configuration, select "Deep Research" and provide a prompt like the following:
-
-```markdown
-Thoroughly research the `fetchLater()` API using the following resources as a starting point and find additional high-quality information from W3C specifications, MDN, developer blogs, and GitHub discussions. Focus on technical constraints, performance implications, and real-world implementation challenges.
-
-- https://developer.mozilla.org/en-US/docs/Web/API/Window/fetchLater
-- https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Deferred_Fetch
-- https://developer.chrome.com/blog/fetch-later-api-origin-trial
-- https://github.com/WICG/pending-beacon/blob/main/docs/fetch-later-api.md
-```
-
-This seeds the model with known good resources and asks it to perform deep research to surface additional technical details, constraints, and discussions.
-
-**Step 2: Identify use cases**
-
-Once the model has a deep understanding of the feature, prompt it to identify the top use cases:
-
-```markdown
-Based on your research, identify 2-5 distinct developer use cases for the `fetchLater()` API.
-
-Follow these constraints for each use case:
-- **Succinct**: Provide a single-sentence description for each use case.
-- **Action-oriented**: Frame it as a task the developer wants to perform (e.g., "Ensure analytics data is sent reliably when a user navigates away").
-- **Outcome-focused**: Focus on the problem being solved, bridging the gap between what a developer wants to build and the technical solution.
-- **Distinct**: Each use case must represent a unique implementation pattern or a significant variation in application.
-```
-
-The user should manually review the proposed use cases for accuracy and completeness, and select the most relevant ones. Your job is to confirm that their selected use cases follow the constraints described in this skill.
+The process will result in:
+1.  A research report saved to `guides/.research/<feature-id>.md`.
+2.  Proposed use cases that follow the constraints described in this skill.
+3.  Scaffolded `guide.md` and `demo.html` stubs.
 
 ## Identifying action-oriented tasks
 


### PR DESCRIPTION
Cleanly applies the changes in #429 on top of `main` instead of the deprecated `notebook-api` branch