### PR TITLE
Add design-token-reactivity guide

### DIFF
--- a/guides/user-experience/design-token-reactivity/demo.html
+++ b/guides/user-experience/design-token-reactivity/demo.html
@@ -2,9 +2,12 @@
 <html lang="en">
 <head>
   <style>
+		:root {
+			--style-queries-supported: check;
+		}
+
     .container {
       --density: compact;
-      /* No container-type required for style queries! */
     }
 
     .item {
@@ -23,6 +26,16 @@
         padding: 2.5rem;
       }
     }
+
+		#toggle-spacious {
+			display: none;
+		}
+
+		@container style(--style-queries-supported) {
+			#toggle-spacious {
+				display: revert;
+			}
+		}
   </style>
 </head>
 <body>

--- a/guides/user-experience/design-token-reactivity/demo.html
+++ b/guides/user-experience/design-token-reactivity/demo.html
@@ -2,9 +2,9 @@
 <html lang="en">
 <head>
   <style>
-		:root {
-			--style-queries-supported: check;
-		}
+    :root {
+      --style-queries-supported: check;
+    }
 
     .container {
       --density: compact;
@@ -27,15 +27,15 @@
       }
     }
 
-		#toggle-spacious {
-			display: none;
-		}
+    #toggle-spacious {
+      display: none;
+    }
 
-		@container style(--style-queries-supported) {
-			#toggle-spacious {
-				display: revert;
-			}
-		}
+    @container style(--style-queries-supported) {
+      #toggle-spacious {
+        display: revert;
+      }
+    }
   </style>
 </head>
 <body>

--- a/guides/user-experience/design-token-reactivity/expectations.md
+++ b/guides/user-experience/design-token-reactivity/expectations.md
@@ -1,0 +1,1 @@
+- Only use container style queries with custom properties.

--- a/guides/user-experience/design-token-reactivity/expectations.md
+++ b/guides/user-experience/design-token-reactivity/expectations.md
@@ -1,1 +1,6 @@
-- Only use container style queries with custom properties.
+- The implementation MUST use `@container style()` queries to respond to changes in custom property values.
+- The implementation MUST define the queried custom property on an ancestor element of the element being styled.
+- The implementation MUST NOT use JavaScript for applying the styles that react to custom property changes.
+- The implementation MUST NOT attempt to style the container element using its own style query.
+- The implementation MUST use custom properties (CSS variables) when querying styles with `@container style()`.
+- The implementation SHOULD use a style query to feature-check for container style query support when conditionally displaying UI that relies on it.

--- a/guides/user-experience/design-token-reactivity/guide.md
+++ b/guides/user-experience/design-token-reactivity/guide.md
@@ -3,4 +3,213 @@ name: design-token-reactivity
 description: Define higher-order design tokens, like density modes (compact, comfortable, spacious) or themes and have descendant components react to changes directly and in component-appropriate ways.
 web-feature-ids:
   - container-style-queries
+sources:
+  - https://developer.mozilla.org/docs/Web/CSS/Reference/At-rules/@container#container_style_queries
+  - https://developer.chrome.com/docs/css-ui/style-queries 
 ---
