### PR TITLE
publish: transition to tag-based versioning

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,10 +70,4 @@ jobs:
       #     npm publish --dry-run --provenance --access public --registry https://registry.npmjs.org/
       # =========================================================================
 
-      - name: Create and Push Tag
-        run: |
-          VERSION=$(node -p "require('./dist/skills-cli/package.json').version")
-          TAG="v$VERSION"
-          echo "Creating tag $TAG"
-          git tag $TAG
-          git push origin $TAG
+

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,15 +70,10 @@ jobs:
       #     npm publish --dry-run --provenance --access public --registry https://registry.npmjs.org/
       # =========================================================================
 
-      - name: Commit and Push Version Bump
+      - name: Create and Push Tag
         run: |
-          git add serving/skills-cli/template/
-          if ! git diff --quiet --exit-code --cached; then
-            git commit -m "chore: bump version [skip ci]"
-
-            # Fetch latest changes and rebase our commit on top of them
-            git fetch origin main
-            git rebase origin/main
-
-            git push origin main
-          fi
+          VERSION=$(node -p "require('./dist/skills-cli/package.json').version")
+          TAG="v$VERSION"
+          echo "Creating tag $TAG"
+          git tag $TAG
+          git push origin $TAG

--- a/serving/skills-cli/build-dist.ts
+++ b/serving/skills-cli/build-dist.ts
@@ -41,47 +41,31 @@ async function acquireLock(lockFilePath: string) {
 function updateVersionsInDir(publishCliDir: string, newVersion: string) {
   // Gemini
   const geminiPath = path.join(publishCliDir, "gemini-extension.json");
-  try {
-    const geminiData = JSON.parse(fs.readFileSync(geminiPath, 'utf8'));
-    geminiData.version = newVersion;
-    fs.writeFileSync(geminiPath, JSON.stringify(geminiData, null, 2) + '\n');
-    console.log(`Updated ${geminiPath}`);
-  } catch (e: any) {
-    console.error(`Failed to update ${geminiPath}: ${e.message}`);
-  }
+  const geminiData = JSON.parse(fs.readFileSync(geminiPath, 'utf8'));
+  geminiData.version = newVersion;
+  fs.writeFileSync(geminiPath, JSON.stringify(geminiData, null, 2) + '\n');
+  console.log(`Updated ${geminiPath}`);
 
   // VSCode
   const vscodePath = path.join(publishCliDir, "package.json");
-  try {
-    const vscodeData = JSON.parse(fs.readFileSync(vscodePath, 'utf8'));
-    vscodeData.version = newVersion;
-    fs.writeFileSync(vscodePath, JSON.stringify(vscodeData, null, 2) + '\n');
-    console.log(`Updated ${vscodePath}`);
-  } catch (e: any) {
-    console.error(`Failed to update ${vscodePath}: ${e.message}`);
-  }
+  const vscodeData = JSON.parse(fs.readFileSync(vscodePath, 'utf8'));
+  vscodeData.version = newVersion;
+  fs.writeFileSync(vscodePath, JSON.stringify(vscodeData, null, 2) + '\n');
+  console.log(`Updated ${vscodePath}`);
 
   // Claude Plugin
   const claudePluginPath = path.join(publishCliDir, ".claude-plugin/plugin.json");
-  try {
-    const claudePluginData = JSON.parse(fs.readFileSync(claudePluginPath, 'utf8'));
-    claudePluginData.version = newVersion;
-    fs.writeFileSync(claudePluginPath, JSON.stringify(claudePluginData, null, 2) + '\n');
-    console.log(`Updated ${claudePluginPath}`);
-  } catch (e: any) {
-    console.error(`Failed to update ${claudePluginPath}: ${e.message}`);
-  }
+  const claudePluginData = JSON.parse(fs.readFileSync(claudePluginPath, 'utf8'));
+  claudePluginData.version = newVersion;
+  fs.writeFileSync(claudePluginPath, JSON.stringify(claudePluginData, null, 2) + '\n');
+  console.log(`Updated ${claudePluginPath}`);
 
   // Claude Marketplace
   const marketplacePath = path.join(publishCliDir, ".claude-plugin/marketplace.json");
-  try {
-    const marketplaceData = JSON.parse(fs.readFileSync(marketplacePath, 'utf8'));
-    marketplaceData.plugins[0].version = newVersion;
-    fs.writeFileSync(marketplacePath, JSON.stringify(marketplaceData, null, 2) + '\n');
-    console.log(`Updated ${marketplacePath}`);
-  } catch (e: any) {
-    console.error(`Failed to update ${marketplacePath}: ${e.message}`);
-  }
+  const marketplaceData = JSON.parse(fs.readFileSync(marketplacePath, 'utf8'));
+  marketplaceData.plugins[0].version = newVersion;
+  fs.writeFileSync(marketplacePath, JSON.stringify(marketplaceData, null, 2) + '\n');
+  console.log(`Updated ${marketplacePath}`);
 }
 
 async function main(version?: string): Promise<BuildResult | undefined> {

--- a/serving/skills-cli/build-dist.ts
+++ b/serving/skills-cli/build-dist.ts
@@ -389,7 +389,10 @@ function generateThirdPartyNotices(metafiles: esbuild.Metafile[], outputFilePath
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  main().catch(console.error);
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
 }
 
 export { main as buildDist };

--- a/serving/skills-cli/build-dist.ts
+++ b/serving/skills-cli/build-dist.ts
@@ -38,7 +38,53 @@ async function acquireLock(lockFilePath: string) {
   fs.writeFileSync(lockFilePath, process.pid.toString());
 }
 
-async function main(): Promise<BuildResult | undefined> {
+function updateVersionsInDir(publishCliDir: string, newVersion: string) {
+  // Gemini
+  const geminiPath = path.join(publishCliDir, "gemini-extension.json");
+  try {
+    const geminiData = JSON.parse(fs.readFileSync(geminiPath, 'utf8'));
+    geminiData.version = newVersion;
+    fs.writeFileSync(geminiPath, JSON.stringify(geminiData, null, 2) + '\n');
+    console.log(`Updated ${geminiPath}`);
+  } catch (e: any) {
+    console.error(`Failed to update ${geminiPath}: ${e.message}`);
+  }
+
+  // VSCode
+  const vscodePath = path.join(publishCliDir, "package.json");
+  try {
+    const vscodeData = JSON.parse(fs.readFileSync(vscodePath, 'utf8'));
+    vscodeData.version = newVersion;
+    fs.writeFileSync(vscodePath, JSON.stringify(vscodeData, null, 2) + '\n');
+    console.log(`Updated ${vscodePath}`);
+  } catch (e: any) {
+    console.error(`Failed to update ${vscodePath}: ${e.message}`);
+  }
+
+  // Claude Plugin
+  const claudePluginPath = path.join(publishCliDir, ".claude-plugin/plugin.json");
+  try {
+    const claudePluginData = JSON.parse(fs.readFileSync(claudePluginPath, 'utf8'));
+    claudePluginData.version = newVersion;
+    fs.writeFileSync(claudePluginPath, JSON.stringify(claudePluginData, null, 2) + '\n');
+    console.log(`Updated ${claudePluginPath}`);
+  } catch (e: any) {
+    console.error(`Failed to update ${claudePluginPath}: ${e.message}`);
+  }
+
+  // Claude Marketplace
+  const marketplacePath = path.join(publishCliDir, ".claude-plugin/marketplace.json");
+  try {
+    const marketplaceData = JSON.parse(fs.readFileSync(marketplacePath, 'utf8'));
+    marketplaceData.plugins[0].version = newVersion;
+    fs.writeFileSync(marketplacePath, JSON.stringify(marketplaceData, null, 2) + '\n');
+    console.log(`Updated ${marketplacePath}`);
+  } catch (e: any) {
+    console.error(`Failed to update ${marketplacePath}: ${e.message}`);
+  }
+}
+
+async function main(version?: string): Promise<BuildResult | undefined> {
   fs.mkdirSync(ROOT_DIST_DIR, { recursive: true });
   const lockFilePath = path.join(ROOT_DIST_DIR, "build-dist.lock");
 
@@ -66,6 +112,11 @@ async function main(): Promise<BuildResult | undefined> {
 
   console.log("Copying installation manifests and metadata for AI tools...");
   fs.cpSync(path.join(SERVING_DIR, "skills-cli/template"), PUBLISH_ROOT, { recursive: true });
+
+  if (version) {
+    console.log(`Updating version to ${version} in distribution files...`);
+    updateVersionsInDir(PUBLISH_ROOT, version);
+  }
 
 
   console.log("Copying data files...");

--- a/serving/skills-cli/publish-skills.test.ts
+++ b/serving/skills-cli/publish-skills.test.ts
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { mock } from 'node:test';
+import { getNextVersion, _internal } from './publish-skills.ts';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+test('getNextVersion derive from git tag', async () => {
+  // Mock getLatestGitTag to return a tag
+  const mockGetTag = mock.method(_internal, 'getLatestGitTag', () => {
+    return 'v0.0.22';
+  });
+
+  try {
+    const version = await getNextVersion();
+    assert.strictEqual(version, '0.0.23');
+  } finally {
+    mockGetTag.mock.restore();
+  }
+});
+
+test('getNextVersion fallback to package.json', async () => {
+  // Mock getLatestGitTag to fail (no tags)
+  const mockGetTag = mock.method(_internal, 'getLatestGitTag', () => {
+    throw new Error('fatal: No names found, cannot describe anything.');
+  });
+
+  // Mock fs.readFile to return a version from package.json
+  const mockReadFile = mock.method(fs, 'readFile', async (p: string | any) => {
+    if (typeof p === 'string' && p.includes('package.json')) {
+      return JSON.stringify({ version: '0.0.24' });
+    }
+    throw new Error(`Unexpected file read: ${p}`);
+  });
+
+  try {
+    const version = await getNextVersion();
+    assert.strictEqual(version, '0.0.25');
+  } finally {
+    mockGetTag.mock.restore();
+    mockReadFile.mock.restore();
+  }
+});

--- a/serving/skills-cli/publish-skills.test.ts
+++ b/serving/skills-cli/publish-skills.test.ts
@@ -1,29 +1,20 @@
 import test from 'node:test';
 import assert from 'node:assert';
 import { mock } from 'node:test';
-import { getNextVersion, _internal } from './publish-skills.ts';
+import { getNextVersion } from './publish-skills.ts';
 import fs from 'node:fs/promises';
-import path from 'node:path';
 
 test('getNextVersion derive from git tag', async () => {
-  // Mock getLatestGitTag to return a tag
-  const mockGetTag = mock.method(_internal, 'getLatestGitTag', () => {
-    return 'v0.0.22';
-  });
-
-  try {
-    const version = await getNextVersion();
-    assert.strictEqual(version, '0.0.23');
-  } finally {
-    mockGetTag.mock.restore();
-  }
+  const mockGetTag = () => 'v0.0.22';
+  
+  const version = await getNextVersion(mockGetTag);
+  assert.strictEqual(version, '0.0.23');
 });
 
 test('getNextVersion fallback to package.json', async () => {
-  // Mock getLatestGitTag to fail (no tags)
-  const mockGetTag = mock.method(_internal, 'getLatestGitTag', () => {
+  const mockGetTag = () => {
     throw new Error('fatal: No names found, cannot describe anything.');
-  });
+  };
 
   // Mock fs.readFile to return a version from package.json
   const mockReadFile = mock.method(fs, 'readFile', async (p: string | any) => {
@@ -34,10 +25,9 @@ test('getNextVersion fallback to package.json', async () => {
   });
 
   try {
-    const version = await getNextVersion();
+    const version = await getNextVersion(mockGetTag);
     assert.strictEqual(version, '0.0.25');
   } finally {
-    mockGetTag.mock.restore();
     mockReadFile.mock.restore();
   }
 });

--- a/serving/skills-cli/publish-skills.ts
+++ b/serving/skills-cli/publish-skills.ts
@@ -19,19 +19,15 @@ function incrementVersion(version: string): string {
 }
 
 
-export const _internal = {
-  getLatestGitTag(): string {
-    return execSync('git describe --tags --abbrev=0 --match="v*.*.*"', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim();
-  }
-};
-
-export async function getNextVersion(): Promise<string> {
+export async function getNextVersion(
+  getLatestTag = () => execSync('git describe --tags --abbrev=0 --match="v*.*.*"', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim()
+): Promise<string> {
   console.log("Determining next version...");
   let currentVersion = "0.0.0";
 
   try {
     // Get the latest tag that looks like v*.*.*
-    const latestTag = _internal.getLatestGitTag();
+    const latestTag = getLatestTag();
     currentVersion = latestTag.startsWith('v') ? latestTag.slice(1) : latestTag;
     console.log(`Found latest tag: ${latestTag}`);
   } catch (e) {

--- a/serving/skills-cli/publish-skills.ts
+++ b/serving/skills-cli/publish-skills.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { execSync } from 'node:child_process';
 import ghpages from 'gh-pages';
 import { buildDist } from './build-dist.ts';
+import { fileURLToPath } from 'node:url';
 
 const ROOT_DIR = path.resolve(import.meta.dirname, "../.."); // guidance/
 const SERVING_DIR = path.join(ROOT_DIR, "serving");
@@ -18,13 +19,19 @@ function incrementVersion(version: string): string {
 }
 
 
-async function getNextVersion(): Promise<string> {
+export const _internal = {
+  getLatestGitTag(): string {
+    return execSync('git describe --tags --abbrev=0 --match="v*.*.*"', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim();
+  }
+};
+
+export async function getNextVersion(): Promise<string> {
   console.log("Determining next version...");
   let currentVersion = "0.0.0";
 
   try {
     // Get the latest tag that looks like v*.*.*
-    const latestTag = execSync('git describe --tags --abbrev=0 --match="v*.*.*"', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim();
+    const latestTag = _internal.getLatestGitTag();
     currentVersion = latestTag.startsWith('v') ? latestTag.slice(1) : latestTag;
     console.log(`Found latest tag: ${latestTag}`);
   } catch (e) {
@@ -111,7 +118,9 @@ async function main() {
   }
 }
 
-main().catch((err) => {
-  console.error("Publishing failed!", err);
-  process.exit(1);
-});
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    console.error("Publishing failed!", err);
+    process.exit(1);
+  });
+}

--- a/serving/skills-cli/publish-skills.ts
+++ b/serving/skills-cli/publish-skills.ts
@@ -19,9 +19,9 @@ function incrementVersion(version: string): string {
 }
 
 
-export async function getNextVersion(
-  getLatestTag = () => execSync('git describe --tags --abbrev=0 --match="v*.*.*"', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim()
-): Promise<string> {
+const getLatestGitTag = () => execSync('git describe --tags --abbrev=0 --match="v*.*.*"', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim();
+
+export async function getNextVersion(getLatestTag = getLatestGitTag): Promise<string> {
   console.log("Determining next version...");
   let currentVersion = "0.0.0";
 

--- a/serving/skills-cli/publish-skills.ts
+++ b/serving/skills-cli/publish-skills.ts
@@ -32,13 +32,9 @@ export async function getNextVersion(getLatestTag = getLatestGitTag): Promise<st
     console.log(`Found latest tag: ${latestTag}`);
   } catch (e) {
     console.warn("No version tags found, falling back to package.json version.");
-    try {
-      const vscodePath = path.join(SKILLS_CLI_TEMPLATE_DIR, "package.json");
-      const vscodeData = JSON.parse(await fs.readFile(vscodePath, 'utf8'));
-      currentVersion = vscodeData.version;
-    } catch (err) {
-      console.error("Failed to read package.json version, using fallback 0.0.0");
-    }
+    const vscodePath = path.join(SKILLS_CLI_TEMPLATE_DIR, "package.json");
+    const vscodeData = JSON.parse(await fs.readFile(vscodePath, 'utf8'));
+    currentVersion = vscodeData.version;
   }
 
   const newVersion = incrementVersion(currentVersion);
@@ -97,13 +93,9 @@ async function main() {
     console.log(`\n✅ Successfully published v${newVersion} to GoogleChrome/modern-web-guidance!`);
 
     // Create and push tag on current repo
-    try {
-      console.log(`Creating and pushing Git tag v${newVersion}...`);
-      execSync(`git tag v${newVersion}`, { stdio: 'inherit' });
-      execSync(`git push origin v${newVersion}`, { stdio: 'inherit' });
-    } catch (e: any) {
-      console.error(`Failed to create or push tag: ${e.message}`);
-    }
+    console.log(`Creating and pushing Git tag v${newVersion}...`);
+    execSync(`git tag v${newVersion}`, { stdio: 'inherit' });
+    execSync(`git push origin v${newVersion}`, { stdio: 'inherit' });
 
     console.log(`\nv${newVersion} published.  https://github.com/GoogleChrome/modern-web-guidance  and [GoB repo](https://user.git.corp.google.com/rviscomi/modern-web-guidance/)`);
     console.log(`${useCasesCount} usecases.`);

--- a/serving/skills-cli/publish-skills.ts
+++ b/serving/skills-cli/publish-skills.ts
@@ -18,52 +18,42 @@ function incrementVersion(version: string): string {
 }
 
 
-async function bumpVersions() {
-  console.log("Bumping versions in skills-cli templates...");
-  
-  // Gemini
-  const geminiPath = path.join(SKILLS_CLI_TEMPLATE_DIR, "gemini-extension.json");
-  const geminiData = JSON.parse(await fs.readFile(geminiPath, 'utf8'));
-  const newVersion = incrementVersion(geminiData.version);
-  geminiData.version = newVersion;
+async function getNextVersion(): Promise<string> {
+  console.log("Determining next version...");
+  let currentVersion = "0.0.0";
 
-  // VSCode
-  const vscodePath = path.join(SKILLS_CLI_TEMPLATE_DIR, "package.json");
-  const vscodeData = JSON.parse(await fs.readFile(vscodePath, 'utf8'));
-  vscodeData.version = newVersion;
-
-  // Claude Plugin
-  const claudePluginPath = path.join(SKILLS_CLI_TEMPLATE_DIR, ".claude-plugin/plugin.json");
-  const claudePluginData = JSON.parse(await fs.readFile(claudePluginPath, 'utf8'));
-  claudePluginData.version = newVersion;
-
-  // Claude Marketplace
-  const marketplacePath = path.join(SKILLS_CLI_TEMPLATE_DIR, ".claude-plugin/marketplace.json");
-  const marketplaceData = JSON.parse(await fs.readFile(marketplacePath, 'utf8'));
-  marketplaceData.plugins[0].version = newVersion;
-
-  if (isDryRun) {
-    console.log(`[Dry Run] Would have updated files to version ${newVersion}`);
-  } else {
-    await fs.writeFile(geminiPath, JSON.stringify(geminiData, null, 2) + '\n');
-    await fs.writeFile(vscodePath, JSON.stringify(vscodeData, null, 2) + '\n');
-    await fs.writeFile(claudePluginPath, JSON.stringify(claudePluginData, null, 2) + '\n');
-    await fs.writeFile(marketplacePath, JSON.stringify(marketplaceData, null, 2) + '\n');
+  try {
+    // Get the latest tag that looks like v*.*.*
+    const latestTag = execSync('git describe --tags --abbrev=0 --match="v*.*.*"', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim();
+    currentVersion = latestTag.startsWith('v') ? latestTag.slice(1) : latestTag;
+    console.log(`Found latest tag: ${latestTag}`);
+  } catch (e) {
+    console.warn("No version tags found, falling back to package.json version.");
+    try {
+      const vscodePath = path.join(SKILLS_CLI_TEMPLATE_DIR, "package.json");
+      const vscodeData = JSON.parse(await fs.readFile(vscodePath, 'utf8'));
+      currentVersion = vscodeData.version;
+    } catch (err) {
+      console.error("Failed to read package.json version, using fallback 0.0.0");
+    }
   }
 
-  console.log(`Successfully bumped to version ${newVersion}`);
+  const newVersion = incrementVersion(currentVersion);
+  console.log(`Next version will be: ${newVersion}`);
   return newVersion;
 }
 
+
+
 async function main() {
-  const newVersion = await bumpVersions();
+  const newVersion = await getNextVersion();
   
   const publishCliDir = path.join(DIST_DIR, "skills-cli");
   await fs.mkdir(publishCliDir, {recursive: true});
   await fs.rm(publishCliDir, { recursive: true, force: true });
 
   console.log(`\nRebuilding distribution with version ${newVersion}...`);
-  const result = await buildDist();
+  const result = await buildDist(newVersion);
   if (!result) {
     throw new Error("Build failed or was already in progress.");
   }

--- a/serving/skills-cli/publish-skills.ts
+++ b/serving/skills-cli/publish-skills.ts
@@ -93,6 +93,15 @@ async function main() {
 
     console.log(`\n✅ Successfully published v${newVersion} to GoogleChrome/modern-web-guidance!`);
 
+    // Create and push tag on current repo
+    try {
+      console.log(`Creating and pushing Git tag v${newVersion}...`);
+      execSync(`git tag v${newVersion}`, { stdio: 'inherit' });
+      execSync(`git push origin v${newVersion}`, { stdio: 'inherit' });
+    } catch (e: any) {
+      console.error(`Failed to create or push tag: ${e.message}`);
+    }
+
     console.log(`\nv${newVersion} published.  https://github.com/GoogleChrome/modern-web-guidance  and [GoB repo](https://user.git.corp.google.com/rviscomi/modern-web-guidance/)`);
     console.log(`${useCasesCount} usecases.`);
     console.log(`${featuresCount} features`);


### PR DESCRIPTION
Transition from file-based versioning  to Git tag-based versioning for skills distribution. 

This eliminates noisy `chore: bump version [skip ci]` commits on the `main` branch.  I also realized we had a race condition between when the commit landed .. it wasn't guaranteed to land after the commit that was published. 


- **publish-skills.ts**: Derives the next version from the latest Git tag (`v*.*.*`) using `git describe`. Falls back to `package.json` version if no tags are found.
- **build-dist.ts**: Accepts the derived version as an argument and injects it into distribution files (`package.json`, manifests) during the build process, ensuring the generated README reflects the correct version.
- **publish.yml**: Removed automated version bump commits. The release process is now fully driven by the script, including creating and pushing the release tag.
- **Tests**: Added unit tests for `getNextVersion` to verify tag resolution and fallback behavior, refactoring the function to use dependency injection for clean and idiomatic mocking.
- **Moved version injection into the build process (`build-dist.ts`)**: The distribution's `README.md` is auto-generated by reading the version from `package.json` during the build. To ensure the README reflects the *new* version (and not the old template version), we must inject the derived version into the `dist/` files *during* the build process (right after copying template files but before generating the README), rather than after the build completes.


Also caught a bug.. build-dist would exit with 0 if there was an error. ruh roh.  fixed that so fatal problems are loud and will fail the build/publish.