### PR TITLE
Clarify image dimension settings in SKILL.md

### DIFF
--- a/guides/performance/SKILL.md
+++ b/guides/performance/SKILL.md
@@ -192,7 +192,7 @@ Images typically represent the largest payload on a given web page. Optimization
 
 ### DOs
 *   **DO serve modern formats (AVIF / WebP)**: Use the `<picture>` element to offer AVIF (best compression), falling back to WebP, and finally JPEG/PNG for legacy browsers.
-*   **DO apply explicit `width` and `height` attributes**: Setting native attributes allows the browser to compute the aspect ratio immediately, reserving space and eliminating CLS.
+*   **DO apply explicit `width` and `height` attributes**: Setting native attributes allows the browser to compute the aspect ratio immediately, reserving space and eliminating CLS. Image dimensions may be set either as HTML attributes or CSS properties.
 *   **DO utilize `loading="lazy"` on all below-the-fold images**: Utilize native browser lazy loading to defer network requests for images outside the initial viewport.
 *   **DO implement responsive images with `srcset` and `sizes`**: Serve tailored resolutions based on screen density and viewport width to prevent mobile devices from downloading desktop-sized images.
 


### PR DESCRIPTION
Added clarification on setting image dimensions

This came from trusted tester feedback:

> High: Missing width**/**height on images — causes CLS
>The skill says: "DO apply explicit width and height attributes" to reserve layout space.
>It was set via CSS (Tailwind), so there were no CLS