+
+## Background & Overview
+
+Often an author will need to make contextual changes to the design of a component. Historically authors would need to use selectors to apply such changes. This often meant that while many of their design tokens could exist as custom properties, higher-order design tokens could only be encoded as a selector pattern (i.e. using a class name or attribute convention) or as props/context in a JavaScript framework.
+
+**Container style queries** allow authors to style elements based on the computed custom property value of an ancestor element. This means authors can write meaningful design token values within their stylesheets rather than relying on markup or JavaScript for presentation.
+
+## How to implement
+
+Implementing a reactive design token using a container style query is quite straightforward:
+
+1. Set the higher-order design token as a custom property on a container. This does not need to be a registered custom property.
+2. Use the `@container style()` rule to query the value of that custom property.
+3. Apply the appropriate styles to a descendant element within the container.
+
+A few things to keep in mind:
+
+- The container being queried with a style query does not need to have a `container-type` or `container-name` set, however, a `container-name` can allow for more specific querying.
+- The container itself cannot be styled by the container style query.
+
+The following is a basic example of the above implementation steps.
+
+```html
+<div class="features">
+  <div class="card"></div>
+  <div class="card"></div>
+</div>
+<div class="bugs">
+  <div class="card"></div>
+  <div class="card"></div>
+  <div class="card"></div>
+  <div class="card"></div>
+</div>
+```
+
+```css
+.features {
+  --density: spacious;
+}
+
+.bugs {
+  --density: compact;
+}
+
+@container style(--density: compact) {
+  .card {
+    padding: 8px;
+  }
+}
+
+@container style(--density: spacious) {
+  .card {
+    padding: 24px;
+  }
+}
+```
+
+## Fallback strategies
+
+{{ BASELINE_STATUS("container-style-queries") }}
+
+Until there is Baseline support for container style queries it is NOT RECOMMENDED that they be used for core features that must be available across all browsers, since it is not simple to create a fallback for them that does not take away from their benefits or that have their own limitations. For example, if a UI density user preference is not deemed to be a core feature that must be available across all experiences, then container style queries can be use to implement the feature without a fallback.
+
+### Using selectors instead
+
+For core features, an alternate approach using selectors should be used. This example uses a `data-density` attribute to encode the density design token in the markup rather than as a custom property:
+
+```html
+<div class="features" data-density="spacious">
+  <div class="card"></div>
+  <div class="card"></div>
+</div>
+<div class="bugs" data-density="compact">
+  <div class="card"></div>
+  <div class="card"></div>
+  <div class="card"></div>
+  <div class="card"></div>
+</div>
+```
+
+```css
+/* This example uses `:where()` to avoid increasing specificity */
+:where([data-density="compact"]) .card {
+  padding: var(--card-padding-compact);
+}
+
+:where([data-density="spacious"]) .card {
+  padding: var(--card-padding-spacious);
+}
+```
+
+While it’s NOT RECOMMENDED, if you want to use style queries as a progressive enhancement for a core feature, then to avoid duplication you can create some custom properties, then include the style queries after. Make sure the fallback approach uses `:where()` when selecting the container elements to avoid increasing the specificity.
+
+```css
+.card {
+  --card-padding-compact: 8px;
+  --card-padding-spacious: 24px;
+}
+
+:where([data-density="compact"]) .card {
+  padding: var(--card-padding-compact);
+}
+
+:where([data-density="spacious"]) .card {
+  padding: var(--card-padding-spacious);
+}
+
+/* Use style queries as a progressive enhancement: same specificity, so order of appearance is used */
+
+@container style(--density: compact) {
+  .card {
+    padding: var(--card-padding-compact);
+  }
+}
+
+@container style(--density: spacious) {
+  .card {
+    padding: var(--card-padding-spacious);
+  }
+}
+```
+
+One limitation of this approach is that it does not support nesting elements with the `data-density` attribute set as order of appearance will be used to determine the styles (i.e. `[data-density="spacious"]` will always take precendence over `[data-density="compact"]`). If your browser support permits it, you can use `@scope` to apply the styles using proximity instead of order of appearance.
+
+{{ BASELINE_STATUS("scope") }}
+
+When using this approach, to ensure the style queries are used instead of the fallback, you’ll need to wrap them with a `@scope` rule that has equal or stronger proximity:
+
+```css
+@scope ([data-density="compact"]) {
+  .card {
+    padding: var(--card-padding-compact);
+  }
+}
+
+@scope ([data-density="spacious"]) {
+  .card {
+    padding: var(--card-padding-spacious);
+  }
+}
+
+/* A direct parent selector using `:has()` will have equal or stronger proximity, causing the style queries to be used when supported */
+@scope (:has(> .card)) {
+  @container style(--density: compact) {
+    .card {
+      padding: var(--card-padding-compact);
+    }
+  }
+
+  @container style(--density: spacious) {
+    .card {
+      padding: var(--card-padding-spacious);
+    }
+  }
+}
+```
+
+If you need wider support you can use this approach as a progressive enhancement for the prior approach that does not use `@scope`.
+
+### Feature-checking with just CSS
+
+If you need to feature check container style queries to conditionally display some UI that relies on it, you can use a style query to do so:
+
+```css
+:root {
+  --style-queries-supported: check;
+}
+
+.density-toggle {
+  display: none;
+}
+
+@container style(--style-queries-supported) {
+  .density-toggle {
+    display: revert;
+  }
+}
+```
+
+### Feature-checking with JavaScript
+
+For feature-checking with JavaScript, it is slightly more complicated as the `CSSContainerRule` interface existed prior to the addition of container style queries, so it is unreliable for this purpose. Instead, you’ll need to check the computed value of a known property that is being set with a style query.
+
+This example uses a custom property as it will have no visual effect:
+
+```css
+:root {
+  --style-queries-supported: check;
+}
+
+@container style(--style-queries-supported: check) {
+  body {
+    --style-queries-supported: yes;
+  }
+}
+```
+
+Then check the computed value in JavaScript like this:
+
+```js
+if (getComputedStyle(document.body).getPropertyValue("--style-queries-supported") === "yes") {
+  // Use container style queries
+} else {
+  // Use fallback strategy
+}
+```

