### PR TITLE
Add markdown check & fix conflicts

### DIFF
--- a/guides/guides-integrity.test.ts
+++ b/guides/guides-integrity.test.ts
@@ -1,6 +1,9 @@
 import test, { describe, it } from 'node:test';
 import assert from 'node:assert';
 import path from 'node:path';
+import fs from 'node:fs';
+import matter from 'gray-matter';
+import { marked } from 'marked';
 
 // Import shared utilities
 import { scanAllGuides, processGuideInventory } from '../lib/guide-validation.ts';
@@ -25,6 +28,36 @@ describe('Guides Validation (Single Source of Truth)', () => {
       
       if (result.hasError) {
         assert.fail(`Validation errors found in ${relativeDir}:\n${result.errors.join('\n')}`);
+      }
+    });
+
+    it(`validates markdown soundness for ${relativeDir}`, () => {
+      const guidePath = path.join(guide.dir, 'guide.md');
+      if (!fs.existsSync(guidePath)) return;
+
+      const content = fs.readFileSync(guidePath, 'utf8');
+
+      // 1. Check frontmatter with gray-matter
+      try {
+        const { data } = matter(content);
+        assert.ok(data, 'Frontmatter should be parsable');
+      } catch (e) {
+        assert.fail(`Frontmatter parsing failed: ${e}`);
+      }
+
+      // 2. Check for unclosed code blocks (fence count)
+      const lines = content.split('\n');
+      const fenceLines = lines.filter(line => line.trim().startsWith('```'));
+      if (fenceLines.length % 2 !== 0) {
+        assert.fail(`Odd number of code block fences (\`\`\`) in ${relativeDir}. Likely an unclosed code block.`);
+      }
+
+      // 3. Check with marked
+      try {
+        const tokens = marked.lexer(content);
+        assert.ok(tokens.length > 0, 'Marked should produce tokens');
+      } catch (e) {
+        assert.fail(`Marked parsing failed: ${e}`);
       }
     });
   }

--- a/guides/guides-integrity.test.ts
+++ b/guides/guides-integrity.test.ts
@@ -63,6 +63,14 @@ describe('Guides Validation (Single Source of Truth)', () => {
       } catch (e) {
         assert.fail(`Marked parsing failed: ${e}`);
       }
+
+      // 4. Check for git conflict markers
+      const conflictMarkers = ['<<<<<<<', '=======', '>>>>>>>'];
+      for (const marker of conflictMarkers) {
+        if (content.includes(marker)) {
+          assert.fail(`File contains git conflict marker "${marker}" in ${relativeDir}`);
+        }
+      }
     });
   }
 });

--- a/guides/guides-integrity.test.ts
+++ b/guides/guides-integrity.test.ts
@@ -46,6 +46,10 @@ describe('Guides Validation (Single Source of Truth)', () => {
       }
 
       // 2. Check for unclosed code blocks (fence count)
+      // Note: We use a simple fence count check because standard parsers like marked
+      // silently consume unclosed blocks to the end of the file. Since many guides
+      // legitimately end with a code block, checking if the last token is a code block
+      // yields too many false positives. Linters are also too noisy with style rules.
       const lines = content.split('\n');
       const fenceLines = lines.filter(line => line.trim().startsWith('```'));
       if (fenceLines.length % 2 !== 0) {

--- a/guides/package.json
+++ b/guides/package.json
@@ -10,6 +10,7 @@
     "@octokit/rest": "^22.0.1",
     "@playwright/test": "^1.58.2",
     "gray-matter": "^4.0.3",
+    "marked": "^17.0.4",
     "web-features": "latest"
   }
 }

--- a/guides/user-experience/declarative-button-actions/guide.md
+++ b/guides/user-experience/declarative-button-actions/guide.md
@@ -12,16 +12,11 @@ sources:
   - https://londonwebstandards.org/talks/everything-you-need-to-know-about-invoker-commands/
 ---
 
