### PR TITLE
fix: allow test-fixture to proceed if package.json exists

### DIFF
--- a/guides/test-fixture.ts
+++ b/guides/test-fixture.ts
@@ -29,13 +29,13 @@ export const test = base.extend<{}, ServerWorkerFixtures>({
       throw new Error('TARGET_FILE environment variable not set.');
     }
     
-    if (!fs.existsSync(targetFile)) {
-      throw new Error(`Target file not found: ${targetFile}`);
-    }
-    
     const targetDir = path.dirname(targetFile);
     const pkgJsonPath = path.join(targetDir, 'package.json');
     const demoName = path.basename(targetFile);
+
+    if (!fs.existsSync(pkgJsonPath) && !fs.existsSync(targetFile)) {
+      throw new Error(`Target file not found: ${targetFile}`);
+    }
 
     console.log(`[TEST-FIXTURE] targetFile: ${targetFile}`);
     console.log(`[TEST-FIXTURE] targetDir: ${targetDir}`);


### PR DESCRIPTION
This issue was masked by the `--frozen-lockfile` flag. For the base app `devtools-times`, `index.html` is not generated until `pnpm build`. This commit relaxes the check so that if a `package.json` is present, the test harness will proceed to build the app rather than crashing immediately. 

Tested with both `gd eval guides/forms/autofill-sign-in-form/tasks/task.md` and `gd eval` on my side.