--- a/guides/user-experience/design-token-reactivity/guide.md
+++ b/guides/user-experience/design-token-reactivity/guide.md
@@ -3,9 +3,6 @@ name: design-token-reactivity
 description: Define higher-order design tokens, like density modes (compact, comfortable, spacious) or themes and have descendant components react to changes directly and in component-appropriate ways.
 web-feature-ids:
   - container-style-queries
-sources:
-  - https://developer.mozilla.org/docs/Web/CSS/Reference/At-rules/@container#container_style_queries
-  - https://developer.chrome.com/docs/css-ui/style-queries
 ---
 
 ## Background & Overview

--- a/guides/user-experience/design-token-reactivity/guide.md
+++ b/guides/user-experience/design-token-reactivity/guide.md
@@ -5,7 +5,7 @@ web-feature-ids:
   - container-style-queries
 sources:
   - https://developer.mozilla.org/docs/Web/CSS/Reference/At-rules/@container#container_style_queries
-  - https://developer.chrome.com/docs/css-ui/style-queries 
+  - https://developer.chrome.com/docs/css-ui/style-queries
 ---
 
 ## Background & Overview
@@ -98,6 +98,10 @@ For core features, an alternate approach using selectors should be used. This ex
 }
 ```
 
+A major limitation of this fallback approach is that it does not support nesting elements with the `data-density` attribute set, since the selector specificity is the same, order of appearance will be used to determine the styles (i.e. `[data-density="spacious"]` will always take precendence over `[data-density="compact"]`).
+
+### Using style queries as a progressive enhancement
+
 While it’s NOT RECOMMENDED, if you want to use style queries as a progressive enhancement for a core feature, then to avoid duplication you can create some custom properties, then include the style queries after. Make sure the fallback approach uses `:where()` when selecting the container elements to avoid increasing the specificity.
 
 ```css
@@ -128,43 +132,6 @@ While it’s NOT RECOMMENDED, if you want to use style queries as a progressive 
   }
 }
 ```
-
-One limitation of this approach is that it does not support nesting elements with the `data-density` attribute set as order of appearance will be used to determine the styles (i.e. `[data-density="spacious"]` will always take precendence over `[data-density="compact"]`). If your browser support permits it, you can use `@scope` to apply the styles using proximity instead of order of appearance.
-
-{{ BASELINE_STATUS("scope") }}
-
-When using this approach, to ensure the style queries are used instead of the fallback, you’ll need to wrap them with a `@scope` rule that has equal or stronger proximity:
-
-```css
-@scope ([data-density="compact"]) {
-  .card {
-    padding: var(--card-padding-compact);
-  }
-}
-
-@scope ([data-density="spacious"]) {
-  .card {
-    padding: var(--card-padding-spacious);
-  }
-}
-
-/* A direct parent selector using `:has()` will have equal or stronger proximity, causing the style queries to be used when supported */
-@scope (:has(> .card)) {
-  @container style(--density: compact) {
-    .card {
-      padding: var(--card-padding-compact);
-    }
-  }
-
-  @container style(--density: spacious) {
-    .card {
-      padding: var(--card-padding-spacious);
-    }
-  }
-}
-```
-
-If you need wider support you can use this approach as a progressive enhancement for the prior approach that does not use `@scope`.
 
 ### Feature-checking with just CSS
 
@@ -213,3 +180,4 @@ if (getComputedStyle(document.body).getPropertyValue("--style-queries-supported"
   // Use fallback strategy
 }
 ```
+


### PR DESCRIPTION
Resolves #163 

My recommended guidance is to not use container style queries for core/baseline experiences and to use it for feature that are a progressive enhancement instead (e.g. a UI density use preference that does not need to be a part of every cross-browser experience). I have included how to implement it as a progressive enhancement in the guide as well as how to create an adequate fallback experience. I only updated the demo to hide the toggle when style queries are not supported.

A challenge with this feature is that it’s not super clean to create a fallback for and, as explained in the guide, using a fallback defeats a lot of the purpose of using the feature (i.e. style queries help with maintainability and separation of concerns, but a fallback undermines that).