### PR TITLE
docs: add guide and evals for `animate-to-from-top-layer`

### DIFF
--- a/guides/user-experience/animate-to-from-top-layer/demo.html
+++ b/guides/user-experience/animate-to-from-top-layer/demo.html
@@ -74,7 +74,9 @@
         cursor: pointer;
         font-family: inherit;
         font-weight: 400;
-        transition: all 0.3s ease;
+        transition-property: background, border-color, transform, box-shadow;
+        transition-duration: 0.3s;
+        transition-timing-function: ease;
       }
 
       button:hover {
@@ -135,11 +137,10 @@
         transform: scale(0.9) translateY(20px);
 
         /* Transition for closing */
-        transition:
-          opacity 0.5s ease,
-          transform 0.5s cubic-bezier(0.19, 1, 0.22, 1),
-          overlay 0.5s allow-discrete,
-          display 0.5s allow-discrete;
+        transition-property: opacity, transform, overlay, display;
+        transition-duration: 0.5s;
+        transition-timing-function: cubic-bezier(0.19, 1, 0.22, 1);
+        transition-behavior: allow-discrete;
       }
 
       dialog[open] {
@@ -159,10 +160,10 @@
       /* Dialog Backdrop */
       dialog::backdrop {
         background-color: rgb(0 0 0 / 0%);
-        transition:
-          background-color 0.5s ease,
-          overlay 0.5s allow-discrete,
-          display 0.5s allow-discrete;
+        transition-property: background-color, overlay, display;
+        transition-duration: 0.5s;
+        transition-timing-function: ease;
+        transition-behavior: allow-discrete;
       }
 
       dialog[open]::backdrop {
@@ -183,11 +184,10 @@
         /* Base state for popover */
         opacity: 0;
         transform: scale(0.95);
-        transition:
-          opacity 0.4s ease,
-          transform 0.4s cubic-bezier(0.19, 1, 0.22, 1),
-          overlay 0.4s allow-discrete,
-          display 0.4s allow-discrete;
+        transition-property: opacity, transform, overlay, display;
+        transition-duration: 0.4s;
+        transition-timing-function: cubic-bezier(0.19, 1, 0.22, 1);
+        transition-behavior: allow-discrete;
       }
 
       [popover]:popover-open {
@@ -204,10 +204,10 @@
 
       [popover]::backdrop {
         background-color: rgb(0 0 0 / 0%);
-        transition:
-          background-color 0.4s ease,
-          overlay 0.4s allow-discrete,
-          display 0.4s allow-discrete;
+        transition-property: background-color, display, overlay;
+        transition-duration: 0.4s;
+        transition-timing-function: ease;
+        transition-behavior: allow-discrete;
       }
 
       [popover]:popover-open::backdrop {
@@ -217,6 +217,26 @@
       @starting-style {
         [popover]:popover-open::backdrop {
           background-color: rgb(0 0 0 / 0%);
+        }
+      }
+
+      /* ========================================= */
+      /* RESPECT USER PREFERENCE FOR REDUCED MOTION */
+      /* ========================================= */
+
+      @media (prefers-reduced-motion: reduce) {
+        dialog,
+        [popover] {
+          /* Disable movement and shorten duration for a simple fade */
+          transform: none;
+          transition-duration: 0.1s;
+        }
+
+        @starting-style {
+          dialog[open],
+          [popover]:popover-open {
+            transform: none;
+          }
         }
       }
     </style>

--- a/guides/user-experience/animate-to-from-top-layer/demo.html
+++ b/guides/user-experience/animate-to-from-top-layer/demo.html
@@ -147,10 +147,8 @@
         /* Open state */
         opacity: 1;
         transform: scale(1) translateY(0);
-      }
 
-      @starting-style {
-        dialog[open] {
+        @starting-style {
           /* Open starting state */
           opacity: 0;
           transform: scale(1.05) translateY(-20px);
@@ -160,18 +158,17 @@
       /* Dialog Backdrop */
       dialog::backdrop {
         background-color: rgb(0 0 0 / 0%);
-        transition-property: background-color, overlay, display;
-        transition-duration: 0.5s;
-        transition-timing-function: ease;
-        transition-behavior: allow-discrete;
+        /* The transition shorthand can also be used with allow-discrete */
+        transition:
+          display 0.5s allow-discrete,
+          overlay 0.5s allow-discrete,
+          background-color 0.5s ease;
       }
 
       dialog[open]::backdrop {
         background-color: rgb(0 0 0 / 50%);
-      }
 
-      @starting-style {
-        dialog[open]::backdrop {
+        @starting-style {
           background-color: rgb(0 0 0 / 0%);
         }
       }
@@ -193,10 +190,8 @@
       [popover]:popover-open {
         opacity: 1;
         transform: scale(1);
-      }
 
-      @starting-style {
-        [popover]:popover-open {
+        @starting-style {
           opacity: 0;
           transform: scale(0.8);
         }
@@ -204,18 +199,17 @@
 
       [popover]::backdrop {
         background-color: rgb(0 0 0 / 0%);
-        transition-property: background-color, display, overlay;
-        transition-duration: 0.4s;
-        transition-timing-function: ease;
-        transition-behavior: allow-discrete;
+        /* The transition shorthand can also be used with allow-discrete */
+        transition:
+          display 0.4s allow-discrete,
+          overlay 0.4s allow-discrete,
+          background-color 0.4s ease;
       }
 
       [popover]:popover-open::backdrop {
         background-color: rgb(15 23 42 / 70%);
-      }
 
-      @starting-style {
-        [popover]:popover-open::backdrop {
+        @starting-style {
           background-color: rgb(0 0 0 / 0%);
         }
       }

--- a/guides/user-experience/animate-to-from-top-layer/expectations.md
+++ b/guides/user-experience/animate-to-from-top-layer/expectations.md
@@ -1,0 +1,7 @@
+- The `<dialog>` element must use the `@starting-style` at-rule to define starting property values for its entry animation.
+- The `[popover]` element must use the `@starting-style` at-rule to define starting property values for its entry animation.
+- Both the `<dialog>` and `[popover]` elements must include `overlay` and `display` in their `transition` property with the `allow-discrete` keyword.
+- When the dialog or popover is opened, it must smoothly transition from its starting styles to its visible styles.
+- When the dialog or popover is closed, it must smoothly transition to its base (closed) styles before being removed from the top layer and layout.
+- The `::backdrop` pseudo-element for the dialog should also be animated (e.g., transition `background-color`).
+- The implementation must respect user preferences for reduced motion using the `prefers-reduced-motion` media query by disabling or simplifying transitions (e.g., removing transforms and shortening durations).

--- a/guides/user-experience/animate-to-from-top-layer/grader.ts
+++ b/guides/user-experience/animate-to-from-top-layer/grader.ts
@@ -1,0 +1,219 @@
+/// <reference types="node" />
+import { test, expect } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Setup
+const targetFile = process.env.TARGET_FILE;
+if (!targetFile) {
+  throw new Error('TARGET_FILE environment variable not set.');
+}
+
+const filePath = path.resolve(targetFile);
+const targetDir = path.dirname(filePath);
+const demoName = path.basename(filePath);
+const demoUrl = `http://localhost/${demoName}`;
+
+test.describe(`Top Layer Animation Expectations: ${demoName}`, () => {
+
+  test.beforeEach(async ({ page }) => {
+    await page.route('http://localhost/*', async (route) => {
+      const requestPath = new URL(route.request().url()).pathname;
+      const localFilePath = path.join(targetDir, requestPath === '/' ? demoName : requestPath);
+
+      if (fs.existsSync(localFilePath)) {
+        await route.fulfill({ path: localFilePath });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await page.goto(demoUrl);
+  });
+
+  test('The <dialog> element must include "overlay" and "display" in its transition properties with "allow-discrete"', async ({ page }) => {
+    const dialog = page.locator('dialog');
+    const props = await dialog.evaluate((el) => {
+      const style = window.getComputedStyle(el);
+      return {
+        transitionProperty: style.transitionProperty,
+        // @ts-ignore - transitionBehavior is a newer property
+        transitionBehavior: style.transitionBehavior || (style as any).webkitTransitionBehavior
+      };
+    });
+
+    const transitionProps = props.transitionProperty.split(',').map(p => p.trim());
+    expect(transitionProps).toContain('overlay');
+    expect(transitionProps).toContain('display');
+    expect(props.transitionBehavior).toContain('allow-discrete');
+  });
+
+  test('The [popover] element must include "overlay" and "display" in its transition properties with "allow-discrete"', async ({ page }) => {
+    const popover = page.locator('[popover]');
+    const props = await popover.evaluate((el) => {
+      const style = window.getComputedStyle(el);
+      return {
+        transitionProperty: style.transitionProperty,
+        // @ts-ignore
+        transitionBehavior: style.transitionBehavior || (style as any).webkitTransitionBehavior
+      };
+    });
+
+    const transitionProps = props.transitionProperty.split(',').map(p => p.trim());
+    expect(transitionProps).toContain('overlay');
+    expect(transitionProps).toContain('display');
+    expect(props.transitionBehavior).toContain('allow-discrete');
+  });
+
+  test('The <dialog> element must use the @starting-style at-rule', async ({ page }) => {
+    const hasStartingStyle = await page.evaluate(() => {
+      for (const sheet of document.styleSheets) {
+        try {
+          for (const rule of sheet.cssRules) {
+            // Check if the rule is @starting-style (type 17) or if its text contains it
+            if (rule.type === 17 || rule.constructor.name === 'CSSStartingStyleRule' || rule.cssText.includes('@starting-style')) {
+              // Ensure it's applied to a dialog
+              if (rule.cssText.includes('dialog')) return true;
+              // Also check nested rules if it's a starting-style rule
+              if ((rule as any).cssRules) {
+                for (const subRule of (rule as any).cssRules) {
+                  if (subRule.selectorText && subRule.selectorText.includes('dialog')) return true;
+                }
+              }
+            }
+          }
+        } catch (e) {}
+      }
+      return false;
+    });
+    expect(hasStartingStyle).toBe(true);
+  });
+
+  test('The [popover] element must use the @starting-style at-rule', async ({ page }) => {
+    const hasStartingStyle = await page.evaluate(() => {
+      for (const sheet of document.styleSheets) {
+        try {
+          for (const rule of sheet.cssRules) {
+            if (rule.type === 17 || rule.constructor.name === 'CSSStartingStyleRule' || rule.cssText.includes('@starting-style')) {
+              if (rule.cssText.includes('popover')) return true;
+              if ((rule as any).cssRules) {
+                for (const subRule of (rule as any).cssRules) {
+                  if (subRule.selectorText && subRule.selectorText.includes('popover')) return true;
+                }
+              }
+            }
+          }
+        } catch (e) {}
+      }
+      return false;
+    });
+    expect(hasStartingStyle).toBe(true);
+  });
+
+  test('The <dialog> element must smoothly transition when opened', async ({ page }) => {
+    const openBtn = page.locator('#open-dialog-btn, #openDialog').first();
+    const dialog = page.locator('dialog').first();
+
+    // Ensure it's closed
+    await expect(dialog).not.toBeVisible();
+
+    // Open it
+    await openBtn.click();
+
+    // Immediately check if it's transitioning (opacity should be less than 1 if it started from 0 or @starting-style)
+    const opacity = await dialog.evaluate((el) => {
+      return parseFloat(window.getComputedStyle(el).opacity);
+    });
+
+    expect(opacity).toBeLessThan(1);
+
+    // Wait for it to be fully open
+    await expect(dialog).toHaveCSS('opacity', '1');
+  });
+
+  test('The <dialog> element must smoothly transition when closed', async ({ page }) => {
+    const openBtn = page.locator('#open-dialog-btn, #openDialog').first();
+    const closeBtn = page.locator('#close-dialog-btn, #closeDialog').first();
+    const dialog = page.locator('dialog').first();
+
+    await openBtn.click();
+    await expect(dialog).toHaveCSS('opacity', '1');
+
+    // Close it
+    await closeBtn.click();
+
+    // Because of allow-discrete and overlay, it should still be in the DOM and visible during transition
+    const isVisibleDuringTransition = await dialog.evaluate((el) => {
+      const style = window.getComputedStyle(el);
+      return style.display !== 'none' && parseFloat(style.opacity) > 0 && parseFloat(style.opacity) < 1;
+    });
+
+    expect(isVisibleDuringTransition).toBe(true);
+
+    // Eventually it should be gone
+    await expect(dialog).not.toBeVisible();
+  });
+
+  test('The [popover] element must smoothly transition when opened', async ({ page }) => {
+    const popoverBtn = page.locator('[popovertarget]').first();
+    const popover = page.locator('[popover]').first();
+
+    await expect(popover).not.toBeVisible();
+    await popoverBtn.click();
+
+    const opacity = await popover.evaluate((el) => {
+      return parseFloat(window.getComputedStyle(el).opacity);
+    });
+
+    expect(opacity).toBeLessThan(1);
+    await expect(popover).toHaveCSS('opacity', '1');
+  });
+
+  test('The <dialog> ::backdrop must be animated', async ({ page }) => {
+    const openBtn = page.locator('#open-dialog-btn, #openDialog').first();
+    const dialog = page.locator('dialog').first();
+
+    await openBtn.click();
+
+    // Check backdrop transition properties
+    const backdropProps = await dialog.evaluate((el) => {
+      const style = window.getComputedStyle(el, '::backdrop');
+      return {
+        transitionProperty: style.transitionProperty,
+        transitionDuration: style.transitionDuration,
+        // @ts-ignore
+        transitionBehavior: style.transitionBehavior || (style as any).webkitTransitionBehavior
+      };
+    });
+
+    expect(backdropProps.transitionProperty).toMatch(/background-color|opacity|all/);
+    expect(parseFloat(backdropProps.transitionDuration)).toBeGreaterThan(0);
+    expect(backdropProps.transitionBehavior).toContain('allow-discrete');
+  });
+
+  test('The implementation must respect prefers-reduced-motion', async ({ page }) => {
+    const dialog = page.locator('dialog').first();
+    const openBtn = page.locator('#open-dialog-btn, #openDialog').first();
+
+    // Get normal duration
+    await openBtn.click();
+    const normalDuration = await dialog.evaluate((el) => {
+      return parseFloat(window.getComputedStyle(el).transitionDuration);
+    });
+
+    // Enable reduced motion
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+
+    const reducedDuration = await dialog.evaluate((el) => {
+      return parseFloat(window.getComputedStyle(el).transitionDuration);
+    });
+
+    await dialog.evaluate((el) => {
+      return window.getComputedStyle(el).transform;
+    });
+
+    // In reduced motion, duration should be significantly shorter than normal
+    expect(reducedDuration).toBeLessThan(normalDuration);
+    expect(reducedDuration).toBeLessThanOrEqual(0.11);
+  });
+});

--- a/guides/user-experience/animate-to-from-top-layer/grader.ts
+++ b/guides/user-experience/animate-to-from-top-layer/grader.ts
@@ -143,19 +143,19 @@ test.describe(`Top Layer Animation Expectations: ${demoName}`, () => {
     await closeBtn.click();
 
     // Because of allow-discrete and overlay, it should still be in the DOM and visible during transition
-    const isVisibleDuringTransition = await dialog.evaluate((el) => {
-      const style = window.getComputedStyle(el);
-      return style.display !== 'none' && parseFloat(style.opacity) > 0 && parseFloat(style.opacity) < 1;
-    });
-
-    expect(isVisibleDuringTransition).toBe(true);
+    await expect.poll(async () => {
+      return await dialog.evaluate((el) => {
+        const style = window.getComputedStyle(el);
+        return style.display !== 'none' && parseFloat(style.opacity) > 0 && parseFloat(style.opacity) < 1;
+      });
+    }, { timeout: 1000 }).toBe(true);
 
     // Eventually it should be gone
     await expect(dialog).not.toBeVisible();
   });
 
   test('The [popover] element must smoothly transition when opened', async ({ page }) => {
-    const popoverBtn = page.locator('[popovertarget]').first();
+    const popoverBtn = page.locator('#foobar, [popovertarget]').first();
     const popover = page.locator('[popover]').first();
 
     await expect(popover).not.toBeVisible();

--- a/guides/user-experience/animate-to-from-top-layer/guide.md
+++ b/guides/user-experience/animate-to-from-top-layer/guide.md
@@ -114,16 +114,38 @@ dialog[open]::backdrop,
 
 ## Fallback strategies
 
+#### Top-layer animation features
+
 {{ BASELINE_STATUS("starting-style") }}
+{{ BASELINE_STATUS("transition-behavior") }}
+{{ BASELINE_STATUS("overlay") }}
 
 For browsers that do not support these features, top-layer elements will appear and disappear instantly. To provide animations in older browsers, you must use JavaScript to coordinate classes and wait for `transitionend` events or use the Web Animations API.
 
 ```javascript
-// Feature detection for discrete transitions
-const supportsDiscreteTransitions =
-  window.CSS && CSS.supports('transition-behavior', 'allow-discrete');
+// Feature detection for top-layer animations
+const supportsTopLayerAnimation =
+  window.CSS &&
+  CSS.supports('transition-behavior', 'allow-discrete') &&
+  CSS.supports('overlay', 'auto');
 
-if (!supportsDiscreteTransitions) {
+if (!supportsTopLayerAnimation) {
   // Manual JS fallback for entry/exit animations
 }
 ```
+
+#### popover
+
+{{ BASELINE_STATUS("popover") }}
+
+If the browser does not support Popover, use the `@oddbird/popover-polyfill`:
+
+```html
+<script type="module">
+  if (!HTMLElement.prototype.hasOwnProperty('popover')) {
+    await import('https://unpkg.com/@oddbird/popover-polyfill');
+  }
+</script>
+```
+
+Alternatively, for legacy support without a polyfill, use `position: fixed` and manually calculate coordinates via JavaScript `getBoundingClientRect()`.

--- a/guides/user-experience/animate-to-from-top-layer/guide.md
+++ b/guides/user-experience/animate-to-from-top-layer/guide.md
@@ -8,4 +8,122 @@ web-feature-ids:
   - popover
   - starting-style
   - transition-behavior
+sources:
+  - https://web.dev/articles/baseline-in-action-dialog-popover
+  - https://web.dev/blog/baseline-entry-animations
+  - https://developer.chrome.com/blog/entry-exit-animations
+  - https://www.smashingmagazine.com/2025/01/transitioning-top-layer-entries-display-property-css/
+  - https://developer.mozilla.org/en-US/docs/Web/CSS/@starting-style
+  - https://developer.mozilla.org/en-US/docs/Web/CSS/overlay
 ---
+
+Elements that render in the "top layer" (like `<dialog>`, elements with the `popover` attribute, or tooltips) have historically been difficult to animate because they toggle between `display: none` and a visible state. Modern CSS provides `@starting-style`, `transition-behavior: allow-discrete`, and the `overlay` property to enable smooth entry and exit transitions for these elements.
+
+## Implementation
+
+### 1. Enable Discrete Transitions
+
+To animate the `display` property, you must set `transition-behavior: allow-discrete`. This allows the element to remain visible during its exit transition. If using transition shorthands, be sure to place the `transition-behavior: allow-discrete` afterwards to prevent the shorthand from negating it.
+
+### 2. The `overlay` Property
+
+When an element moves in or out of the top layer, it must transition the `overlay` property. This ensures the element stays in the top layer for the duration of the animation, preventing it from being clipped by other elements or the viewport prematurely.
+
+### 3. Entry Animations with `@starting-style`
+
+Use the `@starting-style` at-rule to define the styles an element should transition *from* when it is first rendered or its `display` changes from `none`.
+
+### 4. Animating the Backdrop
+
+The `::backdrop` pseudo-element can be animated similarly by applying transitions to its own properties.
+
+## Example
+
+```css
+/* 1. Define the visible (open) state */
+dialog[open],
+[popover]:popover-open {
+  opacity: 1;
+  transform: scale(1);
+
+  /* 2. Define the starting state for entry (must come after open state) */
+  @starting-style {
+    opacity: 0;
+    transform: scale(0.9);
+  }
+}
+
+/* 3. Define the base (closed/exit) state and transitions */
+dialog,
+[popover] {
+  opacity: 0;
+  transform: scale(0.9);
+
+  /* MANDATORY: transition display and overlay for top-layer elements */
+  transition-property: opacity, transform, display, overlay;
+  transition-duration: 0.3s;
+  transition-timing-function: ease-out;
+  /* Applies to discrete properties like display and overlay */
+  transition-behavior: allow-discrete; /* Note: be sure to write this after the shorthand */
+}
+
+/* 4. Animate the backdrop */
+dialog::backdrop,
+[popover]::backdrop {
+  background-color: rgba(0, 0, 0, 0);
+  transition-property: display, overlay, background-color;
+  transition-duration: 0.3s;
+  transition-timing-function: ease-out;
+  transition-behavior: allow-discrete;
+}
+
+dialog[open]::backdrop,
+[popover]:popover-open::backdrop {
+  background-color: rgba(0, 0, 0, 0.5);
+
+  @starting-style {
+    background-color: rgba(0, 0, 0, 0);
+  }
+}
+
+/* 5. Respect user preference for reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  dialog,
+  [popover] {
+    /* Disable movement and shorten duration for a simple fade */
+    transform: none;
+    transition-duration: 0.1s;
+  }
+
+  @starting-style {
+    dialog[open],
+    [popover]:popover-open {
+      transform: none;
+    }
+  }
+}
+```
+
+## Constraints & Accessibility
+
+- **MANDATORY**: Include `overlay` in your `transition` list for any element moving into or out of the top layer.
+- **MANDATORY**: Use `allow-discrete` for the `display` property transition.
+- **DO**: Place the `@starting-style` block inside or after the "open" state selector to ensure proper cascading.
+- **DO**: Respect user preferences for reduced motion using `prefers-reduced-motion`.
+- **DO NOT**: Use `@starting-style` for exit animations; exit animations are defined by the transition to the base (closed) state.
+
+## Fallback strategies
+
+{{ BASELINE_STATUS("starting-style") }}
+
+For browsers that do not support these features, top-layer elements will appear and disappear instantly. To provide animations in older browsers, you must use JavaScript to coordinate classes and wait for `transitionend` events or use the Web Animations API.
+
+```javascript
+// Feature detection for discrete transitions
+const supportsDiscreteTransitions =
+  window.CSS && CSS.supports('transition-behavior', 'allow-discrete');
+
+if (!supportsDiscreteTransitions) {
+  // Manual JS fallback for entry/exit animations
+}
+```

--- a/guides/user-experience/animate-to-from-top-layer/guide.md
+++ b/guides/user-experience/animate-to-from-top-layer/guide.md
@@ -17,7 +17,7 @@ sources:
   - https://developer.mozilla.org/en-US/docs/Web/CSS/overlay
 ---
 
-Elements that render in the "top layer" (like `<dialog>`, elements with the `popover` attribute, or tooltips) have historically been difficult to animate because they toggle between `display: none` and a visible state. Modern CSS provides `@starting-style`, `transition-behavior: allow-discrete`, and the `overlay` property to enable smooth entry and exit transitions for these elements.
+Elements that render in the "top layer" (like `<dialog>`, elements with the `popover` attribute, or tooltips) have historically been difficult to animate because they toggle between `display: none` and a visible state. Modern CSS provides `@starting-style`, `transition-behavior: allow-discrete`, and the `overlay` property to enable smooth entry and exit transitions for these elements. Note that native CSS nesting is used in the examples below.
 
 ## Implementation
 
@@ -71,10 +71,11 @@ dialog,
 dialog::backdrop,
 [popover]::backdrop {
   background-color: rgba(0, 0, 0, 0);
-  transition-property: display, overlay, background-color;
-  transition-duration: 0.3s;
-  transition-timing-function: ease-out;
-  transition-behavior: allow-discrete;
+  /* The transition shorthand can also be used with allow-discrete */
+  transition:
+    display 0.3s allow-discrete,
+    overlay 0.3s allow-discrete,
+    background-color 0.3s ease-out;
 }
 
 dialog[open]::backdrop,
@@ -130,7 +131,9 @@ const supportsTopLayerAnimation =
   CSS.supports('overlay', 'auto');
 
 if (!supportsTopLayerAnimation) {
-  // Manual JS fallback for entry/exit animations
+  // Manual JS fallback for entry/exit animations:
+  // 1. Add an `.is-opening` class for entry.
+  // 2. On close, add an `.is-closing` class, wait for the `transitionend` event, then call .close() or hide the popover.
 }
 ```
 

--- a/guides/user-experience/animate-to-from-top-layer/guide.md
+++ b/guides/user-experience/animate-to-from-top-layer/guide.md
@@ -108,8 +108,8 @@ dialog[open]::backdrop,
 
 - **MANDATORY**: Include `overlay` in your `transition` list for any element moving into or out of the top layer.
 - **MANDATORY**: Use `allow-discrete` for the `display` property transition.
+- **MANDATORY**: Respect user preferences for reduced motion using `prefers-reduced-motion` by simplifying transitions (e.g., removing transforms and shortening duration).
 - **DO**: Place the `@starting-style` block inside or after the "open" state selector to ensure proper cascading.
-- **DO**: Respect user preferences for reduced motion using `prefers-reduced-motion`.
 - **DO NOT**: Use `@starting-style` for exit animations; exit animations are defined by the transition to the base (closed) state.
 
 ## Fallback strategies

--- a/guides/user-experience/animate-to-from-top-layer/negative-demo.html
+++ b/guides/user-experience/animate-to-from-top-layer/negative-demo.html
@@ -1,0 +1,93 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Top Layer Animation Demo</title>
+    <style>
+      :root {
+        --bg: #121212;
+        --text: #ffffff;
+        --accent: #ff4081;
+      }
+
+      body {
+        margin: 0;
+        height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-family: sans-serif;
+        background: var(--bg);
+        color: var(--text);
+      }
+
+      .controls {
+        display: flex;
+        gap: 10px;
+      }
+
+      button {
+        padding: 10px 20px;
+        font-size: 16px;
+        cursor: pointer;
+        background: var(--accent);
+        border: none;
+        color: white;
+        border-radius: 4px;
+      }
+
+      dialog, [popover] {
+        border: none;
+        border-radius: 8px;
+        padding: 20px;
+        background: #333;
+        color: white;
+        width: 300px;
+        opacity: 0;
+        transform: translateY(-20px);
+        transition: opacity 0.5s ease, transform 0.5s ease;
+      }
+
+      dialog[open], [popover]:popover-open {
+        opacity: 1;
+        transform: translateY(0);
+      }
+
+      dialog::backdrop, [popover]::backdrop {
+        background: rgba(0, 0, 0, 0.5);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="controls">
+      <button id="openDialog">Open Dialog</button>
+      <button popovertarget="myPopover">Open Popover</button>
+    </div>
+
+    <dialog id="myDialog">
+      <h2>Dialog Header</h2>
+      <p>This is a standard dialog element.</p>
+      <button id="closeDialog">Close</button>
+    </dialog>
+
+    <div id="myPopover" popover>
+      <h2>Popover Header</h2>
+      <p>This is a standard popover element.</p>
+    </div>
+
+    <script>
+      const dialog = document.getElementById('myDialog');
+      const openBtn = document.getElementById('openDialog');
+      const closeBtn = document.getElementById('closeDialog');
+
+      openBtn.addEventListener('click', () => {
+        dialog.showModal();
+      });
+
+      closeBtn.addEventListener('click', () => {
+        dialog.close();
+      });
+    </script>
+  </body>
+</html>

--- a/guides/user-experience/animate-to-from-top-layer/tasks/task.md
+++ b/guides/user-experience/animate-to-from-top-layer/tasks/task.md
@@ -1,6 +1,6 @@
 ---
 base_app: daily-grind
 ---
-- add a confirmation modal when someone clicks the logout link in the nav. it needs to have a smooth fade and scale-in animation when it opens and should animate out when closed too. also make the backdrop fade in.
+- Add a confirmation modal when someone clicks the logout link in the nav (add id "open-dialog-btn" to the logout link, and "close-dialog-btn" to the modal's close button). The modal must use smooth CSS animations for entering and exiting, and include a backdrop fade animation. Also, add a dismissible informational floating overlay triggered by a button with the ID "foobar", showing the text "online ordering is currently offline", using similar smooth CSS entry and exit animations.
 - can you make the 'order now' button trigger a popover that says 'online ordering is currently offline'? it should have some kind of nice transition so it doesn't just jump onto the screen.
 - add a newsletter popup that appears after a few seconds. make it pop in with a zoom effect and fade out smoothly.

--- a/guides/user-experience/animate-to-from-top-layer/tasks/task.md
+++ b/guides/user-experience/animate-to-from-top-layer/tasks/task.md
@@ -1,0 +1,6 @@
+---
+base_app: daily-grind
+---
+- add a confirmation modal when someone clicks the logout link in the nav. it needs to have a smooth fade and scale-in animation when it opens and should animate out when closed too. also make the backdrop fade in.
+- can you make the 'order now' button trigger a popover that says 'online ordering is currently offline'? it should have some kind of nice transition so it doesn't just jump onto the screen.
+- add a newsletter popup that appears after a few seconds. make it pop in with a zoom effect and fade out smoothly.


### PR DESCRIPTION
## Description
This PR introduces a new guide for animating elements entering and exiting the top layer (dialogs, popovers, and tooltips) using modern CSS features.

The guide focuses on using `@starting-style`, `transition-behavior: allow-discrete`, and the `overlay` property to create smooth entry and exit animations, ensuring elements remain in the top layer during transitions.

## Validation Results

Successfully ran the `gd dev` pipeline:
   - Calibration: Passed on Attempt 1.
     - demo.html: 100% pass (9/9 tests).
     - negative-demo.html: 0% pass (9/9 tests failed correctly).
   - Agent Test: Not run (calibration only).

## Checklist
   - [x] guide.md with citations and examples
   - [x] demo.html demonstrates the "Do" patterns in the guide
   - [x] grader generated and calibrated
   - [x] task.md generated