-<<<<<<< Updated upstream
 # Declarative Button Actions
-
-=======
->>>>>>> Stashed changes
 The Invoker Commands API allows buttons to trigger actions on target elements declaratively using HTML attributes. This approach reduces the need for manual event listeners and ensures interactivity as soon as the HTML is parsed.
 
 For custom, application-specific actions, you can define your own command names. Custom commands must be prefixed with a double dash (`--`) to avoid collisions with future built-in browser commands.
 
-<<<<<<< Updated upstream
 ## Implementation steps
 
 1.  **Define the target element**: Identify the element that will respond to the action. It must have a unique `id`.
@@ -29,15 +24,6 @@ For custom, application-specific actions, you can define your own command names.
 3.  **Handle the command event**: Attach a `command` event listener to the `document` (or a common parent). This ensures that the event is captured even if it is dispatched by a polyfill or from a child element. The event object contains a `command` property and a `target` property (referring to the element identified by `commandfor`).
 
 ## Example: Custom Animation Controls
-=======
-### Implementation steps
-
-1.  **Define the target element**: Identify the element that will respond to the action. It must have a unique `id`.
-2.  **Configure the invoker button**: Use the `commandfor` attribute to point to the target's `id`, and the `command` attribute to specify the custom command name (prefixed with `--`).
-3.  **Handle the command event**: Attach a `command` event listener to the target element. The event object contains a `command` property matching the value defined in HTML.
-
-### Example: Custom Animation Controls
->>>>>>> Stashed changes
 
 ```html
 <!-- The target element that will respond to custom commands -->
@@ -60,7 +46,6 @@ For custom, application-specific actions, you can define your own command names.
 </button>
 
 <script>
-<<<<<<< Updated upstream
   // Listen for the 'command' event globally (or on a stable parent)
   document.addEventListener('command', (event) => {
     // Robustly handle both native API and manual/polyfill fallbacks
@@ -76,18 +61,6 @@ For custom, application-specific actions, you can define your own command names.
     } else if (command === '--grow') {
       target.classList.toggle('is-grown');
     } else if (command === '--reset') {
-=======
-  const target = document.getElementById('action-target');
-
-  // Logic is centralized on the target element using the 'command' event
-  target.addEventListener('command', (event) => {
-    // Custom commands are checked to identify the requested action
-    if (event.command === '--spin') {
-      target.classList.toggle('is-spun');
-    } else if (event.command === '--grow') {
-      target.classList.toggle('is-grown');
-    } else if (event.command === '--reset') {
->>>>>>> Stashed changes
       // Clear all custom classes to return to initial state
       target.classList.remove('is-spun', 'is-grown');
     }
@@ -95,7 +68,6 @@ For custom, application-specific actions, you can define your own command names.
 </script>
 ```
 
-<<<<<<< Updated upstream
 ## Key constraints
 
 *   **Prefix custom commands**: MANDATORY: All custom command names must start with `--` (e.g., `command="--my-action"`).
@@ -170,51 +142,4 @@ document.addEventListener('command', (event) => {
     action(target);
   }
 });
