### PR TITLE
fix playwright config ESM crash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,4 +98,5 @@ jobs:
         run: pnpm --filter eval-view run test:e2e
 
       - name: Test Grader Calibration
-        run: ./bin/gd.ts dev guides/user-experience/adapt-scrollbar-to-contrast-preferences/ --test-grader
+        # Ensuring playwright is happy
+        run: pnpm gd dev guides/user-experience/adapt-scrollbar-to-contrast-preferences/ --test-grader

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,4 +99,4 @@ jobs:
 
       - name: Test Grader Calibration
         # Ensuring playwright is happy
-        run: pnpm gd dev guides/user-experience/adapt-scrollbar-to-contrast-preferences/ --test-grader
+        run: node bin/gd.ts dev guides/user-experience/adapt-scrollbar-to-contrast-preferences/ --test-grader

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,3 +96,6 @@ jobs:
 
       - name: Playwright E2E Tests
         run: pnpm --filter eval-view run test:e2e
+
+      - name: Test Grader Calibration
+        run: ./bin/gd.ts dev guides/user-experience/adapt-scrollbar-to-contrast-preferences/ --test-grader

--- a/guides/package.json
+++ b/guides/package.json
@@ -4,8 +4,6 @@
   "type": "module",
   "scripts": {
     "test": "node --experimental-strip-types --test --test-reporter ${TEST_REPORTER:-dot} **/*.test.ts",
-    "test:unit": "node --experimental-strip-types --test --test-reporter ${TEST_REPORTER:-dot} ./sync-use-cases.test.ts ./playwright-config.test.ts",
-    "test:validation": "node --experimental-strip-types --test --test-reporter ${TEST_REPORTER:-dot} ./guides-integrity.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/guides/package.json
+++ b/guides/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "test": "npm run test:unit && npm run test:validation",
+    "test": "node --experimental-strip-types --test --test-reporter ${TEST_REPORTER:-dot} **/*.test.ts",
     "test:unit": "node --experimental-strip-types --test --test-reporter ${TEST_REPORTER:-dot} ./sync-use-cases.test.ts ./playwright-config.test.ts",
     "test:validation": "node --experimental-strip-types --test --test-reporter ${TEST_REPORTER:-dot} ./guides-integrity.test.ts",
     "typecheck": "tsc --noEmit"

--- a/guides/package.json
+++ b/guides/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "test": "npm run test:unit && npm run test:validation",
-    "test:unit": "node --experimental-strip-types --test --test-reporter ${TEST_REPORTER:-dot} ./sync-use-cases.test.ts",
+    "test:unit": "node --experimental-strip-types --test --test-reporter ${TEST_REPORTER:-dot} ./sync-use-cases.test.ts ./playwright-config.test.ts",
     "test:validation": "node --experimental-strip-types --test --test-reporter ${TEST_REPORTER:-dot} ./guides-integrity.test.ts",
     "typecheck": "tsc --noEmit"
   },

--- a/guides/playwright-config.test.ts
+++ b/guides/playwright-config.test.ts
@@ -1,4 +1,4 @@
-import test, { describe, it } from 'node:test';
+import { describe, it } from 'node:test';
 import assert from 'node:assert';
 
 describe('Playwright Config', () => {

--- a/guides/playwright-config.test.ts
+++ b/guides/playwright-config.test.ts
@@ -1,0 +1,11 @@
+import test, { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+describe('Playwright Config', () => {
+  it('loads without error', async () => {
+    // Attempt to load the config file to ensure it doesn't throw ReferenceError
+    // or other ESM related errors.
+    const config = await import('./playwright.config.ts');
+    assert.ok(config.default, 'Config should have a default export');
+  });
+});

--- a/guides/playwright.config.ts
+++ b/guides/playwright.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   expect: { timeout: 3000 },
   // Forces Playwright to always search relative to this config file (the guides directory),
   // regardless of where you run it from (e.g., when run from within a specific results folder).
-  testDir: __dirname,
+  testDir: import.meta.dirname,
   testMatch: '**/grader.ts',
   fullyParallel: false,
   forbidOnly: !!process.env.CI,


### PR DESCRIPTION
ref: https://github.com/GoogleChrome/guidance/pull/507#issuecomment-4210986603 ..  (rick flagging that eval running failed because `__dirname` isn't defined in ESM scope.)

Switched it to `import.meta.dirname` in `playwright.config.ts` to keep the absolute path resolution but make it ESM-friendly. 

improved test coverage.. added regression test