### PR TITLE
More eval investigation skill fine tuning

### DIFF
--- a/.agents/skills/eval-investigation/SKILL.md
+++ b/.agents/skills/eval-investigation/SKILL.md
@@ -14,17 +14,23 @@ This skill helps you diagnose why AI coding agents are failing evaluations, spec
 - **Platform Boundary**: When investigating an eval, strictly modify use-case specific files (i.e., `task.md`, `grader.ts`, `expectations.md`, demo apps, and `guide.md`). Do not attempt to fix bugs in the underlying platform infrastructure or Playwright test environment. If you identify infrastructure issues, note them clearly for the user and suggest filing an issue on GitHub for the engineering team, ensuring the use-case investigation remains focused and clean.
 - **Success Rate Goal**: The ultimate objective of every investigation is to achieve a **100% Guided Pass Rate**. The unguided pass rate does not matter and can be ignored.
 - **Autonomous Initiative & Iteration**: An investigation is not a single pass. You must autonomously loop through fixing files, re-running evaluations, measuring progress, and rolling back failed attempts until you hit 100% success. Never stop early, and run tests multiple times to ensure your fix is consistently non-flaky.
+
 ## Communication Protocol
 
 Because evaluation runs (`gd eval`) take time, check in with the user approximately every **30 seconds** to provide a helpful narrative summary of what the agent is currently doing.
 
-Whenever you summarize progress during these check-ins, you **MUST** include a direct quote or code block of the underlying log lines to substantiate your update. However, **NEVER include timestamps** in your updates, as they add absolutely zero value to the user.
+Whenever you summarize progress during these check-ins, you **MUST**:
+1. Include a direct quote or code block of the underlying log lines to substantiate your update.
+2. Provide a clickable markdown link to the specific log file being referenced so the user can click through to see the full contents.
+
+However, **NEVER include timestamps** in your updates, as they add absolutely zero value to the user.
 
 **Example of a good check-in:**
 > The agent has successfully retrieved the reference guidance using the modern web skill:
 > ```json
 > [Modern Web Log]: {"tool":"get_best_practices"}
 > ```
