### PR TITLE
Fix Claude yolo flag

### DIFF
--- a/serving/TESTING.md
+++ b/serving/TESTING.md
@@ -49,7 +49,7 @@ DISABLE_TELEMETRY=1 npx skills add GoogleChrome/modern-web-guidance
 Example one-liners to test integration:
 
 ```sh
-claude --plugin-dir ~/code/guidance/dist/skills-cli --allow-dangerously-skip-permissions -p "add an address form to the bottom of the page"
+claude --plugin-dir ~/code/guidance/dist/skills-cli --dangerously-skip-permissions -p "add an address form to the bottom of the page"
 ```
 
 


### PR DESCRIPTION
https://code.claude.com/docs/en/permission-modes

> the --allow- variant adds the mode to the cycle without activating it

`--allow-dangerously-skip-permissions` is a half-flag that enables the option but doesn't turn it on. The canonical form is `--permission-mode bypassPermissions` and `--dangerously-skip-permissions` is the documented shortcut.