### PR TITLE
publish: re-align names & upgrade coding agent integration tests

### DIFF
--- a/eval-view/dumbbell-chart.js
+++ b/eval-view/dumbbell-chart.js
@@ -46,7 +46,6 @@ export class DumbbellChart {
 
     // Group items by Feature Name (lookup from features_mapping.gen.js if available)
     const groups = {};
-    // @ts-expect-error global property
     const featuresMap = window.__featuresMapping || {};
 
     labels.forEach((label, i) => {

--- a/eval-view/evals.d.ts
+++ b/eval-view/evals.d.ts
@@ -5,5 +5,6 @@ import type { EvalsReport } from '../harness/lib/metrics.ts';
 declare global {
   interface Window {
     google: any;
+    __featuresMapping: any;
   }
 }

--- a/eval-view/tsconfig.json
+++ b/eval-view/tsconfig.json
@@ -15,6 +15,7 @@
   "exclude": [
     "node_modules",
     "test-results",
-    "mock-results"
+    "mock-results",
+    "features_mapping.gen.js"
   ]
 }

--- a/harness/agents/claude-code-agent.ts
+++ b/harness/agents/claude-code-agent.ts
@@ -228,7 +228,7 @@ export function extractClaudeCodeModel(resultsDir: string): string {
 
 export function collectClaudeToolsFromTrajectory(dir: string): string[] {
   const toolsUsed: string[] = [];
-  const sessionFiles = fs.globSync('session-*.jsonl', { cwd: dir });
+  const sessionFiles = fs.globSync('**/*.jsonl', { cwd: dir });
   const firstSession = sessionFiles[0];
   if (!firstSession) return toolsUsed;
 

--- a/harness/agents/claude-code-agent.ts
+++ b/harness/agents/claude-code-agent.ts
@@ -106,7 +106,8 @@ async function run() {
     const commandArgs = [
       '-p', userPrompt,
       '--dangerously-skip-permissions',
-      '--verbose'
+      '--verbose',
+      '--output-format', 'stream-json'
     ];
 
     console.log(`Executing: ${command} ${commandArgs.join(' ')}`);

--- a/harness/agents/gemini-cli-agent.ts
+++ b/harness/agents/gemini-cli-agent.ts
@@ -227,6 +227,42 @@ export function collectGeminiToolsFromTrajectory(dir: string): string[] {
   return Array.from(new Set(toolsUsed));
 }
 
+export function parseGeminiStreamOutput(outputStr: string, skillName: string = 'modern-web-use-cases'): {
+    skillActivated: boolean;
+    searchCalled: boolean;
+    retrieveCalled: boolean;
+} {
+    const lines = outputStr.split('\n');
+    let skillActivated = false;
+    let searchCalled = false;
+    let retrieveCalled = false;
+    
+    for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+            const event = JSON.parse(line);
+            if (event.type === 'tool_use') {
+                if (event.tool_name === 'activate_skill' && event.parameters?.name === skillName) {
+                    skillActivated = true;
+                }
+                if (event.tool_name === 'run_shell_command') {
+                    const command = event.parameters?.command || '';
+                    if (command.includes('--search')) {
+                        searchCalled = true;
+                    }
+                    if (command.includes('--retrieve')) {
+                        retrieveCalled = true;
+                    }
+                }
+            }
+        } catch (e) {
+            // Ignore parse errors
+        }
+    }
+    
+    return { skillActivated, searchCalled, retrieveCalled };
+}
+
 const isMain = process.argv[1] === fileURLToPath(import.meta.url);
 if (isMain) {
   run();

--- a/harness/agents/gemini-cli-agent.ts
+++ b/harness/agents/gemini-cli-agent.ts
@@ -199,8 +199,7 @@ export function extractGeminiCliModel(resultsDir: string): string {
 
 export function collectGeminiToolsFromTrajectory(dir: string): string[] {
   const toolsUsed: string[] = [];
-  const files = fs.readdirSync(dir);
-  const sessionFiles = files.filter(f => f.startsWith('session-') && f.endsWith('.json'));
+  const sessionFiles = fs.globSync('**/*.json', { cwd: dir });
   const firstSession = sessionFiles[0];
   if (!firstSession) return toolsUsed;
 

--- a/harness/agents/gemini-cli-agent.ts
+++ b/harness/agents/gemini-cli-agent.ts
@@ -199,7 +199,8 @@ export function extractGeminiCliModel(resultsDir: string): string {
 
 export function collectGeminiToolsFromTrajectory(dir: string): string[] {
   const toolsUsed: string[] = [];
-  const sessionFiles = fs.globSync('**/*.json', { cwd: dir });
+  const files = fs.readdirSync(dir);
+  const sessionFiles = files.filter(f => f.startsWith('session-') && f.endsWith('.json'));
   const firstSession = sessionFiles[0];
   if (!firstSession) return toolsUsed;
 

--- a/harness/tests/copy-skills.test.ts
+++ b/harness/tests/copy-skills.test.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import { execSync } from 'child_process';
 import { createIsolatedHome, copySkills, cleanupIsolatedHome } from '../lib/agent-shared.ts';
 import { Agents } from '../config.ts';
+import { parseGeminiStreamOutput } from '../agents/gemini-cli-agent.ts';
 function assertSearchResults(output: string) {
     const results = JSON.parse(output);
     assert.ok(Array.isArray(results), 'Output should be a JSON array');
@@ -103,33 +104,7 @@ test('invoking gemini-cli-agent.ts works end-to-end like in eval suite', { skip:
         assert.ok(fs.existsSync(logPath), 'chat_log.txt should exist');
         
         const logContent = fs.readFileSync(logPath, 'utf8');
-        const lines = logContent.split('\n').filter(line => line.trim() !== '');
-        
-        let skillActivated = false;
-        let searchCalled = false;
-        let retrieveCalled = false;
-        
-        for (const line of lines) {
-            try {
-                const event = JSON.parse(line);
-                if (event.type === 'tool_use') {
-                    if (event.tool_name === 'activate_skill' && event.parameters?.name === 'modern-web-use-cases') {
-                        skillActivated = true;
-                    }
-                    if (event.tool_name === 'run_shell_command') {
-                        const command = event.parameters?.command || '';
-                        if (command.includes('--search')) {
-                            searchCalled = true;
-                        }
-                        if (command.includes('--retrieve')) {
-                            retrieveCalled = true;
-                        }
-                    }
-                }
-            } catch (e) {
-                // Ignore parse errors for partial lines if any
-            }
-        }
+        const { skillActivated, searchCalled, retrieveCalled } = parseGeminiStreamOutput(logContent);
         
         console.log(`\n[Validation State]`);
         console.log(`- Skill Activated: ${skillActivated}`);

--- a/serving/TESTING.md
+++ b/serving/TESTING.md
@@ -1,32 +1,19 @@
-# Testing modern-web
+# Testing the serving stack
 
 ## Automated Tests
 
 ```sh
-cd serving
-npm run test
-```
+cd ~/serving
+# With FULL=1 we do functional tests:
 
-## Uninstalling Deprecated Alpha Versions
-
-If you have the old `skills-alpha` versions installed, use these commands to clean them up:
-
-```sh
-# Claude Code
-claude plugin uninstall googlechrome-skills@skills-alpha
-
-# Gemini CLI
-gemini extensions uninstall https://github.com/GoogleChrome/skills-alpha
-
-# Universal Skills CLI
-DISABLE_TELEMETRY=1 npx -y skills remove --global modern-web-use-cases
+env FULL=1 TEST_REPORTER=spec npm run test
 ```
 
 ## Manual Testing & Reset Procedures
 
 To verify that skills and the MCP server are installing and activating correctly in different clients, you can use these reset and install sequences.
 
-### 1. Reset Environment (New Names)
+### 1. Reset Environment
 
 Clear any global installs or CLI state to ensure a clean slate:
 
@@ -35,7 +22,7 @@ npm uninstall --global modern-web
 
 # Claude Code
 claude plugin uninstall modern-web-guidance@googlechrome
-# To remove the marketplace, use the interactive command inside Claude: /plugin marketplace remove googlechrome
+# To remove the marketplace, run within claude: /plugin marketplace remove googlechrome
 
 # Gemini CLI
 gemini extensions uninstall https://github.com/GoogleChrome/modern-web-guidance
@@ -64,4 +51,24 @@ Example one-liners to test integration:
 
 ```sh
 claude --plugin-dir ~/code/guidance/dist/skills-cli --allow-dangerously-skip-permissions -p "add an address form to the bottom of the page"
+```
+
+
+
+## Appendix: Uninstalling skilla-alpha versions.
+
+We migrated names, so please drop the old ones.
+
+If you have the old `skills-alpha`, use these commands to clean them up:
+
+```sh
+claude # and then
+# /plugin uninstall googlechrome-skills@skills-alpha
+# /plugin marketplace remove skills-alpha
+
+# Gemini CLI
+gemini extensions uninstall https://github.com/GoogleChrome/skills-alpha
+
+# Universal Skills CLI
+DISABLE_TELEMETRY=1 npx -y skills remove --global modern-web-use-cases
 ```

--- a/serving/TESTING.md
+++ b/serving/TESTING.md
@@ -7,42 +7,61 @@ cd serving
 npm run test
 ```
 
+## Uninstalling Deprecated Alpha Versions
+
+If you have the old `skills-alpha` versions installed, use these commands to clean them up:
+
+```sh
+# Claude Code
+claude plugin uninstall googlechrome-skills@skills-alpha
+
+# Gemini CLI
+gemini extensions uninstall https://github.com/GoogleChrome/skills-alpha
+
+# Universal Skills CLI
+DISABLE_TELEMETRY=1 npx -y skills remove --global modern-web-use-cases
+```
+
 ## Manual Testing & Reset Procedures
 
 To verify that skills and the MCP server are installing and activating correctly in different clients, you can use these reset and install sequences.
 
-### 1. Reset Environment
+### 1. Reset Environment (New Names)
 
-Clear any old global installs or CLI state to ensure a clean slate:
+Clear any global installs or CLI state to ensure a clean slate:
 
 ```sh
 npm uninstall --global modern-web
 
-claude plugin uninstall googlechrome-skills@skills-alpha
-#   To remove the marketplace, need to use `/plugin`
+# Claude Code
+claude plugin uninstall modern-web-guidance@googlechrome
+# To remove the marketplace, use the interactive command inside Claude: /plugin marketplace remove googlechrome
 
-gemini extensions uninstall https://github.com/GoogleChrome/skills-alpha
+# Gemini CLI
+gemini extensions uninstall https://github.com/GoogleChrome/modern-web-guidance
 
+# Universal Skills CLI
 DISABLE_TELEMETRY=1 npx -y skills remove --global modern-web-use-cases
 ```
 
 ### 2. Verification Install Sequence
 
-Re-install the standard web skills to prove runtime behavior:
+Re-install the skills to prove runtime behavior:
 
 ```sh
-# Claude, assuming marketplace already added via: /plugin marketplace add GoogleChrome/skills-alpha
-claude plugin install googlechrome-skills@skills-alpha
+# Claude, assuming marketplace already added via interactive command:
+# /plugin marketplace add GoogleChrome/modern-web-guidance
+claude plugin install modern-web-guidance@googlechrome
 
-gemini extensions install https://github.com/GoogleChrome/skills-alpha --auto-update
+# Gemini CLI
+gemini extensions install https://github.com/GoogleChrome/modern-web-guidance --auto-update
 
-DISABLE_TELEMETRY=1 npx skills add GoogleChrome/skills-alpha
+# Universal Skills CLI
+DISABLE_TELEMETRY=1 npx skills add GoogleChrome/modern-web-guidance
 ```
-
 
 Example one-liners to test integration:
 
 ```sh
 claude --plugin-dir ~/code/guidance/dist/skills-cli --allow-dangerously-skip-permissions -p "add an address form to the bottom of the page"
-
 ```

--- a/serving/TESTING.md
+++ b/serving/TESTING.md
@@ -62,6 +62,8 @@ We migrated names, so please drop the old ones.
 If you have the old `skills-alpha`, use these commands to clean them up:
 
 ```sh
+npm uninstall --global modern-web
+
 claude # and then
 # /plugin uninstall googlechrome-skills@skills-alpha
 # /plugin marketplace remove skills-alpha

--- a/serving/TESTING.md
+++ b/serving/TESTING.md
@@ -3,10 +3,9 @@
 ## Automated Tests
 
 ```sh
-cd ~/serving
 # With FULL=1 we do functional tests:
 
-env FULL=1 TEST_REPORTER=spec npm run test
+env FULL=1 TEST_REPORTER=spec pnpm --filter serving test
 ```
 
 ## Manual Testing & Reset Procedures

--- a/serving/skills-cli/install-claude.test.ts
+++ b/serving/skills-cli/install-claude.test.ts
@@ -3,12 +3,9 @@ import assert from 'node:assert';
 import fs from 'node:fs';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
-import { createIsolatedHome, cleanupIsolatedHome } from '../../harness/lib/agent-shared.ts';
 
 test('Claude Code loads plugin from local dist directory', { skip: !process.env.FULL }, async () => {
-    let homeDir = '';
     try {
-        homeDir = createIsolatedHome('test-install-claude');
         const distDir = path.resolve(import.meta.dirname, '../../dist/skills-cli');
         
         if (!fs.existsSync(distDir)) {
@@ -132,9 +129,6 @@ test('Claude Code loads plugin from local dist directory', { skip: !process.env.
         assert.ok(retrieveSuccess, 'Modern web retrieve should be successful');
         
     } finally {
-        if (homeDir) {
-            console.log(`Cleaning up isolated HOME at ${homeDir}`);
-            cleanupIsolatedHome(homeDir);
-        }
+        // No cleanup needed as we use real HOME for Claude auth
     }
 });

--- a/serving/skills-cli/install-claude.test.ts
+++ b/serving/skills-cli/install-claude.test.ts
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert';
 import fs from 'node:fs';
 import path from 'node:path';
-import { execSync } from 'node:child_process';
+import { execSync, spawn } from 'node:child_process';
 import { createIsolatedHome, cleanupIsolatedHome } from '../../harness/lib/agent-shared.ts';
 
 test('Claude Code loads plugin from local dist directory', { skip: !process.env.FULL }, async () => {
@@ -23,17 +23,45 @@ test('Claude Code loads plugin from local dist directory', { skip: !process.env.
             }
         }
 
-        const cmd = `claude --model claude-sonnet-4-6 --plugin-dir ${distDir} -p "use the modern-web-use-cases skill and tell me best practices on implementing an address form" --dangerously-skip-permissions --verbose --output-format stream-json`;
-        
         console.log(`\nRunning Claude Code with local plugin...`);
-        const output = execSync(cmd, { 
-            stdio: ['ignore', 'pipe', 'pipe'], 
-            timeout: 90000, 
-            env: { ...process.env, ...anthropicEnv, HOME: homeDir } 
+        const child = spawn('claude', [
+            '--model', 'claude-sonnet-4-6',
+            '--plugin-dir', distDir,
+            '-p', 'use the modern-web-use-cases skill and tell me best practices on implementing an address form',
+            '--dangerously-skip-permissions',
+            '--verbose',
+            '--output-format', 'stream-json'
+        ], {
+            env: { ...process.env, ...anthropicEnv, HOME: homeDir },
+            stdio: ['ignore', 'pipe', 'pipe']
         });
 
+        let outputStr = '';
+        child.stdout.on('data', (data) => {
+            const str = data.toString();
+            outputStr += str;
+            process.stdout.write(str);
+        });
+
+        child.stderr.on('data', (data) => {
+            process.stderr.write(data);
+        });
+
+        const timeout = setTimeout(() => {
+            console.log('\nClaude timed out! Killing process...');
+            child.kill();
+        }, 90000);
+
+        const exitCode = await new Promise<number | null>((resolve) => {
+            child.on('close', (code) => {
+                clearTimeout(timeout);
+                resolve(code);
+            });
+        });
+
+        console.log(`\nClaude exited with code ${exitCode}`);
+        
         console.log(`\nVerifying Claude used the skill...`);
-        const outputStr = output.toString();
         const lines = outputStr.split('\n');
         
         let searchCalled = false;

--- a/serving/skills-cli/install-claude.test.ts
+++ b/serving/skills-cli/install-claude.test.ts
@@ -24,7 +24,7 @@ test('Claude Code loads plugin from local dist directory', { skip: !process.env.
             }
         }
 
-        const cmd = `claude --plugin-dir ${distDir} -p "use the modern-web-use-cases skill and tell me best practices on implementing an address form" --dangerously-skip-permissions --verbose --output-format stream-json`;
+        const cmd = `claude --model claude-sonnet-4-6 --plugin-dir ${distDir} -p "use the modern-web-use-cases skill and tell me best practices on implementing an address form" --dangerously-skip-permissions --verbose --output-format stream-json`;
         
         console.log(`\nRunning Claude Code with local plugin...`);
         const output = execSync(cmd, { 

--- a/serving/skills-cli/install-claude.test.ts
+++ b/serving/skills-cli/install-claude.test.ts
@@ -29,7 +29,7 @@ test('Claude Code loads plugin from local dist directory', { skip: !process.env.
         const output = execSync(cmd, { 
             stdio: ['ignore', 'pipe', 'pipe'], 
             timeout: 90000, 
-            env: { ...process.env, ...anthropicEnv } 
+            env: { ...process.env, ...anthropicEnv, HOME: homeDir } 
         });
 
         console.log(`\nVerifying Claude used the skill...`);

--- a/serving/skills-cli/install-claude.test.ts
+++ b/serving/skills-cli/install-claude.test.ts
@@ -21,6 +21,7 @@ test('Claude Code loads plugin from local dist directory', { skip: !process.env.
         }
 
         console.log(`\nRunning Claude Code with local plugin...`);
+        // Claude won't run in an isolated home, so we use the real HOME.
         const child = spawn('claude', [
             '--model', 'claude-sonnet-4-6',
             '--plugin-dir', distDir,

--- a/serving/skills-cli/install-claude.test.ts
+++ b/serving/skills-cli/install-claude.test.ts
@@ -2,7 +2,6 @@ import test from 'node:test';
 import assert from 'node:assert';
 import fs from 'node:fs';
 import path from 'node:path';
-import os from 'node:os';
 import { execSync } from 'node:child_process';
 import { createIsolatedHome, cleanupIsolatedHome } from '../../harness/lib/agent-shared.ts';
 

--- a/serving/skills-cli/install-claude.test.ts
+++ b/serving/skills-cli/install-claude.test.ts
@@ -106,8 +106,8 @@ test('Claude Code loads plugin from local dist directory', { skip: !process.env.
         
     } finally {
         if (homeDir) {
-            console.log(`Skipping cleanup of isolated HOME at ${homeDir}`);
-            // cleanupIsolatedHome(homeDir);
+            console.log(`Cleaning up isolated HOME at ${homeDir}`);
+            cleanupIsolatedHome(homeDir);
         }
     }
 });

--- a/serving/skills-cli/install-claude.test.ts
+++ b/serving/skills-cli/install-claude.test.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
 import { createIsolatedHome, cleanupIsolatedHome } from '../../harness/lib/agent-shared.ts';
+import { collectClaudeToolsFromTrajectory } from '../../harness/agents/claude-code-agent.ts';
 
 test('Claude Code loads plugin from local dist directory', { skip: !process.env.FULL }, async () => {
     let homeDir = '';
@@ -34,36 +35,8 @@ test('Claude Code loads plugin from local dist directory', { skip: !process.env.
 
         console.log(`\nVerifying Claude used the skill...`);
         const projectsDir = path.join(homeDir, '.claude', 'projects');
-        const files = fs.globSync('**/*.jsonl', { cwd: projectsDir });
-        let skillUsed = false;
-        
-        for (const file of files) {
-            const content = fs.readFileSync(path.join(projectsDir, file), 'utf8');
-            const lines = content.split('\n');
-            for (const line of lines) {
-                if (!line.trim()) continue;
-                try {
-                    const obj = JSON.parse(line);
-                    if (obj.message && Array.isArray(obj.message.content)) {
-                        for (const item of obj.message.content) {
-                            if (item.type === 'tool_use') {
-                                if ((item.name === 'Skill' && item.input?.skill === 'modern-web-use-cases') ||
-                                    (item.name === 'activate_skill' && item.input?.name === 'modern-web-use-cases')) {
-                                    skillUsed = true;
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                } catch (e) {
-                    // Ignore parse errors
-                }
-                if (skillUsed) break;
-            }
-            if (skillUsed) break;
-        }
-        
-        assert.ok(skillUsed, 'Claude did not use the modern-web-use-cases skill');
+        const toolsUsed = collectClaudeToolsFromTrajectory(projectsDir);
+        assert.ok(toolsUsed.includes('modern-web-use-cases'), 'Claude did not use the modern-web-use-cases skill');
         
     } finally {
         if (homeDir) {

--- a/serving/skills-cli/install-claude.test.ts
+++ b/serving/skills-cli/install-claude.test.ts
@@ -32,7 +32,7 @@ test('Claude Code loads plugin from local dist directory', { skip: !process.env.
             '--verbose',
             '--output-format', 'stream-json'
         ], {
-            env: { ...process.env, ...anthropicEnv, HOME: homeDir },
+            env: { ...process.env, ...anthropicEnv },
             stdio: ['ignore', 'pipe', 'pipe']
         });
 

--- a/serving/skills-cli/install-claude.test.ts
+++ b/serving/skills-cli/install-claude.test.ts
@@ -2,9 +2,9 @@ import test from 'node:test';
 import assert from 'node:assert';
 import fs from 'node:fs';
 import path from 'node:path';
+import os from 'node:os';
 import { execSync } from 'node:child_process';
 import { createIsolatedHome, cleanupIsolatedHome } from '../../harness/lib/agent-shared.ts';
-import { collectClaudeToolsFromTrajectory } from '../../harness/agents/claude-code-agent.ts';
 
 test('Claude Code loads plugin from local dist directory', { skip: !process.env.FULL }, async () => {
     let homeDir = '';
@@ -24,7 +24,7 @@ test('Claude Code loads plugin from local dist directory', { skip: !process.env.
             }
         }
 
-        const cmd = `claude --plugin-dir ${distDir} -p "use the modern-web-use-cases skill and tell me best practices on implementing an address form" --dangerously-skip-permissions`;
+        const cmd = `claude --plugin-dir ${distDir} -p "use the modern-web-use-cases skill and tell me best practices on implementing an address form" --dangerously-skip-permissions --verbose`;
         
         console.log(`\nRunning Claude Code with local plugin...`);
         execSync(cmd, { 
@@ -34,10 +34,47 @@ test('Claude Code loads plugin from local dist directory', { skip: !process.env.
         });
 
         console.log(`\nVerifying Claude used the skill...`);
-        const projectsDir = path.join(homeDir, '.claude', 'projects');
+        const projectsDir = path.join(os.homedir(), '.claude', 'projects');
         const files = fs.globSync('**/*.jsonl', { cwd: projectsDir });
-        console.log(`Found session files: ${JSON.stringify(files)}`);
-        const toolsUsed = collectClaudeToolsFromTrajectory(projectsDir);
+        console.log(`Found ${files.length} session files in real HOME.`);
+        
+        let newestFile = '';
+        let maxMtime = 0;
+        for (const file of files) {
+            const fullPath = path.join(projectsDir, file);
+            const mtime = fs.statSync(fullPath).mtimeMs;
+            if (mtime > maxMtime) {
+                maxMtime = mtime;
+                newestFile = fullPath;
+            }
+        }
+        
+        let toolsUsed: string[] = [];
+        if (newestFile) {
+            console.log(`Analyzing newest session file: ${newestFile}`);
+            const content = fs.readFileSync(newestFile, 'utf8');
+            const lines = content.split('\n');
+            for (const line of lines) {
+                if (!line.trim()) continue;
+                try {
+                    const obj = JSON.parse(line);
+                    if (obj.message && Array.isArray(obj.message.content)) {
+                        for (const item of obj.message.content) {
+                            if (item.type === 'tool_use') {
+                                if (item.name === 'Skill' && item.input?.skill) {
+                                    toolsUsed.push(item.input.skill);
+                                } else if (item.name === 'activate_skill' && item.input?.name) {
+                                    toolsUsed.push(item.input.name);
+                                }
+                            }
+                        }
+                    }
+                } catch (e) {
+                    // Ignore parse errors
+                }
+            }
+        }
+        
         console.log(`Tools used: ${JSON.stringify(toolsUsed)}`);
         assert.ok(toolsUsed.includes('modern-web-use-cases'), 'Claude did not use the modern-web-use-cases skill');
         

--- a/serving/skills-cli/install-claude.test.ts
+++ b/serving/skills-cli/install-claude.test.ts
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert';
 import fs from 'node:fs';
 import path from 'node:path';
-import { execSync, spawn } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import { createIsolatedHome, cleanupIsolatedHome } from '../../harness/lib/agent-shared.ts';
 
 test('Claude Code loads plugin from local dist directory', { skip: !process.env.FULL }, async () => {

--- a/serving/skills-cli/install-claude.test.ts
+++ b/serving/skills-cli/install-claude.test.ts
@@ -30,29 +30,18 @@ test('Claude Code loads plugin from local dist directory', { skip: !process.env.
         execSync(cmd, { 
             stdio: ['ignore', 'inherit', 'inherit'], 
             timeout: 90000, 
-            env: { ...process.env, ...anthropicEnv } 
+            env: { ...process.env, ...anthropicEnv, HOME: homeDir } 
         });
 
         console.log(`\nVerifying Claude used the skill...`);
-        const projectsDir = path.join(os.homedir(), '.claude', 'projects');
+        const projectsDir = path.join(homeDir, '.claude', 'projects');
         const files = fs.globSync('**/*.jsonl', { cwd: projectsDir });
-        console.log(`Found ${files.length} session files in real HOME.`);
-        
-        let newestFile = '';
-        let maxMtime = 0;
-        for (const file of files) {
-            const fullPath = path.join(projectsDir, file);
-            const mtime = fs.statSync(fullPath).mtimeMs;
-            if (mtime > maxMtime) {
-                maxMtime = mtime;
-                newestFile = fullPath;
-            }
-        }
+        console.log(`Found session files: ${JSON.stringify(files)}`);
         
         let toolsUsed: string[] = [];
-        if (newestFile) {
-            console.log(`Analyzing newest session file: ${newestFile}`);
-            const content = fs.readFileSync(newestFile, 'utf8');
+        for (const file of files) {
+            const fullPath = path.join(projectsDir, file);
+            const content = fs.readFileSync(fullPath, 'utf8');
             const lines = content.split('\n');
             for (const line of lines) {
                 if (!line.trim()) continue;

--- a/serving/skills-cli/install-claude.test.ts
+++ b/serving/skills-cli/install-claude.test.ts
@@ -24,48 +24,43 @@ test('Claude Code loads plugin from local dist directory', { skip: !process.env.
             }
         }
 
-        const cmd = `claude --plugin-dir ${distDir} -p "use the modern-web-use-cases skill and tell me best practices on implementing an address form" --dangerously-skip-permissions --verbose`;
+        const cmd = `claude --plugin-dir ${distDir} -p "use the modern-web-use-cases skill and tell me best practices on implementing an address form" --dangerously-skip-permissions --verbose --output-format stream-json`;
         
         console.log(`\nRunning Claude Code with local plugin...`);
-        execSync(cmd, { 
-            stdio: ['ignore', 'inherit', 'inherit'], 
+        const output = execSync(cmd, { 
+            stdio: ['ignore', 'pipe', 'pipe'], 
             timeout: 90000, 
             env: { ...process.env, ...anthropicEnv } 
         });
 
         console.log(`\nVerifying Claude used the skill...`);
-        const projectsDir = path.join(os.homedir(), '.claude', 'projects');
-        const files = fs.globSync('**/*.jsonl', { cwd: projectsDir });
-        console.log(`Found session files: ${JSON.stringify(files)}`);
+        const outputStr = output.toString();
+        const lines = outputStr.split('\n');
+        let skillUsed = false;
         
-        let toolsUsed: string[] = [];
-        for (const file of files) {
-            const fullPath = path.join(projectsDir, file);
-            const content = fs.readFileSync(fullPath, 'utf8');
-            const lines = content.split('\n');
-            for (const line of lines) {
-                if (!line.trim()) continue;
-                try {
-                    const obj = JSON.parse(line);
-                    if (obj.message && Array.isArray(obj.message.content)) {
-                        for (const item of obj.message.content) {
-                            if (item.type === 'tool_use') {
-                                if (item.name === 'Skill' && item.input?.skill) {
-                                    toolsUsed.push(item.input.skill);
-                                } else if (item.name === 'activate_skill' && item.input?.name) {
-                                    toolsUsed.push(item.input.name);
-                                }
+        for (const line of lines) {
+            if (!line.trim()) continue;
+            try {
+                const obj = JSON.parse(line);
+                if (obj.type === 'assistant' && obj.message && Array.isArray(obj.message.content)) {
+                    for (const item of obj.message.content) {
+                        if (item.type === 'tool_use' && item.name === 'Bash') {
+                            const command = item.input?.command;
+                            if (typeof command === 'string' && command.includes('modern-web.mjs')) {
+                                skillUsed = true;
+                                break;
                             }
                         }
                     }
-                } catch (e) {
-                    // Ignore parse errors
                 }
+            } catch (e) {
+                // Ignore parse errors
             }
+            if (skillUsed) break;
         }
         
-        console.log(`Tools used: ${JSON.stringify(toolsUsed)}`);
-        assert.ok(toolsUsed.includes('modern-web-use-cases'), 'Claude did not use the modern-web-use-cases skill');
+        console.log(`Skill used: ${skillUsed}`);
+        assert.ok(skillUsed, 'Claude did not use the modern-web-use-cases skill');
         
     } finally {
         if (homeDir) {

--- a/serving/skills-cli/install-claude.test.ts
+++ b/serving/skills-cli/install-claude.test.ts
@@ -36,19 +36,51 @@ test('Claude Code loads plugin from local dist directory', { skip: !process.env.
         console.log(`\nVerifying Claude used the skill...`);
         const outputStr = output.toString();
         const lines = outputStr.split('\n');
-        let skillUsed = false;
+        
+        let searchCalled = false;
+        let retrieveCalled = false;
+        let searchToolId = '';
+        let retrieveToolId = '';
+        let searchSuccess = false;
+        let retrieveSuccess = false;
         
         for (const line of lines) {
             if (!line.trim()) continue;
             try {
                 const obj = JSON.parse(line);
+                
+                // Check for tool use
                 if (obj.type === 'assistant' && obj.message && Array.isArray(obj.message.content)) {
                     for (const item of obj.message.content) {
                         if (item.type === 'tool_use' && item.name === 'Bash') {
                             const command = item.input?.command;
-                            if (typeof command === 'string' && command.includes('modern-web.mjs')) {
-                                skillUsed = true;
-                                break;
+                            if (typeof command === 'string') {
+                                if (command.includes('--search')) {
+                                    searchCalled = true;
+                                    searchToolId = item.id;
+                                }
+                                if (command.includes('--retrieve')) {
+                                    retrieveCalled = true;
+                                    retrieveToolId = item.id;
+                                }
+                            }
+                        }
+                    }
+                }
+                
+                // Check for tool result
+                if (obj.type === 'user' && obj.message && Array.isArray(obj.message.content)) {
+                    for (const item of obj.message.content) {
+                        if (item.type === 'tool_result') {
+                            if (searchToolId && item.tool_use_id === searchToolId) {
+                                if (item.content && !item.is_error) {
+                                    searchSuccess = true;
+                                }
+                            }
+                            if (retrieveToolId && item.tool_use_id === retrieveToolId) {
+                                if (item.content && !item.is_error) {
+                                    retrieveSuccess = true;
+                                }
                             }
                         }
                     }
@@ -56,11 +88,21 @@ test('Claude Code loads plugin from local dist directory', { skip: !process.env.
             } catch (e) {
                 // Ignore parse errors
             }
-            if (skillUsed) break;
         }
         
-        console.log(`Skill used: ${skillUsed}`);
-        assert.ok(skillUsed, 'Claude did not use the modern-web-use-cases skill');
+        const skillActivated = searchCalled || retrieveCalled;
+        
+        console.log(`\n[Validation State]`);
+        console.log(`- Skill Activated: ${skillActivated}`);
+        console.log(`- Search Called: ${searchCalled}`);
+        console.log(`- Retrieve Called: ${retrieveCalled}\n`);
+        
+        // Assert all, but we get the log above first!
+        assert.ok(skillActivated, 'Skill should specify check for modern-web-use-cases activation');
+        assert.ok(searchCalled, 'Modern web search should be called');
+        assert.ok(searchSuccess, 'Modern web search should be successful');
+        assert.ok(retrieveCalled, 'Modern web retrieve should be called');
+        assert.ok(retrieveSuccess, 'Modern web retrieve should be successful');
         
     } finally {
         if (homeDir) {

--- a/serving/skills-cli/install-claude.test.ts
+++ b/serving/skills-cli/install-claude.test.ts
@@ -1,4 +1,5 @@
 import test from 'node:test';
+import assert from 'node:assert';
 import fs from 'node:fs';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
@@ -30,6 +31,39 @@ test('Claude Code loads plugin from local dist directory', { skip: !process.env.
             timeout: 90000, 
             env: { ...process.env, ...anthropicEnv } 
         });
+
+        console.log(`\nVerifying Claude used the skill...`);
+        const projectsDir = path.join(homeDir, '.claude', 'projects');
+        const files = fs.globSync('**/*.jsonl', { cwd: projectsDir });
+        let skillUsed = false;
+        
+        for (const file of files) {
+            const content = fs.readFileSync(path.join(projectsDir, file), 'utf8');
+            const lines = content.split('\n');
+            for (const line of lines) {
+                if (!line.trim()) continue;
+                try {
+                    const obj = JSON.parse(line);
+                    if (obj.message && Array.isArray(obj.message.content)) {
+                        for (const item of obj.message.content) {
+                            if (item.type === 'tool_use') {
+                                if ((item.name === 'Skill' && item.input?.skill === 'modern-web-use-cases') ||
+                                    (item.name === 'activate_skill' && item.input?.name === 'modern-web-use-cases')) {
+                                    skillUsed = true;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                } catch (e) {
+                    // Ignore parse errors
+                }
+                if (skillUsed) break;
+            }
+            if (skillUsed) break;
+        }
+        
+        assert.ok(skillUsed, 'Claude did not use the modern-web-use-cases skill');
         
     } finally {
         if (homeDir) {

--- a/serving/skills-cli/install-claude.test.ts
+++ b/serving/skills-cli/install-claude.test.ts
@@ -27,23 +27,14 @@ test('Claude Code loads plugin from local dist directory', { skip: !process.env.
         const cmd = `claude --plugin-dir ${distDir} -p "use the modern-web-use-cases skill and tell me best practices on implementing an address form" --dangerously-skip-permissions --verbose`;
         
         console.log(`\nRunning Claude Code with local plugin...`);
-        try {
-            console.log(`Running Claude command: ${cmd}`);
-            const output = execSync(cmd, { 
-                stdio: ['ignore', 'pipe', 'pipe'], 
-                timeout: 30000, // 30 seconds timeout
-                env: { ...process.env, ...anthropicEnv, HOME: homeDir } 
-            });
-            console.log(`Claude Output:\n${output.toString()}`);
-        } catch (e: any) {
-            console.error(`Claude failed or timed out!`);
-            if (e.stdout) console.log(`Stdout:\n${e.stdout.toString()}`);
-            if (e.stderr) console.log(`Stderr:\n${e.stderr.toString()}`);
-            throw e;
-        }
+        execSync(cmd, { 
+            stdio: ['ignore', 'inherit', 'inherit'], 
+            timeout: 90000, 
+            env: { ...process.env, ...anthropicEnv } 
+        });
 
         console.log(`\nVerifying Claude used the skill...`);
-        const projectsDir = path.join(homeDir, '.claude', 'projects');
+        const projectsDir = path.join(os.homedir(), '.claude', 'projects');
         const files = fs.globSync('**/*.jsonl', { cwd: projectsDir });
         console.log(`Found session files: ${JSON.stringify(files)}`);
         

--- a/serving/skills-cli/install-claude.test.ts
+++ b/serving/skills-cli/install-claude.test.ts
@@ -35,12 +35,16 @@ test('Claude Code loads plugin from local dist directory', { skip: !process.env.
 
         console.log(`\nVerifying Claude used the skill...`);
         const projectsDir = path.join(homeDir, '.claude', 'projects');
+        const files = fs.globSync('**/*.jsonl', { cwd: projectsDir });
+        console.log(`Found session files: ${JSON.stringify(files)}`);
         const toolsUsed = collectClaudeToolsFromTrajectory(projectsDir);
+        console.log(`Tools used: ${JSON.stringify(toolsUsed)}`);
         assert.ok(toolsUsed.includes('modern-web-use-cases'), 'Claude did not use the modern-web-use-cases skill');
         
     } finally {
         if (homeDir) {
-            cleanupIsolatedHome(homeDir);
+            console.log(`Skipping cleanup of isolated HOME at ${homeDir}`);
+            // cleanupIsolatedHome(homeDir);
         }
     }
 });

--- a/serving/skills-cli/install-claude.test.ts
+++ b/serving/skills-cli/install-claude.test.ts
@@ -27,11 +27,20 @@ test('Claude Code loads plugin from local dist directory', { skip: !process.env.
         const cmd = `claude --plugin-dir ${distDir} -p "use the modern-web-use-cases skill and tell me best practices on implementing an address form" --dangerously-skip-permissions --verbose`;
         
         console.log(`\nRunning Claude Code with local plugin...`);
-        execSync(cmd, { 
-            stdio: ['ignore', 'inherit', 'inherit'], 
-            timeout: 90000, 
-            env: { ...process.env, ...anthropicEnv, HOME: homeDir } 
-        });
+        try {
+            console.log(`Running Claude command: ${cmd}`);
+            const output = execSync(cmd, { 
+                stdio: ['ignore', 'pipe', 'pipe'], 
+                timeout: 30000, // 30 seconds timeout
+                env: { ...process.env, ...anthropicEnv, HOME: homeDir } 
+            });
+            console.log(`Claude Output:\n${output.toString()}`);
+        } catch (e: any) {
+            console.error(`Claude failed or timed out!`);
+            if (e.stdout) console.log(`Stdout:\n${e.stdout.toString()}`);
+            if (e.stderr) console.log(`Stderr:\n${e.stderr.toString()}`);
+            throw e;
+        }
 
         console.log(`\nVerifying Claude used the skill...`);
         const projectsDir = path.join(homeDir, '.claude', 'projects');

--- a/serving/skills-cli/install-claude.test.ts
+++ b/serving/skills-cli/install-claude.test.ts
@@ -5,8 +5,7 @@ import path from 'node:path';
 import { spawn } from 'node:child_process';
 
 test('Claude Code loads plugin from local dist directory', { skip: !process.env.FULL }, async () => {
-    try {
-        const distDir = path.resolve(import.meta.dirname, '../../dist/skills-cli');
+    const distDir = path.resolve(import.meta.dirname, '../../dist/skills-cli');
         
         if (!fs.existsSync(distDir)) {
             test.skip('dist/skills-cli not found, skipping');
@@ -129,7 +128,5 @@ test('Claude Code loads plugin from local dist directory', { skip: !process.env.
         assert.ok(retrieveCalled, 'Modern web retrieve should be called');
         assert.ok(retrieveSuccess, 'Modern web retrieve should be successful');
         
-    } finally {
-        // No cleanup needed as we use real HOME for Claude auth
-    }
+
 });

--- a/serving/skills-cli/install-gemini.test.ts
+++ b/serving/skills-cli/install-gemini.test.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
 import { createIsolatedHome, cleanupIsolatedHome } from '../../harness/lib/agent-shared.ts';
+import { parseGeminiStreamOutput } from '../../harness/agents/gemini-cli-agent.ts';
 
 test('Gemini CLI verifies extension install capability', { skip: !process.env.FULL }, async () => {
     let homeDir = '';
@@ -38,34 +39,7 @@ test('Gemini CLI verifies extension install capability', { skip: !process.env.FU
 
         console.log(`\nVerifying Gemini used the skill...`);
         const outputStr = output.toString();
-        const lines = outputStr.split('\n');
-        
-        let skillActivated = false;
-        let searchCalled = false;
-        let retrieveCalled = false;
-        
-        for (const line of lines) {
-            if (!line.trim()) continue;
-            try {
-                const event = JSON.parse(line);
-                if (event.type === 'tool_use') {
-                    if (event.tool_name === 'activate_skill' && event.parameters?.name === 'modern-web-use-cases') {
-                        skillActivated = true;
-                    }
-                    if (event.tool_name === 'run_shell_command') {
-                        const command = event.parameters?.command || '';
-                        if (command.includes('--search')) {
-                            searchCalled = true;
-                        }
-                        if (command.includes('--retrieve')) {
-                            retrieveCalled = true;
-                        }
-                    }
-                }
-            } catch (e) {
-                // Ignore parse errors
-            }
-        }
+        const { skillActivated, searchCalled, retrieveCalled } = parseGeminiStreamOutput(outputStr);
         
         console.log(`\n[Validation State]`);
         console.log(`- Skill Activated: ${skillActivated}`);

--- a/serving/skills-cli/install-gemini.test.ts
+++ b/serving/skills-cli/install-gemini.test.ts
@@ -35,6 +35,37 @@ test('Gemini CLI verifies extension install capability', { skip: !process.env.FU
             timeout: 90000,
             env: { ...process.env, HOME: homeDir }
         });
+
+        console.log(`\nVerifying Gemini used the skill...`);
+        const tmpDir = path.join(homeDir, '.gemini', 'tmp');
+        const files = fs.globSync('**/chats/*.json', { cwd: tmpDir });
+        let skillUsed = false;
+        
+        for (const file of files) {
+            const content = fs.readFileSync(path.join(tmpDir, file), 'utf8');
+            try {
+                const session = JSON.parse(content);
+                if (Array.isArray(session.messages)) {
+                    for (const msg of session.messages) {
+                        if (msg.type === 'gemini' && Array.isArray(msg.toolCalls)) {
+                            for (const tc of msg.toolCalls) {
+                                if (tc.name.includes('get_best_practices') || 
+                                    (tc.name === 'activate_skill' && tc.args && tc.args.name === 'modern-web-use-cases')) {
+                                    skillUsed = true;
+                                    break;
+                                }
+                            }
+                        }
+                        if (skillUsed) break;
+                    }
+                }
+            } catch (e) {
+                // Ignore parse errors
+            }
+            if (skillUsed) break;
+        }
+        
+        assert.ok(skillUsed, 'Gemini did not use the modern-web-use-cases skill');
         
     } finally {
         if (homeDir) {

--- a/serving/skills-cli/install-gemini.test.ts
+++ b/serving/skills-cli/install-gemini.test.ts
@@ -31,16 +31,51 @@ test('Gemini CLI verifies extension install capability', { skip: !process.env.FU
 
         console.log(`\nRunning Gemini prompt using the skill...`);
         const promptCmd = `${geminiBin} -p "use the modern-web-use-cases skill and tell me best practices on implementing an address form" -o stream-json --yolo`;
-        execSync(promptCmd, { 
-            stdio: 'inherit', 
+        const output = execSync(promptCmd, { 
+            stdio: ['ignore', 'pipe', 'pipe'], 
             timeout: 90000,
             env: { ...process.env, HOME: homeDir }
         });
 
         console.log(`\nVerifying Gemini used the skill...`);
-        const tmpDir = path.join(homeDir, '.gemini', 'tmp');
-        const toolsUsed = collectGeminiToolsFromTrajectory(tmpDir);
-        assert.ok(toolsUsed.includes('modern-web') || toolsUsed.includes('modern-web-use-cases'), 'Gemini did not use the skill');
+        const outputStr = output.toString();
+        const lines = outputStr.split('\n');
+        
+        let skillActivated = false;
+        let searchCalled = false;
+        let retrieveCalled = false;
+        
+        for (const line of lines) {
+            if (!line.trim()) continue;
+            try {
+                const event = JSON.parse(line);
+                if (event.type === 'tool_use') {
+                    if (event.tool_name === 'activate_skill' && event.parameters?.name === 'modern-web-use-cases') {
+                        skillActivated = true;
+                    }
+                    if (event.tool_name === 'run_shell_command') {
+                        const command = event.parameters?.command || '';
+                        if (command.includes('--search')) {
+                            searchCalled = true;
+                        }
+                        if (command.includes('--retrieve')) {
+                            retrieveCalled = true;
+                        }
+                    }
+                }
+            } catch (e) {
+                // Ignore parse errors
+            }
+        }
+        
+        console.log(`\n[Validation State]`);
+        console.log(`- Skill Activated: ${skillActivated}`);
+        console.log(`- Search Called: ${searchCalled}`);
+        console.log(`- Retrieve Called: ${retrieveCalled}\n`);
+        
+        assert.ok(skillActivated, 'Skill should specify check for modern-web-use-cases activation');
+        assert.ok(searchCalled, 'Modern web search should be called');
+        assert.ok(retrieveCalled, 'Modern web retrieve should be called');
         
     } finally {
         if (homeDir) {

--- a/serving/skills-cli/install-gemini.test.ts
+++ b/serving/skills-cli/install-gemini.test.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
 import { createIsolatedHome, cleanupIsolatedHome } from '../../harness/lib/agent-shared.ts';
+import { collectGeminiToolsFromTrajectory } from '../../harness/agents/gemini-cli-agent.ts';
 
 test('Gemini CLI verifies extension install capability', { skip: !process.env.FULL }, async () => {
     let homeDir = '';
@@ -38,34 +39,8 @@ test('Gemini CLI verifies extension install capability', { skip: !process.env.FU
 
         console.log(`\nVerifying Gemini used the skill...`);
         const tmpDir = path.join(homeDir, '.gemini', 'tmp');
-        const files = fs.globSync('**/chats/*.json', { cwd: tmpDir });
-        let skillUsed = false;
-        
-        for (const file of files) {
-            const content = fs.readFileSync(path.join(tmpDir, file), 'utf8');
-            try {
-                const session = JSON.parse(content);
-                if (Array.isArray(session.messages)) {
-                    for (const msg of session.messages) {
-                        if (msg.type === 'gemini' && Array.isArray(msg.toolCalls)) {
-                            for (const tc of msg.toolCalls) {
-                                if (tc.name.includes('get_best_practices') || 
-                                    (tc.name === 'activate_skill' && tc.args && tc.args.name === 'modern-web-use-cases')) {
-                                    skillUsed = true;
-                                    break;
-                                }
-                            }
-                        }
-                        if (skillUsed) break;
-                    }
-                }
-            } catch (e) {
-                // Ignore parse errors
-            }
-            if (skillUsed) break;
-        }
-        
-        assert.ok(skillUsed, 'Gemini did not use the modern-web-use-cases skill');
+        const toolsUsed = collectGeminiToolsFromTrajectory(tmpDir);
+        assert.ok(toolsUsed.includes('modern-web') || toolsUsed.includes('modern-web-use-cases'), 'Gemini did not use the skill');
         
     } finally {
         if (homeDir) {

--- a/serving/skills-cli/install-gemini.test.ts
+++ b/serving/skills-cli/install-gemini.test.ts
@@ -4,7 +4,6 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
 import { createIsolatedHome, cleanupIsolatedHome } from '../../harness/lib/agent-shared.ts';
-import { collectGeminiToolsFromTrajectory } from '../../harness/agents/gemini-cli-agent.ts';
 
 test('Gemini CLI verifies extension install capability', { skip: !process.env.FULL }, async () => {
     let homeDir = '';

--- a/serving/skills-cli/install-skills.test.ts
+++ b/serving/skills-cli/install-skills.test.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
 import { createIsolatedHome, cleanupIsolatedHome } from '../../harness/lib/agent-shared.ts';
+import { parseGeminiStreamOutput } from '../../harness/agents/gemini-cli-agent.ts';
 
 test('npx skills add from local path', { skip: !process.env.FULL }, async () => {
     let homeDir = '';
@@ -48,34 +49,7 @@ test('npx skills add from local path', { skip: !process.env.FULL }, async () => 
 
             console.log(`\nVerifying Gemini used the skill...`);
             const outputStr = output.toString();
-            const lines = outputStr.split('\n');
-            
-            let skillActivated = false;
-            let searchCalled = false;
-            let retrieveCalled = false;
-            
-            for (const line of lines) {
-                if (!line.trim()) continue;
-                try {
-                    const event = JSON.parse(line);
-                    if (event.type === 'tool_use') {
-                        if (event.tool_name === 'activate_skill' && event.parameters?.name === 'modern-web-use-cases') {
-                            skillActivated = true;
-                        }
-                        if (event.tool_name === 'run_shell_command') {
-                            const command = event.parameters?.command || '';
-                            if (command.includes('--search')) {
-                                searchCalled = true;
-                            }
-                            if (command.includes('--retrieve')) {
-                                retrieveCalled = true;
-                            }
-                        }
-                    }
-                } catch (e) {
-                    // Ignore parse errors
-                }
-            }
+            const { skillActivated, searchCalled, retrieveCalled } = parseGeminiStreamOutput(outputStr);
             
             console.log(`\n[Validation State]`);
             console.log(`- Skill Activated: ${skillActivated}`);

--- a/serving/skills-cli/install-skills.test.ts
+++ b/serving/skills-cli/install-skills.test.ts
@@ -1,4 +1,5 @@
 import test from 'node:test';
+import assert from 'node:assert';
 import fs from 'node:fs';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
@@ -44,6 +45,37 @@ test('npx skills add from local path', { skip: !process.env.FULL }, async () => 
                 timeout: 90000,
                 env: { ...process.env, HOME: homeDir }
             });
+
+            console.log(`\nVerifying Gemini used the skill...`);
+            const tmpDir = path.join(homeDir, '.gemini', 'tmp');
+            const files = fs.globSync('**/chats/*.json', { cwd: tmpDir });
+            let skillUsed = false;
+            
+            for (const file of files) {
+                const content = fs.readFileSync(path.join(tmpDir, file), 'utf8');
+                try {
+                    const session = JSON.parse(content);
+                    if (Array.isArray(session.messages)) {
+                        for (const msg of session.messages) {
+                            if (msg.type === 'gemini' && Array.isArray(msg.toolCalls)) {
+                                for (const tc of msg.toolCalls) {
+                                    if (tc.name.includes('get_best_practices') || 
+                                        (tc.name === 'activate_skill' && tc.args && tc.args.name === 'modern-web-use-cases')) {
+                                        skillUsed = true;
+                                        break;
+                                    }
+                                }
+                            }
+                            if (skillUsed) break;
+                        }
+                    }
+                } catch (e) {
+                    // Ignore parse errors
+                }
+                if (skillUsed) break;
+            }
+            
+            assert.ok(skillUsed, 'Gemini did not use the modern-web-use-cases skill');
         }
         
     } finally {

--- a/serving/skills-cli/install-skills.test.ts
+++ b/serving/skills-cli/install-skills.test.ts
@@ -4,7 +4,6 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
 import { createIsolatedHome, cleanupIsolatedHome } from '../../harness/lib/agent-shared.ts';
-import { collectGeminiToolsFromTrajectory } from '../../harness/agents/gemini-cli-agent.ts';
 
 test('npx skills add from local path', { skip: !process.env.FULL }, async () => {
     let homeDir = '';

--- a/serving/skills-cli/install-skills.test.ts
+++ b/serving/skills-cli/install-skills.test.ts
@@ -41,16 +41,51 @@ test('npx skills add from local path', { skip: !process.env.FULL }, async () => 
         if (fs.existsSync(geminiBin)) {
             console.log(`\nVerifying Gemini can use the added skill...`);
             const promptCmd = `${geminiBin} -p "use the modern-web-use-cases skill and tell me best practices on implementing an address form" -o stream-json --yolo`;
-            execSync(promptCmd, { 
-                stdio: ['ignore', 'inherit', 'inherit'], 
+            const output = execSync(promptCmd, { 
+                stdio: ['ignore', 'pipe', 'pipe'], 
                 timeout: 90000,
                 env: { ...process.env, HOME: homeDir }
             });
 
             console.log(`\nVerifying Gemini used the skill...`);
-            const tmpDir = path.join(homeDir, '.gemini', 'tmp');
-            const toolsUsed = collectGeminiToolsFromTrajectory(tmpDir);
-            assert.ok(toolsUsed.includes('modern-web') || toolsUsed.includes('modern-web-use-cases'), 'Gemini did not use the skill');
+            const outputStr = output.toString();
+            const lines = outputStr.split('\n');
+            
+            let skillActivated = false;
+            let searchCalled = false;
+            let retrieveCalled = false;
+            
+            for (const line of lines) {
+                if (!line.trim()) continue;
+                try {
+                    const event = JSON.parse(line);
+                    if (event.type === 'tool_use') {
+                        if (event.tool_name === 'activate_skill' && event.parameters?.name === 'modern-web-use-cases') {
+                            skillActivated = true;
+                        }
+                        if (event.tool_name === 'run_shell_command') {
+                            const command = event.parameters?.command || '';
+                            if (command.includes('--search')) {
+                                searchCalled = true;
+                            }
+                            if (command.includes('--retrieve')) {
+                                retrieveCalled = true;
+                            }
+                        }
+                    }
+                } catch (e) {
+                    // Ignore parse errors
+                }
+            }
+            
+            console.log(`\n[Validation State]`);
+            console.log(`- Skill Activated: ${skillActivated}`);
+            console.log(`- Search Called: ${searchCalled}`);
+            console.log(`- Retrieve Called: ${retrieveCalled}\n`);
+            
+            assert.ok(skillActivated, 'Skill should specify check for modern-web-use-cases activation');
+            assert.ok(searchCalled, 'Modern web search should be called');
+            assert.ok(retrieveCalled, 'Modern web retrieve should be called');
         }
         
     } finally {

--- a/serving/skills-cli/install-skills.test.ts
+++ b/serving/skills-cli/install-skills.test.ts
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
 import { createIsolatedHome, cleanupIsolatedHome } from '../../harness/lib/agent-shared.ts';
+import { collectGeminiToolsFromTrajectory } from '../../harness/agents/gemini-cli-agent.ts';
 
 test('npx skills add from local path', { skip: !process.env.FULL }, async () => {
     let homeDir = '';
@@ -48,34 +49,8 @@ test('npx skills add from local path', { skip: !process.env.FULL }, async () => 
 
             console.log(`\nVerifying Gemini used the skill...`);
             const tmpDir = path.join(homeDir, '.gemini', 'tmp');
-            const files = fs.globSync('**/chats/*.json', { cwd: tmpDir });
-            let skillUsed = false;
-            
-            for (const file of files) {
-                const content = fs.readFileSync(path.join(tmpDir, file), 'utf8');
-                try {
-                    const session = JSON.parse(content);
-                    if (Array.isArray(session.messages)) {
-                        for (const msg of session.messages) {
-                            if (msg.type === 'gemini' && Array.isArray(msg.toolCalls)) {
-                                for (const tc of msg.toolCalls) {
-                                    if (tc.name.includes('get_best_practices') || 
-                                        (tc.name === 'activate_skill' && tc.args && tc.args.name === 'modern-web-use-cases')) {
-                                        skillUsed = true;
-                                        break;
-                                    }
-                                }
-                            }
-                            if (skillUsed) break;
-                        }
-                    }
-                } catch (e) {
-                    // Ignore parse errors
-                }
-                if (skillUsed) break;
-            }
-            
-            assert.ok(skillUsed, 'Gemini did not use the modern-web-use-cases skill');
+            const toolsUsed = collectGeminiToolsFromTrajectory(tmpDir);
+            assert.ok(toolsUsed.includes('modern-web') || toolsUsed.includes('modern-web-use-cases'), 'Gemini did not use the skill');
         }
         
     } finally {

--- a/serving/skills-cli/publish-skills.ts
+++ b/serving/skills-cli/publish-skills.ts
@@ -89,21 +89,21 @@ async function main() {
     console.log(`\n💡 Tip: Run thorough pre-flight verification with FULL=1 to include heavy agent tests:`);
     console.log(`   FULL=1 pnpm run preflight`);
 
-    console.log(`\nPublishing new dist/skills-cli/ to GoogleChrome/skills-alpha (main branch)...`);
+    console.log(`\nPublishing new dist/skills-cli/ to GoogleChrome/modern-web-guidance (main branch)...`);
     
     await ghpages.publish(publishCliDir, {
       src: ['**/*'], // No longer vendor node_modules! Users will install via npx -y!
       branch: 'main',
-      repo: 'git@github.com:GoogleChrome/skills-alpha.git',
+      repo: 'git@github.com:GoogleChrome/modern-web-guidance.git',
       dotfiles: true,
       message: `Release v${newVersion}`,
       remove: "**/*"
     });
 
 
-    console.log(`\n✅ Successfully published v${newVersion} to GoogleChrome/skills-alpha!`);
+    console.log(`\n✅ Successfully published v${newVersion} to GoogleChrome/modern-web-guidance!`);
 
-    console.log(`\nv${newVersion} published.  https://github.com/GoogleChrome/skills-alpha  and [GoB repo](https://user.git.corp.google.com/rviscomi/modern-web-guidance/)`);
+    console.log(`\nv${newVersion} published.  https://github.com/GoogleChrome/modern-web-guidance  and [GoB repo](https://user.git.corp.google.com/rviscomi/modern-web-guidance/)`);
     console.log(`${useCasesCount} usecases.`);
     console.log(`${featuresCount} features`);
     console.log(`${skillsCount} skills (${skillNames.join(', ')})`);

--- a/serving/skills-cli/publish-skills.ts
+++ b/serving/skills-cli/publish-skills.ts
@@ -84,10 +84,10 @@ async function main() {
     console.log(` - Skills: ${skillsCount} (${skillNames.join(', ')})`);
 
     console.log(`\n💡 Tip: Run thorough pre-flight verification with FULL=1 to include heavy agent tests:`);
-    console.log(`   FULL=1 pnpm run preflight`);
+    console.log(`   env FULL=1 TEST_REPORTER=spec pnpm test`);
   } else {
     console.log(`\n💡 Tip: Run thorough pre-flight verification with FULL=1 to include heavy agent tests:`);
-    console.log(`   FULL=1 pnpm run preflight`);
+    console.log(`   env FULL=1 TEST_REPORTER=spec pnpm test`);
 
     console.log(`\nPublishing new dist/skills-cli/ to GoogleChrome/modern-web-guidance (main branch)...`);
     

--- a/serving/skills-cli/template/.claude-plugin/marketplace.json
+++ b/serving/skills-cli/template/.claude-plugin/marketplace.json
@@ -1,11 +1,11 @@
 {
-  "name": "skills-alpha",
+  "name": "googlechrome",
   "owner": {
     "name": "Google Chrome"
   },
   "plugins": [
     {
-      "name": "googlechrome-skills",
+      "name": "modern-web-guidance",
       "source": "./",
       "description": "Google Chrome's agent skills collection",
       "version": "0.0.12"

--- a/serving/skills-cli/template/.claude-plugin/marketplace.json
+++ b/serving/skills-cli/template/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "modern-web-guidance",
       "source": "./",
       "description": "Google Chrome's agent skills collection",
-      "version": "0.0.12"
+      "version": "0.0.13"
     }
   ]
 }

--- a/serving/skills-cli/template/.claude-plugin/plugin.json
+++ b/serving/skills-cli/template/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "googlechrome-skills",
+  "name": "modern-web-guidance",
   "description": "Google Chrome's agent skills collection",
   "version": "0.0.12",
   "author": {

--- a/serving/skills-cli/template/.claude-plugin/plugin.json
+++ b/serving/skills-cli/template/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "modern-web-guidance",
   "description": "Google Chrome's agent skills collection",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "author": {
     "name": "Google Chrome"
   }

--- a/serving/skills-cli/template/README.md
+++ b/serving/skills-cli/template/README.md
@@ -7,19 +7,19 @@ This curated collection of skills, tools, and AI-ready documentation injects Chr
 ### 🍦 Universal Skills Pack
 Consult your coding agent's documentation for installation instructions. You can also use Vercel's `skills` CLI:
 ```bash
-DISABLE_TELEMETRY=1 npx skills add GoogleChrome/skills-alpha
+DISABLE_TELEMETRY=1 npx skills add GoogleChrome/modern-web-guidance
 ```
 
 ### ✴️ Claude Code
 ```bash
-/plugin marketplace add GoogleChrome/skills-alpha
-/plugin install googlechrome-skills@skills-alpha
+/plugin marketplace add GoogleChrome/modern-web-guidance
+/plugin install modern-web-guidance@googlechrome
 /reload-plugins
 ```
 
 ### ♊ Gemini CLI
 ```bash
-gemini extensions install https://github.com/GoogleChrome/skills-alpha --auto-update
+gemini extensions install https://github.com/GoogleChrome/modern-web-guidance --auto-update
 ```
 *(Note: If the CLI hits a 404 error and asks to install via "git clone" instead, simply say yes! This is perfectly normal while the project is in private alpha.)*
 
@@ -31,6 +31,6 @@ gemini extensions install https://github.com/GoogleChrome/skills-alpha --auto-up
 * Clone this repo
 * In VSCode, open the Command Palette (`Cmd+Shift+P` or `Ctrl+Shift+P`)
 * Select "Extensions: Install from Location..."
-* Navigate to the `skills-alpha` directory and select it.
+* Navigate to the `modern-web-guidance` directory and select it.
 
 Compatibility with VSCode forks: unknown.

--- a/serving/skills-cli/template/gemini-extension.json
+++ b/serving/skills-cli/template/gemini-extension.json
@@ -1,5 +1,5 @@
 {
-  "name": "googlechrome-skills",
+  "name": "modern-web-guidance",
   "description": "Google Chrome's web development agent skills.",
   "version": "0.0.12",
   "author": {

--- a/serving/skills-cli/template/gemini-extension.json
+++ b/serving/skills-cli/template/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "modern-web-guidance",
   "description": "Google Chrome's web development agent skills.",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "author": {
     "name": "Google Chrome"
   }

--- a/serving/skills-cli/template/package.json
+++ b/serving/skills-cli/template/package.json
@@ -3,7 +3,7 @@
   "displayName": "Modern Web Guidance",
   "private": true,
   "description": "Curated collection of agent skills for modern web development.",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "publisher": "GoogleChrome",
   "engines": {
     "vscode": "^1.90.0",

--- a/serving/skills-cli/template/package.json
+++ b/serving/skills-cli/template/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "modern-web",
-  "displayName": "Chrome Web Development Skills",
+  "name": "modern-web-guidance",
+  "displayName": "Modern Web Guidance",
   "private": true,
   "description": "Curated collection of agent skills for modern web development.",
   "version": "0.0.12",

--- a/serving/skills-cli/test-dist.test.ts
+++ b/serving/skills-cli/test-dist.test.ts
@@ -40,22 +40,22 @@ try {
 test('Claude Plugin Config in Dist', async () => {
   const marketplaceJsonRaw = await fs.readFile(path.join(DIST_DIR, '.claude-plugin/marketplace.json'), 'utf8');
   const marketplaceJson = JSON.parse(marketplaceJsonRaw);
-  assert.strictEqual(marketplaceJson.name, 'skills-alpha', 'marketplace.json name should be skills-alpha');
+  assert.strictEqual(marketplaceJson.name, 'googlechrome', 'marketplace.json name should be googlechrome');
   assert.strictEqual(marketplaceJson.owner.name, 'Google Chrome', 'marketplace.json owner should be Google Chrome');
   
   assert.ok(Array.isArray(marketplaceJson.plugins) && marketplaceJson.plugins.length > 0, 'should have plugins');
-  assert.strictEqual(marketplaceJson.plugins[0].name, 'googlechrome-skills');
+  assert.strictEqual(marketplaceJson.plugins[0].name, 'modern-web-guidance');
   assert.strictEqual(marketplaceJson.plugins[0].source, './');
 
   const pluginJsonRaw = await fs.readFile(path.join(DIST_DIR, '.claude-plugin/plugin.json'), 'utf8');
   const pluginJson = JSON.parse(pluginJsonRaw);
-  assert.strictEqual(pluginJson.name, 'googlechrome-skills', 'plugin.json name should match');
+  assert.strictEqual(pluginJson.name, 'modern-web-guidance', 'plugin.json name should match');
   assert.strictEqual(pluginJson.author.name, 'Google Chrome', 'plugin.json author should be Google Chrome');
 });
 
 test('Gemini and VS Code manifests', async () => {
   const geminiJson = JSON.parse(await fs.readFile(path.join(DIST_DIR, 'gemini-extension.json'), 'utf8'));
-  assert.strictEqual(geminiJson.name, 'googlechrome-skills');
+  assert.strictEqual(geminiJson.name, 'modern-web-guidance');
   assert.strictEqual(geminiJson.author.name, 'Google Chrome');
 
   const pkgJsonRaw = await fs.readFile(path.join(DIST_DIR, 'package.json'), 'utf8');


### PR DESCRIPTION
We're changing the skills-alpha repo to be our intended destination: https://github.com/GoogleChrome/modern-web-guidance

Along with that we have some other updated names:

| Entity | Old Name | New Name | Context / Notes |
| :--- | :--- | :--- | :--- |
| **Repository** | `skills-alpha` | `modern-web-guidance` | Updated in documentation and install URLs. |
| **Claude Marketplace** | `skills-alpha` | `googlechrome` | The identifier used in `.claude-plugin/marketplace.json`. |
| **Claude Plugin ID** | `googlechrome-skills` | `modern-web-guidance` | The ID used when installing (e.g., `modern-web-guidance@googlechrome`). |
| **Gemini Extension** | `modern-web` | `modern-web-guidance` | Updated in `gemini-extension.json`. |
| **CLI Binary** | `modern-web` | `modern-web` | **Unchanged** (remains `modern-web` as requested). |

# cleanup commands:

For anyone who's had it installed until now..   these are the instructions (also available in TESTING.md)

```sh
npm uninstall --global modern-web

claude # and then
# /plugin uninstall googlechrome-skills@skills-alpha
# /plugin marketplace remove skills-alpha

# Gemini CLI
gemini extensions uninstall https://github.com/GoogleChrome/skills-alpha

# Universal Skills CLI
DISABLE_TELEMETRY=1 npx -y skills remove --global modern-web-use-cases
```

---

I also made our coding agent integration tests a lot better because now they not only try to use the plugin, but also confirm that the plug-in was used successfully.  Again those tests are behind the FULL env var. so:  `env FULL=1 TEST_REPORTER=spec pnpm --filter serving test`