-=======
-
-### Key constraints
-
-*   **Prefix custom commands**: MANDATORY: All custom command names must start with `--` (e.g., `command="--my-action"`).
-*   **Targeting**: The `commandfor` attribute must match the `id` of an element in the same document tree.
-*   **Button types**: Only `<button>` and `<input type="button">` (or `type="submit"`) can act as invokers.
-
-### Fallback strategies
-
-{{ BASELINE_STATUS("invoker-commands") }}
-
-If the Invoker Commands API is not supported, the `command` event will not fire. You should detect support and fall back to traditional click event listeners.
-
-```javascript
-// Feature detection: check if HTMLButtonElement supports commandfor
-const supportsInvokers = 'commandForElement' in HTMLButtonElement.prototype;
-
-if (!supportsInvokers) {
-  // Manual fallback for browsers without Invoker support
-  const invokers = document.querySelectorAll('button[commandfor]');
-  
-  invokers.forEach(button => {
-    button.addEventListener('click', () => {
-      const targetId = button.getAttribute('commandfor');
-      const command = button.getAttribute('command');
-      const target = document.getElementById(targetId);
-      
-      if (target) {
-        // Manually dispatch a custom event or call the handler directly
-        target.dispatchEvent(new CustomEvent('command', {
-          detail: { command }, // Note: native event uses .command, not .detail.command
-          bubbles: true
-        }));
-      }
-    });
-  });
-  
-  // Adjust handler to support both native and fallback event structures
-  target.addEventListener('command', (event) => {
-    const commandName = event.command || (event.detail && event.detail.command);
-    if (commandName === '--spin') {
-      // ... logic
-    }
-  });
-}
->>>>>>> Stashed changes
 ```

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
+      marked:
+        specifier: ^17.0.4
+        version: 17.0.4
       web-features:
         specifier: latest
         version: 3.22.1
@@ -79,7 +82,7 @@ importers:
         version: 2.1.76
       '@anthropic-ai/vertex-sdk':
         specifier: ^0.14.4
-        version: 0.14.4(encoding@0.1.13)(zod@4.3.6)
+        version: 0.14.4(encoding@0.1.13)(zod@3.25.76)
       '@google-cloud/storage':
         specifier: ^7.19.0
         version: 7.19.0(encoding@0.1.13)
@@ -3409,15 +3412,15 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
 
-  '@anthropic-ai/sdk@0.78.0(zod@4.3.6)':
+  '@anthropic-ai/sdk@0.78.0(zod@3.25.76)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
-      zod: 4.3.6
+      zod: 3.25.76
 
-  '@anthropic-ai/vertex-sdk@0.14.4(encoding@0.1.13)(zod@4.3.6)':
+  '@anthropic-ai/vertex-sdk@0.14.4(encoding@0.1.13)(zod@3.25.76)':
     dependencies:
-      '@anthropic-ai/sdk': 0.78.0(zod@4.3.6)
+      '@anthropic-ai/sdk': 0.78.0(zod@3.25.76)
       google-auth-library: 9.15.1(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
@@ -3637,7 +3640,7 @@ snapshots:
       '@grpc/grpc-js': 1.14.3
       '@iarna/toml': 2.2.5
       '@joshua.litt/get-ripgrep': 0.0.3
-      '@modelcontextprotocol/sdk': 1.27.1(zod@4.3.6)
+      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/api-logs': 0.211.0
       '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
@@ -3734,7 +3737,7 @@ snapshots:
       google-auth-library: 10.6.1
       ws: 8.19.0
     optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.27.1(zod@4.3.6)
+      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -3939,6 +3942,28 @@ snapshots:
       '@lydell/node-pty-win32-x64': 1.1.0
     optional: true
 
+  '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.9(hono@4.12.2)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.6
+      express: 5.2.1
+      express-rate-limit: 8.2.1(express@5.2.1)
+      hono: 4.12.2
+      jose: 6.1.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+
   '@modelcontextprotocol/sdk@1.27.1(zod@4.3.6)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.12.2)
@@ -3957,7 +3982,7 @@ snapshots:
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
       zod: 4.3.6
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
+      zod-to-json-schema: 3.25.1(zod@4.3.6)
     transitivePeerDependencies:
       - supports-color
 
@@ -6835,6 +6860,10 @@ snapshots:
   zod-to-json-schema@3.25.1(zod@3.25.76):
     dependencies:
       zod: 3.25.76
+
+  zod-to-json-schema@3.25.1(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
Added a test to make sure our markdown is sound 

- catches unclosed code blocks
- catches git conflict markers
- ensures it lexes with `marked`.

Also fixed conflicts in declarative-button-actions guide that snuck in during #538 
