### PR TITLE
#338 cross-document-transitions

### DIFF
--- a/guides/user-experience/cross-document-transitions/demo.html
+++ b/guides/user-experience/cross-document-transitions/demo.html
@@ -1,75 +1,113 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-
-<head>
-  <meta charset="UTF-8">
-  <title>Cross-document Transitions</title>
-  <style>
-    /* CORE: View Transitions API */
-    @view-transition {
-      navigation: auto;
-    }
-
-    ::view-transition-old(root) {
-      animation: fade-out 0.4s ease-out forwards;
-    }
-
-    ::view-transition-new(root) {
-      animation: fade-in 0.4s ease-out forwards;
-    }
-
-    @keyframes fade-out {
-      to {
-        opacity: 0;
+  <head>
+    <meta charset="UTF-8" />
+    <title>Cross-document Transitions</title>
+    <style>
+      @media (prefers-reduced-motion: no-preference) {
+        @view-transition {
+          navigation: auto;
+        }
       }
-    }
+      :active-view-transition-type(next) {
+        &::view-transition-old(root) {
+          animation: slide-out-next 0.4s ease-out forwards;
+        }
 
-    @keyframes fade-in {
-      from {
-        opacity: 0;
+        &::view-transition-new(root) {
+          animation: slide-in-next 0.4s ease-out forwards;
+        }
       }
+      :active-view-transition-type(previous) {
+        &::view-transition-old(root) {
+          animation: slide-out-previous 0.4s ease-out forwards;
+        }
+
+        &::view-transition-new(root) {
+          animation: slide-in-previous 0.4s ease-out forwards;
+        }
+      }
+
+      @keyframes slide-out-next {
+        to {
+          opacity: 0;
+          translate: -10% 0;
+        }
+      }
+
+      @keyframes slide-in-next {
+        from {
+          opacity: 0;
+          translate: 10% 0;
+        }
+      }
+
+      @keyframes slide-out-previous {
+        to {
+          opacity: 0;
+          translate: 10% 0;
+        }
+      }
+
+      @keyframes slide-in-previous {
+        from {
+          opacity: 0;
+          translate: -10% 0;
+        }
+      }
+      /* DEMO: Styling */
+      body {
+        font-family: monospace;
+        max-width: 500px;
+        margin: 50px auto;
+        padding: 0 20px;
+        text-align: center;
+      }
+
+      a {
+        display: inline-block;
+        margin-top: 20px;
+        padding: 10px 20px;
+        background: #0066cc;
+        color: white;
+        text-decoration: none;
+        border-radius: 4px;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h1>Cross-document Transitions</h1>
+    <p>Cross-document navigation with view transitions.</p>
+
+    <a href="?page=0" id="previous">← Go to Page 0</a>
+    <a href="?page=2" id="next">Go to Page 2 →</a>
+  </body>
+
+  <script>
+    const params = new URLSearchParams(location.search);
+    const page = params.get("page");
+
+    if (page) {
+      document.title = `Page ${page}`;
+      document.querySelector("h1").textContent = `Page ${page}`;
+
+      const nextPage = Number(page) + 1;
+      const next = document.getElementById("next");
+      next.href = `?page=${nextPage}&direction=next`;
+      next.textContent = `Go to Page ${nextPage} →`;
+
+      const previousPage = Number(page) - 1;
+      const previous = document.getElementById("previous");
+      previous.href = `?page=${previousPage}&direction=previous`;
+      previous.textContent = `← Go to Page ${previousPage}`;
     }
-
-    /* DEMO: Styling */
-    body {
-      font-family: monospace;
-      max-width: 500px;
-      margin: 50px auto;
-      padding: 0 20px;
-      text-align: center;
-    }
-
-    a {
-      display: inline-block;
-      margin-top: 20px;
-      padding: 10px 20px;
-      background: #0066cc;
-      color: white;
-      text-decoration: none;
-      border-radius: 4px;
-    }
-  </style>
-</head>
-
-<body>
-  <h1>Cross-document Transitions</h1>
-  <p>Cross-document navigation with view transitions.</p>
-  <a href="?page=2">→ Go to Page 2</a>
-</body>
-
-<script>
-  const params = new URLSearchParams(location.search);
-  const page = params.get('page');
-
-  if (page) {
-    document.title = `Page ${page}`;
-    document.querySelector('h1').textContent = `Page ${page}`;
-
-    const nextPage = Number(page) + 1;
-    const a = document.querySelector('a');
-    a.href = `?page=${nextPage}`;
-    a.textContent = `→ Go to Page ${nextPage}`;
-  }
-</script>
-
+    window.addEventListener("pagereveal", async (e) => {
+      if (e.viewTransition) {
+        const params = new URLSearchParams(location.search);
+        const direction = params.get("direction");
+        e.viewTransition.types.add(direction ?? "next");
+      }
+    });
+  </script>
 </html>

--- a/guides/user-experience/cross-document-transitions/demo.html
+++ b/guides/user-experience/cross-document-transitions/demo.html
@@ -94,19 +94,29 @@
 
       const nextPage = Number(page) + 1;
       const next = document.getElementById("next");
-      next.href = `?page=${nextPage}&direction=next`;
+      next.href = `?page=${nextPage}`;
       next.textContent = `Go to Page ${nextPage} →`;
 
       const previousPage = Number(page) - 1;
       const previous = document.getElementById("previous");
-      previous.href = `?page=${previousPage}&direction=previous`;
+      previous.href = `?page=${previousPage}`;
       previous.textContent = `← Go to Page ${previousPage}`;
     }
+    const getTransitionType = (from, to) => {
+      const fromUrl = new URL(from.url);
+      const fromPage = fromUrl.searchParams.get("page");
+      const toUrl = new URL(to.url);
+      const toPage = toUrl.searchParams.get("page");
+      if (!toPage || !fromPage) return;
+      return toPage > fromPage ? "next" : "previous";
+    };
     window.addEventListener("pagereveal", async (e) => {
-      if (e.viewTransition) {
-        const params = new URLSearchParams(location.search);
-        const direction = params.get("direction");
-        e.viewTransition.types.add(direction ?? "next");
+      if (e.viewTransition && window.navigation?.activation) {
+        const transitionType = getTransitionType(
+          navigation.activation.from,
+          navigation.activation.entry,
+        );
+        if (transitionType) e.viewTransition.types.add(transitionType);
       }
     });
   </script>

--- a/guides/user-experience/cross-document-transitions/expectations.md
+++ b/guides/user-experience/cross-document-transitions/expectations.md
@@ -1,0 +1,5 @@
+- The `@view-transition` at-rule is defined with `navigation: auto` to enable cross-document transitions.
+- The `@view-transition` rule is wrapped in a `prefers-reduced-motion: no-preference` media query to respect user accessibility settings.
+- Custom animations are defined for different transition types using the `:active-view-transition-type()` pseudo-class (e.g., for "next" and "previous" directions).
+- A `pagereveal` event listener is added to the `window` to dynamically add transition types to the `viewTransition` object.
+- The page-level transition animations use `::view-transition-old(root)` and `::view-transition-new(root)` to create slide or fade effects.

--- a/guides/user-experience/cross-document-transitions/guide.md
+++ b/guides/user-experience/cross-document-transitions/guide.md
@@ -4,6 +4,7 @@ description: Create smooth, seamless transitions between full page navigations, 
 web-feature-ids:
   - view-transitions
   - cross-document-view-transitions
+  - navigation
 sources:
   - https://developer.chrome.com/docs/web-platform/view-transitions/cross-document
   - https://blog.robino.dev/posts/cross-document-view-transitions
@@ -20,10 +21,13 @@ Cross-document view transitions allow you to create smooth, app-like transitions
 Both the source and destination pages must opt-in to view transitions for the browser to trigger them on navigation.
 
 ```css
-/* Add to a global stylesheet shared by both pages */
-@view-transition {
-  /* Enables transitions for same-origin navigations */
-  navigation: auto;
+/* Respect user's preference for reduced motion */
+@media (prefers-reduced-motion: no-preference) {
+  /* Add to a global stylesheet shared by both pages */
+  @view-transition {
+    /* Enables transitions for same-origin navigations */
+    navigation: auto;
+  }
 }
 ```
 
@@ -60,10 +64,12 @@ You may want different transition effects depending on the pages you are navigat
 If the page you are navigating to will always have the same transition type, regardless of how you get to the page, you can specify it with `types` in the `@view-transition` rule.
 
 ```css
- @view-transition {
-  navigation: auto;
-  /* Specify the types of view transitions that will always be used on this page. */
-  types: previous;
+@media (prefers-reduced-motion: no-preference) {
+  @view-transition {
+    navigation: auto;
+    /* Specify the types of view transitions that will always be used on this page. */
+    types: previous;
+  }
 }
 ```
 
@@ -71,7 +77,7 @@ You can also conditionally specify transition types inside of an event listener 
 
 ```js
 window.addEventListener("pagereveal", async (e) => {
-  if (e.viewTransition) {
+  if (e.viewTransition && window.navigation?.activation) {
     // Use application-specific logic to compute a transition type
      const transitionType = yourTransitionTypeLogic(navigation.activation.from, navigation.activation.entry);
     e.viewTransition.types.add(transitionType);
@@ -102,17 +108,6 @@ Then, use the `:active-view-transition-type()` pseudo selector to apply the diff
 }
 ```
 
-#### 4. Respect User Preferences for Reduced Motion
-
-
-```css
-@media (prefers-reduced-motion: no-preference) {
-  @view-transition {
-    navigation: auto;
-  }
-}
-```
-
 ### Fallback strategies
 
 {{ BASELINE_STATUS("view-transitions") }}
@@ -126,5 +121,17 @@ To check for support in JavaScript:
 ```javascript
 if ('onpagereveal' in window) {
   // Browser supports cross-document view transitions
+}
+```
+
+{{ BASELINE_STATUS("navigation") }}
+
+If a browser does not support the Navigation API, you will not be able to use it to determine a transition type. Use an alternate method for determining the transition type, or provide a fallback transition type. Otherwise, the browser will perform a standard instant page navigation.
+
+To check for support in JavaScript:
+
+```javascript
+if (window.navigation?.activation) {
+  // Browser supports the Navigation API
 }
 ```

--- a/guides/user-experience/cross-document-transitions/guide.md
+++ b/guides/user-experience/cross-document-transitions/guide.md
@@ -4,4 +4,127 @@ description: Create smooth, seamless transitions between full page navigations, 
 web-feature-ids:
   - view-transitions
   - cross-document-view-transitions
+sources:
+  - https://developer.chrome.com/docs/web-platform/view-transitions/cross-document
+  - https://blog.robino.dev/posts/cross-document-view-transitions
+  - https://css-tricks.com/toe-dipping-into-view-transitions/
+  - https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@view-transition
 ---
+
+Cross-document view transitions allow you to create smooth, app-like transitions between different pages of a Multi-Page Application (MPA). By default, the browser performs a cross-fade, but you can customize this to match your site's aesthetic.
+
+### Implementation Steps
+
+#### 1. Opt-in to Cross-Document View Transitions
+
+Both the source and destination pages must opt-in to view transitions for the browser to trigger them on navigation.
+
+```css
+/* Add to a global stylesheet shared by both pages */
+@view-transition {
+  /* Enables transitions for same-origin navigations */
+  navigation: auto;
+}
+```
+
+#### 2. Customize Transition Animations (Optional)
+
+You can target the old and new states of the transition using pseudo-elements to create effects like slides or reveals.
+
+```css
+/* Customizing the outgoing page animation */
+::view-transition-old(root) {
+  /* Move the old page out to the left */
+  animation: 0.4s ease-in both slide-out;
+}
+
+/* Customizing the incoming page animation */
+::view-transition-new(root) {
+  /* Move the new page in from the right */
+  animation: 0.4s ease-out both slide-in;
+}
+
+@keyframes slide-out {
+  to { transform: translateX(-20%); opacity: 0; }
+}
+
+@keyframes slide-in {
+  from { transform: translateX(100%); }
+}
+```
+
+#### 3. Create Directional Transitions (Optional)
+
+You may want different transition effects depending on the pages you are navigating between. For instance, when navigating from a home page to a contact page, you may want the effect of new content coming from the right. When navigating back to the home page, it wouldn't make sense to have the same effect. 
+
+If the page you are navigating to will always have the same transition type, regardless of how you get to the page, you can specify it with `types` in the `@view-transition` rule.
+
+```css
+ @view-transition {
+  navigation: auto;
+  /* Specify the types of view transitions that will always be used on this page. */
+  types: previous;
+}
+```
+
+You can also conditionally specify transition types inside of an event listener for `pagereveal`.
+
+```js
+window.addEventListener("pagereveal", async (e) => {
+  if (e.viewTransition) {
+    // Use application-specific logic to compute a transition type
+     const transitionType = yourTransitionTypeLogic(navigation.activation.from, navigation.activation.entry);
+    e.viewTransition.types.add(transitionType);
+  }
+});
+```
+
+Then, use the `:active-view-transition-type()` pseudo selector to apply the different animations for each type.
+
+```css
+:active-view-transition-type(next) {
+  &::view-transition-old(root) {
+    animation-name: slide-out-next;
+  }
+
+  &::view-transition-new(root) {
+    animation-name: slide-in-next;
+  }
+}
+:active-view-transition-type(previous) {
+  &::view-transition-old(root) {
+    animation-name: slide-out-previous;
+  }
+
+  &::view-transition-new(root) {
+    animation-name: slide-in-previous;
+  }
+}
+```
+
+#### 4. Respect User Preferences for Reduced Motion
+
+
+```css
+@media (prefers-reduced-motion: no-preference) {
+  @view-transition {
+    navigation: auto;
+  }
+}
+```
+
+### Fallback strategies
+
+{{ BASELINE_STATUS("view-transitions") }}
+
+{{ BASELINE_STATUS("cross-document-view-transitions") }}
+
+If a browser does not support view transitions, or cross-document view transitions, it will perform a standard instant page navigation. Cross-document view transitions are a progressive enhancement; the core functionality of the site remains unaffected.
+
+To check for support in JavaScript:
+
+```javascript
+if ('onpagereveal' in window) {
+  // Browser supports cross-document view transitions
+}
+```


### PR DESCRIPTION
Addresses #338 

View transition types for cross document view transitions are not covered in other use cases, so I added those here. I think other parts (like shared element transitions) will be covered in the other use cases.