### PR TITLE
Fix Dashboard CI Push

### DIFF
--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -8,6 +8,9 @@ on:
       - 'guides/**'
       - '.github/workflows/deploy-dashboard.yml'
 
+permissions:
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Follow-up from https://github.com/GoogleChrome/guidance/pull/504. Upon merging, the CI failed with the following errors:

1. Dashboard deployment error.
```
ProcessError: remote: Write access to repository not granted.
fatal: unable to access 'https://github.com/GoogleChrome/guidance/': The requested URL returned error: 403

    at ChildProcess.<anonymous> (/home/runner/work/guidance/guidance/node_modules/.pnpm/gh-pages@6.3.0/node_modules/gh-pages/lib/git.js:42:16)
    at ChildProcess.emit (node:events:508:28)
    at maybeClose (node:internal/child_process:1100:16)
    at ChildProcess._handle.onexit (node:internal/child_process:305:5)
/home/runner/work/guidance/guidance/eval-view:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  eval-view@1.0.0 deploy-pages: `node generate-mapping.js && gh-pages --nojekyll --add --dist .`
Exit status 1
 ELIFECYCLE  Command failed with exit code 1.
Error: Process completed with exit code 1.
```
This PR has a fix for this issue.

2. Version bump failure (committing to `main`).
```
Run git add serving/skills-cli/template/
[main 5398f2f] chore: bump version [skip ci]
 4 files changed, 4 insertions(+), 4 deletions(-)
From https://github.com/GoogleChrome/guidance
 * branch            main       -> FETCH_HEAD
Current branch main is up to date.
remote: error: GH006: Protected branch update failed for refs/heads/main.        
remote: 
remote: - Changes must be made through a pull request.        
remote: 
remote: - 2 of 2 required status checks are expected.        
To https://github.com/GoogleChrome/guidance
 ! [remote rejected] main -> main (protected branch hook declined)
error: failed to push some refs to 'https://github.com/GoogleChrome/guidance'
Error: Process completed with exit code 1.
```

To fix this, I updated `guidance` repo settings to add  `chrome-devrel-infra` GH App as an actor that can bypass the checks for pushing to `main`.