### PR TITLE
Add guidance for `move-dom-element-without-losing-state`

### DIFF
--- a/guides/user-experience/move-dom-element-without-losing-state/demo.html
+++ b/guides/user-experience/move-dom-element-without-losing-state/demo.html
@@ -1,1 +1,92 @@
-<!-- TODO -->
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Move DOM Element Preserving State Demo</title>
+  <style>
+    body {
+      font-family: system-ui, sans-serif;
+      padding: 2rem;
+      display: flex;
+      gap: 2rem;
+      align-items: flex-start;
+    }
+
+    .container {
+      border: 2px dashed #ccc;
+      padding: 1rem;
+      min-height: 200px;
+      min-width: 300px;
+    }
+
+    .controls {
+      margin-top: 1rem;
+    }
+
+    .card {
+      border: 1px solid #005fcc;
+      background: #e6f2ff;
+      padding: 1rem;
+    }
+
+    iframe {
+      width: 100%;
+      border: 1px solid #ccc;
+      margin-bottom: 0.5rem;
+    }
+
+    input {
+      width: 100%;
+      box-sizing: border-box;
+      padding: 0.5rem;
+    }
+  </style>
+</head>
+
+<body>
+
+  <div>
+    <h2>Container A</h2>
+    <div id="container-a" class="container">
+      <div id="stateful-element" class="card">
+        <p>This element has state.</p>
+        <!-- Iframe with a test URL -->
+        <iframe src="https://www.youtube.com/embed/LXb3EKWsInQ?si=Zx3qCFtJeqP6Qrt2"
+          title="YouTube video player"></iframe>
+      </div>
+    </div>
+  </div>
+
+  <div>
+    <h2>Container B</h2>
+    <div id="container-b" class="container"></div>
+  </div>
+
+  <div class="controls">
+    <button id="move-btn">Move Element</button>
+  </div>
+
+  <script>
+    const btn = document.getElementById('move-btn');
+    const statefulElement = document.getElementById('stateful-element');
+    const containerA = document.getElementById('container-a');
+    const containerB = document.getElementById('container-b');
+
+    btn.addEventListener('click', () => {
+      // Determine current parent and target parent
+      const currentParent = statefulElement.parentElement;
+      const targetParent = currentParent === containerA ? containerB : containerA;
+
+      // Feature detect moveBefore
+      if ('moveBefore' in Element.prototype) {
+        targetParent.moveBefore(statefulElement, null);
+      } else {
+        // Fallback that resets state
+        targetParent.insertBefore(statefulElement, null);
+      }
+    });
+  </script>
+</body>
+  </html>

--- a/guides/user-experience/move-dom-element-without-losing-state/expectations.md
+++ b/guides/user-experience/move-dom-element-without-losing-state/expectations.md
@@ -1,0 +1,4 @@
+* The document contains a script that performs DOM reparenting.
+* The script contains a feature detection check for `moveBefore` to safely handle unsupported browsers.
+* The script uses `moveBefore` to move a stateful element (e.g., an element containing an iframe, input, video, or audio) to a new parent if the feature is supported.
+* The script falls back to using `insertBefore` or `appendChild` if `moveBefore` is not supported.

