### PR TITLE
Resolve temporal polyfill implementation in guides & demos

### DIFF
--- a/guides/user-experience/calculate-event-differentials/demo.html
+++ b/guides/user-experience/calculate-event-differentials/demo.html
@@ -290,23 +290,26 @@
     const statusValue = document.getElementById('statusValue');
     const unsupportedBanner = document.getElementById('unsupportedBanner');
 
-    // Check Support and load polyfill if needed
-    if (typeof Temporal === 'undefined') {
-      import('https://unpkg.com/@js-temporal/polyfill').then(({ Temporal: polyfill }) => {
-        globalThis.Temporal = polyfill;
+      (async () => {
+      // Check Support and load polyfill if needed
+      if (typeof Temporal === 'undefined') {
+        try {
+          const module = await import("https://esm.sh/@js-temporal/polyfill");
+          globalThis.Temporal = module.Temporal;
+          initializeDemo();
+        } catch (e) {
+          console.error("Failed to load Temporal polyfill:", e);
+          unsupportedBanner.style.display = 'flex';
+          unsupportedBanner.querySelector('div:last-child').textContent = 'Failed to load Temporal polyfill. Some features may be disabled.';
+          startDateInput.disabled = true;
+          startTimeInput.disabled = true;
+          endDateInput.disabled = true;
+          endTimeInput.disabled = true;
+        }
+      } else {
         initializeDemo();
-      }).catch(err => {
-        console.error('Failed to load Temporal polyfill:', err);
-        unsupportedBanner.style.display = 'flex';
-        unsupportedBanner.querySelector('div:last-child').textContent = 'Failed to load Temporal polyfill. Some features may be disabled.';
-        startDateInput.disabled = true;
-        startTimeInput.disabled = true;
-        endDateInput.disabled = true;
-        endTimeInput.disabled = true;
-      });
-    } else {
-      initializeDemo();
-    }
+      }
+    })();
 
     function initializeDemo() {
       const now = Temporal.Now.zonedDateTimeISO();

--- a/guides/user-experience/calculate-event-differentials/guide.md
+++ b/guides/user-experience/calculate-event-differentials/guide.md
@@ -75,19 +75,16 @@ For browsers that do not yet support the native `Temporal` API, use feature dete
 
 ```javascript
 // Check if Temporal is supported natively
-if (typeof Temporal === 'undefined') {
-  // Load the polyfill conditionally
-  import('@js-temporal/polyfill').then(({ Temporal: TemporalPolyfill, toTemporalInstant }) => {
-    // Manually assign to global scope if your app code uses the global 'Temporal'
-    globalThis.Temporal = TemporalPolyfill;
+(async () => {
+  if (typeof Temporal === 'undefined') {
+    // Load the polyfill conditionally
+    const module = await import("https://esm.sh/@js-temporal/polyfill");
+    globalThis.Temporal = module.Temporal;
     // Extend Date.prototype if needed
-    Date.prototype.toTemporalInstant = toTemporalInstant;
+    Date.prototype.toTemporalInstant = module.toTemporalInstant;
     initializeApp();
-  });
-} else {
-  // Native Temporal is available
-  initializeApp();
-}
+  }
+})();
 
 function initializeApp() {
   const now = Temporal.Now.zonedDateTimeISO();

--- a/guides/user-experience/capture-location-agnostic-data/demo.html
+++ b/guides/user-experience/capture-location-agnostic-data/demo.html
@@ -315,24 +315,25 @@
     const unsupportedBanner = document.getElementById('unsupportedBanner');
 
     // Check Support
-    if (typeof Temporal === 'undefined') {
-      // Load the polyfill conditionally as defined in guide.md
-      // Note: In a non-bundled browser environment, you may need to use a CDN URL like 'https://esm.sh/@js-temporal/polyfill'
-      import('@js-temporal/polyfill').then(({ Temporal: TemporalPolyfill, toTemporalInstant }) => {
+      (async () => {
+      if (typeof Temporal === 'undefined') {
+        try {
+          const module = await import('https://esm.sh/@js-temporal/polyfill');
         // Manually assign to global scope if needed
-        globalThis.Temporal = TemporalPolyfill;
-        // Extend Date.prototype as recommended by polyfill docs
-        Date.prototype.toTemporalInstant = toTemporalInstant;
+          globalThis.Temporal = module.Temporal;
+          // Extend Date.prototype as recommended by polyfill docs
+          Date.prototype.toTemporalInstant = module.toTemporalInstant;
+          initializeDemo();
+        } catch (err) {
+          console.error("Failed to load polyfill:", err);
+          unsupportedBanner.style.display = 'flex';
+          birthdateInput.disabled = true;
+          timezoneSelect.disabled = true;
+        }
+      } else {
         initializeDemo();
-      }).catch(err => {
-        console.error("Failed to load polyfill:", err);
-        unsupportedBanner.style.display = 'flex';
-        birthdateInput.disabled = true;
-        timezoneSelect.disabled = true;
-      });
-    } else {
-      initializeDemo();
-    }
+      }
+        })(); 
 
     function initializeDemo() {
       // Event Listeners

--- a/guides/user-experience/capture-location-agnostic-data/guide.md
+++ b/guides/user-experience/capture-location-agnostic-data/guide.md
@@ -56,19 +56,16 @@ Note that the polyfill does not automatically assign the `Temporal` object to th
 
 ```javascript
 // Check if Temporal is supported natively
-if (typeof Temporal === 'undefined') {
-  // Load the polyfill conditionally (example using dynamic import)
-  import('@js-temporal/polyfill').then(({ Temporal: TemporalPolyfill, toTemporalInstant }) => {
-    // Manually assign to global scope if needed
-    globalThis.Temporal = TemporalPolyfill;
-    // Extend Date.prototype as recommended by polyfill docs
-    Date.prototype.toTemporalInstant = toTemporalInstant;
+(async () => {
+  if (typeof Temporal === 'undefined') {
+    // Load the polyfill conditionally
+    const module = await import("https://esm.sh/@js-temporal/polyfill");
+    globalThis.Temporal = module.Temporal;
+    // Extend Date.prototype if needed
+    Date.prototype.toTemporalInstant = module.toTemporalInstant;
     initializeApp();
-  });
-} else {
-  // Native Temporal is available
-  initializeApp();
-}
+  }
+})();
 
 function initializeApp() {
   const plainDate = Temporal.PlainDate.from("1990-01-01");

--- a/guides/user-experience/coordinate-global-events/demo.html
+++ b/guides/user-experience/coordinate-global-events/demo.html
@@ -316,21 +316,24 @@
       { zone: 'UTC', name: 'UTC', flag: '🌐' }
     ];
 
-    // Check Support
-    if (typeof Temporal === 'undefined') {
-      import('@js-temporal/polyfill').then(({ Temporal: TemporalPolyfill }) => {
-        globalThis.Temporal = TemporalPolyfill;
+    (async () => {
+      // Check Support and load polyfill if needed
+      if (typeof Temporal === 'undefined') {
+        try {
+          const module = await import("https://esm.sh/@js-temporal/polyfill");
+          globalThis.Temporal = module.Temporal;
+          initializeDemo();
+        } catch (e) {
+          console.error("Failed to load Temporal polyfill:", e);
+          unsupportedBanner.style.display = 'flex';
+          dateInput.disabled = true;
+          timeInput.disabled = true;
+          hostTzSelect.disabled = true;
+        }
+      } else {
         initializeDemo();
-      }).catch(err => {
-        console.error("Failed to load Temporal polyfill:", err);
-        unsupportedBanner.style.display = 'flex';
-        dateInput.disabled = true;
-        timeInput.disabled = true;
-        hostTzSelect.disabled = true;
-      });
-    } else {
-      initializeDemo();
-    }
+      }
+    })();
 
     function initializeDemo() {
       [dateInput, timeInput, hostTzSelect].forEach(el => {

--- a/guides/user-experience/coordinate-global-events/guide.md
+++ b/guides/user-experience/coordinate-global-events/guide.md
@@ -69,23 +69,16 @@ For environments without native `Temporal` support, you must conditionally load 
 
 ```javascript
 // Check if Temporal is supported natively
-if (typeof Temporal === 'undefined') {
-  // Load the polyfill conditionally
-  import('@js-temporal/polyfill').then(({ Temporal: TemporalPolyfill, toTemporalInstant }) => {
-    // Manually assign to global scope if your app code uses the global 'Temporal'
-    globalThis.Temporal = TemporalPolyfill;
-    
-    // Extend Date.prototype if needed for interoperability
-    if (toTemporalInstant) {
-      Date.prototype.toTemporalInstant = toTemporalInstant;
-    }
-    
+(async () => {
+  if (typeof Temporal === 'undefined') {
+    // Load the polyfill conditionally
+    const module = await import("https://esm.sh/@js-temporal/polyfill");
+    globalThis.Temporal = module.Temporal;
+    // Extend Date.prototype if needed
+    Date.prototype.toTemporalInstant = module.toTemporalInstant;
     initializeApp();
-  });
-} else {
-  // Native Temporal is available
-  initializeApp();
-}
+  }
+})();
 
 function initializeApp() {
   // Your app logic here

--- a/guides/user-experience/format-human-readable-durations/demo.html
+++ b/guides/user-experience/format-human-readable-durations/demo.html
@@ -286,20 +286,23 @@
     const codeSnippet = document.getElementById('codeSnippet');
     const unsupportedBanner = document.getElementById('unsupportedBanner');
 
-    // Check Support
-    if (typeof Temporal === 'undefined') {
-      import('@js-temporal/polyfill').then(({ Temporal: TemporalPolyfill }) => {
-        globalThis.Temporal = TemporalPolyfill;
+    (async () => {
+      // Check Support and load polyfill if needed
+      if (typeof Temporal === 'undefined') {
+        try {
+          const module = await import("https://esm.sh/@js-temporal/polyfill");
+          globalThis.Temporal = module.Temporal;
+          initializeDemo();
+        } catch (e) {
+          console.error("Failed to load Temporal polyfill:", e);
+          unsupportedBanner.style.display = 'flex';
+          [hoursInput, minutesInput, secondsInput].forEach(el => el.disabled = true);
+          radioButtons.forEach(el => el.disabled = true);
+        }
+      } else {
         initializeDemo();
-      }).catch(err => {
-        console.error('Failed to load Temporal polyfill:', err);
-        unsupportedBanner.style.display = 'flex';
-        [hoursInput, minutesInput, secondsInput].forEach(el => el.disabled = true);
-        radioButtons.forEach(el => el.disabled = true);
-      });
-    } else {
-      initializeDemo();
-    }
+      }
+    })();
 
     function initializeDemo() {
       const inputs = [hoursInput, minutesInput, secondsInput];

--- a/guides/user-experience/format-human-readable-durations/guide.md
+++ b/guides/user-experience/format-human-readable-durations/guide.md
@@ -53,16 +53,16 @@ For environments without native `Temporal` support, you must conditionally load 
 
 ```javascript
 // Check if Temporal is supported natively
-if (typeof Temporal === 'undefined') {
-  // Load the polyfill conditionally
-  import('@js-temporal/polyfill').then(({ Temporal: TemporalPolyfill }) => {
-    // Assign to global scope if your app code uses the global 'Temporal'
-    globalThis.Temporal = TemporalPolyfill;
+(async () => {
+  if (typeof Temporal === 'undefined') {
+    // Load the polyfill conditionally
+    const module = await import("https://esm.sh/@js-temporal/polyfill");
+    globalThis.Temporal = module.Temporal;
+    // Extend Date.prototype if needed
+    Date.prototype.toTemporalInstant = module.toTemporalInstant;
     initializeApp();
-  });
-} else {
-  initializeApp();
-}
+  }
+})();
 
 function initializeApp() {
   // App logic here

--- a/guides/user-experience/manage-recurring-intervals/demo.html
+++ b/guides/user-experience/manage-recurring-intervals/demo.html
@@ -250,22 +250,23 @@
       updateCalculation();
     }
 
+    (async () => {
+      // Check Support and load polyfill if needed
       if (typeof Temporal === 'undefined') {
-        unsupportedBanner.style.display = 'flex';
-        unsupportedBanner.innerHTML = '<div>⏳ Loading Temporal polyfill...</div>';
-
-        import('@js-temporal/polyfill').then(({ Temporal: TemporalPolyfill }) => {
-          globalThis.Temporal = TemporalPolyfill;
-          unsupportedBanner.style.display = 'none';
+        try {
+          const module = await import("https://esm.sh/@js-temporal/polyfill");
+          globalThis.Temporal = module.Temporal;
           initializeApp();
-        }).catch(err => {
-          console.error("Failed to load polyfill", err);
+        } catch (e) {
+          console.error("Failed to load Temporal polyfill:", e);
+          unsupportedBanner.style.display = 'flex';
           unsupportedBanner.innerHTML = '<div>🚫 Failed to load polyfill. This demo requires a browser with native Temporal support or internet access.</div>';
           inputs.forEach(el => el.disabled = true);
-        });
+        }
       } else {
         initializeApp();
       }
+    })();
 
     function updateCalculation() {
       const startDateStr = startDateInput.value;

--- a/guides/user-experience/manage-recurring-intervals/guide.md
+++ b/guides/user-experience/manage-recurring-intervals/guide.md
@@ -63,15 +63,16 @@ For browsers that do not yet support the native `Temporal` API, use feature dete
 
 ```javascript
 // Check if Temporal is supported natively
-if (typeof Temporal === 'undefined') {
-  // Load the polyfill conditionally
-  import('@js-temporal/polyfill').then(({ Temporal: TemporalPolyfill }) => {
-    globalThis.Temporal = TemporalPolyfill;
+(async () => {
+  if (typeof Temporal === 'undefined') {
+    // Load the polyfill conditionally
+    const module = await import("https://esm.sh/@js-temporal/polyfill");
+    globalThis.Temporal = module.Temporal;
+    // Extend Date.prototype if needed
+    Date.prototype.toTemporalInstant = module.toTemporalInstant;
     initializeApp();
-  });
-} else {
-  initializeApp();
-}
+  }
+})();
 
 function initializeApp() {
   const date = Temporal.PlainDate.from('2024-01-31');

--- a/guides/user-experience/model-partial-time-concepts/demo.html
+++ b/guides/user-experience/model-partial-time-concepts/demo.html
@@ -245,20 +245,24 @@
     const unsupportedWarning = document.getElementById('unsupported-warning');
 
     // Check Support and load polyfill if needed
-    if (typeof Temporal === 'undefined') {
-      import('@js-temporal/polyfill').then(({ Temporal: polyfill }) => {
-        globalThis.Temporal = polyfill;
+    (async () => {
+      // Check Support and load polyfill if needed
+      if (typeof Temporal === 'undefined') {
+        try {
+          const module = await import("https://esm.sh/@js-temporal/polyfill");
+          globalThis.Temporal = module.Temporal;
+          unsupportedWarning.style.display = 'none';
+          initializeDemo();
+        } catch (e) {
+          console.error("Failed to load Temporal polyfill:", e);
+          unsupportedWarning.textContent = '🚫 Failed to load Temporal polyfill. Demo may not function.';
+          document.querySelectorAll('button').forEach(b => b.disabled = true);
+        }
+      } else {
         unsupportedWarning.style.display = 'none';
         initializeDemo();
-      }).catch(err => {
-        console.error('Failed to load Temporal polyfill:', err);
-        unsupportedWarning.textContent = '🚫 Failed to load Temporal polyfill. Demo may not function.';
-        document.querySelectorAll('button').forEach(b => b.disabled = true);
-      });
-    } else {
-      unsupportedWarning.style.display = 'none';
-      initializeDemo();
-    }
+      }
+    })();
 
     function initializeDemo() {
       // Run initial calculation

--- a/guides/user-experience/model-partial-time-concepts/guide.md
+++ b/guides/user-experience/model-partial-time-concepts/guide.md
@@ -85,21 +85,17 @@ console.log(`Snoozed alarm: ${snoozedTime.toString()}`);
 For environments without native `Temporal` support, use feature detection and load the `@js-temporal/polyfill`.
 
 ```javascript
-// Feature detect Temporal support
-if (typeof Temporal === 'undefined') {
-  // Conditionally load the polyfill
-  import('@js-temporal/polyfill').then(({ Temporal: TemporalPolyfill, toTemporalInstant }) => {
-    // Assign to global scope if application code expects global Temporal
-    globalThis.Temporal = TemporalPolyfill;
-    // Extend Date.prototype if needed for legacy interop
-    if (toTemporalInstant) {
-      Date.prototype.toTemporalInstant = toTemporalInstant;
-    }
+// Check if Temporal is supported natively
+(async () => {
+  if (typeof Temporal === 'undefined') {
+    // Load the polyfill conditionally
+    const module = await import("https://esm.sh/@js-temporal/polyfill");
+    globalThis.Temporal = module.Temporal;
+    // Extend Date.prototype if needed
+    Date.prototype.toTemporalInstant = module.toTemporalInstant;
     initializeApp();
-  });
-} else {
-  initializeApp();
-}
+  }
+})();
 
 function initializeApp() {
   // Application logic using Temporal


### PR DESCRIPTION
Fixes and updates use cases to use `https://esm.sh/@js-temporal/polyfill` as main temporal polyfill fallback.

Mentioned: [feat/temporal-use-cases-guides-8](https://github.com/GoogleChrome/guidance/pull/554)