### PR TITLE
Accessibility skill review

### DIFF
--- a/skills-drafts/accessibility/SKILL.md
+++ b/skills-drafts/accessibility/SKILL.md
@@ -363,27 +363,15 @@ Modern browsers provide native mechanisms for focus trapping and modal overlays 
 
 **CSS: Standard Visually Hidden for secondary text**
 ```css
-.visually-hidden {
+.visually-hidden:where(:not(:focus-within, :active)) {
   position: absolute !important;
+  clip-path: inset(50%) !important;
+  overflow: hidden !important;
   width: 1px !important;
   height: 1px !important;
-  padding: 0 !important;
   margin: -1px !important;
-  overflow: hidden !important;
-  clip-path: inset(50%) !important;
-  white-space: nowrap !important;
+  padding: 0 !important;
   border: 0 !important;
-}
-
-/* Reverse visually hidden on focus for interactive elements */
-.visually-hidden-focusable:focus,
-.visually-hidden-focusable:active {
-  position: static !important;
-  width: auto !important;
-  height: auto !important;
-  overflow: visible !important;
-  clip: auto !important;
-  clip-path: none !important;
-  white-space: normal !important;
+  white-space: nowrap !important;
 }
 ```


### PR DESCRIPTION
I’m reviewing the accessibility skill. I’ll use this PR description as a dumping ground for thoughts I have, but then I’ll be committing some things when it makes sense.

- - -

Unorganized thoughts + observations:

- [x] Use a single `.visually-hidden` class that covers exceptions with `:not()`.
- “Invoke the dialog using the `.showModal()` method to automatically lock focus into the popup and dim the background.”
	- Technically it doesn’t lock the focus to the “popup” (use a different term here as well) as the focus can go to the browser chrome. I think what it’s trying to say is that the background content is made inert.
- Should the `<dialog>` example use an `<h1>`? From what I understand this is correct as the rest of the document is inert and `role=dialog` is considered its own separate window (i.e. `role=dialog` inherits from the abstract `role=window`).
- The visually hidden utility class doesn’t make sense in the Modals and Native Dialogs section.
- `clip-path` likely doesn’t need to be mentioned every time `sr-only` or `visually-hidden` is.
- `<main id="content">` likely still needs `tabindex="-1"` for its skip link to work with certain assistive technologies (e.g. screen magnifiers iirc).
- The “Good” custom key handler for a custom button implements the space key wrong—it should happen on `keyup` (`Enter` is good for `keydown`).
- Avoid using the `disabled` attribute to disable `<button>` elements.

## Outline

Considering the topics covered and organization…

> 1. Semantic HTML and Landmarks
> 2. Document Metadata and Language
> 3. Keyboard and Focus Management
> 4. Alternate Text and Media
> 5. Forms and Inputs Controls
> 6. Color, Contrast, and Typography
> 7. Motion and Preference
> 8. Testing Validations
> 9. Modals and Native Dialogs

There probably should be some guidance on accessible names as its own section.

## Accessible names and descriptions

Here are some rough guidelines for a section on accessible name/descriptions.

- For form controls, prefer `<label>` when labelling.
	- Include `for` with an explicit association even when nesting a form control within `<label>` as some assistive technologies struggle with associating controls with their labels without the explicit reference (see voice recognition software).
- Otherwise, give preference to `aria-labelledby` paired with a visual label.
	- This encourages not hiding content that might be relevant visually.
	- As a side effect, this avoids duplication which improves maintainability
	- There are also (unresolved?) issues around translation for `aria-label`.
- Avoid including the role within the accessible name (e.g. `<nav aria-label="Primary navigation">`)
- Accessible names should only be given for things that are allowed to have them.
	- **DO NOT** use `aria-label` or `aria-labelledby` on an element that’s not interesting for accessibility (e.g. `<div>` or `<span>` without a relevant role).
	- `role=tooltip` is an example of something that shouldn’t have a name.
- Hyperlinks with the same `href` should generally use the same accessible name.
	- This isn’t a hard rule, but generally it should be followed.
- Links with different `href` should not have the same name.
	- Visually hidden text can help this case (e.g. `Read more <span class="visually-hidden">about perhaps something from the surrounding context</span>).
- Buttons that have different effects should not have the same name.
	- Visually hidden text can help this case.
- Elements with ARIA state should not reflect that state in their naming as this is redundant and can create ambiguity (e.g. instead of “open menu” for a button with `aria-expanded` just use “menu” — make sure visual affordances still exist to communicate state).
- Interactive elements should not be used in the referent(s) of `aria-describedby` unless their text content can standalone.
	- If descriptive text must include interactive content that cannot standalone, use `aria-details` instead. It has much less support with assistive technologies, but this is a use case that it covers.