### PR TITLE
Update sync-use-cases to handle IDs in the new feature template

### DIFF
--- a/guides/sync-use-cases.ts
+++ b/guides/sync-use-cases.ts
@@ -161,7 +161,7 @@ export function buildIssueContent(
 export function buildFeatureToIssueMap(issues: any[]): Map<string, FeatureIssueData> {
   const map = new Map<string, FeatureIssueData>();
   for (const issue of issues) {
-    const match = issue.body?.match(/Feature ID: ([a-z0-9-]+)/);
+    const match = issue.body?.match(/(?:Feature ID:|### web-feature-id)[\s\r\n]+([a-z0-9-]+)/i);
     if (match) {
       const priorityLabel = issue.labels
         .map((l: any) => (typeof l === 'string' ? l : l.name))


### PR DESCRIPTION
The [new feature issue template](https://github.com/GoogleChrome/guidance/blob/main/.github/ISSUE_TEMPLATE/new-feature.yml) annotates web-feature IDs differently

This change makes sure the sync script can match both old and new annotation styles