+> Reference: [task-log](file:///path/to/log/file.log)
 
 **Example of a bad check-in:**
 > The agent is currently executing a command to update the workspace CSS files! (timestamp: 00:22:21Z)
@@ -90,16 +96,17 @@ If you are reviewing a shared dashboard and need to investigate specific histori
 gcloud storage cp -r gs://guidance-evals/<suite_id> harness/results/
 ```
 
-## 2. Investigation Flow
+## 2. Investigation Checklist
 
-*Overview of the investigation process:*
-1. **Audit the Prompt First**: Verify the prompt in `tasks/task.md` is valid and non-prescriptive.
-2. **Execute Evals**: Run `gd eval` to evaluate the agent against the use case.
-3. **Inspect Results**: Review pass rates in `evals.json` and verify tool activation.
-4. **Validate Grader Tolerance (False Negatives)**: Check if a correct implementation failed due to a brittle grader.
-5. **Validate Guidance Coverage (True Negatives)**: Check if an incorrect implementation failed due to missing guidance.
-6. **Trace the Trajectory**: Read the agent's thought logs to diagnose search queries and execution logic.
-7. **Integrity Audit**: Conduct a mandatory final review against all skill best practices to verify honest success.
+To guarantee full adherence to this protocol, you **MUST output this exact verification checklist at the very beginning of your first response to the user** to establish your operational plan, and continuously update it as you complete each step:
+
+1. [ ] **Step 1: Audit the Prompt First** - Verified the target prompt in `tasks/task.md` is valid, non-prescriptive, and completely devoid of hardcoded technical APIs or explicit fallback requirements.
+2. [ ] **Step 2: Execute Evals & Check Base App** - Ran `gd eval` to establish a baseline and confirmed the base app (`index.html`) contains the necessary structural elements to support the required implementation.
+3. [ ] **Step 3: Inspect Results & Verify Tool Activation** - Reviewed the pass rates in `evals.json` and confirmed that the agent successfully discovered and utilized the relevant reference guide.
+4. [ ] **Step 4: Validate Grader Tolerance (False Negatives)** - Confirmed via `gd dev --test-grader` that the grader successfully passes a correct implementation (`demo.html`) and accurately fails an incorrect one (`negative-demo.html`) without relying on overly rigid regular expressions.
+5. [ ] **Step 5: Validate Guidance Coverage (True Negatives)** - Verified that all success criteria evaluated by the grader are explicitly documented as `MANDATORY` requirements in `guide.md`.
+6. [ ] **Step 6: Trace the Trajectory** - Read the agent's local execution thought logs (`session-*.json`) to diagnose and resolve any search query mismatches or silent implementation rejections.
+7. [ ] **Step 7: Final Integrity Audit** - Conducted a strict final review against all skill best practices to confirm that the 100% Guided Pass Rate was earned honestly and completely.
 
 ### Step 1: Audit the Prompt First (`tasks/task.md`)
 - **Solution Agnostic**: Ensure the prompt describes the **user problem or outcome**, not the technical solution. If it explicitly names the API or feature (e.g., "Use the Temporal API"), any high pass rate is a false positive.
@@ -108,6 +115,9 @@ gcloud storage cp -r gs://guidance-evals/<suite_id> harness/results/
 - **Legacy Fallbacks Are Automatic**: Prompts should almost never need to mandate that legacy fallbacks are applied. If the agent successfully discovers and reads the relevant guide, it will automatically follow any documented fallback requirements.
 - **Base App Alignment**: Any elements, selectors, or layout locations mentioned in the prompt must actually exist in the initial state of the base app.
 - **Prescriptive Constraints vs Open Solutions**: Update the prompt to prescribe specific validation constraints (such as IDs, class names, or resource filenames) if the grader requires them. However, **never** be prescriptive about the specific web platform mechanism.
+  > [!IMPORTANT]
+  > **Functional Locators vs. Technical Solutions**
+  > It is completely acceptable (and sometimes necessary) to mandate specific DOM IDs or CSS classes (e.g., `"add a .fan-card class"`) if the grader requires them to locate elements. What is strictly banned is mandating the underlying implementation technology (e.g., commanding the model to `"use sibling-index()"` or `"use the Temporal API"`).
 - **Mandatory List Formatting**: The `task.md` file **must always be formatted as a markdown list** (`- item`). Even though the file may contain multiple unused prompts for future expansion, remember that the evaluation harness currently **only executes the very first list item**.
 - **No Line Breaks in the Target Prompt**: Anything you want included in the prompt that actually gets evaluated must be entirely contained on the first bullet point line without any line breaks.
 - **Over-Prescription "Smell"**: If both the unguided and guided tests pass at 100%, this is a strong code smell indicating that your prompt may be overly prescriptive and practically giving away the modern solution.
@@ -157,9 +167,7 @@ gcloud storage cp -r gs://guidance-evals/<suite_id> harness/results/
      - *Action*: Use strict directive keywords like `"MANDATORY:"` or `"CRITICAL:"` in the guide to override the agent's pre-trained biases.
 
 ### Step 7: Integrity Audit (Mandatory Final Review)
-- After you successfully achieve a **100% Guided Pass Rate**, you must perform a strict final audit of your changes.
-- Check the best practices defined in this skill and all other relevant skills (e.g., `project-evals`, `project-guides`).
-- Ensure you did not "cheat" your way to 100% (e.g., by hardcoding explicit platform APIs into the user prompt, or by making the grader tests trivially empty). Take immense pride in your success by proving it was earned the honest and fully compliant way!
+- After you successfully achieve a **100% Guided Pass Rate**, you must perform a strict final audit of your changes to ensure no steps were skipped.
 
 ## 3. Some Observed Patterns & Solutions
 

--- a/.agents/skills/eval-investigation/SKILL.md
+++ b/.agents/skills/eval-investigation/SKILL.md
@@ -109,11 +109,12 @@ To guarantee full adherence to this protocol, you **MUST output this exact verif
 7. [ ] **Step 7: Final Integrity Audit** - Conducted a strict final review against all skill best practices to confirm that the 100% Guided Pass Rate was earned honestly and completely.
 
 ### Step 1: Audit the Prompt First (`tasks/task.md`)
+- **Mandatory Substantiation**: When reporting the completion of this step, you MUST explicitly quote the target prompt to the user and summarize exactly why it adheres to all non-prescriptive guidelines.
 - **Solution Agnostic**: Ensure the prompt describes the **user problem or outcome**, not the technical solution. If it explicitly names the API or feature (e.g., "Use the Temporal API"), any high pass rate is a false positive.
 - **Command vs Question**: Ensure the prompt uses imperative language (e.g., `"Add a section..."` or `"Modify the layout..."`) rather than asking an open-ended question (`"How can I..."`).
 - **Explicit Target File (Optional)**: If an ambiguous prompt causes the agent to create new files instead of modifying existing ones, explicitly name the target file (e.g., `"in index.html"`) to guide it correctly. This is only necessary if the grader is strictly locked to that specific file.
 - **Legacy Fallbacks Are Automatic**: Prompts should almost never need to mandate that legacy fallbacks are applied. If the agent successfully discovers and reads the relevant guide, it will automatically follow any documented fallback requirements.
-- **Base App Alignment**: Any elements, selectors, or layout locations mentioned in the prompt must actually exist in the initial state of the base app.
+- **Base App Alignment**: If the prompt instructs the agent to modify an existing element, confirm that such an element actually exists in the base app template.
 - **Prescriptive Constraints vs Open Solutions**: Update the prompt to prescribe specific validation constraints (such as IDs, class names, or resource filenames) if the grader requires them. However, **never** be prescriptive about the specific web platform mechanism.
   > [!IMPORTANT]
   > **Functional Locators vs. Technical Solutions**
@@ -125,7 +126,10 @@ To guarantee full adherence to this protocol, you **MUST output this exact verif
 
 ### Step 2: Execute Evals & Report Results
 - Run `gd eval <path/to/use-case>` to execute the test suite.
-- **Check-in Requirement**: Because this command takes time, you must check in with the user approximately every **30 seconds** while it runs to report on progress, output errors, and tool usage (as defined in Core Philosophy).
+- **Check-in Requirement (Meaningful Trajectory & RAG Guidance Only)**: Because this command takes time, you must check in with the user approximately every **30 seconds** while it runs. When providing these updates, **NEVER output noisy internal JSON tool executions for file edits (e.g., `read`, `repl`, `write_file`, etc.)**. These provide zero value to the user. You MUST exclusively quote domain-relevant activations:
+  1. **Guidance Activations**: When the agent successfully uses the search or retrieval mechanisms against the `modern-web` MCP server to find our specific reference documentation.
+  2. **Agent Reasoning**: When the agent's natural language thought trajectory explicitly explains its technical strategy for solving the problem.
+  3. **Playwright Output**: When the test suite produces a final failure or success status.
 - **Results Table Requirement**: Whenever you report evaluation results to the user, you **MUST** format them as a markdown table containing the use case name, the unguided pass rate, the guided pass rate, and an indicator showing whether the reference guide was successfully used.
 
 **Example Output Format:**
@@ -167,6 +171,10 @@ To guarantee full adherence to this protocol, you **MUST output this exact verif
      - *Action*: Use strict directive keywords like `"MANDATORY:"` or `"CRITICAL:"` in the guide to override the agent's pre-trained biases.
 
 ### Step 7: Integrity Audit (Mandatory Final Review)
+- **Mandatory Substantiation**: When concluding the investigation, you MUST provide a final Markdown table showing the exact outcome:
+  | Use Case | Unguided Pass Rate | Guided Pass Rate | Guide Used |
+  | :--- | :--- | :--- | :---: |
+  | `style-parent-with-has` | 0% (0/5) | 100% (5/5) | ✅ |
 - After you successfully achieve a **100% Guided Pass Rate**, you must perform a strict final audit of your changes to ensure no steps were skipped.
 
 ## 3. Some Observed Patterns & Solutions

--- a/.agents/skills/eval-investigation/SKILL.md
+++ b/.agents/skills/eval-investigation/SKILL.md
@@ -12,6 +12,22 @@ This skill helps you diagnose why AI coding agents are failing evaluations, spec
 ### Core Philosophy: Immediate Resolution
 - **Fix It Now**: Do not create tracking issues or delay work. The goal of an investigation is to identify the root cause and implement the fix immediately in the active session.
 - **Platform Boundary**: When investigating an eval, strictly modify use-case specific files (i.e., `task.md`, `grader.ts`, `expectations.md`, demo apps, and `guide.md`). Do not attempt to fix bugs in the underlying platform infrastructure or Playwright test environment. If you identify infrastructure issues, note them clearly for the user and suggest filing an issue on GitHub for the engineering team, ensuring the use-case investigation remains focused and clean.
+- **Success Rate Goal**: The ultimate objective of every investigation is to achieve a **100% Guided Pass Rate**. The unguided pass rate does not matter and can be ignored.
+- **Autonomous Initiative & Iteration**: An investigation is not a single pass. You must autonomously loop through fixing files, re-running evaluations, measuring progress, and rolling back failed attempts until you hit 100% success. Never stop early, and run tests multiple times to ensure your fix is consistently non-flaky.
+## Communication Protocol
+
+Because evaluation runs (`gd eval`) take time, check in with the user approximately every **30 seconds** to provide a helpful narrative summary of what the agent is currently doing.
+
+Whenever you summarize progress during these check-ins, you **MUST** include a direct quote or code block of the underlying log lines to substantiate your update. However, **NEVER include timestamps** in your updates, as they add absolutely zero value to the user.
+
+**Example of a good check-in:**
+> The agent has successfully retrieved the reference guidance using the modern web skill:
+> ```json
+> [Modern Web Log]: {"tool":"get_best_practices"}
+> ```
+
+**Example of a bad check-in:**
+> The agent is currently executing a command to update the workspace CSS files! (timestamp: 00:22:21Z)
 
 ## Quick Reference: Investigation Files
 
@@ -74,43 +90,89 @@ If you are reviewing a shared dashboard and need to investigate specific histori
 gcloud storage cp -r gs://guidance-evals/<suite_id> harness/results/
 ```
 
-
 ## 2. Investigation Flow
 
-1.  **Run `gd eval`** to execute the evaluation suite for a given use case.
-2.  **Check `evals.json` First**: Review the top-level summary in `evals.json` to inspect unguided and guided pass statuses.
-    - **Crucial Check**: In the guided run results, verify whether the skill tools were called and if the specific use case guide was used.
-    - **If the guide was NOT used**, investigate why and correct the usage:
-      - **Check the Prompt**: Review and modify the prompt directly in the use case's `tasks/task.md` file.
-      - **First Prompt Only**: Be aware that the evaluation suite only executes the **first** list item in `task.md`. Adding additional bullet points will not change the prompt used in the eval.
-      - **Base App Alignment**: Ensure the prompt makes sense against the starting conditions of the `base_app` (e.g., `daily-grind`). Any elements, selectors, or locations mentioned in the prompt must exist in the initial state of the base app.
-      - **Temporary Workaround (Debugging Only)**: If the agent fails to discover the guide, you can temporarily append `"use the modern web skill"` to the prompt in `task.md`. This forces the agent to search for and retrieve the guide, allowing you to bypass discovery issues and debug grader or implementation failures. **Crucial**: This is strictly a temporary debugging workaround and must be removed before finalizing the task.
-      - **Enforce Product Requirements (Last Resort)**: If the agent still ignores the skill, emphasize mandatory product requirements or constraints that legacy methods cannot satisfy (e.g., "mandatory: you must ensure X behavior"). This signals to the agent that its baseline training is insufficient, forcing it to look up the skill.
-      - **Always Re-Run Evals After Prompt Changes**: Prompting is extremely sensitive. If you modify the prompt in any way, you MUST immediately re-run the evaluation to validate that your changes successfully encourage skill usage and improve pass rates.
-3.  **Check which tests failed**: The most reliable way to see which tests are failing is to examine the `evals.json` file for the entire eval run. It contains a `results` object where each test run has a `results` array listing every check, including a `passed` boolean (`true` or `false`) and the test message.
-4.  **Inspect the trajectory** (`session-<timestamp>.json`) to determine how the agent used skill tools. Trajectory files for `gd eval` runs are located in the harness results directory as defined in the Quick Reference table above.
-    - *Failure Diagnosis*: Refer to Section 3 (Observed Patterns & Solutions) to match the trajectory behavior to known failure patterns, such as silent skips, poor search selection, or content ambiguity.
-5.  **Verify Harness Integration & Logs**: Review standard error and harness output files to confirm whether skill tools were registered, and check if folder trust logic (e.g., `security.folderTrust.enabled`) is silently blocking discovery.
+*Overview of the investigation process:*
+1. **Audit the Prompt First**: Verify the prompt in `tasks/task.md` is valid and non-prescriptive.
+2. **Execute Evals**: Run `gd eval` to evaluate the agent against the use case.
+3. **Inspect Results**: Review pass rates in `evals.json` and verify tool activation.
+4. **Validate Grader Tolerance (False Negatives)**: Check if a correct implementation failed due to a brittle grader.
+5. **Validate Guidance Coverage (True Negatives)**: Check if an incorrect implementation failed due to missing guidance.
+6. **Trace the Trajectory**: Read the agent's thought logs to diagnose search queries and execution logic.
+7. **Integrity Audit**: Conduct a mandatory final review against all skill best practices to verify honest success.
+
+### Step 1: Audit the Prompt First (`tasks/task.md`)
+- **Solution Agnostic**: Ensure the prompt describes the **user problem or outcome**, not the technical solution. If it explicitly names the API or feature (e.g., "Use the Temporal API"), any high pass rate is a false positive.
+- **Command vs Question**: Ensure the prompt uses imperative language (e.g., `"Add a section..."` or `"Modify the layout..."`) rather than asking an open-ended question (`"How can I..."`).
+- **Explicit Target File (Optional)**: If an ambiguous prompt causes the agent to create new files instead of modifying existing ones, explicitly name the target file (e.g., `"in index.html"`) to guide it correctly. This is only necessary if the grader is strictly locked to that specific file.
+- **Legacy Fallbacks Are Automatic**: Prompts should almost never need to mandate that legacy fallbacks are applied. If the agent successfully discovers and reads the relevant guide, it will automatically follow any documented fallback requirements.
+- **Base App Alignment**: Any elements, selectors, or layout locations mentioned in the prompt must actually exist in the initial state of the base app.
+- **Prescriptive Constraints vs Open Solutions**: Update the prompt to prescribe specific validation constraints (such as IDs, class names, or resource filenames) if the grader requires them. However, **never** be prescriptive about the specific web platform mechanism.
+- **Mandatory List Formatting**: The `task.md` file **must always be formatted as a markdown list** (`- item`). Even though the file may contain multiple unused prompts for future expansion, remember that the evaluation harness currently **only executes the very first list item**.
+- **No Line Breaks in the Target Prompt**: Anything you want included in the prompt that actually gets evaluated must be entirely contained on the first bullet point line without any line breaks.
+- **Over-Prescription "Smell"**: If both the unguided and guided tests pass at 100%, this is a strong code smell indicating that your prompt may be overly prescriptive and practically giving away the modern solution.
+- **Always Re-Run**: Because prompting is highly sensitive, you MUST immediately re-run `gd eval` after any change to validate its effectiveness.
+
+### Step 2: Execute Evals & Report Results
+- Run `gd eval <path/to/use-case>` to execute the test suite.
+- **Check-in Requirement**: Because this command takes time, you must check in with the user approximately every **30 seconds** while it runs to report on progress, output errors, and tool usage (as defined in Core Philosophy).
+- **Results Table Requirement**: Whenever you report evaluation results to the user, you **MUST** format them as a markdown table containing the use case name, the unguided pass rate, the guided pass rate, and an indicator showing whether the reference guide was successfully used.
+
+**Example Output Format:**
+| Use Case | Unguided Pass Rate | Guided Pass Rate | Guide Used |
+| :--- | :--- | :--- | :---: |
+| `customize-scrollbar` | 0% (0/5) | 100% (5/5) | ✅ |
+
+### Step 3: Inspect Results (`evals.json`)
+- Check the top-level summary in `evals.json` to compare unguided vs. guided pass statuses.
+- **Crucial Discovery Check**: One of the very first things to verify is whether the use case's guidance file was discovered and used by the agent. 
+  - **If it wasn't used (Tool Evasion)**: No amount of guide or grader changes will matter. You must immediately fix the prompt in `tasks/task.md` to force discovery:
+    - **CRITICAL RULE**: The primary skill's description (`modern-web-use-cases/SKILL.md`) is **OFF-LIMITS**. It is carefully tuned for general system health and must **never** be modified on a use-case by use-case basis.
+    - **Constraint Forcing (Correct Approach)**: Modify the prompt to introduce strict performance, layout, or declarative synchronization constraints that legacy methods cannot satisfy. This naturally forces the agent to recognize a gap in its training data and retrieve the reference guide.
+    - *Force Discovery (Temporary Check)*: Append `"use the modern web skill"` to isolate discovery failures from implementation bugs, but ensure you remove this before your final integrity audit.
+    - Always re-run `gd eval` immediately after updating the prompt.
+  - **If it was used**: This successfully narrows down the problem space to either the grader calibration or the specific implementation instructions in the guide.
+
+### Step 4: Validate Grader Tolerance (False Negatives)
+- **Eyeball the Implementation (`index.html`)**: If the guide was referenced but failures persist, visually verify the agent's output in `index.html`. 
+- Determine if the agent implemented the use case correctly **in spirit**. 
+- If the output looks correct but the grader failed it, you have found a **false negative**. 
+- Update `grader.ts` to be more tolerant and resilient (e.g., removing overly rigid or brittle regular expressions).
+- **Expectations Alignment**: If you substantively change the grader file, you must ensure that the `expectations.md` file stays in tight 1:1 alignment with the new test logic.
+- **Calibration Verification**: After editing the grader, immediately run `gd dev <path/to/use-case> --test-grader` to confirm that your updates did not break calibration against the standard `demo.html` and `negative-demo.html` reference files.
+
+### Step 5: Validate Guidance Coverage (True Negatives)
+- If the generated output in `index.html` is genuinely incorrect or missing required features, the agent failed due to a **true negative**.
+- **Clarify Requirements (`guide.md`)**: Update the guide to explicitly highlight mandatory steps using strong keywords like `"MANDATORY:"` and provide concrete code examples.
+- **Compare Guide vs Expectations**: Directly cross-reference `expectations.md` against `guide.md`. Make absolutely sure that every single grading criteria is explicitly documented in the guide, as agents cannot be expected to implement undocumented rules.
+- Map any other unexplainable trajectory behavior to the failure patterns listed in **Section 3**.
+
+### Step 6: Trace the Trajectory (`session-<timestamp>.json`)
+- If the failure persists despite perfect prompts and guides, read the agent's exact thought process to uncover hidden logic traps:
+  1. **Search Query Mismatch**: Did the agent search for a generic phrase (e.g., "custom animations") but the relevant guide required a highly specific keyword? 
+     - *Action*: Add the agent's exact search string as a keyword to the guide's metadata so it naturally surfaces in future runs.
+  2. **Guide Disambiguation**: Did the agent find the right guide but select a competing one instead because their descriptions overlapped too heavily?
+     - *Action*: Disambiguate the metadata descriptions of both guides so their unique use cases are crystal clear.
+  3. **Silent Rejection**: Did the agent read the guide but explicitly decide to ignore a crucial instruction (e.g., deciding a fallback rule wasn't necessary)?
+     - *Action*: Use strict directive keywords like `"MANDATORY:"` or `"CRITICAL:"` in the guide to override the agent's pre-trained biases.
+
+### Step 7: Integrity Audit (Mandatory Final Review)
+- After you successfully achieve a **100% Guided Pass Rate**, you must perform a strict final audit of your changes.
+- Check the best practices defined in this skill and all other relevant skills (e.g., `project-evals`, `project-guides`).
+- Ensure you did not "cheat" your way to 100% (e.g., by hardcoding explicit platform APIs into the user prompt, or by making the grader tests trivially empty). Take immense pride in your success by proving it was earned the honest and fully compliant way!
 
 ## 3. Some Observed Patterns & Solutions
 
--   **Conversational Answer Instead of Code Edits (Informational Prompt)**:
-    -   *Investigation*: The agent retrieves the guide and understands the task, but the trajectory shows it outputting a text explanation instead of modifying the target files (causing all grader checks to fail).
-    -   *Solution*: Update the prompt in `tasks/task.md` to be an explicit command (e.g., `"update index.html to..."`) rather than an open-ended question (`"how can I..."`).
-
--   **Agent Searches Skills but Picks the Wrong Guide**:
+-   **Tool Evasion (Agent Completely Bypasses Guidance Tools)**: 
+    -   *Investigation*: Check `evals.json` and confirm `guideUsageRate` is 0.
+    -   *Solution*: Apply **Constraint Forcing** to the prompt in `tasks/task.md`. Introduce non-negotiable declarative layout, rendering, or synchronization constraints that legacy web technologies cannot resolve. This naturally drives the agent to look up the reference guide.
+-   **Search Mismatch (Agent Searches Skills but Picks the Wrong Guide)**:
     -   *Investigation*: Verify in the trajectory which guide titles or keywords the agent searched for versus what the metadata returned.
     -   *Solution*: Improve the guide's metadata description, title, or associated search keywords so that it ranks higher or explicitly matches likely agent queries.
 -   **Missing Skill Tools (Silent Skip)**: GCLI skips tool discovery in untrusted folders.
     -   *Solution*: Disable `folderTrust` in the harness `settings.json` or set `GEMINI_CLI_INTEGRATION_TEST=true`.
--   **Salient changes in new files**: Graders typically only inspect `index.html`. If a prompt is ambiguous, the agent might happily create a new page or subresource, causing all grader checks to fail because the grader never sees those edits.
-    -   *Investigation*: Check the agent's output in the results directory to see exactly which files were modified or created.
-    -   *Solution*: Prepend a specific target instruction to the prompt, for example: `"add to index.html: <rest of prompt>"`. This removes ambiguity and forces the agent to modify the exact file the grader expects.
 -   **Conflicting Image Sourcing**: The prompt specifies a filename but a global instruction causes the agent to use external URLs.
     -   *Solution*: Remove conflicting global instructions.
--   **Ambiguous Prompt vs Rigid Grader**: A disconnect exists between what the agent generates and what the grader targets. For example, the grader might query for `#my-button` or `hero.jpg`, but the prompt never specifies those names.
-    -   *Investigation*: Compare the agent's output in `index.html` with the precise selectors and resource names expected by the `grader.ts` file to spot discrepancies.
-    -   *Solution*: Update the prompt to be explicitly prescriptive about validation constraints (such as specific IDs, class names, or resource filenames). However, **never** be prescriptive about the specific modern web features or solution mechanisms.
 -   **Overly Rigid Graders vs Valid Alternatives**: If the agent's `index.html` changes faithfully follow the guide but still fail the checks, the grader is likely too brittle (often due to relying on regular expressions).
     -   *Solution*: Update the `grader.ts` file to be more resilient. Avoid regular expressions at all costs. Instead, verify the implementation using computed styles, structural descendant selectors, or behavior-based Playwright assertions to tolerate non-deterministic but correct agent outputs.
 -   **Unreasonable or Untestable Expectations**: Grader files are auto-generated from `expectations.md`. If the expectations themselves are flawed, the resulting grader will be untestable or redundant.

--- a/.agents/skills/project-evals/SKILL.md
+++ b/.agents/skills/project-evals/SKILL.md
@@ -94,6 +94,9 @@ base_app: daily-grind
 - DO NOT mention the guide, the feature name, or hint that guidance exists.
 - DO NOT name the base app (e.g., "daily-grind") — a real developer wouldn't refer to it that way.
 - DO NOT tell the agent which web API or CSS property to use unless a real developer would naturally do so. The point is to test whether the agent discovers the right solution via the guide.
+  > [!IMPORTANT]
+  > **Functional Locators vs. Technical Solutions**
+  > It is completely acceptable (and sometimes necessary) to mandate specific DOM IDs or CSS classes (e.g., `"add a .fan-card class"`) if the grader requires them to locate elements. What is strictly banned is mandating the underlying implementation technology (e.g., commanding the model to `"use sibling-index()"` or `"use the Temporal API"`).
 
 **Quantity:** 1–4 prompts is typical. A single highly specific prompt is fine for technical use cases. Multiple prompts are useful for use cases with multiple valid entry points (e.g., "accordion", "tabs", "drawer" all exercising the same feature).
 

--- a/guides/dev-guide.ts
+++ b/guides/dev-guide.ts
@@ -250,10 +250,11 @@ Rules:
 - The first prompt is the most important: it must be specific enough that an agent implementing it would produce a grader-testable result.
 - Vary specificity: include at least one vague/intent-based prompt and one specific/technical ask.
 - Assume the developer is working on the existing app seen in base-app.html. Reference its real assets and content where relevant.
+- Do NOT mention or mandate legacy fallbacks in the prompt. The RAG system handles fallbacks automatically.
 - Do NOT mention the guide itself or indicate that guidance exists.
 - Do NOT name the base app (e.g. "${baseApp}") — a real developer wouldn't refer to it that way.
-- Do NOT tell the agent which web API or CSS property to use unless a real developer would naturally do so.
-- Each prompt must be on its own line, prefixed with "- ".
+- Do NOT dictate the underlying technical implementation. NEVER name specific web platform APIs, framework features, or explicit CSS functions (e.g., do not command the agent to 'use the Temporal API' or 'use sibling-index()'). You MUST describe the desired user outcome instead. However, it is completely acceptable (and sometimes necessary) to include specific DOM IDs or class names if the grader requires them to locate elements.
+- Each prompt must be on its own line, prefixed with "- ", containing absolutely no internal line breaks.
 - When writing files, you MUST use your built-in structured file editing tools (e.g., \`write_file\` or \`replace\`). Do not use shell commands (like \`cat\`, \`echo\`, or heredocs \`<<\`) to create files in the terminal.
 
 Only create the ${TASK_FILE} file. Do not modify any other files.`;
@@ -497,12 +498,12 @@ export async function devAll(options: DevGuideOptions = {}): Promise<void> {
 }
 
 const statusLabel: Record<GuideStatus, { label: string; color: (s: string) => string }> = {
-  'incomplete':         { label: 'Incomplete (missing guide.md or demo.html)', color: cRed },
-  'stub':               { label: 'Stub (yaml frontmatter only, no content)', color: cYellow },
+  'incomplete': { label: 'Incomplete (missing guide.md or demo.html)', color: cRed },
+  'stub': { label: 'Stub (yaml frontmatter only, no content)', color: cYellow },
   'needs-expectations': { label: 'Needs expectations.md', color: cYellow },
-  'needs-calibration':  { label: 'Needs calibration (run gd dev)', color: cYellow },
-  'needs-test':         { label: 'Needs agent test run (missing prompts/task)', color: cCyan },
-  'eval-ready':         { label: 'Ready for eval', color: cGreen },
+  'needs-calibration': { label: 'Needs calibration (run gd dev)', color: cYellow },
+  'needs-test': { label: 'Needs agent test run (missing prompts/task)', color: cCyan },
+  'eval-ready': { label: 'Ready for eval', color: cGreen },
 };
 
 export function auditGuides(options: { groupByUsecases?: boolean } = {}): void {
@@ -664,12 +665,12 @@ function renderFeatureMatrix(allGuides: GuideInventory[]): void {
     const expctDots = guides.map(inv => (inv.expectationsEmpty ? cYellow('○') : dot(inv.hasExpectations))).join('');
 
     const row = col(renderDots(guideDot)) +
-                col(renderDots(inv => dot(inv.hasDemo))) +
-                col(expctDots) +
-                cDim('│') + ' ' +
-                col(renderDots(inv => dot(inv.hasNegativeDemo))) +
-                col(renderDots(inv => dot(inv.hasGrader))) +
-                renderDots(inv => dot(inv.hasTask));
+      col(renderDots(inv => dot(inv.hasDemo))) +
+      col(expctDots) +
+      cDim('│') + ' ' +
+      col(renderDots(inv => dot(inv.hasNegativeDemo))) +
+      col(renderDots(inv => dot(inv.hasGrader))) +
+      renderDots(inv => dot(inv.hasTask));
 
     console.log(`  ${color(name.padEnd(32))} ${String(guides.length).padStart(5)}  ${row}`);
   }


### PR DESCRIPTION
- use checklists in eval investigations
- require the agent to share artifacts during the investigation
- sync other prompt-related guidance for consistency, including the `gd dev` prompt generation