### PR TITLE
separate guide usage metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ gd eval                       # run the full evaluation suite
 gd eval [task1] [task2]       # run specific tasks (which are the names of guides e.g. `batch-analytics-events`)
 gd eval --config <custom_config>       # run with config overrides (defaults to config.ts, or harness/config.ts)
 gd dashboard                  # start the evaluation dashboard
+gd backfill                   # backfill metrics for historical suites
 
 # To upload results to GCS (Project: chrome-kiwi-air-force-dev, Bucket: guidance-evals)
 gd upload <suite-name>

--- a/bin/gd.ts
+++ b/bin/gd.ts
@@ -44,6 +44,7 @@ const COMMAND_METADATA = {
   run: { desc: 'Run an ad-hoc agent test against a template', flags: ['config'] },
   deploy: { desc: 'Deploy the dashboard to GitHub Pages', flags: [] },
   upload: { desc: 'Upload generated evaluation suite to GCS', flags: [] },
+  backfill: { desc: 'Backfill metrics for historical suites', flags: [] },
   baselinestatus: { desc: 'Check browser support and Baseline status', flags: [] },
 
   'setup-completion': { desc: 'Install shell auto-completion', flags: [] },
@@ -192,7 +193,7 @@ function showHelp() {
     },
     {
       title: 'Evaluation & Dashboard',
-      commands: ['eval', 'run', 'dashboard', 'deploy', 'upload'],
+      commands: ['eval', 'run', 'dashboard', 'deploy', 'upload', 'backfill'],
     },
     {
       title: 'Utilities & Setup',
@@ -348,6 +349,11 @@ async function main() {
       const args = positionals.slice(1);
       const code = await runNpm(['upload', ...args]);
       process.exit(code);
+    }
+
+    case 'backfill': {
+      await import('../harness/backfill.ts');
+      break;
     }
 
     case 'deploy': {

--- a/eval-view/dashboard.js
+++ b/eval-view/dashboard.js
@@ -594,14 +594,34 @@ async function showDetails(testName, runs, stats, testId) {
                         </div>` : ''}
 
                         ${hasGuideData ? `
-                        <div style="display: flex; align-items: center; gap: 8px;">
-                            <strong style="font-size: 0.9em; font-weight: 600; color: var(--text-secondary); min-width: 90px;">Guides Used:</strong>
-                            <div style="display: flex; gap: 6px; flex-wrap: wrap;">
-                                ${guidesUsed.length > 0 ? guidesUsed.map(g => {
-                                    const isExpected = g === expectedGuide;
-                                    return `<code style="background: ${isExpected ? 'rgba(0, 200, 0, 0.1)' : 'rgba(255,255,255,0.05)'}; padding: 3px 6px; border-radius: 4px; font-size: 0.85em; border: 1px solid ${isExpected ? 'var(--accent-success)' : 'var(--border-color)'}; color: ${isExpected ? 'var(--accent-success)' : 'var(--text-primary)'}">${escapeHtml(g)}</code>`;
-                                }).join('') : '<span style="color: var(--text-secondary); font-style: italic; font-size: 0.85em;">None</span>'}
-                            </div>
+                        <div style="display: flex; flex-direction: column; gap: 6px;">
+                          <div style="display: flex; align-items: center; gap: 8px;">
+                              <strong style="font-size: 0.9em; font-weight: 600; color: var(--text-secondary); min-width: 120px;">Retrieved Guides:</strong>
+                              <div style="display: flex; gap: 6px; flex-wrap: wrap;">
+                                  ${run.retrievedGuides && run.retrievedGuides.length > 0 ? run.retrievedGuides.map(g => {
+                                      const isExpected = g === expectedGuide;
+                                      return `<code style="background: ${isExpected ? 'rgba(0, 200, 0, 0.1)' : 'rgba(255,255,255,0.05)'}; padding: 3px 6px; border-radius: 4px; font-size: 0.85em; border: 1px solid ${isExpected ? 'var(--accent-success)' : 'var(--border-color)'}; color: ${isExpected ? 'var(--accent-success)' : 'var(--text-primary)'}">${escapeHtml(g)}</code>`;
+                                  }).join('') : '<span style="color: var(--text-secondary); font-style: italic; font-size: 0.85em;">None</span>'}
+                              </div>
+                          </div>
+                          <div style="display: flex; align-items: center; gap: 8px;">
+                              <strong style="font-size: 0.9em; font-weight: 600; color: var(--text-secondary); min-width: 120px;">File Read Guides:</strong>
+                              <div style="display: flex; gap: 6px; flex-wrap: wrap;">
+                                  ${run.fileReadGuides && run.fileReadGuides.length > 0 ? run.fileReadGuides.map(g => {
+                                      const isExpected = g === expectedGuide;
+                                      return `<code style="background: ${isExpected ? 'rgba(0, 200, 0, 0.1)' : 'rgba(255,255,255,0.05)'}; padding: 3px 6px; border-radius: 4px; font-size: 0.85em; border: 1px solid ${isExpected ? 'var(--accent-success)' : 'var(--border-color)'}; color: ${isExpected ? 'var(--accent-success)' : 'var(--text-primary)'}">${escapeHtml(g)}</code>`;
+                                  }).join('') : '<span style="color: var(--text-secondary); font-style: italic; font-size: 0.85em;">None</span>'}
+                              </div>
+                          </div>
+                          <div style="display: flex; align-items: center; gap: 8px;">
+                              <strong style="font-size: 0.9em; font-weight: 600; color: var(--text-secondary); min-width: 120px;">Combined Guides:</strong>
+                              <div style="display: flex; gap: 6px; flex-wrap: wrap;">
+                                  ${guidesUsed.length > 0 ? guidesUsed.map(g => {
+                                      const isExpected = g === expectedGuide;
+                                      return `<code style="background: ${isExpected ? 'rgba(0, 200, 0, 0.1)' : 'rgba(255,255,255,0.05)'}; padding: 3px 6px; border-radius: 4px; font-size: 0.85em; border: 1px solid ${isExpected ? 'var(--accent-success)' : 'var(--border-color)'}; color: ${isExpected ? 'var(--accent-success)' : 'var(--text-primary)'}">${escapeHtml(g)}</code>`;
+                                  }).join('') : '<span style="color: var(--text-secondary); font-style: italic; font-size: 0.85em;">None</span>'}
+                              </div>
+                          </div>
                         </div>` : ''}
 
                         <div style="margin-top: 5px; padding-top: 8px; border-top: 1px solid rgba(255,255,255,0.05); display: flex; justify-content: flex-end;">

--- a/eval-view/dashboard.js
+++ b/eval-view/dashboard.js
@@ -347,6 +347,8 @@ function renderSummary(data) {
     const unguidedEarlyFailureRate = summary.unguidedEarlyFailureRate || 0;
     const guidedEarlyFailureRate = summary.guidedEarlyFailureRate || 0;
 
+    const completedGuidedRuns = summary.totalGuidedRuns - (summary.guidedEarlyFailures || 0);
+
     container.innerHTML = `
         <div class="stat-card">
             <span class="stat-value" style="color: ${getColor(unguidedRate)}">
@@ -390,13 +392,13 @@ function renderSummary(data) {
             ${summary.toolActivationRate !== undefined ? `
             <div style="margin-top: 6px; font-size: 0.85em; color: var(--text-secondary);">
                 Tool Activation: <span style="font-weight: bold; color: ${getColor(summary.toolActivationRate)}">${summary.toolActivationRate}%</span>
-                <span style="opacity: 0.8; color: ${getColor(summary.toolActivationRate)}">(${summary.toolActivationCount}/${summary.totalGuidedRuns} runs)</span>
+                <span style="opacity: 0.8; color: ${getColor(summary.toolActivationRate)}">(${summary.toolActivationCount}/${completedGuidedRuns} completed runs)</span>
             </div>
             ` : ''}
             ${summary.guideUsageRate !== undefined ? `
             <div style="margin-top: 6px; font-size: 0.85em; color: var(--text-secondary);">
                 Guide Usage: <span style="font-weight: bold; color: ${getColor(summary.guideUsageRate)}">${summary.guideUsageRate}%</span>
-                <span style="opacity: 0.8; color: ${getColor(summary.guideUsageRate)}">(${summary.guideUsageCount}/${summary.totalGuidedRuns} runs)</span>
+                <span style="opacity: 0.8; color: ${getColor(summary.guideUsageRate)}">(${summary.guideUsageCount}/${completedGuidedRuns} completed runs)</span>
             </div>
             ` : ''}
         </div>

--- a/eval-view/dashboard.js
+++ b/eval-view/dashboard.js
@@ -363,7 +363,7 @@ function renderSummary(data) {
             ` : ''}
             ${summary.unguidedEarlyFailures !== undefined ? `
             <div style="margin-top: 6px; font-size: 0.85em; color: var(--text-secondary);">
-                File Not Found: <span style="font-weight: bold; color: ${getColor(100 - unguidedEarlyFailureRate)}">${unguidedEarlyFailureRate}%</span>
+                Generation Errors: <span style="font-weight: bold; color: ${getColor(100 - unguidedEarlyFailureRate)}">${unguidedEarlyFailureRate}%</span>
                 <span style="opacity: 0.8; color: ${getColor(100 - unguidedEarlyFailureRate)}">(${summary.unguidedEarlyFailures} runs)</span>
             </div>
             ` : ''}
@@ -383,7 +383,7 @@ function renderSummary(data) {
             ` : ''}
             ${summary.guidedEarlyFailures !== undefined ? `
             <div style="margin-top: 6px; font-size: 0.85em; color: var(--text-secondary);">
-                File Not Found: <span style="font-weight: bold; color: ${getColor(100 - guidedEarlyFailureRate)}">${guidedEarlyFailureRate}%</span>
+                Generation Errors: <span style="font-weight: bold; color: ${getColor(100 - guidedEarlyFailureRate)}">${guidedEarlyFailureRate}%</span>
                 <span style="opacity: 0.8; color: ${getColor(100 - guidedEarlyFailureRate)}">(${summary.guidedEarlyFailures} runs)</span>
             </div>
             ` : ''}

--- a/eval-view/dashboard.js
+++ b/eval-view/dashboard.js
@@ -82,7 +82,7 @@ async function loadDashboardData(testId) {
         const checkId = params.get('checkId');
 
         if (testName) {
-            const results = data.results;
+            const results = data.results || data.allResults;
             const stats = data.stats;
             const runData = results[testName];
             const testStats = stats[testName];
@@ -268,11 +268,12 @@ document.addEventListener('DOMContentLoaded', () => {
             const nextRunType = currentRunTypes[rIdx];
             const nextTestName = `${nextScenario} - ${nextRunType}`;
 
-            if (nextTestName !== currentDetails.testName && allTestData.results[nextTestName]) {
+            const results = allTestData.results || allTestData.allResults;
+            if (nextTestName !== currentDetails.testName && results[nextTestName]) {
                 e.preventDefault();
                 showDetails(
                     nextTestName,
-                    allTestData.results[nextTestName],
+                    results[nextTestName],
                     allTestData.stats[nextTestName],
                     currentTestID
                 );
@@ -379,7 +380,7 @@ function renderSummary(data) {
 
 function renderGrid(data, testId) {
     const grid = document.getElementById('dashboard-grid');
-    const results = data.results;
+    const results = data.results || data.allResults;
     const stats = data.stats;
 
     sortedScenarios = [];
@@ -902,7 +903,8 @@ async function viewDiff(setupPath, resultPath, testName, runNumber) {
 }
 
 function renderDashboardDumbbellChart(data, testId) {
-    const { labels, guided, unguided } = calculateChartData(data.results);
+    const results = data.results || data.allResults;
+    const { labels, guided, unguided } = calculateChartData(results);
 
     if (labels.length < 1) {
         document.getElementById('chart-section').classList.add('hidden');
@@ -915,14 +917,14 @@ function renderDashboardDumbbellChart(data, testId) {
         const runType = type.toLowerCase(); // "guided" or "unguided"
 
         // Find the original key in the results
-        const originalKey = Object.keys(data.results).find(key => {
+        const originalKey = Object.keys(results).find(key => {
             const parts = key.split(' - ');
             return `${parts[0]} (${parts[1]})` === scenarioName && parts[2] === runType;
         });
 
         if (originalKey) {
             const testName = originalKey;
-            const runData = data.results[testName];
+            const runData = results[testName];
             const testStats = data.stats[testName];
             showDetails(testName, runData, testStats, testId);
         }

--- a/eval-view/dashboard.js
+++ b/eval-view/dashboard.js
@@ -356,6 +356,11 @@ function renderSummary(data) {
             <div style="margin-top: 8px; font-size: 0.9em; color: var(--text-secondary);">
                 ${summary.unguidedPassed}/${summary.unguidedTotal} checks passed
             </div>
+            ${summary.expectedTotalRuns !== undefined ? `
+            <div style="margin-top: 4px; font-size: 0.85em; color: var(--text-secondary);">
+                Expected Runs: <span style="font-weight: bold; color: var(--text-primary);">${summary.expectedTotalRuns}</span>
+            </div>
+            ` : ''}
             ${summary.unguidedEarlyFailures !== undefined ? `
             <div style="margin-top: 6px; font-size: 0.85em; color: var(--text-secondary);">
                 File Not Found: <span style="font-weight: bold; color: ${getColor(100 - unguidedEarlyFailureRate)}">${unguidedEarlyFailureRate}%</span>
@@ -371,6 +376,11 @@ function renderSummary(data) {
             <div style="margin-top: 8px; font-size: 0.9em; color: var(--text-secondary);">
                 ${summary.guidedPassed}/${summary.guidedTotal} checks passed
             </div>
+            ${summary.expectedTotalRuns !== undefined ? `
+            <div style="margin-top: 4px; font-size: 0.85em; color: var(--text-secondary);">
+                Expected Runs: <span style="font-weight: bold; color: var(--text-primary);">${summary.expectedTotalRuns}</span>
+            </div>
+            ` : ''}
             ${summary.guidedEarlyFailures !== undefined ? `
             <div style="margin-top: 6px; font-size: 0.85em; color: var(--text-secondary);">
                 File Not Found: <span style="font-weight: bold; color: ${getColor(100 - guidedEarlyFailureRate)}">${guidedEarlyFailureRate}%</span>

--- a/eval-view/dashboard.js
+++ b/eval-view/dashboard.js
@@ -344,6 +344,9 @@ function renderSummary(data) {
     const unguidedRate = summary.unguidedPassRate;
     const guidedRate = summary.guidedPassRate;
 
+    const unguidedEarlyFailureRate = summary.unguidedEarlyFailureRate || 0;
+    const guidedEarlyFailureRate = summary.guidedEarlyFailureRate || 0;
+
     container.innerHTML = `
         <div class="stat-card">
             <span class="stat-value" style="color: ${getColor(unguidedRate)}">
@@ -353,6 +356,12 @@ function renderSummary(data) {
             <div style="margin-top: 8px; font-size: 0.9em; color: var(--text-secondary);">
                 ${summary.unguidedPassed}/${summary.unguidedTotal} checks passed
             </div>
+            ${summary.unguidedEarlyFailures !== undefined ? `
+            <div style="margin-top: 6px; font-size: 0.85em; color: var(--text-secondary);">
+                File Not Found: <span style="font-weight: bold; color: ${getColor(100 - unguidedEarlyFailureRate)}">${unguidedEarlyFailureRate}%</span>
+                <span style="opacity: 0.8; color: ${getColor(100 - unguidedEarlyFailureRate)}">(${summary.unguidedEarlyFailures} runs)</span>
+            </div>
+            ` : ''}
         </div>
         <div class="stat-card">
             <span class="stat-value" style="color: ${getColor(guidedRate)}">
@@ -362,6 +371,12 @@ function renderSummary(data) {
             <div style="margin-top: 8px; font-size: 0.9em; color: var(--text-secondary);">
                 ${summary.guidedPassed}/${summary.guidedTotal} checks passed
             </div>
+            ${summary.guidedEarlyFailures !== undefined ? `
+            <div style="margin-top: 6px; font-size: 0.85em; color: var(--text-secondary);">
+                File Not Found: <span style="font-weight: bold; color: ${getColor(100 - guidedEarlyFailureRate)}">${guidedEarlyFailureRate}%</span>
+                <span style="opacity: 0.8; color: ${getColor(100 - guidedEarlyFailureRate)}">(${summary.guidedEarlyFailures} runs)</span>
+            </div>
+            ` : ''}
             ${summary.toolActivationRate !== undefined ? `
             <div style="margin-top: 6px; font-size: 0.85em; color: var(--text-secondary);">
                 Tool Activation: <span style="font-weight: bold; color: ${getColor(summary.toolActivationRate)}">${summary.toolActivationRate}%</span>
@@ -464,7 +479,7 @@ function renderGrid(data, testId) {
                     </div>
                     <div style="display: flex; justify-content: space-between; font-size: 0.9em; color: var(--text-secondary);">
                         <span>Average: ${avgRate}% <span style="opacity: 0.8">(${totalPassed}/${totalChecks})</span></span>
-                        <span>Runs: ${runData.length}</span>
+                        <span>Runs: ${runData.length}${testStats && testStats.earlyFailures ? ` (<span style="color: var(--accent-failure); font-weight: bold;">${testStats.earlyFailures} failed</span>)` : ''}</span>
                     </div>
                     ${toolActivationHtml}
                     ${guideUsageHtml}
@@ -600,7 +615,7 @@ async function showDetails(testName, runs, stats, testId) {
                               <strong style="font-size: 0.9em; font-weight: 600; color: var(--text-secondary); min-width: 120px;">Retrieved Guides:</strong>
                               <div style="display: flex; gap: 6px; flex-wrap: wrap;">
                                   ${(() => {
-                                      const retrieved = run.fileReadGuides === undefined ? (run.retrievedGuides || run.guidesUsed) : run.retrievedGuides;
+                                      const retrieved = run.fileReadGuides === undefined ? (run.retrievedGuides || guidesUsed) : run.retrievedGuides;
                                       return retrieved && retrieved.length > 0 ? retrieved.map(g => {
                                           const isExpected = g === expectedGuide;
                                           return `<code style="background: ${isExpected ? 'rgba(0, 200, 0, 0.1)' : 'rgba(255,255,255,0.05)'}; padding: 3px 6px; border-radius: 4px; font-size: 0.85em; border: 1px solid ${isExpected ? 'var(--accent-success)' : 'var(--border-color)'}; color: ${isExpected ? 'var(--accent-success)' : 'var(--text-primary)'}">${escapeHtml(g)}</code>`;

--- a/eval-view/dashboard.js
+++ b/eval-view/dashboard.js
@@ -82,7 +82,7 @@ async function loadDashboardData(testId) {
         const checkId = params.get('checkId');
 
         if (testName) {
-            const results = data.results || data.allResults;
+            const results = data.results;
             const stats = data.stats;
             const runData = results[testName];
             const testStats = stats[testName];
@@ -268,7 +268,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const nextRunType = currentRunTypes[rIdx];
             const nextTestName = `${nextScenario} - ${nextRunType}`;
 
-            const results = allTestData.results || allTestData.allResults;
+            const results = allTestData.results;
             if (nextTestName !== currentDetails.testName && results[nextTestName]) {
                 e.preventDefault();
                 showDetails(
@@ -380,7 +380,7 @@ function renderSummary(data) {
 
 function renderGrid(data, testId) {
     const grid = document.getElementById('dashboard-grid');
-    const results = data.results || data.allResults;
+    const results = data.results;
     const stats = data.stats;
 
     sortedScenarios = [];
@@ -903,7 +903,7 @@ async function viewDiff(setupPath, resultPath, testName, runNumber) {
 }
 
 function renderDashboardDumbbellChart(data, testId) {
-    const results = data.results || data.allResults;
+    const results = data.results;
     const { labels, guided, unguided } = calculateChartData(results);
 
     if (labels.length < 1) {

--- a/eval-view/dashboard.js
+++ b/eval-view/dashboard.js
@@ -615,7 +615,7 @@ async function showDetails(testName, runs, stats, testId) {
                             <strong style="font-size: 0.9em; font-weight: 600; color: var(--text-secondary); min-width: 90px;">Tools Used:</strong>
                             <div style="display: flex; gap: 6px; flex-wrap: wrap;">
                                 ${toolsUsed.length > 0 ? toolsUsed.map(t => {
-                                    const isExpected = t === expectedTool;
+                                    const isExpected = expectedTool && t.startsWith(expectedTool);
                                     return `<code style="background: ${isExpected ? 'rgba(0, 200, 0, 0.1)' : 'rgba(255,255,255,0.05)'}; padding: 3px 6px; border-radius: 4px; font-size: 0.85em; border: 1px solid ${isExpected ? 'var(--accent-success)' : 'var(--border-color)'}; color: ${isExpected ? 'var(--accent-success)' : 'var(--text-primary)'}">${escapeHtml(t)}</code>`;
                                 }).join('') : '<span style="color: var(--text-secondary); font-style: italic; font-size: 0.85em;">None</span>'}
                             </div>

--- a/eval-view/dashboard.js
+++ b/eval-view/dashboard.js
@@ -593,7 +593,7 @@ async function showDetails(testName, runs, stats, testId) {
 
         let usageSection = '';
         const toolsUsed = run.guidanceToolsUsed || [];
-        const expectedTool = run.expectedGuidanceTool;
+        const expectedToolPrefixes = run.expectedToolPrefixes || [];
         const hasToolData = run.guidanceToolsUsed !== undefined;
 
         const guidesUsed = run.guidesUsed || 
@@ -615,7 +615,7 @@ async function showDetails(testName, runs, stats, testId) {
                             <strong style="font-size: 0.9em; font-weight: 600; color: var(--text-secondary); min-width: 90px;">Tools Used:</strong>
                             <div style="display: flex; gap: 6px; flex-wrap: wrap;">
                                 ${toolsUsed.length > 0 ? toolsUsed.map(t => {
-                                    const isExpected = expectedTool && t.startsWith(expectedTool);
+                                    const isExpected = expectedToolPrefixes.some(p => t.startsWith(p));
                                     return `<code style="background: ${isExpected ? 'rgba(0, 200, 0, 0.1)' : 'rgba(255,255,255,0.05)'}; padding: 3px 6px; border-radius: 4px; font-size: 0.85em; border: 1px solid ${isExpected ? 'var(--accent-success)' : 'var(--border-color)'}; color: ${isExpected ? 'var(--accent-success)' : 'var(--text-primary)'}">${escapeHtml(t)}</code>`;
                                 }).join('') : '<span style="color: var(--text-secondary); font-style: italic; font-size: 0.85em;">None</span>'}
                             </div>

--- a/eval-view/dashboard.js
+++ b/eval-view/dashboard.js
@@ -599,25 +599,19 @@ async function showDetails(testName, runs, stats, testId) {
                           <div style="display: flex; align-items: center; gap: 8px;">
                               <strong style="font-size: 0.9em; font-weight: 600; color: var(--text-secondary); min-width: 120px;">Retrieved Guides:</strong>
                               <div style="display: flex; gap: 6px; flex-wrap: wrap;">
-                                  ${run.retrievedGuides && run.retrievedGuides.length > 0 ? run.retrievedGuides.map(g => {
-                                      const isExpected = g === expectedGuide;
-                                      return `<code style="background: ${isExpected ? 'rgba(0, 200, 0, 0.1)' : 'rgba(255,255,255,0.05)'}; padding: 3px 6px; border-radius: 4px; font-size: 0.85em; border: 1px solid ${isExpected ? 'var(--accent-success)' : 'var(--border-color)'}; color: ${isExpected ? 'var(--accent-success)' : 'var(--text-primary)'}">${escapeHtml(g)}</code>`;
-                                  }).join('') : '<span style="color: var(--text-secondary); font-style: italic; font-size: 0.85em;">None</span>'}
+                                  ${(() => {
+                                      const retrieved = run.fileReadGuides === undefined ? (run.retrievedGuides || run.guidesUsed) : run.retrievedGuides;
+                                      return retrieved && retrieved.length > 0 ? retrieved.map(g => {
+                                          const isExpected = g === expectedGuide;
+                                          return `<code style="background: ${isExpected ? 'rgba(0, 200, 0, 0.1)' : 'rgba(255,255,255,0.05)'}; padding: 3px 6px; border-radius: 4px; font-size: 0.85em; border: 1px solid ${isExpected ? 'var(--accent-success)' : 'var(--border-color)'}; color: ${isExpected ? 'var(--accent-success)' : 'var(--text-primary)'}">${escapeHtml(g)}</code>`;
+                                      }).join('') : '<span style="color: var(--text-secondary); font-style: italic; font-size: 0.85em;">None</span>';
+                                  })()}
                               </div>
                           </div>
                           <div style="display: flex; align-items: center; gap: 8px;">
                               <strong style="font-size: 0.9em; font-weight: 600; color: var(--text-secondary); min-width: 120px;">File Read Guides:</strong>
                               <div style="display: flex; gap: 6px; flex-wrap: wrap;">
                                   ${run.fileReadGuides && run.fileReadGuides.length > 0 ? run.fileReadGuides.map(g => {
-                                      const isExpected = g === expectedGuide;
-                                      return `<code style="background: ${isExpected ? 'rgba(0, 200, 0, 0.1)' : 'rgba(255,255,255,0.05)'}; padding: 3px 6px; border-radius: 4px; font-size: 0.85em; border: 1px solid ${isExpected ? 'var(--accent-success)' : 'var(--border-color)'}; color: ${isExpected ? 'var(--accent-success)' : 'var(--text-primary)'}">${escapeHtml(g)}</code>`;
-                                  }).join('') : '<span style="color: var(--text-secondary); font-style: italic; font-size: 0.85em;">None</span>'}
-                              </div>
-                          </div>
-                          <div style="display: flex; align-items: center; gap: 8px;">
-                              <strong style="font-size: 0.9em; font-weight: 600; color: var(--text-secondary); min-width: 120px;">Combined Guides:</strong>
-                              <div style="display: flex; gap: 6px; flex-wrap: wrap;">
-                                  ${guidesUsed.length > 0 ? guidesUsed.map(g => {
                                       const isExpected = g === expectedGuide;
                                       return `<code style="background: ${isExpected ? 'rgba(0, 200, 0, 0.1)' : 'rgba(255,255,255,0.05)'}; padding: 3px 6px; border-radius: 4px; font-size: 0.85em; border: 1px solid ${isExpected ? 'var(--accent-success)' : 'var(--border-color)'}; color: ${isExpected ? 'var(--accent-success)' : 'var(--text-primary)'}">${escapeHtml(g)}</code>`;
                                   }).join('') : '<span style="color: var(--text-secondary); font-style: italic; font-size: 0.85em;">None</span>'}

--- a/eval-view/dashboard.js
+++ b/eval-view/dashboard.js
@@ -358,7 +358,7 @@ function renderSummary(data) {
             </div>
             ${summary.expectedTotalRuns !== undefined ? `
             <div style="margin-top: 4px; font-size: 0.85em; color: var(--text-secondary);">
-                Expected Runs: <span style="font-weight: bold; color: var(--text-primary);">${summary.expectedTotalRuns}</span>
+                Expected Runs: <span style="font-weight: bold; color: var(--text-primary);">${summary.expectedTotalRuns}${summary.taskCount ? ` (${summary.taskCount} tasks x ${summary.runCountPerTask} runs)` : ''}</span>
             </div>
             ` : ''}
             ${summary.unguidedEarlyFailures !== undefined ? `
@@ -378,7 +378,7 @@ function renderSummary(data) {
             </div>
             ${summary.expectedTotalRuns !== undefined ? `
             <div style="margin-top: 4px; font-size: 0.85em; color: var(--text-secondary);">
-                Expected Runs: <span style="font-weight: bold; color: var(--text-primary);">${summary.expectedTotalRuns}</span>
+                Expected Runs: <span style="font-weight: bold; color: var(--text-primary);">${summary.expectedTotalRuns}${summary.taskCount ? ` (${summary.taskCount} tasks x ${summary.runCountPerTask} runs)` : ''}</span>
             </div>
             ` : ''}
             ${summary.guidedEarlyFailures !== undefined ? `

--- a/eval-view/evals.d.ts
+++ b/eval-view/evals.d.ts
@@ -1,9 +1,6 @@
 import type { EvalsReport } from '../harness/lib/metrics.ts';
 
-export interface LooseEvalsReport extends Partial<Omit<EvalsReport, 'results'>> {
-  results?: Record<string, any>;
-  [key: string]: any;
-}
+
 
 declare global {
   interface Window {

--- a/eval-view/evals.d.ts
+++ b/eval-view/evals.d.ts
@@ -1,0 +1,29 @@
+import type { Metrics, RunResult as HarnessRunResult } from '../harness/lib/metrics.ts';
+
+export interface FullRunResult extends HarnessRunResult {
+  taskName?: string;
+  baseApp?: string;
+  prompt?: string;
+}
+
+export interface EvalsReport {
+  summary: Metrics['summary'];
+  results: Record<string, FullRunResult[]>;
+  stats: Metrics['testStats'];
+  timestamp: string;
+  runCount: number;
+  agent: string;
+  serving: string;
+  model: string;
+}
+
+export interface LooseEvalsReport extends Partial<Omit<EvalsReport, 'results'>> {
+  results?: Record<string, any>;
+  [key: string]: any;
+}
+
+declare global {
+  interface Window {
+    google: any;
+  }
+}

--- a/eval-view/evals.d.ts
+++ b/eval-view/evals.d.ts
@@ -1,21 +1,4 @@
-import type { Metrics, RunResult as HarnessRunResult } from '../harness/lib/metrics.ts';
-
-export interface FullRunResult extends HarnessRunResult {
-  taskName?: string;
-  baseApp?: string;
-  prompt?: string;
-}
-
-export interface EvalsReport {
-  summary: Metrics['summary'];
-  results: Record<string, FullRunResult[]>;
-  stats: Metrics['testStats'];
-  timestamp: string;
-  runCount: number;
-  agent: string;
-  serving: string;
-  model: string;
-}
+import type { EvalsReport } from '../harness/lib/metrics.ts';
 
 export interface LooseEvalsReport extends Partial<Omit<EvalsReport, 'results'>> {
   results?: Record<string, any>;

--- a/eval-view/index.html
+++ b/eval-view/index.html
@@ -58,20 +58,16 @@
               <th>
                 <select id="filter-agent" class="header-filter-select">
                   <option value="all">Agent</option>
-                  <optgroup label="Select Agent">
-                    <option value="jetski">jetski</option>
-                    <option value="gemini_cli">gemini_cli</option>
-                    <option value="claude_code">claude_code</option>
+                  <optgroup label="Select Agent" id="filter-agent-group">
+                    <!-- populated dynamically -->
                   </optgroup>
                 </select>
               </th>
               <th>
                 <select id="filter-serving" class="header-filter-select">
                   <option value="all">Serving</option>
-                  <optgroup label="Select Architecture">
-                    <option value="skills">Skills</option>
-                    <option value="skills_cli">Skills (CLI)</option>
-                    <option value="mcp">MCP</option>
+                  <optgroup label="Select Architecture" id="filter-serving-group">
+                    <!-- populated dynamically -->
                   </optgroup>
                 </select>
               </th>

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -333,6 +333,53 @@ function registerTestData(testId, source, parsed, forcedTimestamp) {
     };
     
     updateModelFilterOptions();
+    updateServingFilterOptions();
+    updateAgentFilterOptions();
+}
+
+function updateAgentFilterOptions() {
+    const agentGroup = document.getElementById('filter-agent-group');
+    if (!agentGroup) return;
+
+    const agents = new Set();
+    Object.values(allTestData).forEach(test => {
+        if (test.agent) agents.add(test.agent);
+    });
+
+    const sortedAgents = Array.from(agents).sort();
+    
+    const currentOptions = Array.from(agentGroup.querySelectorAll('option')).map(o => o.value);
+    if (JSON.stringify(currentOptions) === JSON.stringify(sortedAgents)) return;
+
+    agentGroup.innerHTML = sortedAgents.map(agent => 
+        `<option value="${escapeHtml(agent)}">${escapeHtml(agent)}</option>`
+    ).join('');
+}
+
+function updateServingFilterOptions() {
+    const servingGroup = document.getElementById('filter-serving-group');
+    if (!servingGroup) return;
+
+    const servings = new Set();
+    Object.values(allTestData).forEach(test => {
+        if (test.serving) servings.add(test.serving);
+    });
+
+    const sortedServings = Array.from(servings).sort();
+    
+    const servingDisplayNames = {
+        'skills': 'Skills',
+        'skills_cli': 'Skills (CLI)',
+        'mcp': 'MCP',
+        'megaskill': 'Megaskill'
+    };
+
+    const currentOptions = Array.from(servingGroup.querySelectorAll('option')).map(o => o.value);
+    if (JSON.stringify(currentOptions) === JSON.stringify(sortedServings)) return;
+
+    servingGroup.innerHTML = sortedServings.map(serving => 
+        `<option value="${escapeHtml(serving)}">${escapeHtml(servingDisplayNames[serving] || serving)}</option>`
+    ).join('');
 }
 
 function updateModelFilterOptions() {

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -387,6 +387,7 @@ function renderSuites() {
         if (currentModelFilter !== 'all' && testInfo.model !== currentModelFilter) return;
 
         const data = testInfo.data;
+        const results = data.results || data.allResults;
         const _date = new Date(testInfo.timestamp);
 
         // Custom format to match "March 5, 2:25PM"
@@ -398,8 +399,8 @@ function renderSuites() {
             hour12: true
         }).replace(' at ', ', ');
 
-        const gStats = calculateGroupTotalStats(data.results, 'guided');
-        const uStats = calculateGroupTotalStats(data.results, 'unguided');
+        const gStats = calculateGroupTotalStats(results, 'guided');
+        const uStats = calculateGroupTotalStats(results, 'unguided');
 
         const gRate = gStats.total > 0 ? Math.round((gStats.passed / gStats.total) * 100) : 0;
         const uRate = uStats.total > 0 ? Math.round((uStats.passed / uStats.total) * 100) : 0;
@@ -477,7 +478,8 @@ function showTooltipChart(testInfo, x, y, compoundKey) {
         `;
     }
 
-    const { labels, guided, unguided } = calculateChartData(testInfo.data.results);
+    const results = testInfo.data.results || testInfo.data.allResults;
+    const { labels, guided, unguided } = calculateChartData(results);
     if (labels.length < 1) return;
 
     tooltipContainer.classList.remove('hidden');

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -332,73 +332,22 @@ function registerTestData(testId, source, parsed, forcedTimestamp) {
         guideUsageRate: parsed.summary?.guideUsageRate || 0
     };
     
-    updateModelFilterOptions();
-    updateServingFilterOptions();
-    updateAgentFilterOptions();
+    updateFilterOptions('filter-model-group', 'model');
+    updateFilterOptions('filter-serving-group', 'serving');
+    updateFilterOptions('filter-agent-group', 'agent');
 }
 
-function updateAgentFilterOptions() {
-    const agentGroup = document.getElementById('filter-agent-group');
-    if (!agentGroup) return;
+function updateFilterOptions(groupId, key) {
+    const group = document.getElementById(groupId);
+    if (!group) return;
 
-    const agents = new Set();
-    Object.values(allTestData).forEach(test => {
-        if (test.agent) agents.add(test.agent);
-    });
-
-    const sortedAgents = Array.from(agents).sort();
+    const values = [...new Set(Object.values(allTestData).map(t => t[key]).filter(Boolean))].sort();
     
-    const currentOptions = Array.from(agentGroup.querySelectorAll('option')).map(o => o.value);
-    if (JSON.stringify(currentOptions) === JSON.stringify(sortedAgents)) return;
+    const currentOptions = Array.from(group.querySelectorAll('option')).map(o => o.value);
+    if (JSON.stringify(currentOptions) === JSON.stringify(values)) return;
 
-    agentGroup.innerHTML = sortedAgents.map(agent => 
-        `<option value="${escapeHtml(agent)}">${escapeHtml(agent)}</option>`
-    ).join('');
-}
-
-function updateServingFilterOptions() {
-    const servingGroup = document.getElementById('filter-serving-group');
-    if (!servingGroup) return;
-
-    const servings = new Set();
-    Object.values(allTestData).forEach(test => {
-        if (test.serving) servings.add(test.serving);
-    });
-
-    const sortedServings = Array.from(servings).sort();
-    
-    const servingDisplayNames = {
-        'skills': 'Skills',
-        'skills_cli': 'Skills (CLI)',
-        'mcp': 'MCP',
-        'megaskill': 'Megaskill'
-    };
-
-    const currentOptions = Array.from(servingGroup.querySelectorAll('option')).map(o => o.value);
-    if (JSON.stringify(currentOptions) === JSON.stringify(sortedServings)) return;
-
-    servingGroup.innerHTML = sortedServings.map(serving => 
-        `<option value="${escapeHtml(serving)}">${escapeHtml(servingDisplayNames[serving] || serving)}</option>`
-    ).join('');
-}
-
-function updateModelFilterOptions() {
-    const modelGroup = document.getElementById('filter-model-group');
-    if (!modelGroup) return;
-
-    const models = new Set();
-    Object.values(allTestData).forEach(test => {
-        if (test.model) models.add(test.model);
-    });
-
-    const sortedModels = Array.from(models).sort();
-    
-    // Only update if changed to avoid unnecessary re-renders or losing selection
-    const currentOptions = Array.from(modelGroup.querySelectorAll('option')).map(o => o.value);
-    if (JSON.stringify(currentOptions) === JSON.stringify(sortedModels)) return;
-
-    modelGroup.innerHTML = sortedModels.map(model => 
-        `<option value="${escapeHtml(model)}">${escapeHtml(model)}</option>`
+    group.innerHTML = values.map(val => 
+        `<option value="${escapeHtml(val)}">${escapeHtml(val)}</option>`
     ).join('');
 }
 

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -387,7 +387,7 @@ function renderSuites() {
         if (currentModelFilter !== 'all' && testInfo.model !== currentModelFilter) return;
 
         const data = testInfo.data;
-        const results = data.results || data.allResults;
+        const results = data.results;
         const _date = new Date(testInfo.timestamp);
 
         // Custom format to match "March 5, 2:25PM"
@@ -478,7 +478,7 @@ function showTooltipChart(testInfo, x, y, compoundKey) {
         `;
     }
 
-    const results = testInfo.data.results || testInfo.data.allResults;
+    const results = testInfo.data.results;
     const { labels, guided, unguided } = calculateChartData(results);
     if (labels.length < 1) return;
 

--- a/eval-view/tsconfig.json
+++ b/eval-view/tsconfig.json
@@ -13,6 +13,7 @@
     "lib": ["esnext", "dom", "dom.iterable"]
   },
   "include": [
+    // TODO: remove this 'include' block so we typecheck ALL of eval-view!
     "server.js",
     "utils.js",
     "evals.d.ts"

--- a/eval-view/tsconfig.json
+++ b/eval-view/tsconfig.json
@@ -13,7 +13,9 @@
     "lib": ["esnext", "dom", "dom.iterable"]
   },
   "include": [
-    "server.js"
+    "server.js",
+    "utils.js",
+    "evals.d.ts"
   ],
   "exclude": [
     "node_modules",

--- a/eval-view/utils.js
+++ b/eval-view/utils.js
@@ -45,7 +45,7 @@ export function capitalize(s) {
 }
 
 export function timeAgo(date) {
-    const diff = Math.floor((new Date() - new Date(date)) / 1000);
+    const diff = Math.floor((new Date().getTime() - new Date(date).getTime()) / 1000);
     const rtf = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
     const units = [
         { name: 'year', s: 31536000 }, { name: 'month', s: 2592000 },
@@ -53,7 +53,7 @@ export function timeAgo(date) {
         { name: 'minute', s: 60 }, { name: 'second', s: 1 }
     ];
     const u = units.find(u => Math.abs(diff) >= u.s) || units[units.length - 1];
-    return rtf.format(-Math.floor(diff / u.s), u.name);
+    return rtf.format(-Math.floor(diff / u.s), /** @type {Intl.RelativeTimeFormatUnit} */ (u.name));
 }
 
 export function calculateChartData(results) {
@@ -113,7 +113,7 @@ export function initGoogleAuth(onAuthSuccess) {
             return;
         }
 
-        const authBtn = document.getElementById('auth-btn');
+        const authBtn = /** @type {HTMLButtonElement | null} */ (document.getElementById('auth-btn'));
         if (authBtn) {
             authBtn.style.display = 'block';
             if (accessToken) {
@@ -166,7 +166,7 @@ export async function authenticatedFetch(url, options = {}) {
         accessToken = null;
         
         // Reset button UI if available
-        const authBtn = document.getElementById('auth-btn');
+        const authBtn = /** @type {HTMLButtonElement | null} */ (document.getElementById('auth-btn'));
         if (authBtn) {
             authBtn.textContent = 'Sign in with Google';
             authBtn.disabled = false;

--- a/guides/playwright.config.ts
+++ b/guides/playwright.config.ts
@@ -5,6 +5,8 @@ import * as os from 'os';
 export default defineConfig({
   timeout: 10000,
   expect: { timeout: 3000 },
+  // Forces Playwright to always search relative to this config file (the guides directory),
+  // regardless of where you run it from (e.g., when run from within a specific results folder).
   testDir: __dirname,
   testMatch: '**/grader.ts',
   fullyParallel: false,

--- a/guides/playwright.config.ts
+++ b/guides/playwright.config.ts
@@ -5,7 +5,7 @@ import * as os from 'os';
 export default defineConfig({
   timeout: 10000,
   expect: { timeout: 3000 },
-  testDir: '.',
+  testDir: __dirname,
   testMatch: '**/grader.ts',
   fullyParallel: false,
   forbidOnly: !!process.env.CI,

--- a/harness/agents/claude-code-agent.ts
+++ b/harness/agents/claude-code-agent.ts
@@ -140,7 +140,7 @@ async function run() {
   }
 }
 
-export async function collectClaudeGuidesFromTrajectory(dirPath: string, serving: string): Promise<{ retrievedGuides: string[]; fileReadGuides: string[] }> {
+export async function collectClaudeGuidesFromTrajectory(dirPath: string, _serving: string): Promise<{ retrievedGuides: string[]; fileReadGuides: string[] }> {
   const result = { retrievedGuides: [] as string[], fileReadGuides: [] as string[] };
   try {
     const files = fs.readdirSync(dirPath);

--- a/harness/agents/claude-code-agent.ts
+++ b/harness/agents/claude-code-agent.ts
@@ -242,8 +242,12 @@ export function collectClaudeToolsFromTrajectory(dir: string): string[] {
         const obj = JSON.parse(line);
         if (obj.message && Array.isArray(obj.message.content)) {
           for (const item of obj.message.content) {
-            if (item.type === 'tool_use' && item.name === 'Skill' && item.input?.skill) {
-              toolsUsed.push(item.input.skill);
+            if (item.type === 'tool_use') {
+              if (item.name === 'Skill' && item.input?.skill) {
+                toolsUsed.push(item.input.skill);
+              } else if (item.name === 'activate_skill' && item.input?.name) {
+                toolsUsed.push(item.input.name);
+              }
             }
           }
         }

--- a/harness/agents/claude-code-agent.ts
+++ b/harness/agents/claude-code-agent.ts
@@ -140,8 +140,8 @@ async function run() {
   }
 }
 
-export async function collectClaudeGuidesFromTrajectory(dirPath: string, serving: string): Promise<string[]> {
-  const guidesFromSkills: string[] = [];
+export async function collectClaudeGuidesFromTrajectory(dirPath: string, serving: string): Promise<{ retrievedGuides: string[]; fileReadGuides: string[] }> {
+  const result = { retrievedGuides: [] as string[], fileReadGuides: [] as string[] };
   try {
     const files = fs.readdirSync(dirPath);
     const sessionFiles = files.filter(f => f.startsWith('session-') && f.endsWith('.jsonl'));
@@ -157,23 +157,23 @@ export async function collectClaudeGuidesFromTrajectory(dirPath: string, serving
           const obj = JSON.parse(line);
           if (obj.message && obj.message.content) {
             for (const contentItem of obj.message.content) {
-              if (serving === Serving.SKILLS_CLI && contentItem.type === 'tool_use' && contentItem.name === 'Bash' && contentItem.input && contentItem.input.command) {
+              if (contentItem.type === 'tool_use' && contentItem.name === 'Bash' && contentItem.input && contentItem.input.command) {
                 const command = contentItem.input.command;
                 if (command.includes('modern-web') && command.includes('--retrieve')) {
                   const match = command.match(/--retrieve\s+["']?([^"'\s]+)["']?/);
                   if (match) {
                     const ids = match[1].split(',');
                     for (const id of ids) {
-                      guidesFromSkills.push(id.trim());
+                      result.retrievedGuides.push(id.trim());
                     }
                   }
                 }
-              } else if (serving === Serving.SKILLS && contentItem.type === 'tool_use' && contentItem.name === 'Read' && contentItem.input && contentItem.input.file_path) {
+              } else if (contentItem.type === 'tool_use' && contentItem.name === 'Read' && contentItem.input && contentItem.input.file_path) {
                 const filePath = contentItem.input.file_path;
                 if (filePath.includes('/skills/') && filePath.endsWith('/guide.md')) {
                   const match = filePath.match(/\/skills\/[^/]+\/([^/]+)\/guide\.md$/);
                   if (match) {
-                    guidesFromSkills.push(match[1]);
+                    result.fileReadGuides.push(match[1]);
                   }
                 }
               }
@@ -187,7 +187,10 @@ export async function collectClaudeGuidesFromTrajectory(dirPath: string, serving
   } catch (e) {
     console.error(`Error reading session files in ${dirPath}:`, e);
   }
-  return [...new Set(guidesFromSkills)];
+  
+  result.retrievedGuides = [...new Set(result.retrievedGuides)];
+  result.fileReadGuides = [...new Set(result.fileReadGuides)];
+  return result;
 }
 
 export function extractClaudeCodeModel(resultsDir: string): string {

--- a/harness/agents/gemini-cli-agent.ts
+++ b/harness/agents/gemini-cli-agent.ts
@@ -117,6 +117,11 @@ async function run() {
   }
 }
 
+function readTrajectory(filePath: string): ConversationRecord {
+  const content = fs.readFileSync(filePath, 'utf8');
+  return JSON.parse(content) as ConversationRecord;
+}
+
 export async function collectGeminiGuidesFromTrajectory(dirPath: string, _serving: string): Promise<GuidedUsage> {
   const retrievedGuides: string[] = [];
   const fileReadGuides: string[] = [];
@@ -126,8 +131,7 @@ export async function collectGeminiGuidesFromTrajectory(dirPath: string, _servin
 
     for (const file of sessionFiles) {
       const sessionPath = path.join(dirPath, file);
-      const sessionContent = fs.readFileSync(sessionPath, 'utf8');
-      const session = JSON.parse(sessionContent) as ConversationRecord;
+      const session = readTrajectory(sessionPath);
 
       if (session.messages) {
         for (const msg of session.messages) {
@@ -187,8 +191,7 @@ export function extractGeminiCliModel(resultsDir: string): string {
   for (const relativePath of sessionFiles as string[]) {
     const sessionPath = path.join(resultsDir, relativePath);
     try {
-      const content = fs.readFileSync(sessionPath, 'utf8');
-      const session = JSON.parse(content);
+      const session = readTrajectory(sessionPath);
       if (session.messages) {
         for (const m of session.messages) {
           if (m.type === 'gemini' && m.model) {
@@ -216,8 +219,7 @@ export function collectGeminiToolsFromTrajectory(dir: string): string[] {
 
   try {
     const sessionPath = path.join(dir, firstSession);
-    const content = fs.readFileSync(sessionPath, 'utf8');
-    const session = JSON.parse(content) as ConversationRecord;
+    const session = readTrajectory(sessionPath);
     if (Array.isArray(session.messages)) {
       for (const msg of session.messages) {
         if (msg.type === 'gemini' && Array.isArray(msg.toolCalls)) {

--- a/harness/agents/gemini-cli-agent.ts
+++ b/harness/agents/gemini-cli-agent.ts
@@ -6,6 +6,13 @@ import { fileURLToPath } from 'url';
 import config, { Agents, Serving } from '../config.ts';
 import { getSuiteConfig, updateMcpConfig, createIsolatedHome, cleanupIsolatedHome, copyFileIfExists, parseAgentArgs, createWorkDir, copySkills, watchLogFile, exportTrajectories, runCliAgentCommand } from '../lib/agent-shared.ts';
 
+import type { ConversationRecord, MessageRecord, ToolCallRecord } from '@google/gemini-cli-core';
+import type { CoreToolCallStatus } from '@google/gemini-cli-core/dist/src/scheduler/types.js';
+
+export interface GuidedUsage {
+  retrievedGuides: string[];
+  fileReadGuides: string[];
+}
 import { MODERN_WEB_LOG_FILE } from '../../constants.ts';
 
 // Usage: node gemini-cli-agent.ts <prompt> <runType> <targetDir> <templateDir>
@@ -111,8 +118,9 @@ async function run() {
   }
 }
 
-export async function collectGeminiGuidesFromTrajectory(dirPath: string, serving: string): Promise<string[]> {
-  const guidesFromSkills: string[] = [];
+export async function collectGeminiGuidesFromTrajectory(dirPath: string, serving: string): Promise<GuidedUsage> {
+  const retrievedGuides: string[] = [];
+  const fileReadGuides: string[] = [];
   try {
     const files = fs.readdirSync(dirPath);
     const sessionFiles = files.filter(f => f.startsWith('session-') && f.endsWith('.json'));
@@ -126,25 +134,33 @@ export async function collectGeminiGuidesFromTrajectory(dirPath: string, serving
         for (const msg of session.messages) {
           if (msg.toolCalls) {
             for (const tc of msg.toolCalls) {
-              if (serving === Serving.SKILLS && tc.name === 'read_file' && tc.args && tc.args.file_path) {
-                const filePath = tc.args.file_path;
-                if (filePath.includes('/skills/') && filePath.endsWith('/guide.md')) {
-                  const match = filePath.match(/\/skills\/[^/]+\/([^/]+)\/guide\.md$/);
-                  if (match) {
-                    guidesFromSkills.push(match[1]);
-                  }
-                }
-              } else if (serving === Serving.SKILLS_CLI && tc.name === 'run_shell_command' && tc.args && tc.args.command) {
-                const command = tc.args.command;
-                if (command.includes('modern-web') && command.includes('--retrieve')) {
-                  const match = command.match(/--retrieve\s+["']?([^"'\s]+)["']?/);
-                  if (match) {
-                    const ids = match[1].split(',');
-                    for (const id of ids) {
-                      guidesFromSkills.push(id.trim());
+              if ((serving === Serving.SKILLS || serving === Serving.MEGASKILL) && tc.name === 'read_file' && tc.args && (tc.args as any).file_path) {
+                const filePath = (tc.args as any).file_path;
+                  if (filePath.includes('/skills/')) {
+                    if (filePath.endsWith('/guide.md')) {
+                      const match = filePath.match(/\/skills\/[^/]+\/([^/]+)\/guide\.md$/);
+                      if (match) {
+                        fileReadGuides.push(match[1]);
+                      }
+                    } else if (filePath.endsWith('.md')) {
+                      const match = filePath.match(/\/skills\/[^/]+\/(?:references\/)?(?:[^/]+\/)*([^/]+)\.md$/);
+                      if (match) {
+                        fileReadGuides.push(match[1]);
+                      }
                     }
                   }
-                }
+              } else if (serving === Serving.SKILLS_CLI && tc.name === 'run_shell_command' && tc.args && (tc.args as any).command) {
+                const command = (tc.args as any).command;
+                  if (command.includes('modern-web') && command.includes('--retrieve')) {
+                    const match = command.match(/--retrieve\s+["']?([^"'\s]+)["']?/);
+                    if (match) {
+                      const ids = match[1].split(',');
+                      for (const id of ids) {
+                        retrievedGuides.push(id.trim());
+                      }
+                    }
+                  }
+              }
               }
             }
           }
@@ -154,7 +170,10 @@ export async function collectGeminiGuidesFromTrajectory(dirPath: string, serving
   } catch (e) {
     console.error(`Error reading session files in ${dirPath}:`, e);
   }
-  return [...new Set(guidesFromSkills)];
+  return {
+    retrievedGuides: [...new Set(retrievedGuides)],
+    fileReadGuides: [...new Set(fileReadGuides)]
+  };
 }
 
 export function extractGeminiCliModel(resultsDir: string): string {

--- a/harness/agents/gemini-cli-agent.ts
+++ b/harness/agents/gemini-cli-agent.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'url';
 import config, { Agents, Serving } from '../config.ts';
 import { getSuiteConfig, updateMcpConfig, createIsolatedHome, cleanupIsolatedHome, copyFileIfExists, parseAgentArgs, createWorkDir, copySkills, watchLogFile, exportTrajectories, runCliAgentCommand } from '../lib/agent-shared.ts';
 
-import type { ConversationRecord, MessageRecord, ToolCallRecord } from '@google/gemini-cli-core';
+import type { ConversationRecord } from '@google/gemini-cli-core';
 
 export interface GuidedUsage {
   retrievedGuides: string[];

--- a/harness/agents/gemini-cli-agent.ts
+++ b/harness/agents/gemini-cli-agent.ts
@@ -209,7 +209,8 @@ export function extractGeminiCliModel(resultsDir: string): string {
 
 export function collectGeminiToolsFromTrajectory(dir: string): string[] {
   const toolsUsed: string[] = [];
-  const sessionFiles = fs.globSync('session-*.json', { cwd: dir });
+  const files = fs.readdirSync(dir);
+  const sessionFiles = files.filter(f => f.startsWith('session-') && f.endsWith('.json'));
   const firstSession = sessionFiles[0];
   if (!firstSession) return toolsUsed;
 

--- a/harness/agents/gemini-cli-agent.ts
+++ b/harness/agents/gemini-cli-agent.ts
@@ -133,12 +133,12 @@ export async function collectGeminiGuidesFromTrajectory(dirPath: string, serving
         for (const msg of session.messages) {
           if (msg.toolCalls) {
             for (const tc of msg.toolCalls) {
-              if (tc.name === 'mcp_modern-web_get_best_practices' || tc.name === 'get_best_practices') {
+              if (tc.name.includes('get_best_practices')) {
                 const args = tc.args as any;
                 if (args && args.use_case_id) {
                   retrievedGuides.push(args.use_case_id);
                 }
-              } else if ((serving === Serving.SKILLS || serving === Serving.MEGASKILL) && tc.name === 'read_file' && tc.args && (tc.args as any).file_path) {
+              } else if (tc.name === 'read_file' && tc.args && (tc.args as any).file_path) {
                 const filePath = (tc.args as any).file_path;
                   if (filePath.includes('/skills/')) {
                     if (filePath.endsWith('/guide.md')) {
@@ -153,7 +153,7 @@ export async function collectGeminiGuidesFromTrajectory(dirPath: string, serving
                       }
                     }
                   }
-              } else if (serving === Serving.SKILLS_CLI && tc.name === 'run_shell_command' && tc.args && (tc.args as any).command) {
+              } else if (tc.name === 'run_shell_command' && tc.args && (tc.args as any).command) {
                 const command = (tc.args as any).command;
                   if (command.includes('modern-web') && command.includes('--retrieve')) {
                     const match = command.match(/--retrieve\s+["']?([^"'\s]+)["']?/);
@@ -222,7 +222,7 @@ export function collectGeminiToolsFromTrajectory(dir: string): string[] {
       for (const msg of session.messages) {
         if (Array.isArray(msg.toolCalls)) {
           for (const tc of msg.toolCalls) {
-            if (tc.name === 'mcp_modern-web_get_best_practices' || tc.name === 'get_best_practices') {
+            if (tc.name.includes('get_best_practices')) {
               toolsUsed.push('modern-web');
             } else if (tc.name === 'activate_skill' && tc.args?.name) {
               toolsUsed.push(tc.args.name);

--- a/harness/agents/gemini-cli-agent.ts
+++ b/harness/agents/gemini-cli-agent.ts
@@ -161,7 +161,6 @@ export async function collectGeminiGuidesFromTrajectory(dirPath: string, serving
                     }
                   }
               }
-              }
             }
           }
         }

--- a/harness/agents/gemini-cli-agent.ts
+++ b/harness/agents/gemini-cli-agent.ts
@@ -6,8 +6,7 @@ import { fileURLToPath } from 'url';
 import config, { Agents, Serving } from '../config.ts';
 import { getSuiteConfig, updateMcpConfig, createIsolatedHome, cleanupIsolatedHome, copyFileIfExists, parseAgentArgs, createWorkDir, copySkills, watchLogFile, exportTrajectories, runCliAgentCommand } from '../lib/agent-shared.ts';
 
-import type { ConversationRecord, MessageRecord, ToolCallRecord } from '@google/gemini-cli-core';
-import type { CoreToolCallStatus } from '@google/gemini-cli-core/dist/src/scheduler/types.js';
+
 
 export interface GuidedUsage {
   retrievedGuides: string[];

--- a/harness/agents/gemini-cli-agent.ts
+++ b/harness/agents/gemini-cli-agent.ts
@@ -117,7 +117,7 @@ async function run() {
   }
 }
 
-export async function collectGeminiGuidesFromTrajectory(dirPath: string, serving: string): Promise<GuidedUsage> {
+export async function collectGeminiGuidesFromTrajectory(dirPath: string, _serving: string): Promise<GuidedUsage> {
   const retrievedGuides: string[] = [];
   const fileReadGuides: string[] = [];
   try {

--- a/harness/agents/gemini-cli-agent.ts
+++ b/harness/agents/gemini-cli-agent.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'url';
 import config, { Agents, Serving } from '../config.ts';
 import { getSuiteConfig, updateMcpConfig, createIsolatedHome, cleanupIsolatedHome, copyFileIfExists, parseAgentArgs, createWorkDir, copySkills, watchLogFile, exportTrajectories, runCliAgentCommand } from '../lib/agent-shared.ts';
 
-
+import type { ConversationRecord, MessageRecord, ToolCallRecord } from '@google/gemini-cli-core';
 
 export interface GuidedUsage {
   retrievedGuides: string[];
@@ -127,19 +127,19 @@ export async function collectGeminiGuidesFromTrajectory(dirPath: string, _servin
     for (const file of sessionFiles) {
       const sessionPath = path.join(dirPath, file);
       const sessionContent = fs.readFileSync(sessionPath, 'utf8');
-      const session = JSON.parse(sessionContent);
+      const session = JSON.parse(sessionContent) as ConversationRecord;
 
       if (session.messages) {
         for (const msg of session.messages) {
-          if (msg.toolCalls) {
+          if (msg.type === 'gemini' && msg.toolCalls) {
             for (const tc of msg.toolCalls) {
               if (tc.name.includes('get_best_practices')) {
-                const args = tc.args as any;
+                const args = tc.args;
                 if (args && args.use_case_id) {
-                  retrievedGuides.push(args.use_case_id);
+                  retrievedGuides.push(args.use_case_id as string);
                 }
-              } else if (tc.name === 'read_file' && tc.args && (tc.args as any).file_path) {
-                const filePath = (tc.args as any).file_path;
+              } else if (tc.name === 'read_file' && tc.args && tc.args.file_path) {
+                const filePath = tc.args.file_path as string;
                   if (filePath.includes('/skills/')) {
                     if (filePath.endsWith('/guide.md')) {
                       const match = filePath.match(/\/skills\/[^/]+\/([^/]+)\/guide\.md$/);
@@ -217,15 +217,15 @@ export function collectGeminiToolsFromTrajectory(dir: string): string[] {
   try {
     const sessionPath = path.join(dir, firstSession);
     const content = fs.readFileSync(sessionPath, 'utf8');
-    const session = JSON.parse(content);
+    const session = JSON.parse(content) as ConversationRecord;
     if (Array.isArray(session.messages)) {
       for (const msg of session.messages) {
-        if (Array.isArray(msg.toolCalls)) {
+        if (msg.type === 'gemini' && Array.isArray(msg.toolCalls)) {
           for (const tc of msg.toolCalls) {
             if (tc.name.includes('get_best_practices')) {
               toolsUsed.push('modern-web');
-            } else if (tc.name === 'activate_skill' && tc.args?.name) {
-              toolsUsed.push(tc.args.name);
+            } else if (tc.name === 'activate_skill' && tc.args && tc.args.name) {
+              toolsUsed.push(tc.args.name as string);
             }
           }
         }

--- a/harness/agents/gemini-cli-agent.ts
+++ b/harness/agents/gemini-cli-agent.ts
@@ -133,7 +133,12 @@ export async function collectGeminiGuidesFromTrajectory(dirPath: string, serving
         for (const msg of session.messages) {
           if (msg.toolCalls) {
             for (const tc of msg.toolCalls) {
-              if ((serving === Serving.SKILLS || serving === Serving.MEGASKILL) && tc.name === 'read_file' && tc.args && (tc.args as any).file_path) {
+              if (tc.name === 'mcp_modern-web_get_best_practices' || tc.name === 'get_best_practices') {
+                const args = tc.args as any;
+                if (args && args.use_case_id) {
+                  retrievedGuides.push(args.use_case_id);
+                }
+              } else if ((serving === Serving.SKILLS || serving === Serving.MEGASKILL) && tc.name === 'read_file' && tc.args && (tc.args as any).file_path) {
                 const filePath = (tc.args as any).file_path;
                   if (filePath.includes('/skills/')) {
                     if (filePath.endsWith('/guide.md')) {

--- a/harness/agents/gemini-cli-agent.ts
+++ b/harness/agents/gemini-cli-agent.ts
@@ -137,37 +137,24 @@ export async function collectGeminiGuidesFromTrajectory(dirPath: string, _servin
         for (const msg of session.messages) {
           if (msg.type === 'gemini' && msg.toolCalls) {
             for (const tc of msg.toolCalls) {
-              if (tc.name.includes('get_best_practices')) {
-                const args = tc.args;
-                if (args && args.use_case_id) {
-                  retrievedGuides.push(args.use_case_id as string);
-                }
-              } else if (tc.name === 'read_file' && tc.args && tc.args.file_path) {
+              if (tc.name.includes('get_best_practices') && tc.args?.use_case_id) {
+                retrievedGuides.push(tc.args.use_case_id as string);
+              } else if (tc.name === 'read_file' && tc.args?.file_path) {
                 const filePath = tc.args.file_path as string;
-                  if (filePath.includes('/skills/')) {
-                    if (filePath.endsWith('/guide.md')) {
-                      const match = filePath.match(/\/skills\/[^/]+\/([^/]+)\/guide\.md$/);
-                      if (match) {
-                        fileReadGuides.push(match[1]);
-                      }
-                    } else if (filePath.endsWith('.md')) {
-                      const match = filePath.match(/\/skills\/[^/]+\/(?:references\/)?(?:[^/]+\/)*([^/]+)\.md$/);
-                      if (match) {
-                        fileReadGuides.push(match[1]);
-                      }
-                    }
+                if (filePath.includes('/skills/')) {
+                  // Prioritize guide.md folder name, fallback to reference filename
+                  const match = filePath.match(/\/skills\/[^/]+\/([^/]+)\/guide\.md$/) ||
+                                filePath.match(/\/skills\/[^/]+\/(?:references\/)?(?:[^/]+\/)*([^/]+)\.md$/);
+                  if (match) {
+                    fileReadGuides.push(match[1]);
                   }
-              } else if (tc.name === 'run_shell_command' && tc.args && (tc.args as any).command) {
-                const command = (tc.args as any).command;
-                  if (command.includes('modern-web') && command.includes('--retrieve')) {
-                    const match = command.match(/--retrieve\s+["']?([^"'\s]+)["']?/);
-                    if (match) {
-                      const ids = match[1].split(',');
-                      for (const id of ids) {
-                        retrievedGuides.push(id.trim());
-                      }
-                    }
-                  }
+                }
+              } else if (tc.name === 'run_shell_command' && tc.args?.command) {
+                const command = tc.args.command as string;
+                const match = command.match(/--retrieve\s+["']?([^"'\s]+)["']?/);
+                if (match) {
+                  retrievedGuides.push(...match[1].split(',').map(s => s.trim()));
+                }
               }
             }
           }

--- a/harness/agents/gemini-cli-agent.ts
+++ b/harness/agents/gemini-cli-agent.ts
@@ -221,7 +221,9 @@ export function collectGeminiToolsFromTrajectory(dir: string): string[] {
       for (const msg of session.messages) {
         if (Array.isArray(msg.toolCalls)) {
           for (const tc of msg.toolCalls) {
-            if (tc.name === 'activate_skill' && tc.args?.name) {
+            if (tc.name === 'mcp_modern-web_get_best_practices' || tc.name === 'get_best_practices') {
+              toolsUsed.push('modern-web');
+            } else if (tc.name === 'activate_skill' && tc.args?.name) {
               toolsUsed.push(tc.args.name);
             }
           }

--- a/harness/backfill.ts
+++ b/harness/backfill.ts
@@ -71,7 +71,7 @@ async function backfillSuite(suiteResultsDir: string, suiteName: string) {
 async function main() {
   console.log('Starting Backfill of all results...'.cyan.bold);
 
-  let mainResultsDir = '/Users/paulirish/code/guidance/harness/results';
+  let mainResultsDir = resultsDir;
   
   // Allow passing a custom results directory as an argument!
   if (process.argv[2]) {

--- a/harness/backfill.ts
+++ b/harness/backfill.ts
@@ -5,7 +5,7 @@ import { collectResults, extractModelFromResults } from './lib/collection.ts';
 import { calculateMetrics } from './lib/metrics.ts';
 import { generateMarkdownReport, generateJsonReport, saveReports } from './lib/reporting.ts';
 import { resultsDir } from '../lib/paths.ts';
-import type { SuiteConfig } from './config.ts';
+import { Serving, type SuiteConfig } from './config.ts';
 
 async function backfillSuite(suiteResultsDir: string, suiteName: string) {
   console.log(`Backfilling suite: ${suiteName}`.cyan);
@@ -24,7 +24,7 @@ async function backfillSuite(suiteResultsDir: string, suiteName: string) {
     console.warn(`⚠️ No suite_config.json found in ${suiteResultsDir}. Inferring config...`.yellow);
     
     let agent = 'gemini-cli';
-    let serving = 'mcp';
+    let serving: Serving = 'mcp';
 
     const evalsPath = path.join(suiteResultsDir, 'evals.json');
     if (fs.existsSync(evalsPath)) {
@@ -40,8 +40,13 @@ async function backfillSuite(suiteResultsDir: string, suiteName: string) {
       }
     }
 
-    suiteConfig = { agent, serving, tasks: [] };
+    suiteConfig = { agent, serving, tasks: [], name: null, numRuns: 1, mcpServersToEnable: [] };
     console.log(`Inferred: agent=${agent}, serving=${serving}`.cyan);
+  }
+
+  if (!suiteConfig) {
+    console.error(`Failed to infer suite config`.red);
+    return;
   }
 
   try {

--- a/harness/backfill.ts
+++ b/harness/backfill.ts
@@ -1,0 +1,75 @@
+import path from 'path';
+import fs from 'fs';
+import 'colors';
+import { collectResults, extractModelFromResults } from './lib/collection.ts';
+import { calculateMetrics } from './lib/metrics.ts';
+import { generateMarkdownReport, generateJsonReport, saveReports } from './lib/reporting.ts';
+import { resultsDir } from '../lib/paths.ts';
+import type { SuiteConfig } from './config.ts';
+
+async function backfillSuite(suiteResultsDir: string, suiteName: string) {
+  console.log(`Backfilling suite: ${suiteName}`.cyan);
+
+  const configPath = path.join(suiteResultsDir, 'suite_config.json');
+  let suiteConfig: SuiteConfig | null = null;
+  if (fs.existsSync(configPath)) {
+    try {
+      suiteConfig = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    } catch {
+      console.warn(`⚠️ Failed to parse suite_config.json in ${suiteResultsDir}`.yellow);
+    }
+  }
+
+  if (!suiteConfig) {
+    console.warn(`⚠️ Skipping ${suiteName}: No suite_config.json found or failed to parse.`.yellow);
+    return;
+  }
+
+  try {
+    // Pass skipGrading=true to avoid re-running Playwright graders!
+    const { allResults, numRuns } = await collectResults(suiteResultsDir, suiteConfig, true);
+    console.log(`Found ${numRuns} test run(s)`.cyan);
+
+    const metrics = calculateMetrics(allResults, numRuns);
+    const mdReport = generateMarkdownReport(metrics, allResults);
+    const timestamp = new Date().toISOString();
+    const model = extractModelFromResults(suiteResultsDir, suiteConfig.agent);
+    const jsonReport = generateJsonReport(metrics, allResults, timestamp, numRuns, suiteConfig.agent, suiteConfig.serving, model);
+
+    saveReports(suiteResultsDir, mdReport, jsonReport);
+    console.log(`Successfully backfilled ${suiteName}`.green);
+
+  } catch (error: any) {
+    console.error(`Backfill failed for ${suiteName}: ${error.message}`.red);
+  }
+}
+
+async function main() {
+  console.log('Starting Backfill of all results...'.cyan.bold);
+
+  let mainResultsDir = '/Users/paulirish/code/guidance/harness/results';
+  
+  // Allow passing a custom results directory as an argument!
+  if (process.argv[2]) {
+    mainResultsDir = path.resolve(process.argv[2]);
+  }
+
+  if (!fs.existsSync(mainResultsDir)) {
+    console.error(`Results directory not found at ${mainResultsDir}!`.red);
+    process.exit(1);
+  }
+
+  const entries = fs.readdirSync(mainResultsDir, { withFileTypes: true });
+  const suiteDirs = entries.filter(e => e.isDirectory()).map(e => e.name);
+
+  console.log(`Found ${suiteDirs.length} potential suites in ${mainResultsDir}.`.cyan);
+
+  for (const suiteName of suiteDirs) {
+    const suiteResultsDir = path.join(mainResultsDir, suiteName);
+    await backfillSuite(suiteResultsDir, suiteName);
+  }
+
+  console.log('Backfill completed!'.cyan.bold);
+}
+
+main().catch(console.error);

--- a/harness/backfill.ts
+++ b/harness/backfill.ts
@@ -1,71 +1,11 @@
 import path from 'path';
 import fs from 'fs';
 import 'colors';
-import { collectResults, extractModelFromResults } from './lib/collection.ts';
-import { calculateMetrics } from './lib/metrics.ts';
-import { generateMarkdownReport, generateJsonReport, saveReports } from './lib/reporting.ts';
+import { evaluateSuite } from './evaluate.ts';
 import { resultsDir } from '../lib/paths.ts';
-import { Serving, type SuiteConfig } from './config.ts';
 
 async function backfillSuite(suiteResultsDir: string, suiteName: string) {
-  console.log(`Backfilling suite: ${suiteName}`.cyan);
-
-  const configPath = path.join(suiteResultsDir, 'suite_config.json');
-  let suiteConfig: SuiteConfig | null = null;
-  if (fs.existsSync(configPath)) {
-    try {
-      suiteConfig = JSON.parse(fs.readFileSync(configPath, 'utf8'));
-    } catch {
-      console.warn(`⚠️ Failed to parse suite_config.json in ${suiteResultsDir}`.yellow);
-    }
-  }
-
-  if (!suiteConfig) {
-    console.warn(`⚠️ No suite_config.json found in ${suiteResultsDir}. Inferring config...`.yellow);
-    
-    let agent = 'gemini-cli';
-    let serving: Serving = 'mcp';
-
-    const evalsPath = path.join(suiteResultsDir, 'evals.json');
-    if (fs.existsSync(evalsPath)) {
-      try {
-        const oldEvals = JSON.parse(fs.readFileSync(evalsPath, 'utf8'));
-        if (oldEvals.agent) agent = oldEvals.agent;
-        if (oldEvals.serving) serving = oldEvals.serving;
-        else if (oldEvals.enableSkills !== undefined) {
-          serving = oldEvals.enableSkills ? 'skills' : 'mcp';
-        }
-      } catch {
-        // Ignore parse error
-      }
-    }
-
-    suiteConfig = { agent, serving, tasks: [], name: null, numRuns: 1, mcpServersToEnable: [] };
-    console.log(`Inferred: agent=${agent}, serving=${serving}`.cyan);
-  }
-
-  if (!suiteConfig) {
-    console.error(`Failed to infer suite config`.red);
-    return;
-  }
-
-  try {
-    // Pass skipGrading=true to avoid re-running Playwright graders!
-    const { allResults, numRuns } = await collectResults(suiteResultsDir, suiteConfig, true);
-    console.log(`Found ${numRuns} test run(s)`.cyan);
-
-    const metrics = calculateMetrics(allResults, numRuns);
-    const mdReport = generateMarkdownReport(metrics, allResults);
-    const timestamp = new Date().toISOString();
-    const model = extractModelFromResults(suiteResultsDir, suiteConfig.agent);
-    const jsonReport = generateJsonReport(metrics, allResults, timestamp, numRuns, suiteConfig.agent, suiteConfig.serving, model);
-
-    saveReports(suiteResultsDir, mdReport, jsonReport);
-    console.log(`Successfully backfilled ${suiteName}`.green);
-
-  } catch (error: any) {
-    console.error(`Backfill failed for ${suiteName}: ${error.message}`.red);
-  }
+  await evaluateSuite(suiteResultsDir, suiteName);
 }
 
 async function main() {

--- a/harness/backfill.ts
+++ b/harness/backfill.ts
@@ -21,8 +21,27 @@ async function backfillSuite(suiteResultsDir: string, suiteName: string) {
   }
 
   if (!suiteConfig) {
-    console.warn(`⚠️ Skipping ${suiteName}: No suite_config.json found or failed to parse.`.yellow);
-    return;
+    console.warn(`⚠️ No suite_config.json found in ${suiteResultsDir}. Inferring config...`.yellow);
+    
+    let agent = 'gemini-cli';
+    let serving = 'mcp';
+
+    const evalsPath = path.join(suiteResultsDir, 'evals.json');
+    if (fs.existsSync(evalsPath)) {
+      try {
+        const oldEvals = JSON.parse(fs.readFileSync(evalsPath, 'utf8'));
+        if (oldEvals.agent) agent = oldEvals.agent;
+        if (oldEvals.serving) serving = oldEvals.serving;
+        else if (oldEvals.enableSkills !== undefined) {
+          serving = oldEvals.enableSkills ? 'skills' : 'mcp';
+        }
+      } catch {
+        // Ignore parse error
+      }
+    }
+
+    suiteConfig = { agent, serving, tasks: [] };
+    console.log(`Inferred: agent=${agent}, serving=${serving}`.cyan);
   }
 
   try {

--- a/harness/backfill.ts
+++ b/harness/backfill.ts
@@ -1,3 +1,19 @@
+/**
+ * @file backfill.ts
+ * @description Backfills evaluation metrics for all suites in a results directory.
+ * 
+ * Rationale:
+ * When reporting logic changes (e.g., adding split guide metrics or handling new directory structures),
+ * we need to re-evaluate historical test runs to update their `evals.json` and `evals.md` reports.
+ * This script iterates over all suite directories in the results folder and delegates to `evaluateSuite`
+ * to re-process results, running grading only if missing, and updating the summary files.
+ * 
+ * Usage:
+ * node harness/backfill.ts [custom_results_dir]
+ * 
+ * If no argument is provided, it defaults to the project's standard results directory.
+ */
+
 import path from 'path';
 import fs from 'fs';
 import 'colors';

--- a/harness/config.ts
+++ b/harness/config.ts
@@ -19,7 +19,8 @@ export const Agents = {
 export const Serving = {
   SKILLS_CLI: 'skills_cli',
   SKILLS: 'skills',
-  MCP: 'mcp'
+  MCP: 'mcp',
+  MEGASKILL: 'megaskill'
 } as const;
 
 export type Serving = typeof Serving[keyof typeof Serving];

--- a/harness/eval-results.md
+++ b/harness/eval-results.md
@@ -1,0 +1,63 @@
+# Evaluation Results Management
+
+This document covers how evaluation results are stored, uploaded to Google Cloud Storage (GCS), and the workflows for syncing and backfilling metrics.
+
+## Storage Location
+Evaluation results are stored locally in:
+- `harness/results/` (default within the repo).
+- Or a custom external directory (e.g., `~/guidance-results`).
+
+Each suite has its own directory containing:
+- `evals.json`: Summary of all runs and assertions.
+- `evals.md`: Markdown report of the suite.
+- Numbered directories (`1`, `2`, `3`...) for each run, containing agent logs and grader results.
+
+---
+
+## Uploading to GCS
+We use `harness/upload_suite.ts` to upload a suite to GCS.
+
+### How it works
+1. Requires `evals.json` to exist in the suite directory (ensures evaluation was run).
+2. Uploads all files in the suite directory to `gs://guidance-evals/<suite-name>/` (skipping `node_modules`).
+3. Uploads concurrently (chunked to 50 files at a time).
+
+### Command
+```bash
+pnpm upload <suite-name>
+```
+*(This maps to running `node --experimental-strip-types harness/upload_suite.ts`)*
+
+---
+
+## Workflows
+
+### 1. Syncing from GCS (Downloading)
+If you need to pull down suites from GCS that you don't have locally (e.g., to run backfill on them):
+
+```bash
+gcloud storage rsync gs://guidance-evals ~/guidance-results
+```
+
+*   **Safe**: It does not delete local files (like `.git`) by default unless you pass `--delete`.
+*   **Dry Run**: To see what it would do without touching files:
+    ```bash
+    gcloud storage rsync gs://guidance-evals ~/guidance-results --dry-run
+    ```
+
+### 2. Backfilling Metrics
+When metrics reporting logic changes, you can backfill all suites in a directory:
+
+```bash
+# Backfill local repo results
+node harness/backfill.ts
+
+# Backfill a custom directory (e.g., synced from GCS)
+node harness/backfill.ts ~/guidance-results
+```
+This updates `evals.json` and `evals.md` in each suite directory.
+
+### 3. Pushing Updates to GCS
+After backfilling, you should push the updated summaries back to GCS.
+
+*(Note: Currently `upload_suite.ts` re-uploads all files. We plan to add a `--summary-only` flag to only upload `evals.json` and `evals.md` to make this sync extremely fast).*

--- a/harness/eval-results.md
+++ b/harness/eval-results.md
@@ -24,9 +24,12 @@ We use `harness/upload_suite.ts` to upload a suite to GCS.
 
 ### Command
 ```bash
+# Upload full suite from local repo results
 pnpm upload <suite-name>
+
+# Upload with flags or from custom directory
+node harness/upload_suite.ts <suite-name> [--summary-only] [custom_results_dir]
 ```
-*(This maps to running `node --experimental-strip-types harness/upload_suite.ts`)*
 
 ---
 
@@ -64,4 +67,12 @@ This updates `evals.json` and `evals.md` in each suite directory.
 ### 3. Pushing Updates to GCS
 After backfilling, you should push the updated summaries back to GCS.
 
-*(Note: Currently `upload_suite.ts` re-uploads all files. We plan to add a `--summary-only` flag to only upload `evals.json` and `evals.md` to make this sync extremely fast).*
+You can use the **`--summary-only`** flag to only upload `evals.json` and `evals.md`, making the sync extremely fast:
+
+```bash
+# Upload ONLY summaries from your custom directory
+node harness/upload_suite.ts <suite-name> ~/guidance-evals --summary-only
+
+# Upload EVERYTHING from your custom directory
+node harness/upload_suite.ts <suite-name> ~/guidance-evals
+```

--- a/harness/eval-results.md
+++ b/harness/eval-results.md
@@ -36,13 +36,17 @@ pnpm upload <suite-name>
 If you need to pull down suites from GCS that you don't have locally (e.g., to run backfill on them):
 
 ```bash
-gcloud storage rsync gs://guidance-evals ~/guidance-results
+gcloud storage rsync gs://guidance-evals ~/guidance-results --recursive
 ```
 
-*   **Safe**: It does not delete local files (like `.git`) by default unless you pass `--delete`.
+*   **Recursive**: You **MUST** pass `--recursive` (or `-r`), otherwise it will not copy files inside the suite folders!
+*   **Safe by Default**: It does not delete local files (like `.git`) by default.
+*   **Destructive Flag**: If you want to delete local files that aren't in the bucket, use `--delete-unmatched-destination-objects`. 
+    > [!WARNING]
+    > If you use this flag when pulling from GCS to local, **it WILL delete your `.git` folder** (because `.git` is not on GCS). Move your `.git` folder out of the target directory before running it with this flag!
 *   **Dry Run**: To see what it would do without touching files:
     ```bash
-    gcloud storage rsync gs://guidance-evals ~/guidance-results --dry-run
+    gcloud storage rsync gs://guidance-evals ~/guidance-results --recursive --dry-run
     ```
 
 ### 2. Backfilling Metrics

--- a/harness/eval-results.md
+++ b/harness/eval-results.md
@@ -5,7 +5,7 @@ This document covers how evaluation results are stored, uploaded to Google Cloud
 ## Storage Location
 Evaluation results are stored locally in:
 - `harness/results/` (default within the repo).
-- Or a custom external directory (e.g., `~/guidance-results`).
+- Or a custom external directory (e.g., `~/guidance-evals`).
 
 Each suite has its own directory containing:
 - `evals.json`: Summary of all runs and assertions.
@@ -36,7 +36,7 @@ pnpm upload <suite-name>
 If you need to pull down suites from GCS that you don't have locally (e.g., to run backfill on them):
 
 ```bash
-gcloud storage rsync gs://guidance-evals ~/guidance-results --recursive
+gcloud storage rsync gs://guidance-evals ~/guidance-evals --recursive
 ```
 
 *   **Recursive**: You **MUST** pass `--recursive` (or `-r`), otherwise it will not copy files inside the suite folders!
@@ -46,7 +46,7 @@ gcloud storage rsync gs://guidance-evals ~/guidance-results --recursive
     > If you use this flag when pulling from GCS to local, **it WILL delete your `.git` folder** (because `.git` is not on GCS). Move your `.git` folder out of the target directory before running it with this flag!
 *   **Dry Run**: To see what it would do without touching files:
     ```bash
-    gcloud storage rsync gs://guidance-evals ~/guidance-results --recursive --dry-run
+    gcloud storage rsync gs://guidance-evals ~/guidance-evals --recursive --dry-run
     ```
 
 ### 2. Backfilling Metrics
@@ -57,7 +57,7 @@ When metrics reporting logic changes, you can backfill all suites in a directory
 node harness/backfill.ts
 
 # Backfill a custom directory (e.g., synced from GCS)
-node harness/backfill.ts ~/guidance-results
+node harness/backfill.ts ~/guidance-evals
 ```
 This updates `evals.json` and `evals.md` in each suite directory.
 

--- a/harness/evaluate.ts
+++ b/harness/evaluate.ts
@@ -9,6 +9,27 @@ import { resultsDir } from '../lib/paths.ts';
 
 import { Serving, type SuiteConfig } from './config.ts';
 
+function inferSuiteConfig(suiteResultsDir: string): SuiteConfig {
+  let agent = 'gemini-cli';
+  let serving: Serving = 'mcp';
+
+  const evalsPath = path.join(suiteResultsDir, 'evals.json');
+  if (fs.existsSync(evalsPath)) {
+    try {
+      const oldEvals = JSON.parse(fs.readFileSync(evalsPath, 'utf8'));
+      if (oldEvals.agent) agent = oldEvals.agent;
+      if (oldEvals.serving) serving = oldEvals.serving;
+      else if (oldEvals.enableSkills !== undefined) {
+        serving = oldEvals.enableSkills ? 'skills' : 'mcp';
+      }
+    } catch {
+      // Ignore parse error
+    }
+  }
+
+  return { agent, serving, tasks: [], name: null, numRuns: 1, mcpServersToEnable: [] };
+}
+
 export async function evaluateSuite(suiteResultsDir: string, suiteName: string) {
   console.log(`Evaluating suite: ${suiteName}`.cyan);
   console.log(`Results directory: ${suiteResultsDir}`.cyan);
@@ -30,26 +51,8 @@ export async function evaluateSuite(suiteResultsDir: string, suiteName: string) 
 
   if (!suiteConfig) {
     console.warn(`⚠️ No suite_config.json found in ${suiteResultsDir}. Inferring config...`.yellow);
-    
-    let agent = 'gemini-cli';
-    let serving: Serving = 'mcp';
-
-    const evalsPath = path.join(suiteResultsDir, 'evals.json');
-    if (fs.existsSync(evalsPath)) {
-      try {
-        const oldEvals = JSON.parse(fs.readFileSync(evalsPath, 'utf8'));
-        if (oldEvals.agent) agent = oldEvals.agent;
-        if (oldEvals.serving) serving = oldEvals.serving;
-        else if (oldEvals.enableSkills !== undefined) {
-          serving = oldEvals.enableSkills ? 'skills' : 'mcp';
-        }
-      } catch {
-        // Ignore parse error
-      }
-    }
-
-    suiteConfig = { agent, serving, tasks: [], name: null, numRuns: 1, mcpServersToEnable: [] };
-    console.log(`Inferred: agent=${agent}, serving=${serving}`.cyan);
+    suiteConfig = inferSuiteConfig(suiteResultsDir);
+    console.log(`Inferred: agent=${suiteConfig.agent}, serving=${suiteConfig.serving}`.cyan);
   }
 
   if (!suiteConfig) {

--- a/harness/evaluate.ts
+++ b/harness/evaluate.ts
@@ -7,7 +7,7 @@ import { calculateMetrics } from './lib/metrics.ts';
 import { generateMarkdownReport, generateJsonReport, saveReports } from './lib/reporting.ts';
 import { resultsDir } from '../lib/paths.ts';
 
-import type { SuiteConfig } from './config.ts';
+import { Serving, type SuiteConfig } from './config.ts';
 
 export async function evaluateSuite(suiteResultsDir: string, suiteName: string) {
   console.log(`Evaluating suite: ${suiteName}`.cyan);
@@ -29,7 +29,31 @@ export async function evaluateSuite(suiteResultsDir: string, suiteName: string) 
   }
 
   if (!suiteConfig) {
-    console.error(`⚠️ No suite_config.json found or failed to parse in ${suiteResultsDir}. Aborting evaluation.`.red);
+    console.warn(`⚠️ No suite_config.json found in ${suiteResultsDir}. Inferring config...`.yellow);
+    
+    let agent = 'gemini-cli';
+    let serving: Serving = 'mcp';
+
+    const evalsPath = path.join(suiteResultsDir, 'evals.json');
+    if (fs.existsSync(evalsPath)) {
+      try {
+        const oldEvals = JSON.parse(fs.readFileSync(evalsPath, 'utf8'));
+        if (oldEvals.agent) agent = oldEvals.agent;
+        if (oldEvals.serving) serving = oldEvals.serving;
+        else if (oldEvals.enableSkills !== undefined) {
+          serving = oldEvals.enableSkills ? 'skills' : 'mcp';
+        }
+      } catch {
+        // Ignore parse error
+      }
+    }
+
+    suiteConfig = { agent, serving, tasks: [], name: null, numRuns: 1, mcpServersToEnable: [] };
+    console.log(`Inferred: agent=${agent}, serving=${serving}`.cyan);
+  }
+
+  if (!suiteConfig) {
+    console.error(`⚠️ Failed to infer suite config for ${suiteResultsDir}. Aborting evaluation.`.red);
     return;
   }
 

--- a/harness/lib/agent-shared.ts
+++ b/harness/lib/agent-shared.ts
@@ -528,12 +528,6 @@ export async function runCliAgentCommand(
     child.on('close', resolve);
   });
 
-  if (exitCode !== 0) {
-    throw new Error(`${agentName} exited with code ${exitCode}`);
-  }
-
-  copyResultsToTarget(workDir, targetDir);
-
   // Save output to chat_log.txt
   const chatLogPath = path.join(targetDir, 'chat_log.txt');
   fs.writeFileSync(chatLogPath, stdoutData, 'utf8');
@@ -544,6 +538,16 @@ export async function runCliAgentCommand(
     const stderrLogPath = path.join(targetDir, 'agent_stderr.log');
     fs.writeFileSync(stderrLogPath, stderrData, 'utf8');
     console.log(`Saved stderr to: ${stderrLogPath}`);
+  }
+
+  try {
+    copyResultsToTarget(workDir, targetDir);
+  } catch (e) {
+    console.error(`Failed to copy results from ${workDir} to ${targetDir}:`, e);
+  }
+
+  if (exitCode !== 0) {
+    throw new Error(`${agentName} exited with code ${exitCode}`);
   }
 }
 

--- a/harness/lib/agent-shared.ts
+++ b/harness/lib/agent-shared.ts
@@ -513,42 +513,57 @@ export async function runCliAgentCommand(
   child.stdout?.on('data', (data) => {
     const chunk = data.toString();
     stdoutData += chunk;
-    // Manually mirror to console so we can see progress while capturing
     process.stdout.write(chunk);
   });
 
   child.stderr?.on('data', (data) => {
     const chunk = data.toString();
     stderrData += chunk;
-    // Manually mirror to console so we can see progress while capturing
     process.stderr.write(chunk);
   });
 
-  const exitCode = await new Promise((resolve) => {
-    child.on('close', resolve);
-  });
-
-  // Save output to chat_log.txt
-  const chatLogPath = path.join(targetDir, 'chat_log.txt');
-  fs.writeFileSync(chatLogPath, stdoutData, 'utf8');
-  console.log(`Saved output to: ${chatLogPath}`);
-
-  // Save stderr to agent_stderr.log to surface unexpected problems
-  if (stderrData.length > 0) {
-    const stderrLogPath = path.join(targetDir, 'agent_stderr.log');
-    fs.writeFileSync(stderrLogPath, stderrData, 'utf8');
-    console.log(`Saved stderr to: ${stderrLogPath}`);
-  }
-
   try {
-    copyResultsToTarget(workDir, targetDir);
-  } catch (e) {
-    console.error(`Failed to copy results from ${workDir} to ${targetDir}:`, e);
-  }
+    const exitCode = await new Promise<number>((resolve, reject) => {
+      child.on('close', (code) => resolve(code ?? 1));
+      child.on('error', (err) => reject(err));
+    });
 
-  if (exitCode !== 0) {
-    throw new Error(`${agentName} exited with code ${exitCode}`);
+    // Save output to chat_log.txt
+    const chatLogPath = path.join(targetDir, 'chat_log.txt');
+    fs.writeFileSync(chatLogPath, stdoutData, 'utf8');
+    console.log(`Saved output to: ${chatLogPath}`);
+
+    // Save stderr to agent_stderr.log to surface unexpected problems
+    if (stderrData.length > 0) {
+      const stderrLogPath = path.join(targetDir, 'agent_stderr.log');
+      fs.writeFileSync(stderrLogPath, stderrData, 'utf8');
+      console.log(`Saved stderr to: ${stderrLogPath}`);
+    }
+
+    try {
+      copyResultsToTarget(workDir, targetDir);
+    } catch (e) {
+      console.error(`Failed to copy results from ${workDir} to ${targetDir}:`, e);
+    }
+
+    if (exitCode !== 0) {
+      throw new Error(`${agentName} exited with code ${exitCode}`);
+    }
+  } catch (err: any) {
+    console.error(`Error in runCliAgentCommand:`, err);
+    
+    // Fallback: Save whatever we have to agent_stderr.log even if it failed
+    const stderrLogPath = path.join(targetDir, 'agent_stderr.log');
+    let fallbackContent = `Execution failed: ${err.message || err}\n`;
+    if (stderrData) {
+      fallbackContent += `\nCaptured stderr:\n${stderrData}`;
+    }
+    fs.writeFileSync(stderrLogPath, fallbackContent, 'utf8');
+    console.log(`Saved fallback error log to: ${stderrLogPath}`);
+    
+    throw err; // Re-throw to propagate failure
   }
+}
 }
 
 /**

--- a/harness/lib/agent-shared.ts
+++ b/harness/lib/agent-shared.ts
@@ -564,7 +564,6 @@ export async function runCliAgentCommand(
     throw err; // Re-throw to propagate failure
   }
 }
-}
 
 /**
  * Generates an HTML file that can load and display a trajectory file (JSON/PB) 

--- a/harness/lib/collection.ts
+++ b/harness/lib/collection.ts
@@ -195,10 +195,8 @@ run();
       let expectedGuidanceTool: string | undefined;
       const serving = suiteConfig.serving;
 
-      if (serving === Serving.MCP || serving === Serving.MEGASKILL || suiteConfig.agent === Agents.JETSKI) {
+      if (serving === Serving.MCP || serving === Serving.MEGASKILL || serving === Serving.SKILLS_CLI || suiteConfig.agent === Agents.JETSKI) {
         expectedGuidanceTool = 'modern-web';
-      } else if (serving === Serving.SKILLS_CLI) {
-        expectedGuidanceTool = 'modern-web-use-cases';
       } else if (serving === Serving.SKILLS) {
         expectedGuidanceTool = taskCategory || undefined;
       }

--- a/harness/lib/collection.ts
+++ b/harness/lib/collection.ts
@@ -41,11 +41,16 @@ export async function collectResults(resultsDir: string, suiteConfig: SuiteConfi
 
   for (const runDir of runDirs) {
     const runPath = path.join(resultsDir, runDir);
-    const directories = glob.sync('*/*/*/', { cwd: runPath, absolute: true });
+    const indexFiles = [
+      ...glob.sync('*/*/index.html', { cwd: runPath, absolute: true }),
+      ...glob.sync('*/*/*/index.html', { cwd: runPath, absolute: true })
+    ];
 
-    for (const dir of directories) {
+    for (const indexFile of indexFiles) {
+      const dir = path.dirname(indexFile);
       const relPath = path.relative(runPath, dir);
       const parts = relPath.split(path.sep);
+      if (parts.includes('grade-report')) continue; // Skip grader reports
       
       let guide: string, taskName: string, runType: string;
       if (parts.length === 2) {
@@ -135,14 +140,16 @@ run();
     const runPath = path.join(resultsDir, runDir);
 
     // Structure: results/{suiteName}/{runNumber}/{guideName}/{taskName}/{runType}
-    const directories = glob.sync('*/*/*/', {
-      cwd: runPath,
-      absolute: true
-    });
+    const indexFiles = [
+      ...glob.sync('*/*/index.html', { cwd: runPath, absolute: true }),
+      ...glob.sync('*/*/*/index.html', { cwd: runPath, absolute: true })
+    ];
 
-    for (const dir of directories) {
+    for (const indexFile of indexFiles) {
+      const dir = path.dirname(indexFile);
       const relPath = path.relative(runPath, dir);
       const parts = relPath.split(path.sep);
+      if (parts.includes('grade-report')) continue; // Skip grader reports
       
       let guide: string, taskName: string, runType: string;
       if (parts.length === 2) {

--- a/harness/lib/collection.ts
+++ b/harness/lib/collection.ts
@@ -70,7 +70,6 @@ export async function collectResults(resultsDir: string, suiteConfig: SuiteConfi
         taskName = 'task'; // Old suites always had a single task
         runType = parts[1];
         guide = parts[0].replace(/-task$/, ''); // Infer guide name by removing suffix
-        console.log(`[Legacy Fallback] Inferred guide=${guide}, task=${taskName} from path ${relPath}`.yellow);
       } else if (parts.length >= 3) {
         [guide, taskName, runType] = parts;
       } else {

--- a/harness/lib/collection.ts
+++ b/harness/lib/collection.ts
@@ -21,7 +21,7 @@ export function extractModelFromResults(resultsDir: string, agent: string): stri
   return 'unknown';
 }
 
-export async function collectResults(resultsDir: string, suiteConfig: SuiteConfig) {
+export async function collectResults(resultsDir: string, suiteConfig: SuiteConfig, skipGrading = false) {
   const taskMap = getTaskMap();
 
   const runDirs = fs.readdirSync(resultsDir)
@@ -103,7 +103,7 @@ run();
   }
 
   // --- PASS 1.5: Execute the accumulated grading runs in parallel ---
-  if (pnpmWorkspacePackages.length > 0) {
+  if (pnpmWorkspacePackages.length > 0 && !skipGrading) {
     console.log(`\n>>> Discovered ${pnpmWorkspacePackages.length} un-graded tasks. Running parallel grading with pnpm -r run-grader...`);
     const pnpmWorkspacePath = path.join(resultsDir, 'pnpm-workspace.yaml');
     fs.writeFileSync(pnpmWorkspacePath, 'packages:\n  - \'**\'\n');

--- a/harness/lib/collection.ts
+++ b/harness/lib/collection.ts
@@ -21,6 +21,24 @@ export function extractModelFromResults(resultsDir: string, agent: string): stri
   return 'unknown';
 }
 
+function extractErrorMessage(dir: string, targetFile: string): string {
+  const stderrPath = path.join(dir, 'agent_stderr.log');
+  
+  if (!fs.existsSync(stderrPath)) {
+    return fs.existsSync(targetFile) ? 'Generation failed' : 'index.html not found';
+  }
+
+  const lines = fs.readFileSync(stderrPath, 'utf8')
+    .split('\n')
+    .map(l => l.trim())
+    .filter(l => l && !l.includes('YOLO mode'));
+
+  const lastLine = lines.pop();
+  if (!lastLine) return 'Generation mysteriously failed';
+
+  return lastLine.length > 100 ? lastLine.substring(0, 100) + '...' : lastLine;
+}
+
 export async function collectResults(resultsDir: string, suiteConfig: SuiteConfig) {
   const taskMap = getTaskMap();
 
@@ -200,23 +218,7 @@ run();
         console.warn(`Grader not found for ${guide} at ${graderPath}`);
         scenarioResults.push({ name: 'Configuration', status: 'fail', message: 'Grader not found' });
       } else if (!fs.existsSync(graderResults)) {
-        const stderrPath = path.join(dir, 'agent_stderr.log');
-        let errorMessage = 'Generation failed';
-        if (fs.existsSync(stderrPath)) {
-          const stderrContent = fs.readFileSync(stderrPath, 'utf8');
-          const lines = stderrContent.split('\n')
-            .map(l => l.trim())
-            .filter(l => l && !l.includes('YOLO mode'));
-          
-          const lastLine = lines[lines.length - 1];
-          if (lastLine) {
-            errorMessage = lastLine.length > 100 ? lastLine.substring(0, 100) + '...' : lastLine;
-          } else {
-            errorMessage = 'Generation mysteriously failed';
-          }
-        } else if (!fs.existsSync(targetFile)) {
-          errorMessage = 'index.html not found';
-        }
+        const errorMessage = extractErrorMessage(dir, targetFile);
         scenarioResults.push({ passed: false, message: errorMessage, isEarlyFailure: true });
       } else {
         try {

--- a/harness/lib/collection.ts
+++ b/harness/lib/collection.ts
@@ -191,6 +191,9 @@ run();
         console.warn(`Skipping grading: Task ${guide} not found in task map`);
         continue;
       }
+      const taskCategory = path.basename(path.dirname(taskInfo.guideDir));
+      let expectedGuidanceTool: string | undefined;
+      const serving = suiteConfig.serving;
 
       if (serving === Serving.MCP || serving === Serving.MEGASKILL || suiteConfig.agent === Agents.JETSKI) {
         expectedGuidanceTool = 'modern-web';

--- a/harness/lib/collection.ts
+++ b/harness/lib/collection.ts
@@ -192,14 +192,7 @@ run();
         continue;
       }
       const taskCategory = path.basename(path.dirname(taskInfo.guideDir));
-      let expectedGuidanceTool: string | undefined;
-      const serving = suiteConfig.serving;
-
-      if (serving === Serving.MCP || serving === Serving.MEGASKILL || serving === Serving.SKILLS_CLI || suiteConfig.agent === Agents.JETSKI) {
-        expectedGuidanceTool = 'modern-web';
-      } else if (serving === Serving.SKILLS) {
-        expectedGuidanceTool = taskCategory || undefined;
-      }
+      const expectedToolPrefixes = ['modern-web', taskCategory].filter(Boolean);
 
       const graderPath = path.join(taskInfo.guideDir, 'grader.ts');
 
@@ -261,7 +254,7 @@ run();
         retrievedGuides: retrievedGuides,
         fileReadGuides: fileReadGuides,
         guidanceToolsUsed: guidanceToolsUsedResult,
-        expectedGuidanceTool: expectedGuidanceTool,
+        expectedToolPrefixes: expectedToolPrefixes,
         guideName: guide,
         taskName: taskName,
         baseApp: actualBaseApp,

--- a/harness/lib/collection.ts
+++ b/harness/lib/collection.ts
@@ -204,16 +204,15 @@ run();
         let errorMessage = 'Generation failed';
         if (fs.existsSync(stderrPath)) {
           const stderrContent = fs.readFileSync(stderrPath, 'utf8');
-          if (stderrContent.includes('RESOURCE_EXHAUSTED')) {
-            errorMessage = 'Quota exceeded (429)';
-          } else if (stderrContent.includes('Please set an Auth method')) {
-            errorMessage = 'Auth method missing';
+          const lines = stderrContent.split('\n')
+            .map(l => l.trim())
+            .filter(l => l && !l.includes('YOLO mode'));
+          
+          const lastLine = lines[lines.length - 1];
+          if (lastLine) {
+            errorMessage = lastLine.length > 100 ? lastLine.substring(0, 100) + '...' : lastLine;
           } else {
-            const lines = stderrContent.trim().split('\n');
-            const lastLine = lines[lines.length - 1];
-            if (lastLine) {
-              errorMessage = lastLine.length > 100 ? lastLine.substring(0, 100) + '...' : lastLine;
-            }
+            errorMessage = 'Generation mysteriously failed';
           }
         } else if (!fs.existsSync(targetFile)) {
           errorMessage = 'index.html not found';

--- a/harness/lib/collection.ts
+++ b/harness/lib/collection.ts
@@ -178,7 +178,23 @@ run();
         console.warn(`Grader not found for ${guide} at ${graderPath}`);
         scenarioResults.push({ name: 'Configuration', status: 'fail', message: 'Grader not found' });
       } else if (!fs.existsSync(targetFile)) {
-        scenarioResults.push({ name: 'File Check', status: 'fail', message: 'index.html not found' });
+        const stderrPath = path.join(dir, 'agent_stderr.log');
+        let errorMessage = 'index.html not found';
+        if (fs.existsSync(stderrPath)) {
+          const stderrContent = fs.readFileSync(stderrPath, 'utf8');
+          if (stderrContent.includes('RESOURCE_EXHAUSTED')) {
+            errorMessage = 'Quota exceeded (429)';
+          } else if (stderrContent.includes('Please set an Auth method')) {
+            errorMessage = 'Auth method missing';
+          } else {
+            const lines = stderrContent.trim().split('\n');
+            const lastLine = lines[lines.length - 1];
+            if (lastLine) {
+              errorMessage = lastLine.length > 100 ? lastLine.substring(0, 100) + '...' : lastLine;
+            }
+          }
+        }
+        scenarioResults.push({ passed: false, message: errorMessage, isEarlyFailure: true });
       } else {
         try {
           let json: any = null;

--- a/harness/lib/collection.ts
+++ b/harness/lib/collection.ts
@@ -137,11 +137,16 @@ run();
       const [guide, taskName, runType] = parts;
       if (runType === 'base_app') continue; // Skip the base app setup folder
       let guidesUsedResult: string[] = [];
+      let retrievedGuides: string[] = [];
+      let fileReadGuides: string[] = [];
       let guidanceToolsUsedResult: string[] = [];
 
       if (runType === 'guided') {
         const serving = suiteConfig.serving;
-        guidesUsedResult = await collectGuidesUsed(dir, serving, suiteConfig.agent);
+        const usage = await collectGuidesUsed(dir, serving, suiteConfig.agent);
+        retrievedGuides = usage.retrievedGuides;
+        fileReadGuides = usage.fileReadGuides;
+        guidesUsedResult = [...new Set([...retrievedGuides, ...fileReadGuides])];
         guidanceToolsUsedResult = await collectGuidanceToolsUsed(dir, serving, suiteConfig.agent);
       }
 
@@ -220,6 +225,8 @@ run();
         runNumber: parseInt(runDir),
         results: scenarioResults,
         guidesUsed: guidesUsedResult,
+        retrievedGuides: retrievedGuides,
+        fileReadGuides: fileReadGuides,
         guidanceToolsUsed: guidanceToolsUsedResult,
         expectedGuidanceTool: expectedGuidanceTool,
         guideName: guide,

--- a/harness/lib/collection.ts
+++ b/harness/lib/collection.ts
@@ -46,8 +46,19 @@ export async function collectResults(resultsDir: string, suiteConfig: SuiteConfi
     for (const dir of directories) {
       const relPath = path.relative(runPath, dir);
       const parts = relPath.split(path.sep);
-      if (parts.length < 3) continue;
-      const [guide, taskName, runType] = parts;
+      
+      let guide: string, taskName: string, runType: string;
+      if (parts.length === 2) {
+        // [Legacy Fallback] Old structure: {taskName}/{runType}
+        taskName = 'task'; // Old suites always had a single task
+        runType = parts[1];
+        guide = parts[0].replace(/-task$/, ''); // Infer guide name by removing suffix
+        console.log(`[Legacy Fallback] Inferred guide=${guide}, task=${taskName} from path ${relPath}`.yellow);
+      } else if (parts.length >= 3) {
+        [guide, taskName, runType] = parts;
+      } else {
+        continue;
+      }
       if (runType === 'base_app') continue; // Skip the base app setup folder
       const targetFile = path.join(dir, 'index.html');
 
@@ -132,9 +143,18 @@ run();
     for (const dir of directories) {
       const relPath = path.relative(runPath, dir);
       const parts = relPath.split(path.sep);
-      if (parts.length < 3) continue;
-
-      const [guide, taskName, runType] = parts;
+      
+      let guide: string, taskName: string, runType: string;
+      if (parts.length === 2) {
+        // [Legacy Fallback] Old structure: {taskName}/{runType}
+        taskName = 'task';
+        runType = parts[1];
+        guide = parts[0].replace(/-task$/, '');
+      } else if (parts.length >= 3) {
+        [guide, taskName, runType] = parts;
+      } else {
+        continue;
+      }
       if (runType === 'base_app') continue; // Skip the base app setup folder
       let guidesUsedResult: string[] = [];
       let retrievedGuides: string[] = [];

--- a/harness/lib/collection.ts
+++ b/harness/lib/collection.ts
@@ -21,7 +21,7 @@ export function extractModelFromResults(resultsDir: string, agent: string): stri
   return 'unknown';
 }
 
-export async function collectResults(resultsDir: string, suiteConfig: SuiteConfig, skipGrading = false) {
+export async function collectResults(resultsDir: string, suiteConfig: SuiteConfig) {
   const taskMap = getTaskMap();
 
   const runDirs = fs.readdirSync(resultsDir)
@@ -117,7 +117,7 @@ run();
   }
 
   // --- PASS 1.5: Execute the accumulated grading runs in parallel ---
-  if (pnpmWorkspacePackages.length > 0 && !skipGrading) {
+  if (pnpmWorkspacePackages.length > 0) {
     console.log(`\n>>> Discovered ${pnpmWorkspacePackages.length} un-graded tasks. Running parallel grading with pnpm -r run-grader...`);
     const pnpmWorkspacePath = path.join(resultsDir, 'pnpm-workspace.yaml');
     fs.writeFileSync(pnpmWorkspacePath, 'packages:\n  - \'**\'\n');

--- a/harness/lib/collection.ts
+++ b/harness/lib/collection.ts
@@ -28,15 +28,11 @@ function extractErrorMessage(dir: string, targetFile: string): string {
     return fs.existsSync(targetFile) ? 'Generation failed' : 'index.html not found';
   }
 
-  const lines = fs.readFileSync(stderrPath, 'utf8')
+  return fs.readFileSync(stderrPath, 'utf8')
     .split('\n')
     .map(l => l.trim())
-    .filter(l => l && !l.includes('YOLO mode'));
-
-  const lastLine = lines.pop();
-  if (!lastLine) return 'Generation mysteriously failed';
-
-  return lastLine.length > 100 ? lastLine.substring(0, 100) + '...' : lastLine;
+    .filter(l => l && !l.includes('YOLO mode'))
+    .pop()?.slice(0, 100) || 'Generation mysteriously failed';
 }
 
 export async function collectResults(resultsDir: string, suiteConfig: SuiteConfig) {

--- a/harness/lib/collection.ts
+++ b/harness/lib/collection.ts
@@ -41,16 +41,14 @@ export async function collectResults(resultsDir: string, suiteConfig: SuiteConfi
 
   for (const runDir of runDirs) {
     const runPath = path.join(resultsDir, runDir);
-    const indexFiles = [
-      ...glob.sync('*/*/index.html', { cwd: runPath, absolute: true }),
-      ...glob.sync('*/*/*/index.html', { cwd: runPath, absolute: true })
+    const runTypeDirs = [
+      ...glob.sync('**/guided', { cwd: runPath, absolute: true }),
+      ...glob.sync('**/unguided', { cwd: runPath, absolute: true })
     ];
 
-    for (const indexFile of indexFiles) {
-      const dir = path.dirname(indexFile);
+    for (const dir of runTypeDirs) {
       const relPath = path.relative(runPath, dir);
       const parts = relPath.split(path.sep);
-      if (parts.includes('grade-report')) continue; // Skip grader reports
       
       let guide: string, taskName: string, runType: string;
       if (parts.length === 2) {
@@ -139,17 +137,14 @@ run();
   for (const runDir of runDirs) {
     const runPath = path.join(resultsDir, runDir);
 
-    // Structure: results/{suiteName}/{runNumber}/{guideName}/{taskName}/{runType}
-    const indexFiles = [
-      ...glob.sync('*/*/index.html', { cwd: runPath, absolute: true }),
-      ...glob.sync('*/*/*/index.html', { cwd: runPath, absolute: true })
+    const runTypeDirs = [
+      ...glob.sync('**/guided', { cwd: runPath, absolute: true }),
+      ...glob.sync('**/unguided', { cwd: runPath, absolute: true })
     ];
 
-    for (const indexFile of indexFiles) {
-      const dir = path.dirname(indexFile);
+    for (const dir of runTypeDirs) {
       const relPath = path.relative(runPath, dir);
       const parts = relPath.split(path.sep);
-      if (parts.includes('grade-report')) continue; // Skip grader reports
       
       let guide: string, taskName: string, runType: string;
       if (parts.length === 2) {

--- a/harness/lib/collection.ts
+++ b/harness/lib/collection.ts
@@ -177,9 +177,9 @@ run();
       if (!fs.existsSync(graderPath)) {
         console.warn(`Grader not found for ${guide} at ${graderPath}`);
         scenarioResults.push({ name: 'Configuration', status: 'fail', message: 'Grader not found' });
-      } else if (!fs.existsSync(targetFile)) {
+      } else if (!fs.existsSync(graderResults)) {
         const stderrPath = path.join(dir, 'agent_stderr.log');
-        let errorMessage = 'index.html not found';
+        let errorMessage = 'Generation failed';
         if (fs.existsSync(stderrPath)) {
           const stderrContent = fs.readFileSync(stderrPath, 'utf8');
           if (stderrContent.includes('RESOURCE_EXHAUSTED')) {
@@ -193,6 +193,8 @@ run();
               errorMessage = lastLine.length > 100 ? lastLine.substring(0, 100) + '...' : lastLine;
             }
           }
+        } else if (!fs.existsSync(targetFile)) {
+          errorMessage = 'index.html not found';
         }
         scenarioResults.push({ passed: false, message: errorMessage, isEarlyFailure: true });
       } else {

--- a/harness/lib/collection.ts
+++ b/harness/lib/collection.ts
@@ -2,7 +2,7 @@ import { glob } from "glob";
 import path from 'path';
 import fs from 'fs';
 import { collectGuidesUsed, collectGuidanceToolsUsed } from './guidance_validation.ts';
-import { Serving, Agents, type SuiteConfig } from '../config.ts';
+import { Agents, type SuiteConfig } from '../config.ts';
 import { guidesDir } from '../../lib/paths.ts';
 import { getTaskMap } from '../../lib/guide-validation.ts';
 import { extractGeminiCliModel } from '../agents/gemini-cli-agent.ts';

--- a/harness/lib/collection.ts
+++ b/harness/lib/collection.ts
@@ -192,11 +192,7 @@ run();
         continue;
       }
 
-      const taskCategory = path.basename(path.dirname(taskInfo.guideDir));
-      let expectedGuidanceTool: string | undefined;
-      const serving = suiteConfig.serving;
-
-      if (serving === Serving.MCP || suiteConfig.agent === Agents.JETSKI) {
+      if (serving === Serving.MCP || serving === Serving.MEGASKILL || suiteConfig.agent === Agents.JETSKI) {
         expectedGuidanceTool = 'modern-web';
       } else if (serving === Serving.SKILLS_CLI) {
         expectedGuidanceTool = 'modern-web-use-cases';

--- a/harness/lib/guidance_validation.ts
+++ b/harness/lib/guidance_validation.ts
@@ -67,6 +67,12 @@ export async function collectGuidesUsed(dirPath: string, serving: Serving, agent
 }
 
 export async function collectGuidanceToolsUsed(dir: string, serving: Serving, agent: string): Promise<string[]> {
+  
+  // For GEMINI_CLI, ALWAYS collect tool usage from trajectory files if present
+  if (agent === Agents.GEMINI_CLI) {
+    return collectGeminiToolsFromTrajectory(dir);
+  }
+
   // For MCP and JETSKI runs, collect tool usage from modern-web log presence
   // JETSKI impl does not support trajectory pb parsing, so we rely on modern-web log (will not be present in SKILLS runs)
   if (serving === Serving.MCP || agent === Agents.JETSKI) {
@@ -77,9 +83,7 @@ export async function collectGuidanceToolsUsed(dir: string, serving: Serving, ag
   }
 
   // For SKILLS and SKILLS_CLI approaches, collect tool usage from trajectory files
-  if (agent === Agents.GEMINI_CLI) {
-    return collectGeminiToolsFromTrajectory(dir);
-  } else if (agent === Agents.CLAUDE_CODE) {
+  if (agent === Agents.CLAUDE_CODE) {
     return collectClaudeToolsFromTrajectory(dir);
   } else if (agent === Agents.CODEX_CLI) {
     return collectCodexToolsFromTrajectory(dir);

--- a/harness/lib/guidance_validation.ts
+++ b/harness/lib/guidance_validation.ts
@@ -8,8 +8,6 @@ import { collectClaudeGuidesFromTrajectory, collectClaudeToolsFromTrajectory } f
 import { collectCodexGuidesFromTrajectory, collectCodexToolsFromTrajectory } from '../agents/codex-cli-agent.ts';
 
 export async function collectGuidesUsed(dirPath: string, serving: Serving, agent: string): Promise<GuidedUsage> {
-  const result: GuidedUsage = { retrievedGuides: [], fileReadGuides: [] };
-
   // For GEMINI_CLI, ALWAYS collect guide usage from trajectory files if present
   if (agent === Agents.GEMINI_CLI) {
     return collectGeminiGuidesFromTrajectory(dirPath, serving);

--- a/harness/lib/guidance_validation.ts
+++ b/harness/lib/guidance_validation.ts
@@ -10,6 +10,11 @@ import { collectCodexGuidesFromTrajectory, collectCodexToolsFromTrajectory } fro
 export async function collectGuidesUsed(dirPath: string, serving: Serving, agent: string): Promise<GuidedUsage> {
   const result: GuidedUsage = { retrievedGuides: [], fileReadGuides: [] };
 
+  // For GEMINI_CLI, ALWAYS collect guide usage from trajectory files if present
+  if (agent === Agents.GEMINI_CLI) {
+    return collectGeminiGuidesFromTrajectory(dirPath, serving);
+  }
+
   // For MCP and Jetski runs, collect guide usage from modern-web log if present
   // Jetski impl does not support trajectory pb parsing, so we rely on modern-web log (will not be present in Skills runs)
   if (serving === Serving.MCP || agent === Agents.JETSKI) {
@@ -47,9 +52,7 @@ export async function collectGuidesUsed(dirPath: string, serving: Serving, agent
   }
 
   // For SKILLS and SKILLS_CLI approaches, collect guide usage from trajectory files
-  if (agent === Agents.GEMINI_CLI) {
-    return collectGeminiGuidesFromTrajectory(dirPath, serving);
-  } else if (agent === Agents.CLAUDE_CODE) {
+  if (agent === Agents.CLAUDE_CODE) {
     return collectClaudeGuidesFromTrajectory(dirPath, serving);
   } else if (agent === Agents.CODEX_CLI) {
     const guides = await collectCodexGuidesFromTrajectory(dirPath, serving);

--- a/harness/lib/guidance_validation.ts
+++ b/harness/lib/guidance_validation.ts
@@ -3,17 +3,20 @@ import path from 'path';
 import { MODERN_WEB_LOG_FILE } from '../../constants.ts';
 import { Agents, Serving } from '../config.ts';
 import { collectGeminiGuidesFromTrajectory, collectGeminiToolsFromTrajectory } from '../agents/gemini-cli-agent.ts';
+import type { GuidedUsage } from '../agents/gemini-cli-agent.ts';
 import { collectClaudeGuidesFromTrajectory, collectClaudeToolsFromTrajectory } from '../agents/claude-code-agent.ts';
 import { collectCodexGuidesFromTrajectory, collectCodexToolsFromTrajectory } from '../agents/codex-cli-agent.ts';
 
-export async function collectGuidesUsed(dirPath: string, serving: Serving, agent: string): Promise<string[]> {
+export async function collectGuidesUsed(dirPath: string, serving: Serving, agent: string): Promise<GuidedUsage> {
+  const result: GuidedUsage = { retrievedGuides: [], fileReadGuides: [] };
+
   // For MCP and Jetski runs, collect guide usage from modern-web log if present
   // Jetski impl does not support trajectory pb parsing, so we rely on modern-web log (will not be present in Skills runs)
   if (serving === Serving.MCP || agent === Agents.JETSKI) {
     const logPath = path.join(dirPath, MODERN_WEB_LOG_FILE);
 
     if (!fs.existsSync(logPath)) {
-      return [];
+      return result;
     }
 
     const logContent = fs.readFileSync(logPath, 'utf8').trim();
@@ -37,19 +40,24 @@ export async function collectGuidesUsed(dirPath: string, serving: Serving, agent
       .flatMap(call => call.result.map((r: any) => r.id || ''))
       .filter(Boolean);
 
-    return [...new Set(guidesFromLog)];
+    result.retrievedGuides = [...new Set(guidesFromLog)];
+    return result;
   }
 
   // For SKILLS and SKILLS_CLI approaches, collect guide usage from trajectory files
   if (agent === Agents.GEMINI_CLI) {
     return collectGeminiGuidesFromTrajectory(dirPath, serving);
   } else if (agent === Agents.CLAUDE_CODE) {
-    return collectClaudeGuidesFromTrajectory(dirPath, serving);
+    const guides = await collectClaudeGuidesFromTrajectory(dirPath, serving);
+    result.retrievedGuides = guides;
+    return result;
   } else if (agent === Agents.CODEX_CLI) {
-    return collectCodexGuidesFromTrajectory(dirPath, serving);
+    const guides = await collectCodexGuidesFromTrajectory(dirPath, serving);
+    result.retrievedGuides = guides;
+    return result;
   }
   console.warn(`Unknown agent ${agent} for skills collection`);
-  return [];
+  return result;
 }
 
 export async function collectGuidanceToolsUsed(dir: string, serving: Serving, agent: string): Promise<string[]> {

--- a/harness/lib/guidance_validation.ts
+++ b/harness/lib/guidance_validation.ts
@@ -16,7 +16,7 @@ export async function collectGuidesUsed(dirPath: string, serving: Serving, agent
     const logPath = path.join(dirPath, MODERN_WEB_LOG_FILE);
 
     if (!fs.existsSync(logPath)) {
-      return result;
+      return { retrievedGuides: ['unknown'], fileReadGuides: ['unknown'] };
     }
 
     const logContent = fs.readFileSync(logPath, 'utf8').trim();
@@ -40,24 +40,27 @@ export async function collectGuidesUsed(dirPath: string, serving: Serving, agent
       .flatMap(call => call.result.map((r: any) => r.id || ''))
       .filter(Boolean);
 
-    result.retrievedGuides = [...new Set(guidesFromLog)];
-    return result;
+    return {
+      retrievedGuides: [...new Set(guidesFromLog)],
+      fileReadGuides: ['unknown']
+    };
   }
 
   // For SKILLS and SKILLS_CLI approaches, collect guide usage from trajectory files
   if (agent === Agents.GEMINI_CLI) {
     return collectGeminiGuidesFromTrajectory(dirPath, serving);
   } else if (agent === Agents.CLAUDE_CODE) {
-    const guides = await collectClaudeGuidesFromTrajectory(dirPath, serving);
-    result.retrievedGuides = guides;
-    return result;
+    return collectClaudeGuidesFromTrajectory(dirPath, serving);
   } else if (agent === Agents.CODEX_CLI) {
     const guides = await collectCodexGuidesFromTrajectory(dirPath, serving);
-    result.retrievedGuides = guides;
-    return result;
+    return {
+      retrievedGuides: guides,
+      fileReadGuides: ['unknown']
+    };
   }
+  
   console.warn(`Unknown agent ${agent} for skills collection`);
-  return result;
+  return { retrievedGuides: ['unknown'], fileReadGuides: ['unknown'] };
 }
 
 export async function collectGuidanceToolsUsed(dir: string, serving: Serving, agent: string): Promise<string[]> {

--- a/harness/lib/metrics.ts
+++ b/harness/lib/metrics.ts
@@ -125,8 +125,14 @@ export function calculateMetrics(allResults: Record<string, RunResult[]>, runsPe
 
         const toolsUsed = run.guidanceToolsUsed || [];
         const expectedTool = run.expectedGuidanceTool;
-        if (expectedTool && toolsUsed.includes(expectedTool)) {
-          toolActivationCount++;
+        if (expectedTool) {
+          const isActivated = toolsUsed.some(t => 
+            t === expectedTool || 
+            (expectedTool === 'modern-web' && t.startsWith('modern-web'))
+          );
+          if (isActivated) {
+            toolActivationCount++;
+          }
         }
       });
     }

--- a/harness/lib/metrics.ts
+++ b/harness/lib/metrics.ts
@@ -26,6 +26,8 @@ export interface Metrics {
     guidedTotal: number;
     runsPerTest: number;
     expectedTotalRuns?: number;
+    taskCount?: number;
+    runCountPerTask?: number;
     guideUsageRate?: number;
     guideUsageCount?: number;
     totalGuidedRuns?: number;
@@ -216,6 +218,8 @@ export function calculateMetrics(allResults: Record<string, RunResult[]>, runsPe
       guidedTotal: gStats.total,
       runsPerTest,
       expectedTotalRuns,
+      taskCount: numberOfTasks,
+      runCountPerTask: runsPerTest,
       guideUsageRate: gStats.guideUsageRate,
       guideUsageCount: gStats.guideUsageCount,
       totalGuidedRuns: gStats.totalGuidedRuns,

--- a/harness/lib/metrics.ts
+++ b/harness/lib/metrics.ts
@@ -125,14 +125,8 @@ export function calculateMetrics(allResults: Record<string, RunResult[]>, runsPe
 
         const toolsUsed = run.guidanceToolsUsed || [];
         const expectedTool = run.expectedGuidanceTool;
-        if (expectedTool) {
-          const isActivated = toolsUsed.some(t => 
-            t === expectedTool || 
-            (expectedTool === 'modern-web' && t.startsWith('modern-web'))
-          );
-          if (isActivated) {
-            toolActivationCount++;
-          }
+        if (expectedTool && toolsUsed.some(t => t.startsWith(expectedTool))) {
+          toolActivationCount++;
         }
       });
     }

--- a/harness/lib/metrics.ts
+++ b/harness/lib/metrics.ts
@@ -158,6 +158,7 @@ export function calculateMetrics(allResults: Record<string, RunResult[]>, runsPe
     let guideUsageCount = 0;
     let toolActivationCount = 0;
     let totalGuidedRuns = 0;
+    let guidedEarlyFailures = 0;
     let earlyFailures = 0;
     let totalRuns = 0;
 
@@ -175,9 +176,12 @@ export function calculateMetrics(allResults: Record<string, RunResult[]>, runsPe
           guideUsageCount += stats.runsUsingGuide || 0;
           toolActivationCount += stats.runsWithToolActivation || 0;
           totalGuidedRuns += stats.runCount || 0;
+          guidedEarlyFailures += stats.earlyFailures || 0;
         }
       }
     });
+
+    const completedGuidedRuns = totalGuidedRuns - guidedEarlyFailures;
 
     return {
       median: Math.round(median),
@@ -190,8 +194,8 @@ export function calculateMetrics(allResults: Record<string, RunResult[]>, runsPe
       earlyFailures,
       totalRuns,
       earlyFailureRate: totalRuns ? Math.round((earlyFailures / totalRuns) * 100) : 0,
-      toolActivationRate: totalGuidedRuns ? Math.round((toolActivationCount / totalGuidedRuns) * 100) : 0,
-      guideUsageRate: totalGuidedRuns ? Math.round((guideUsageCount / totalGuidedRuns) * 100) : 0
+      toolActivationRate: completedGuidedRuns ? Math.round((toolActivationCount / completedGuidedRuns) * 100) : 0,
+      guideUsageRate: completedGuidedRuns ? Math.round((guideUsageCount / completedGuidedRuns) * 100) : 0
     };
   };
 

--- a/harness/lib/metrics.ts
+++ b/harness/lib/metrics.ts
@@ -10,7 +10,7 @@ export interface RunResult {
   results: ScenarioCheck[];
   guidesUsed?: string[];
   guidanceToolsUsed?: string[];
-  expectedGuidanceTool?: string;
+  expectedToolPrefixes?: string[];
   guideName?: string;
 }
 
@@ -124,8 +124,8 @@ export function calculateMetrics(allResults: Record<string, RunResult[]>, runsPe
         }
 
         const toolsUsed = run.guidanceToolsUsed || [];
-        const expectedTool = run.expectedGuidanceTool;
-        if (expectedTool && toolsUsed.some(t => t.startsWith(expectedTool))) {
+        const prefixes = run.expectedToolPrefixes || [];
+        if (prefixes.length > 0 && toolsUsed.some(t => prefixes.some(p => t.startsWith(p)))) {
           toolActivationCount++;
         }
       });

--- a/harness/lib/metrics.ts
+++ b/harness/lib/metrics.ts
@@ -12,6 +12,9 @@ export interface RunResult {
   guidanceToolsUsed?: string[];
   expectedToolPrefixes?: string[];
   guideName?: string;
+  taskName?: string;
+  baseApp?: string;
+  prompt?: string;
 }
 
 export interface Metrics {
@@ -49,6 +52,17 @@ export interface Metrics {
     earlyFailures?: number;
   }>;
   sortedKeys: string[];
+}
+
+export interface EvalsReport {
+  summary: Metrics['summary'];
+  results: Record<string, RunResult[]>;
+  stats: Metrics['testStats'];
+  timestamp: string;
+  runCount: number;
+  agent: string;
+  serving: string;
+  model: string;
 }
 
 export function calculateMetrics(allResults: Record<string, RunResult[]>, runsPerTest: number): Metrics {

--- a/harness/lib/metrics.ts
+++ b/harness/lib/metrics.ts
@@ -2,6 +2,7 @@ export interface ScenarioCheck {
   id: string;
   passed: boolean;
   message: string;
+  isEarlyFailure?: boolean;
 }
 
 export interface RunResult {
@@ -24,6 +25,7 @@ export interface Metrics {
     guidedPassed: number;
     guidedTotal: number;
     runsPerTest: number;
+    expectedTotalRuns?: number;
     guideUsageRate?: number;
     guideUsageCount?: number;
     totalGuidedRuns?: number;
@@ -90,7 +92,7 @@ export function calculateMetrics(allResults: Record<string, RunResult[]>, runsPe
     let earlyFailures = 0;
     const passRates = runs.map(run => {
       const checks = run.results;
-      const isEarlyFailure = checks.some(c => c.message === 'index.html not found');
+      const isEarlyFailure = checks.some(c => c.isEarlyFailure);
       if (isEarlyFailure) {
         earlyFailures++;
       }
@@ -193,6 +195,14 @@ export function calculateMetrics(allResults: Record<string, RunResult[]>, runsPe
   const uStats = calcSummary(sortedKeys.filter(k => k.includes(' - unguided')));
   const gStats = calcSummary(sortedKeys.filter(k => k.includes(' - guided')));
 
+  const uniqueTasks = new Set<string>();
+  Object.keys(allResults).forEach(key => {
+    const [taskName, guideName] = key.split(' - ');
+    uniqueTasks.add(`${taskName} - ${guideName}`);
+  });
+  const numberOfTasks = uniqueTasks.size;
+  const expectedTotalRuns = numberOfTasks * runsPerTest;
+
   return {
     summary: {
       unguidedMedian: uStats.median,
@@ -204,6 +214,7 @@ export function calculateMetrics(allResults: Record<string, RunResult[]>, runsPe
       guidedPassed: gStats.passed,
       guidedTotal: gStats.total,
       runsPerTest,
+      expectedTotalRuns,
       guideUsageRate: gStats.guideUsageRate,
       guideUsageCount: gStats.guideUsageCount,
       totalGuidedRuns: gStats.totalGuidedRuns,

--- a/harness/lib/metrics.ts
+++ b/harness/lib/metrics.ts
@@ -82,6 +82,7 @@ export function calculateMetrics(allResults: Record<string, RunResult[]>, runsPe
     runCount?: number;
     passedChecks: number;
     totalChecks: number;
+    earlyFailures?: number;
   }> = {};
 
   for (const name of sortedKeys) {

--- a/harness/lib/metrics.ts
+++ b/harness/lib/metrics.ts
@@ -29,6 +29,10 @@ export interface Metrics {
     totalGuidedRuns?: number;
     toolActivationRate?: number;
     toolActivationCount?: number;
+    unguidedEarlyFailures?: number;
+    unguidedEarlyFailureRate?: number;
+    guidedEarlyFailures?: number;
+    guidedEarlyFailureRate?: number;
   };
   testStats: Record<string, {
     medianPassRate: number;
@@ -38,6 +42,7 @@ export interface Metrics {
     runCount?: number;
     passedChecks: number;
     totalChecks: number;
+    earlyFailures?: number;
   }>;
   sortedKeys: string[];
 }
@@ -82,8 +87,13 @@ export function calculateMetrics(allResults: Record<string, RunResult[]>, runsPe
     let passedChecks = 0;
     let totalChecks = 0;
 
+    let earlyFailures = 0;
     const passRates = runs.map(run => {
       const checks = run.results;
+      const isEarlyFailure = checks.some(c => c.message === 'index.html not found');
+      if (isEarlyFailure) {
+        earlyFailures++;
+      }
       const passCount = checks.filter(c => c.passed).length;
       const totalCount = checks.length;
       passedChecks += passCount;
@@ -123,7 +133,8 @@ export function calculateMetrics(allResults: Record<string, RunResult[]>, runsPe
       runsWithToolActivation: runType === 'guided' ? toolActivationCount : undefined,
       runCount: runs.length,
       passedChecks,
-      totalChecks
+      totalChecks,
+      earlyFailures
     };
   }
 
@@ -142,6 +153,8 @@ export function calculateMetrics(allResults: Record<string, RunResult[]>, runsPe
     let guideUsageCount = 0;
     let toolActivationCount = 0;
     let totalGuidedRuns = 0;
+    let earlyFailures = 0;
+    let totalRuns = 0;
 
     keys.forEach(k => {
       const [, , runType] = k.split(' - ');
@@ -150,6 +163,8 @@ export function calculateMetrics(allResults: Record<string, RunResult[]>, runsPe
       if (stats) {
         passed += stats.passedChecks;
         total += stats.totalChecks;
+        earlyFailures += stats.earlyFailures || 0;
+        totalRuns += stats.runCount || 0;
 
         if (runType === 'guided') {
           guideUsageCount += stats.runsUsingGuide || 0;
@@ -167,6 +182,9 @@ export function calculateMetrics(allResults: Record<string, RunResult[]>, runsPe
       guideUsageCount,
       totalGuidedRuns,
       toolActivationCount,
+      earlyFailures,
+      totalRuns,
+      earlyFailureRate: totalRuns ? Math.round((earlyFailures / totalRuns) * 100) : 0,
       toolActivationRate: totalGuidedRuns ? Math.round((toolActivationCount / totalGuidedRuns) * 100) : 0,
       guideUsageRate: totalGuidedRuns ? Math.round((guideUsageCount / totalGuidedRuns) * 100) : 0
     };
@@ -190,7 +208,11 @@ export function calculateMetrics(allResults: Record<string, RunResult[]>, runsPe
       guideUsageCount: gStats.guideUsageCount,
       totalGuidedRuns: gStats.totalGuidedRuns,
       toolActivationRate: gStats.toolActivationRate,
-      toolActivationCount: gStats.toolActivationCount
+      toolActivationCount: gStats.toolActivationCount,
+      unguidedEarlyFailures: uStats.earlyFailures,
+      unguidedEarlyFailureRate: uStats.earlyFailureRate,
+      guidedEarlyFailures: gStats.earlyFailures,
+      guidedEarlyFailureRate: gStats.earlyFailureRate
     },
     testStats,
     sortedKeys

--- a/harness/lib/reporting.ts
+++ b/harness/lib/reporting.ts
@@ -1,17 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import type { Metrics, RunResult, ScenarioCheck } from './metrics.ts';
-
-export interface EvalsReport {
-  summary: Metrics['summary'];
-  results: Record<string, RunResult[]>;
-  stats: Metrics['testStats'];
-  timestamp: string;
-  runCount: number;
-  agent: string;
-  serving: string;
-  model: string;
-}
+import type { Metrics, RunResult, ScenarioCheck, EvalsReport } from './metrics.ts';
 
 export function generateMarkdownReport(metrics: Metrics, allResults: Record<string, RunResult[]>): string {
   const { summary, testStats, sortedKeys } = metrics;

--- a/harness/lib/reporting.ts
+++ b/harness/lib/reporting.ts
@@ -2,6 +2,17 @@ import fs from 'fs';
 import path from 'path';
 import type { Metrics, RunResult, ScenarioCheck } from './metrics.ts';
 
+export interface EvalsReport {
+  summary: Metrics['summary'];
+  results: Record<string, RunResult[]>;
+  stats: Metrics['testStats'];
+  timestamp: string;
+  runCount: number;
+  agent: string;
+  serving: string;
+  model: string;
+}
+
 export function generateMarkdownReport(metrics: Metrics, allResults: Record<string, RunResult[]>): string {
   const { summary, testStats, sortedKeys } = metrics;
   let md = '# Evaluation Results\n\n';
@@ -57,7 +68,7 @@ export function generateMarkdownReport(metrics: Metrics, allResults: Record<stri
   return md;
 }
 
-export function generateJsonReport(metrics: Metrics, allResults: Record<string, RunResult[]>, timestamp: string, runCount: number, agent: string, serving: string, model: string) {
+export function generateJsonReport(metrics: Metrics, allResults: Record<string, RunResult[]>, timestamp: string, runCount: number, agent: string, serving: string, model: string): EvalsReport {
   return {
     summary: metrics.summary,
     results: allResults,
@@ -70,7 +81,7 @@ export function generateJsonReport(metrics: Metrics, allResults: Record<string, 
   };
 }
 
-export function saveReports(resultsDir: string, markdown: string, json: any) {
+export function saveReports(resultsDir: string, markdown: string, json: EvalsReport) {
   fs.mkdirSync(resultsDir, { recursive: true });
   fs.writeFileSync(path.join(resultsDir, 'evals.md'), markdown);
   fs.writeFileSync(path.join(resultsDir, 'evals.json'), JSON.stringify(json, null, 2));

--- a/harness/package.json
+++ b/harness/package.json
@@ -24,5 +24,8 @@
     "glob": "^13.0.6",
     "gray-matter": "^4.0.3",
     "puppeteer-core": "^24.39.1"
+  },
+  "devDependencies": {
+    "@google/gemini-cli-core": "^0.36.0"
   }
 }

--- a/harness/tests/setup.ts
+++ b/harness/tests/setup.ts
@@ -1,0 +1,15 @@
+// Polyfill for localStorage in Node.js
+global.localStorage = {
+    getItem: () => null,
+    setItem: () => {},
+    removeItem: () => {},
+    clear: () => {},
+    length: 0,
+    key: () => null
+} as any;
+
+// Polyfill for document if needed
+global.document = {
+    getElementById: () => null,
+    addEventListener: () => {}
+} as any;

--- a/harness/tests/trajectory-parsing.test.ts
+++ b/harness/tests/trajectory-parsing.test.ts
@@ -20,6 +20,7 @@ test('collectGemini metrics from a single trajectory file', async () => {
     const sessionData = {
       messages: [
         {
+          type: 'gemini',
           toolCalls: [
             {
               name: 'mcp_modern-web_get_best_practices',
@@ -32,6 +33,7 @@ test('collectGemini metrics from a single trajectory file', async () => {
           ]
         },
         {
+          type: 'gemini',
           toolCalls: [
             {
               name: 'run_shell_command',

--- a/harness/tests/trajectory-parsing.test.ts
+++ b/harness/tests/trajectory-parsing.test.ts
@@ -1,0 +1,180 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { collectGeminiGuidesFromTrajectory, collectGeminiToolsFromTrajectory } from '../agents/gemini-cli-agent.ts';
+import { collectClaudeGuidesFromTrajectory, collectClaudeToolsFromTrajectory } from '../agents/claude-code-agent.ts';
+
+function createTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'trajectory-test-'));
+}
+
+function removeTempDir(dir: string) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+test('collectGeminiGuidesFromTrajectory parses get_best_practices and read_file', async () => {
+  const tempDir = createTempDir();
+  try {
+    const sessionData = {
+      messages: [
+        {
+          toolCalls: [
+            {
+              name: 'mcp_modern-web_get_best_practices',
+              args: { use_case_id: 'accessible-error-announcement' }
+            },
+            {
+              name: 'read_file',
+              args: { file_path: '/path/to/skills/modern-web/references/forms/required-field-feedback.md' }
+            }
+          ]
+        }
+      ]
+    };
+
+    fs.writeFileSync(path.join(tempDir, 'session-123.json'), JSON.stringify(sessionData));
+
+    const result = await collectGeminiGuidesFromTrajectory(tempDir, 'mcp');
+    
+    assert.deepStrictEqual(result.retrievedGuides, ['accessible-error-announcement']);
+    assert.deepStrictEqual(result.fileReadGuides, ['required-field-feedback']);
+  } finally {
+    removeTempDir(tempDir);
+  }
+});
+
+test('collectGeminiGuidesFromTrajectory parses run_shell_command with modern-web --retrieve', async () => {
+  const tempDir = createTempDir();
+  try {
+    const sessionData = {
+      messages: [
+        {
+          toolCalls: [
+            {
+              name: 'run_shell_command',
+              args: { command: 'npx modern-web --retrieve accessible-error-announcement,required-field-feedback' }
+            }
+          ]
+        }
+      ]
+    };
+
+    fs.writeFileSync(path.join(tempDir, 'session-123.json'), JSON.stringify(sessionData));
+
+    const result = await collectGeminiGuidesFromTrajectory(tempDir, 'skills_cli');
+    
+    assert.deepStrictEqual(result.retrievedGuides, ['accessible-error-announcement', 'required-field-feedback']);
+  } finally {
+    removeTempDir(tempDir);
+  }
+});
+
+test('collectGeminiToolsFromTrajectory parses get_best_practices and activate_skill', async () => {
+  const tempDir = createTempDir();
+  try {
+    const sessionData = {
+      messages: [
+        {
+          toolCalls: [
+            { name: 'mcp_modern-web_get_best_practices' }
+          ]
+        },
+        {
+          toolCalls: [
+            {
+              name: 'activate_skill',
+              args: { name: 'modern-web' }
+            }
+          ]
+        }
+      ]
+    };
+
+    fs.writeFileSync(path.join(tempDir, 'session-123.json'), JSON.stringify(sessionData));
+
+    const result = collectGeminiToolsFromTrajectory(tempDir);
+    
+    assert.deepStrictEqual(result, ['modern-web']);
+  } finally {
+    removeTempDir(tempDir);
+  }
+});
+
+test('collectClaudeGuidesFromTrajectory parses Bash and Read', async () => {
+  const tempDir = createTempDir();
+  try {
+    const lines = [
+      JSON.stringify({
+        message: {
+          content: [
+            {
+              type: 'tool_use',
+              name: 'Bash',
+              input: { command: 'npx modern-web --retrieve accessible-error-announcement' }
+            }
+          ]
+        }
+      }),
+      JSON.stringify({
+        message: {
+          content: [
+            {
+              type: 'tool_use',
+              name: 'Read',
+              input: { file_path: '/path/to/skills/modern-web/accessible-error-announcement/guide.md' }
+            }
+          ]
+        }
+      })
+    ];
+
+    fs.writeFileSync(path.join(tempDir, 'session-123.jsonl'), lines.join('\n'));
+
+    const result = await collectClaudeGuidesFromTrajectory(tempDir, 'mcp');
+    
+    assert.deepStrictEqual(result.retrievedGuides, ['accessible-error-announcement']);
+    assert.deepStrictEqual(result.fileReadGuides, ['accessible-error-announcement']);
+  } finally {
+    removeTempDir(tempDir);
+  }
+});
+
+test('collectClaudeToolsFromTrajectory parses Skill and activate_skill', async () => {
+  const tempDir = createTempDir();
+  try {
+    const lines = [
+      JSON.stringify({
+        message: {
+          content: [
+            {
+              type: 'tool_use',
+              name: 'Skill',
+              input: { skill: 'modern-web' }
+            }
+          ]
+        }
+      }),
+      JSON.stringify({
+        message: {
+          content: [
+            {
+              type: 'tool_use',
+              name: 'activate_skill',
+              input: { name: 'modern-web' }
+            }
+          ]
+        }
+      })
+    ];
+
+    fs.writeFileSync(path.join(tempDir, 'session-123.jsonl'), lines.join('\n'));
+
+    const result = collectClaudeToolsFromTrajectory(tempDir);
+    
+    assert.deepStrictEqual(result, ['modern-web']);
+  } finally {
+    removeTempDir(tempDir);
+  }
+});

--- a/harness/tests/trajectory-parsing.test.ts
+++ b/harness/tests/trajectory-parsing.test.ts
@@ -14,7 +14,7 @@ function removeTempDir(dir: string) {
   fs.rmSync(dir, { recursive: true, force: true });
 }
 
-test('collectGeminiGuidesFromTrajectory parses get_best_practices and read_file', async () => {
+test('collectGemini metrics from a single trajectory file', async () => {
   const tempDir = createTempDir();
   try {
     const sessionData = {
@@ -30,59 +30,13 @@ test('collectGeminiGuidesFromTrajectory parses get_best_practices and read_file'
               args: { file_path: '/path/to/skills/modern-web/references/forms/required-field-feedback.md' }
             }
           ]
-        }
-      ]
-    };
-
-    fs.writeFileSync(path.join(tempDir, 'session-123.json'), JSON.stringify(sessionData));
-
-    const result = await collectGeminiGuidesFromTrajectory(tempDir, 'mcp');
-    
-    assert.deepStrictEqual(result.retrievedGuides, ['accessible-error-announcement']);
-    assert.deepStrictEqual(result.fileReadGuides, ['required-field-feedback']);
-  } finally {
-    removeTempDir(tempDir);
-  }
-});
-
-test('collectGeminiGuidesFromTrajectory parses run_shell_command with modern-web --retrieve', async () => {
-  const tempDir = createTempDir();
-  try {
-    const sessionData = {
-      messages: [
+        },
         {
           toolCalls: [
             {
               name: 'run_shell_command',
-              args: { command: 'npx modern-web --retrieve accessible-error-announcement,required-field-feedback' }
-            }
-          ]
-        }
-      ]
-    };
-
-    fs.writeFileSync(path.join(tempDir, 'session-123.json'), JSON.stringify(sessionData));
-
-    const result = await collectGeminiGuidesFromTrajectory(tempDir, 'skills_cli');
-    
-    assert.deepStrictEqual(result.retrievedGuides, ['accessible-error-announcement', 'required-field-feedback']);
-  } finally {
-    removeTempDir(tempDir);
-  }
-});
-
-test('collectGeminiToolsFromTrajectory parses get_best_practices and activate_skill', async () => {
-  const tempDir = createTempDir();
-  try {
-    const sessionData = {
-      messages: [
-        {
-          toolCalls: [
-            { name: 'mcp_modern-web_get_best_practices' }
-          ]
-        },
-        {
-          toolCalls: [
+              args: { command: 'npx modern-web --retrieve dialog-closedby' }
+            },
             {
               name: 'activate_skill',
               args: { name: 'modern-web' }
@@ -94,15 +48,21 @@ test('collectGeminiToolsFromTrajectory parses get_best_practices and activate_sk
 
     fs.writeFileSync(path.join(tempDir, 'session-123.json'), JSON.stringify(sessionData));
 
-    const result = collectGeminiToolsFromTrajectory(tempDir);
+    // Test Guides
+    const guides = await collectGeminiGuidesFromTrajectory(tempDir, 'mcp');
+    assert.deepStrictEqual(guides.retrievedGuides.sort(), ['accessible-error-announcement', 'dialog-closedby'].sort());
+    assert.deepStrictEqual(guides.fileReadGuides, ['required-field-feedback']);
+
+    // Test Tools
+    const tools = collectGeminiToolsFromTrajectory(tempDir);
+    assert.deepStrictEqual(tools, ['modern-web']);
     
-    assert.deepStrictEqual(result, ['modern-web']);
   } finally {
     removeTempDir(tempDir);
   }
 });
 
-test('collectClaudeGuidesFromTrajectory parses Bash and Read', async () => {
+test('collectClaude metrics from a single trajectory file', async () => {
   const tempDir = createTempDir();
   try {
     const lines = [
@@ -113,13 +73,7 @@ test('collectClaudeGuidesFromTrajectory parses Bash and Read', async () => {
               type: 'tool_use',
               name: 'Bash',
               input: { command: 'npx modern-web --retrieve accessible-error-announcement' }
-            }
-          ]
-        }
-      }),
-      JSON.stringify({
-        message: {
-          content: [
+            },
             {
               type: 'tool_use',
               name: 'Read',
@@ -127,24 +81,7 @@ test('collectClaudeGuidesFromTrajectory parses Bash and Read', async () => {
             }
           ]
         }
-      })
-    ];
-
-    fs.writeFileSync(path.join(tempDir, 'session-123.jsonl'), lines.join('\n'));
-
-    const result = await collectClaudeGuidesFromTrajectory(tempDir, 'mcp');
-    
-    assert.deepStrictEqual(result.retrievedGuides, ['accessible-error-announcement']);
-    assert.deepStrictEqual(result.fileReadGuides, ['accessible-error-announcement']);
-  } finally {
-    removeTempDir(tempDir);
-  }
-});
-
-test('collectClaudeToolsFromTrajectory parses Skill and activate_skill', async () => {
-  const tempDir = createTempDir();
-  try {
-    const lines = [
+      }),
       JSON.stringify({
         message: {
           content: [
@@ -152,13 +89,7 @@ test('collectClaudeToolsFromTrajectory parses Skill and activate_skill', async (
               type: 'tool_use',
               name: 'Skill',
               input: { skill: 'modern-web' }
-            }
-          ]
-        }
-      }),
-      JSON.stringify({
-        message: {
-          content: [
+            },
             {
               type: 'tool_use',
               name: 'activate_skill',
@@ -171,9 +102,15 @@ test('collectClaudeToolsFromTrajectory parses Skill and activate_skill', async (
 
     fs.writeFileSync(path.join(tempDir, 'session-123.jsonl'), lines.join('\n'));
 
-    const result = collectClaudeToolsFromTrajectory(tempDir);
-    
-    assert.deepStrictEqual(result, ['modern-web']);
+    // Test Guides
+    const guides = await collectClaudeGuidesFromTrajectory(tempDir, 'mcp');
+    assert.deepStrictEqual(guides.retrievedGuides, ['accessible-error-announcement']);
+    assert.deepStrictEqual(guides.fileReadGuides, ['accessible-error-announcement']);
+
+    // Test Tools
+    const tools = collectClaudeToolsFromTrajectory(tempDir);
+    assert.deepStrictEqual(tools, ['modern-web']);
+
   } finally {
     removeTempDir(tempDir);
   }

--- a/harness/upload_suite.ts
+++ b/harness/upload_suite.ts
@@ -7,7 +7,7 @@ import { resultsDir as baseResultsDir } from '../lib/paths.ts';
 const PROJECT_ID = 'chrome-kiwi-air-force-dev';
 const BUCKET_NAME = 'guidance-evals';
 
-async function uploadDirectory(bucket: any, dirPath: string, gcsPrefix: string) {
+async function uploadDirectory(bucket: any, dirPath: string, gcsPrefix: string, summaryOnly = false) {
   const uploadTasks: (() => Promise<void>)[] = [];
 
   function collectFiles(currentDir: string, currentPrefix: string) {
@@ -17,10 +17,19 @@ async function uploadDirectory(bucket: any, dirPath: string, gcsPrefix: string) 
       const fullPath = path.join(currentDir, file.name);
       const destinationPath = path.join(currentPrefix, file.name);
 
+      if (file.name === 'node_modules') continue;
+
       if (file.isDirectory()) {
-        collectFiles(fullPath, destinationPath);
+        if (!summaryOnly) {
+          collectFiles(fullPath, destinationPath);
+        }
       } else {
         if (file.name === '.DS_Store' || file.name === 'pnpm-workspace.yaml') continue;
+
+        if (summaryOnly) {
+          // Only upload summary files at the root
+          if (file.name !== 'evals.json' && file.name !== 'evals.md') continue;
+        }
 
         uploadTasks.push(async () => {
           console.log(`Uploading ${fullPath} to gs://${BUCKET_NAME}/${destinationPath}...`);
@@ -45,17 +54,30 @@ async function uploadDirectory(bucket: any, dirPath: string, gcsPrefix: string) 
 }
 
 async function main() {
-  let suiteName = process.argv[2];
+  const args = process.argv.slice(2);
+  const summaryOnly = args.includes('--summary-only');
+  
+  // Remove flags to get positional arguments
+  const positionalArgs = args.filter(a => !a.startsWith('--'));
+  
+  let suiteName = positionalArgs[0];
+  const customResultsDir = positionalArgs[1];
 
   if (!suiteName) {
-    console.error('❌ Please provide a suite name or path as an argument. e.g. pnpm upload <suite-name>');
+    console.error('❌ Please provide a suite name as an argument. e.g. pnpm upload <suite-name>');
     process.exit(1);
   }
 
   // Strip trailing slashes and normalize to just the suite ID
   suiteName = path.basename(suiteName);
 
-  const resultsDir = path.join(baseResultsDir, suiteName);
+  let resultsDir = path.join(baseResultsDir, suiteName);
+  
+  // Support custom results directory!
+  if (customResultsDir) {
+    resultsDir = path.join(path.resolve(customResultsDir), suiteName);
+  }
+  
   const evalsJsonPath = path.join(resultsDir, 'evals.json');
 
   if (!fs.existsSync(resultsDir)) {
@@ -68,13 +90,13 @@ async function main() {
     process.exit(1);
   }
 
-  console.log(cBold(cCyan(`Starting upload for suite: ${suiteName}`)));
+  console.log(cBold(cCyan(`Starting upload for suite: ${suiteName}${summaryOnly ? ' (Summary Only)' : ''}`)));
 
   const storage = new Storage({ projectId: PROJECT_ID });
   const bucket = storage.bucket(BUCKET_NAME);
 
   try {
-    await uploadDirectory(bucket, resultsDir, suiteName);
+    await uploadDirectory(bucket, resultsDir, suiteName, summaryOnly);
     console.log(cBold(cGreen(`\n✅ Successfully uploaded suite '${suiteName}' to gs://${BUCKET_NAME}/${suiteName}`)));
   } catch (error: any) {
     console.error(cRed(`❌ Upload failed: ${error.message}`));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,13 +79,13 @@ importers:
         version: 2.1.76
       '@anthropic-ai/vertex-sdk':
         specifier: ^0.14.4
-        version: 0.14.4(encoding@0.1.13)(zod@3.25.76)
+        version: 0.14.4(encoding@0.1.13)(zod@4.3.6)
       '@google-cloud/storage':
         specifier: ^7.19.0
         version: 7.19.0(encoding@0.1.13)
       '@google/gemini-cli':
         specifier: ^0.33.1
-        version: 0.33.1(encoding@0.1.13)(express@5.2.1)
+        version: 0.33.1(@bufbuild/protobuf@2.11.0)(encoding@0.1.13)(express@5.2.1)
       '@openai/codex':
         specifier: 0.114.0
         version: 0.114.0
@@ -104,6 +104,10 @@ importers:
       puppeteer-core:
         specifier: ^24.39.1
         version: 24.39.1
+    devDependencies:
+      '@google/gemini-cli-core':
+        specifier: ^0.36.0
+        version: 0.36.0(encoding@0.1.13)(express@5.2.1)
 
   serving:
     dependencies:
@@ -149,6 +153,21 @@ importers:
         version: 5.9.3
 
 packages:
+
+  '@a2a-js/sdk@0.3.11':
+    resolution: {integrity: sha512-pXjjlL0ZYHgAxObov1J+W3ylfQV0rOrDBB8Eo4a9eCunqs7iNW5OIfMcV8YnZQdzeVSRomj8jHeudVz0zc4RNw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.10.2
+      '@grpc/grpc-js': ^1.11.0
+      express: ^4.21.2 || ^5.1.0
+    peerDependenciesMeta:
+      '@bufbuild/protobuf':
+        optional: true
+      '@grpc/grpc-js':
+        optional: true
+      express:
+        optional: true
 
   '@a2a-js/sdk@0.3.12':
     resolution: {integrity: sha512-iYV4rkOrAiGGN0ID54NiszHmgtBI0zJwgY3ZfsGOxwfz5CC8ERSSG1te5pwXApyqlZM+GxENad9gvmTk9oS1vQ==}
@@ -202,6 +221,9 @@ packages:
   '@babel/runtime@7.28.6':
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
     engines: {node: '>=6.9.0'}
+
+  '@bufbuild/protobuf@2.11.0':
+    resolution: {integrity: sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==}
 
   '@emnapi/runtime@1.8.1':
     resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
@@ -417,6 +439,10 @@ packages:
 
   '@google/gemini-cli-core@0.33.1':
     resolution: {integrity: sha512-yhXCVOFI7j8SIjwhYLbhKM0KqIz5tSX3GCZGwjblRIGpuPLTVC0mxrfLIyGRPDkk5Pn8SahN2RFsoMfJLtJIpw==}
+    engines: {node: '>=20'}
+
+  '@google/gemini-cli-core@0.36.0':
+    resolution: {integrity: sha512-GXjfegEYKAS4O8q+Hras+iJC3AoxZgzKBIoGIkfpqfNbKbhu6bfNQSUOp161r8vN6DN/R+mOgtPyCUJGDTrwcw==}
     engines: {node: '>=20'}
 
   '@google/gemini-cli@0.33.1':
@@ -1553,6 +1579,10 @@ packages:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
 
+  call-bind@1.0.8:
+    resolution: {integrity: sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==}
+    engines: {node: '>= 0.4'}
+
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
@@ -2511,6 +2541,9 @@ packages:
     resolution: {integrity: sha512-jv+8jaWCl0g2lSBkNSVXdzfBA0npK1HGC2KtWM9FumFRoGS94g3NbCCLVnCYHLjp4GrW2KZeeSTMo5ddtznmGw==}
     engines: {node: '>=18'}
 
+  isarray@2.0.5:
+    resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
@@ -2552,6 +2585,10 @@ packages:
   json-schema-typed@8.0.2:
     resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
+  json-stable-stringify@1.3.0:
+    resolution: {integrity: sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==}
+    engines: {node: '>= 0.4'}
+
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
 
@@ -2560,6 +2597,9 @@ packages:
 
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
+
+  jsonify@0.0.1:
+    resolution: {integrity: sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==}
 
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
@@ -3228,6 +3268,10 @@ packages:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
 
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
+
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
@@ -3712,10 +3756,19 @@ packages:
 
 snapshots:
 
-  '@a2a-js/sdk@0.3.12(@grpc/grpc-js@1.14.3)(express@5.2.1)':
+  '@a2a-js/sdk@0.3.11(@bufbuild/protobuf@2.11.0)(@grpc/grpc-js@1.14.3)(express@5.2.1)':
     dependencies:
       uuid: 11.1.0
     optionalDependencies:
+      '@bufbuild/protobuf': 2.11.0
+      '@grpc/grpc-js': 1.14.3
+      express: 5.2.1
+
+  '@a2a-js/sdk@0.3.12(@bufbuild/protobuf@2.11.0)(@grpc/grpc-js@1.14.3)(express@5.2.1)':
+    dependencies:
+      uuid: 11.1.0
+    optionalDependencies:
+      '@bufbuild/protobuf': 2.11.0
       '@grpc/grpc-js': 1.14.3
       express: 5.2.1
 
@@ -3740,15 +3793,15 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
 
-  '@anthropic-ai/sdk@0.78.0(zod@3.25.76)':
+  '@anthropic-ai/sdk@0.78.0(zod@4.3.6)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
-      zod: 3.25.76
+      zod: 4.3.6
 
-  '@anthropic-ai/vertex-sdk@0.14.4(encoding@0.1.13)(zod@3.25.76)':
+  '@anthropic-ai/vertex-sdk@0.14.4(encoding@0.1.13)(zod@4.3.6)':
     dependencies:
-      '@anthropic-ai/sdk': 0.78.0(zod@3.25.76)
+      '@anthropic-ai/sdk': 0.78.0(zod@4.3.6)
       google-auth-library: 9.15.1(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
@@ -3764,6 +3817,8 @@ snapshots:
   '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/runtime@7.28.6': {}
+
+  '@bufbuild/protobuf@2.11.0': {}
 
   '@emnapi/runtime@1.8.1':
     dependencies:
@@ -3955,9 +4010,9 @@ snapshots:
       - encoding
       - supports-color
 
-  '@google/gemini-cli-core@0.33.1(encoding@0.1.13)(express@5.2.1)':
+  '@google/gemini-cli-core@0.33.1(@bufbuild/protobuf@2.11.0)(encoding@0.1.13)(express@5.2.1)':
     dependencies:
-      '@a2a-js/sdk': 0.3.12(@grpc/grpc-js@1.14.3)(express@5.2.1)
+      '@a2a-js/sdk': 0.3.12(@bufbuild/protobuf@2.11.0)(@grpc/grpc-js@1.14.3)(express@5.2.1)
       '@google-cloud/logging': 11.2.1(encoding@0.1.13)
       '@google-cloud/opentelemetry-cloud-monitoring-exporter': 0.21.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@2.6.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)
       '@google-cloud/opentelemetry-cloud-trace-exporter': 3.0.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)
@@ -4039,13 +4094,103 @@ snapshots:
       - tree-sitter
       - utf-8-validate
 
-  '@google/gemini-cli@0.33.1(encoding@0.1.13)(express@5.2.1)':
+  '@google/gemini-cli-core@0.36.0(encoding@0.1.13)(express@5.2.1)':
+    dependencies:
+      '@a2a-js/sdk': 0.3.11(@bufbuild/protobuf@2.11.0)(@grpc/grpc-js@1.14.3)(express@5.2.1)
+      '@bufbuild/protobuf': 2.11.0
+      '@google-cloud/logging': 11.2.1(encoding@0.1.13)
+      '@google-cloud/opentelemetry-cloud-monitoring-exporter': 0.21.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-metrics@2.6.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)
+      '@google-cloud/opentelemetry-cloud-trace-exporter': 3.0.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/resources@2.6.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)
+      '@google/genai': 1.30.0(@modelcontextprotocol/sdk@1.27.1(zod@3.25.76))
+      '@grpc/grpc-js': 1.14.3
+      '@iarna/toml': 2.2.5
+      '@joshua.litt/get-ripgrep': 0.0.3
+      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.211.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-logs-otlp-grpc': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-logs-otlp-http': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-grpc': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-grpc': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-http': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation-http': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-node': 0.211.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-node': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+      '@types/html-to-text': 9.0.4
+      '@xterm/headless': 5.5.0
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      chardet: 2.1.1
+      diff: 8.0.3
+      dotenv: 17.3.1
+      dotenv-expand: 12.0.3
+      fast-levenshtein: 2.0.6
+      fdir: 6.5.0(picomatch@4.0.3)
+      fzf: 0.5.2
+      glob: 12.0.0
+      google-auth-library: 9.15.1(encoding@0.1.13)
+      html-to-text: 9.0.5
+      https-proxy-agent: 7.0.6
+      ignore: 7.0.5
+      ipaddr.js: 1.9.1
+      js-yaml: 4.1.1
+      json-stable-stringify: 1.3.0
+      marked: 15.0.12
+      mime: 4.0.7
+      mnemonist: 0.40.3
+      open: 10.2.0
+      picomatch: 4.0.3
+      proper-lockfile: 4.1.2
+      puppeteer-core: 24.39.1
+      read-package-up: 11.0.0
+      shell-quote: 1.8.3
+      simple-git: 3.33.0
+      strip-ansi: 7.2.0
+      strip-json-comments: 3.1.1
+      systeminformation: 5.31.4
+      tree-sitter-bash: 0.25.1
+      undici: 7.24.1
+      uuid: 13.0.0
+      web-tree-sitter: 0.25.10
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    optionalDependencies:
+      '@lydell/node-pty': 1.1.0
+      '@lydell/node-pty-darwin-arm64': 1.1.0
+      '@lydell/node-pty-darwin-x64': 1.1.0
+      '@lydell/node-pty-linux-x64': 1.1.0
+      '@lydell/node-pty-win32-arm64': 1.1.0
+      '@lydell/node-pty-win32-x64': 1.1.0
+      keytar: 7.9.0
+      node-pty: 1.1.0
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - '@types/emscripten'
+      - bare-abort-controller
+      - bare-buffer
+      - bufferutil
+      - encoding
+      - express
+      - react-native-b4a
+      - supports-color
+      - tree-sitter
+      - utf-8-validate
+
+  '@google/gemini-cli@0.33.1(@bufbuild/protobuf@2.11.0)(encoding@0.1.13)(express@5.2.1)':
     dependencies:
       '@agentclientprotocol/sdk': 0.12.0(zod@3.25.76)
-      '@google/gemini-cli-core': 0.33.1(encoding@0.1.13)(express@5.2.1)
+      '@google/gemini-cli-core': 0.33.1(@bufbuild/protobuf@2.11.0)(encoding@0.1.13)(express@5.2.1)
       '@google/genai': 1.30.0(@modelcontextprotocol/sdk@1.27.1(zod@3.25.76))
       '@iarna/toml': 2.2.5
-      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.27.1(zod@4.3.6)
       ansi-escapes: 7.3.0
       ansi-regex: 6.2.2
       chalk: 4.1.2
@@ -4100,7 +4245,7 @@ snapshots:
       google-auth-library: 10.6.1
       ws: 8.19.0
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.27.1(zod@4.3.6)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -5191,6 +5336,13 @@ snapshots:
       es-errors: 1.3.0
       function-bind: 1.1.2
 
+  call-bind@1.0.8:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
+
   call-bound@1.0.4:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -6267,6 +6419,8 @@ snapshots:
     dependencies:
       system-architecture: 0.1.0
 
+  isarray@2.0.5: {}
+
   isexe@2.0.0: {}
 
   jackspeak@3.4.3:
@@ -6307,6 +6461,14 @@ snapshots:
 
   json-schema-typed@8.0.2: {}
 
+  json-stable-stringify@1.3.0:
+    dependencies:
+      call-bind: 1.0.8
+      call-bound: 1.0.4
+      isarray: 2.0.5
+      jsonify: 0.0.1
+      object-keys: 1.1.1
+
   json-stringify-safe@5.0.1: {}
 
   json-with-bigint@3.5.7: {}
@@ -6316,6 +6478,8 @@ snapshots:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  jsonify@0.0.1: {}
 
   jwa@2.0.1:
     dependencies:
@@ -7024,6 +7188,15 @@ snapshots:
       send: 1.2.1
     transitivePeerDependencies:
       - supports-color
+
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
 
   setprototypeof@1.2.0: {}
 

--- a/serving/skills-cli/build-dist.ts
+++ b/serving/skills-cli/build-dist.ts
@@ -21,38 +21,42 @@ interface BuildResult {
   skillNames: string[];
 }
 
+async function acquireLock(lockFilePath: string) {
+  while (fs.existsSync(lockFilePath)) {
+    try {
+      const pid = parseInt(fs.readFileSync(lockFilePath, 'utf-8'), 10);
+      process.kill(pid, 0);
+    } catch (e: any) {
+      if (e.code === 'ESRCH') {
+        fs.unlinkSync(lockFilePath);
+        break;
+      }
+    }
+    console.log(" Another build is in progress. Waiting...");
+    await new Promise(resolve => setTimeout(resolve, 2000));
+  }
+  fs.writeFileSync(lockFilePath, process.pid.toString());
+}
+
 async function main(): Promise<BuildResult | undefined> {
-  fs.writeFileSync('build-probe-1.log', 'YES');
   fs.mkdirSync(ROOT_DIST_DIR, { recursive: true });
   const lockFilePath = path.join(ROOT_DIST_DIR, "build-dist.lock");
 
-  if (fs.existsSync(lockFilePath)) {
-    console.log(" Another build is in progress. Waiting for it to finish...");
-    while (fs.existsSync(lockFilePath)) {
-      await new Promise(resolve => setTimeout(resolve, 2000));
-    }
-    console.log(" Previous build finished. Skipping rebuild.");
-    return; 
-  }
-
-  fs.writeFileSync(lockFilePath, process.pid.toString());
+  await acquireLock(lockFilePath);
 
   try {
     console.log("Ensuring dist/ output directory exists...");
-    fs.writeFileSync('build-probe-2.log', 'YES');
     fs.mkdirSync(PUBLISH_ROOT, { recursive: true });
 
   console.log("Generating guides and updating vector store...");
   // 1. Run build-guides.ts to update .modern-web-data and build/guides
   try {
     console.time("⏳ build-guides.ts");
-    fs.writeFileSync('build-probe-3.log', 'YES');
     execSync("node --experimental-strip-types scripts/build-guides.ts", {
       cwd: SERVING_DIR,
       stdio: "inherit",
     });
     console.timeEnd("⏳ build-guides.ts");
-    fs.writeFileSync('build-probe-4.log', 'YES');
   } catch (error) {
     console.error("Failed to build guides:", error);
     process.exit(1);
@@ -92,7 +96,6 @@ async function main(): Promise<BuildResult | undefined> {
   
   try {
     console.time("⏳ esbuild bundle");
-    fs.writeFileSync('build-probe-5.log', 'YES');
     // We emit pure ESM (.mjs) using esbuild! Node 20+ handles import.meta.dirname & url natively!
     await esbuild.build({
       entryPoints: [entryPoint],
@@ -104,7 +107,6 @@ async function main(): Promise<BuildResult | undefined> {
       outfile: outFile,
     });
     console.timeEnd("⏳ esbuild bundle");
-    fs.writeFileSync('build-probe-6.log', 'YES');
 
   } catch (error) {
     console.error("Failed to bundle with esbuild:", error);
@@ -141,7 +143,6 @@ async function main(): Promise<BuildResult | undefined> {
   if (fs.existsSync(path.join(PUBLISH_ROOT, "node_modules"))) {
     try {
       // npm ls will exit with code 0 if all dependencies are satisfied according to package.json!
-      fs.writeFileSync('build-probe-7.log', 'YES');
       execSync("npm ls --depth=0", { cwd: PUBLISH_ROOT, stdio: "ignore" });
       nodeModulesValid = true;
     } catch {

--- a/serving/skills-cli/build-dist.ts
+++ b/serving/skills-cli/build-dist.ts
@@ -22,6 +22,7 @@ interface BuildResult {
 }
 
 async function main(): Promise<BuildResult | undefined> {
+  fs.writeFileSync('build-probe-1.log', 'YES');
   fs.mkdirSync(ROOT_DIST_DIR, { recursive: true });
   const lockFilePath = path.join(ROOT_DIST_DIR, "build-dist.lock");
 
@@ -38,17 +39,20 @@ async function main(): Promise<BuildResult | undefined> {
 
   try {
     console.log("Ensuring dist/ output directory exists...");
+    fs.writeFileSync('build-probe-2.log', 'YES');
     fs.mkdirSync(PUBLISH_ROOT, { recursive: true });
 
   console.log("Generating guides and updating vector store...");
   // 1. Run build-guides.ts to update .modern-web-data and build/guides
   try {
     console.time("⏳ build-guides.ts");
+    fs.writeFileSync('build-probe-3.log', 'YES');
     execSync("node --experimental-strip-types scripts/build-guides.ts", {
       cwd: SERVING_DIR,
       stdio: "inherit",
     });
     console.timeEnd("⏳ build-guides.ts");
+    fs.writeFileSync('build-probe-4.log', 'YES');
   } catch (error) {
     console.error("Failed to build guides:", error);
     process.exit(1);
@@ -88,6 +92,7 @@ async function main(): Promise<BuildResult | undefined> {
   
   try {
     console.time("⏳ esbuild bundle");
+    fs.writeFileSync('build-probe-5.log', 'YES');
     // We emit pure ESM (.mjs) using esbuild! Node 20+ handles import.meta.dirname & url natively!
     await esbuild.build({
       entryPoints: [entryPoint],
@@ -99,6 +104,7 @@ async function main(): Promise<BuildResult | undefined> {
       outfile: outFile,
     });
     console.timeEnd("⏳ esbuild bundle");
+    fs.writeFileSync('build-probe-6.log', 'YES');
 
   } catch (error) {
     console.error("Failed to bundle with esbuild:", error);
@@ -135,6 +141,7 @@ async function main(): Promise<BuildResult | undefined> {
   if (fs.existsSync(path.join(PUBLISH_ROOT, "node_modules"))) {
     try {
       // npm ls will exit with code 0 if all dependencies are satisfied according to package.json!
+      fs.writeFileSync('build-probe-7.log', 'YES');
       execSync("npm ls --depth=0", { cwd: PUBLISH_ROOT, stdio: "ignore" });
       nodeModulesValid = true;
     } catch {

--- a/serving/skills-cli/test-dist.test.ts
+++ b/serving/skills-cli/test-dist.test.ts
@@ -25,10 +25,17 @@ const ROOT_DIR = path.resolve(import.meta.dirname, "../.."); // guidance/
 const DIST_DIR = path.join(ROOT_DIR, "dist/skills-cli");
 
 console.log("Running build-dist to ensure fresh build...");
-execSync('node --experimental-strip-types skills-cli/build-dist.ts', { 
-  cwd: path.resolve(import.meta.dirname, '..'), 
-  stdio: 'pipe' 
-});
+try {
+  execSync('node --experimental-strip-types skills-cli/build-dist.ts', { 
+    cwd: path.resolve(import.meta.dirname, '..'), 
+    stdio: 'pipe' 
+  });
+} catch (error: any) {
+  console.error("\n❌ build-dist.ts failed!");
+  if (error.stdout) console.log(error.stdout.toString('utf8'));
+  if (error.stderr) console.error(error.stderr.toString('utf8'));
+  throw new Error("build-dist.ts failed");
+}
 
 
 test('Dependency parity across package.json manifests', async () => {

--- a/serving/skills-cli/test-dist.test.ts
+++ b/serving/skills-cli/test-dist.test.ts
@@ -25,7 +25,6 @@ const ROOT_DIR = path.resolve(import.meta.dirname, "../.."); // guidance/
 const DIST_DIR = path.join(ROOT_DIR, "dist/skills-cli");
 
 console.log("Running build-dist to ensure fresh build...");
-await fs.writeFile('i-reached-this-point.log', 'YES');
 execSync('node --experimental-strip-types skills-cli/build-dist.ts', { 
   cwd: path.resolve(import.meta.dirname, '..'), 
   stdio: 'pipe' 

--- a/serving/skills-cli/test-dist.test.ts
+++ b/serving/skills-cli/test-dist.test.ts
@@ -25,6 +25,7 @@ const ROOT_DIR = path.resolve(import.meta.dirname, "../.."); // guidance/
 const DIST_DIR = path.join(ROOT_DIR, "dist/skills-cli");
 
 console.log("Running build-dist to ensure fresh build...");
+await fs.writeFile('i-reached-this-point.log', 'YES');
 execSync('node --experimental-strip-types skills-cli/build-dist.ts', { 
   cwd: path.resolve(import.meta.dirname, '..'), 
   stdio: 'pipe' 

--- a/serving/skills-cli/test-dist.test.ts
+++ b/serving/skills-cli/test-dist.test.ts
@@ -27,7 +27,7 @@ const DIST_DIR = path.join(ROOT_DIR, "dist/skills-cli");
 console.log("Running build-dist to ensure fresh build...");
 execSync('node --experimental-strip-types skills-cli/build-dist.ts', { 
   cwd: path.resolve(import.meta.dirname, '..'), 
-  stdio: 'inherit' 
+  stdio: 'pipe' 
 });
 
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
     "**/dist",
     "**/test-app-results/**",
     "**/test-app-results/**",
+    "harness/results/",
     "**/eval-view",
     "**/eval-view/**/*"
   ]


### PR DESCRIPTION
###  main focus: split out "guide usage" metrics" & improved reporting 
*   Differentiated between guides retrieved via tools and those **read directly from files**. Updated dashboard  to match.
*   Added tracking for 'generation errors' when a task straight up failed.

#### evals.json types and backfill. 

*   **Formal Types**: Added formal TypeScript interfaces for `evals.json` to keep things consistent across the pipeline (with loose/strict variants to handle legacy data).
*   Added backfill.ts to update evals.json to modern format.  Handling legacy stuff and upgrading it.   
*    Introduced a workflow to update our GCS results' evals.json safely.  Added `--summary-only` flag to `upload_suite.ts` to only push `evals.json`/`evals.md`. Details covered in `harness/eval-results.md` 


<img width="773" height="309" alt="image" src="https://github.com/user-attachments/assets/6180ec97-d5bf-4ec2-92ce-5ea4bbba1eee" />



#### Drivebys
*   Fixed some lockfile stuff in `build-dist.ts` --  check if the lock-owning PID is still alive. it was buggy before
*   Better logging around build-dist/test-dist
*   nice gemini-cli-core types in gcli agent for trajectory parsing :) 