--- a/guides/user-experience/move-dom-element-without-losing-state/grader.ts
+++ b/guides/user-experience/move-dom-element-without-losing-state/grader.ts
@@ -1,0 +1,70 @@
+import { test, expect } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const targetFile = process.env.TARGET_FILE;
+if (!targetFile) {
+  throw new Error('TARGET_FILE environment variable not set.');
+}
+
+const filePath = path.resolve(targetFile);
+const targetDir = path.dirname(filePath);
+const demoName = path.basename(filePath);
+const demoUrl = `http://localhost/${demoName}`;
+
+test.describe(`move-before Expectations: ${demoName}`, () => {
+
+  test.beforeEach(async ({ page }) => {
+    await page.route('http://localhost/*', async (route) => {
+      const requestPath = new URL(route.request().url()).pathname;
+      const localFilePath = path.join(targetDir, requestPath === '/' ? demoName : requestPath.slice(1));
+
+      if (fs.existsSync(localFilePath)) {
+        await route.fulfill({ path: localFilePath });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.goto(demoUrl);
+  });
+
+  test('Document contains a stateful element (iframe, input, video, or audio)', async ({ page }) => {
+    const statefulElements = await page.locator('iframe, input, video, audio').count();
+    expect(statefulElements).toBeGreaterThan(0);
+  });
+
+  test('Script contains a feature detection check for moveBefore', async ({ page }) => {
+    const scripts = await page.evaluate(() => {
+      return Array.from(document.querySelectorAll('script')).map(s => s.textContent || s.innerText);
+    });
+    const content = scripts.join('\n');
+    
+    const hasFeatureDetection = /['"`]moveBefore['"`]\s*in\s+(?:Element\.prototype|document|window)/.test(content) ||
+                                /typeof\s+[\w.]+\.moveBefore\s*===?\s*['"`]function['"`]/.test(content) ||
+                                /if\s*\(\s*[\w.]+\.moveBefore\s*\)/.test(content);
+                                
+    expect(hasFeatureDetection).toBeTruthy();
+  });
+
+  test('Script uses moveBefore to move an element', async ({ page }) => {
+    const scripts = await page.evaluate(() => {
+      return Array.from(document.querySelectorAll('script')).map(s => s.textContent || s.innerText);
+    });
+    const content = scripts.join('\n');
+    
+    const usesMoveBefore = /\.moveBefore\s*\(/.test(content);
+    expect(usesMoveBefore).toBeTruthy();
+  });
+
+  test('Script falls back to using insertBefore or appendChild', async ({ page }) => {
+    const scripts = await page.evaluate(() => {
+      return Array.from(document.querySelectorAll('script')).map(s => s.textContent || s.innerText);
+    });
+    const content = scripts.join('\n');
+    
+    const usesFallback = /\.insertBefore\s*\(|\.appendChild\s*\(/.test(content);
+    expect(usesFallback).toBeTruthy();
+  });
+
+});

--- a/guides/user-experience/move-dom-element-without-losing-state/guide.md
+++ b/guides/user-experience/move-dom-element-without-losing-state/guide.md
@@ -3,4 +3,64 @@ name: move-dom-element-without-losing-state
 description: Move or reparent a DOM element without losing important element state, such as interactivity states (:focus/:active), <iframe> loading state, animation/transition state, etc
 web-feature-ids:
 - move-before
+sources:
+- https://developer.mozilla.org/en-US/docs/Web/API/Element/moveBefore
+- https://developer.mozilla.org/en-US/docs/Web/API/Document/moveBefore
+- https://developer.chrome.com/blog/movebefore-api
 ---
+
+When reparenting DOM elements using traditional methods like `appendChild()` or `insertBefore()`, the browser implicitly removes the element from the DOM and then inserts it into its new location. This "remove and insert" operation resets many internal states, causing `<iframe>` elements to reload, CSS animations to restart, and input fields to lose focus.
+
+To move an element while preserving its state, use the `moveBefore()` API. This method performs an atomic move, completely bypassing the removal and insertion steps.
+
+### Moving an element with state
+
+Use `moveBefore()` exactly as you would use `insertBefore()`. It requires two arguments: the node to move, and a reference node to insert before (or `null` to append to the end of the new parent).
+
+```javascript
+const newParent = document.getElementById('new-parent');
+const elementWithState = document.getElementById('iframe-or-focused-input');
+
+// MANDATORY: Use moveBefore to preserve state. 
+// Passing null as the second argument appends the element to the end of newParent.
+newParent.moveBefore(elementWithState, null);
+```
+
+### Moving custom elements (Web Components)
+
+If you are moving custom elements using `moveBefore()`, their `connectedCallback` and `disconnectedCallback` lifecycle methods will **not** be fired.
+
+If your custom element needs to perform specific logic when moved, implement the `connectedMoveCallback()` method inside the custom element definition.
+
+```javascript
+class MyCustomElement extends HTMLElement {
+  connectedCallback() {
+    // Runs on initial insertion.
+  }
+  
+  connectedMoveCallback() {
+    // Runs when the element is moved via moveBefore().
+    // Use this to update state that depends on the new DOM location.
+  }
+}
+```
+
+### Fallback strategies
+
+{{ BASELINE_STATUS("move-before") }}
+
+Since `moveBefore()` is a progressive enhancement, you MUST use feature detection before calling it, falling back to traditional `insertBefore()` or `appendChild()` operations for older browsers. 
+
+```javascript
+const targetParent = document.getElementById('target-container');
+const nodeToMove = document.getElementById('moving-element');
+
+// Check if moveBefore is supported on the Element prototype
+if ('moveBefore' in Element.prototype) {
+  targetParent.moveBefore(nodeToMove, null);
+} else {
+  // Fallback: traditional move. 
+  // Note: This WILL reset <iframe>, animation, and focus state in unsupported browsers.
+  targetParent.insertBefore(nodeToMove, null);
+}
+```

--- a/guides/user-experience/move-dom-element-without-losing-state/negative-demo.html
+++ b/guides/user-experience/move-dom-element-without-losing-state/negative-demo.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Demo</title>
+<style>
+  body {
+    padding: 2rem;
+    font-family: sans-serif;
+  }
+  p {
+    border: 1px solid #000;
+    padding: 1rem;
+  }
+  span {
+    color: blue;
+    text-decoration: underline;
+    cursor: pointer;
+  }
+</style>
+</head>
+<body>
+<p id="target">Content</p>
+<span id="act">Move</span>
+<script>
+document.getElementById('act').onmouseenter = function() {
+  var target = document.getElementById('target');
+  if (target) {
+    var html = target.outerHTML;
+    target.remove();
+    document.body.innerHTML += html;
+  }
+};
+</script>
+</body>
+</html>

--- a/guides/user-experience/move-dom-element-without-losing-state/tasks/task.md
+++ b/guides/user-experience/move-dom-element-without-losing-state/tasks/task.md
@@ -1,0 +1,6 @@
+---
+base_app: daily-grind
+---
+- add a youtube iframe with a coffee roasting video to the main container. add a 'theater mode' button that reparents the iframe into the hero section, and moves it back when toggled. make sure the iframe doesn't lose its playback state or reload when it's moved (but be sure to include a fallback for older browsers).
+- put a 'quick feedback' text input in the footer, along with a 'pin to top' button. the button should move the input field to the very top of the main container. make sure that if a user is typing and clicks the pin button, they don't lose focus!
+- can you add a spotify iframe to the footer? also add a button to dock the player into the top nav. write the js to move the element without making the iframe refresh. please include a fallback for older browsers just in case.


### PR DESCRIPTION
https://github.com/GoogleChrome/guidance/issues/175 Add guide, demo, and test suite for using moveBefore API to reparent DOM elements without losing state.

Note: Guide adds additional instructions for using moveBefore() with web components.