### PR TITLE
Early version of high-level WebMCP skill.

### DIFF
--- a/skills-drafts/webmcp/SKILL.md
+++ b/skills-drafts/webmcp/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: webmcp
+description: Instructions for implementing and interacting with WebMCP on websites using both declarative and imperative APIs. Use this when asked to implement WebMCP tools or fix WebMCP integration.
+---
+
+# WebMCP (Web Model Context Protocol)
+
+WebMCP is a browser-native JavaScript API that allows web pages to expose their client-side functionality as structured "tools" to AI agents, browser assistants, and assistive technologies. 
+
+**Crucial Distinction:** WebMCP runs entirely **client-side** in the browser tab. It is *not* a backend server, and it does *not* use HTTP, Server-Sent Events (SSE), or `stdio` transports. The web page itself acts as the tool registry.
+
+Currently, WebMCP **only supports Tools**. It does not support the "Resources" or "Prompts" primitives found in the backend Model Context Protocol.
+
+## Quick Overview
+
+- **Imperative API**: Use `navigator.modelContext.registerTool()` for complex logic and dynamic interactions.
+- **Declarative API**: Annotate standard HTML `<form>` elements with `toolname` and `tooldescription` to turn them into tools.
+
+## Progressive Disclosure
+
+- **Imperative API Details**: See [imperative.md](references/imperative.md) for `ToolRegistry` patterns and lifecycle handling using `AbortController`.
+- **Declarative API Details**: See [declarative.md](references/declarative.md) for HTML attributes, `SubmitEvent` interception (`agentInvoked`, `respondWith()`), and visual feedback CSS.
+- **Best Practices**: See [best-practices.md](references/best-practices.md) for naming and schema design, reliability, and anti-patterns.

--- a/skills-drafts/webmcp/SKILL.md
+++ b/skills-drafts/webmcp/SKILL.md
@@ -7,6 +7,9 @@ description: Instructions for implementing and interacting with WebMCP on websit
 
 WebMCP is a browser-native JavaScript API that allows web pages to expose their client-side functionality as structured "tools" to AI agents, browser assistants, and assistive technologies. 
 
+> [!IMPORTANT]
+> WebMCP is currently **Chrome-only** (Early Preview). It requires Chrome `146.0.7672.0` or higher and the `#enable-webmcp-testing` flag. See [implementation-status.md](references/implementation-status.md) for details.
+
 **Crucial Distinction:** WebMCP runs entirely **client-side** in the browser tab. It is *not* a backend server, and it does *not* use HTTP, Server-Sent Events (SSE), or `stdio` transports. The web page itself acts as the tool registry.
 
 Currently, WebMCP **only supports Tools**. It does not support the "Resources" or "Prompts" primitives found in the backend Model Context Protocol.
@@ -20,4 +23,5 @@ Currently, WebMCP **only supports Tools**. It does not support the "Resources" o
 
 - **Imperative API Details**: See [imperative.md](references/imperative.md) for `ToolRegistry` patterns and lifecycle handling using `AbortController`.
 - **Declarative API Details**: See [declarative.md](references/declarative.md) for HTML attributes, `SubmitEvent` interception (`agentInvoked`, `respondWith()`), and visual feedback CSS.
+- **Implementation Status**: See [implementation-status.md](references/implementation-status.md) for implementation status and browser requirements.
 - **Best Practices**: See [best-practices.md](references/best-practices.md) for naming and schema design, reliability, and anti-patterns.

--- a/skills-drafts/webmcp/references/best-practices.md
+++ b/skills-drafts/webmcp/references/best-practices.md
@@ -1,0 +1,14 @@
+# Best Practices
+
+* **Naming and Semantics**: Use specific verbs describing exact behavior (e.g. `create-event` vs `start-event-creation-process`). Favor positive descriptions over listing limitations.
+* **Schema Design**: Accept raw user input (avoid agent math/calculation). Ensure all parameters have specific types and explain the purpose of options.
+* **Reliability**: Validate constraints in code and return descriptive errors for retries. Handle rate limiting gracefully. Ensure the function returns *after* UI state updates for consistency.
+* **Tool Strategy**: Tools should be atomic, composable, and distinct. Do not force flow control instructions ("Don't call B after A") — let the agent decide. Register/unregister tools dynamically depending on the current page context.
+* **Clean Up**: Always use `AbortSignal` to unregister tools when pages transition or resources are released to avoid leaks and collisions. Do not use `unregisterTool`.
+
+## Anti-Patterns & Warnings (DO NOT DO THIS)
+
+* **Do not use backend transports.** WebMCP is for browser tabs, not Node.js background processes.
+* **Do not include Resources or Prompts.** These are not supported in the current WebMCP spec.
+* **Do not ignore `inputSchema` structure.** Always provide clear descriptions for every parameter to minimize agent hallucinations.
+* **Do not use outside of a Secure Context (HTTPS).**

--- a/skills-drafts/webmcp/references/best-practices.md
+++ b/skills-drafts/webmcp/references/best-practices.md
@@ -6,6 +6,12 @@
 * **Tool Strategy**: Tools should be atomic, composable, and distinct. Do not force flow control instructions ("Don't call B after A") — let the agent decide. Register/unregister tools dynamically depending on the current page context. Use `annotations: { readOnlyHint: true }` (placed after `execute`) for tools that do not modify state to inform the agent of safe execution.
 * **Clean Up**: Always use `AbortSignal` to unregister tools when pages transition or resources are released to avoid leaks and collisions. Do not use `unregisterTool`.
 
+## When to Discourage WebMCP
+
+* **Backend Operations**: If the operation requires intensive compute, access to secure databases, or requires API keys that shouldn't be exposed to the client, use a standard backend MCP server instead of WebMCP.
+* **High-Risk Actions without Guardrails**: Avoid auto-submitting tools for destructive or irreversible actions (e.g., deleting data) unless the UI requires manual user confirmation outside the agent's control.
+* **Hyper-Dynamic State**: If data changes faster than the agent can react, it may work with stale context.
+
 ## Anti-Patterns & Warnings (DO NOT DO THIS)
 
 * **Do not use backend transports.** WebMCP is for browser tabs, not Node.js background processes.

--- a/skills-drafts/webmcp/references/best-practices.md
+++ b/skills-drafts/webmcp/references/best-practices.md
@@ -3,7 +3,7 @@
 * **Naming and Semantics**: Use specific verbs describing exact behavior (e.g. `create-event` vs `start-event-creation-process`). Favor positive descriptions over listing limitations.
 * **Schema Design**: Accept raw user input (avoid agent math/calculation). Ensure all parameters have specific types and explain the purpose of options.
 * **Reliability**: Validate constraints in code and return descriptive errors for retries. Handle rate limiting gracefully. Ensure the function returns *after* UI state updates for consistency.
-* **Tool Strategy**: Tools should be atomic, composable, and distinct. Do not force flow control instructions ("Don't call B after A") — let the agent decide. Register/unregister tools dynamically depending on the current page context.
+* **Tool Strategy**: Tools should be atomic, composable, and distinct. Do not force flow control instructions ("Don't call B after A") — let the agent decide. Register/unregister tools dynamically depending on the current page context. Use `annotations: { readOnlyHint: true }` (placed after `execute`) for tools that do not modify state to inform the agent of safe execution.
 * **Clean Up**: Always use `AbortSignal` to unregister tools when pages transition or resources are released to avoid leaks and collisions. Do not use `unregisterTool`.
 
 ## Anti-Patterns & Warnings (DO NOT DO THIS)

--- a/skills-drafts/webmcp/references/declarative.md
+++ b/skills-drafts/webmcp/references/declarative.md
@@ -1,0 +1,85 @@
+# WebMCP Declarative API
+
+The Declarative API transforms standard HTML `<form>` elements into WebMCP tools via attributes. The browser synthesizes a JSON Schema from the form inputs and handles agent interactions.
+
+## Form Attributes
+
+*   `toolname`: Unique name for the tool.
+*   `tooldescription`: Purpose of the tool.
+*   `toolautosubmit`: (Optional) If present, the agent can submit the form without waiting for user interaction. 
+*   `toolparamdescription`: (Optional, on input) Maps to the property description. Defaults to the `<label>` text.
+    *   *Note*: For `<input type="radio">` groups, place this on the *first* `<input>` element.
+
+### Example
+
+```html
+<form toolname="search-cars" 
+      tooldescription="Perform a car make/model search" 
+      toolautosubmit>
+  <label for="make">Vehicle Make</label>
+  <input type="text" id="make" name="make" required>
+  
+  <label for="model">Vehicle Model</label>
+  <input type="text" id="model" name="model" toolparamdescription="e.g., 330i, F-150" required>
+  
+  <button type="submit">Search</button>
+</form>
+```
+
+## Handling Submissions in JavaScript
+
+When an agent submits the form, the `SubmitEvent` includes `agentInvoked` (boolean) and `respondWith(promise)`.
+
+```javascript
+document.querySelector('form').addEventListener('submit', (event) => {
+  event.preventDefault();
+
+  // Validate the form
+  if (!myFormIsValid()) {
+    if (event.agentInvoked) { 
+      event.respondWith(Promise.resolve({ error: "Validation failed" })); 
+    }
+    return;
+  }
+
+  const resultPromise = performAsyncSearch(new FormData(event.target));
+  
+  // Return the result directly to the agent without navigation
+  if (event.agentInvoked) {
+    event.respondWith(resultPromise);
+  }
+});
+```
+
+## Lifecycle Events
+
+The window emits events when agents start or stop interacting with a tool:
+
+```javascript
+window.addEventListener('toolactivated', ({ toolName }) => {
+  console.log(`Tool "${toolName}" was activated by the agent.`);
+});
+
+window.addEventListener('toolcancel', ({ toolName }) => {
+  console.log(`Tool "${toolName}" interaction was cancelled.`);
+});
+```
+
+## Visual Feedback (CSS)
+
+Use pseudo-classes to highlight forms when an agent interacts with them:
+
+*   `:tool-form-active`: Applied to the `<form>` element actively used by the agent.
+*   `:tool-submit-active`: Applied to the submit button when the browser pauses for user review (if `toolautosubmit` is omitted).
+
+```css
+form:tool-form-active {
+  outline: 2px dashed blue;
+  background-color: rgba(0, 0, 255, 0.05);
+}
+
+button:tool-submit-active {
+  outline: 2px dashed red;
+  animation: pulse 2s infinite;
+}
+```

--- a/skills-drafts/webmcp/references/declarative.md
+++ b/skills-drafts/webmcp/references/declarative.md
@@ -84,3 +84,9 @@ button:tool-submit-active {
   animation: pulse 2s infinite;
 }
 ```
+
+## Browser Support
+
+{{ BASELINE_STATUS("declarative-webmcp") }}
+
+The WebMCP Declarative API is safe to use in all browsers. Browsers that do not support WebMCP will ignore the `tool*` attributes, and the `<form>` will continue to function as a normal HTML form. No feature detection is required.

--- a/skills-drafts/webmcp/references/declarative.md
+++ b/skills-drafts/webmcp/references/declarative.md
@@ -93,6 +93,13 @@ button:tool-submit-active {
 }
 ```
 
+## Form Suitability (When to Avoid)
+
+The Declarative API is best for self-contained, standard forms. It is a poor choice in these scenarios:
+* **Highly Dependent Fields**: Forms where inputs change options or visibility based on other inputs. The synthesized schema cannot express these dependencies well.
+* **Custom UI Components**: Forms relying on non-standard inputs (e.g., canvas, rich text editors) that don't auto-serialize values.
+* **Multi-Step Wizards**: Complex workflows requiring multiple form submissions. The Imperative API or standard DOM interaction is better suited here.
+
 ## Browser Support
 
 {{ BASELINE_STATUS("declarative-webmcp") }}

--- a/skills-drafts/webmcp/references/declarative.md
+++ b/skills-drafts/webmcp/references/declarative.md
@@ -7,8 +7,9 @@ The Declarative API transforms standard HTML `<form>` elements into WebMCP tools
 *   `toolname`: Unique name for the tool.
 *   `tooldescription`: Purpose of the tool.
 *   `toolautosubmit`: (Optional) If present, the agent can submit the form without waiting for user interaction. 
-*   `toolparamdescription`: (Optional, on input) Maps to the property description. Defaults to the `<label>` text.
-    *   *Note*: For `<input type="radio">` groups, place this on the *first* `<input>` element.
+*   `toolparamdescription`: (Optional) Provides a way to define a property description within the JSON Schema.
+    *   **Resolution Order**: The browser uses `toolparamdescription` if present. In its absence, it uses the `textContent` of the associated `<label>` (skipping labelable descendants). If no label exists, it falls back to the `aria-description`.
+    *   **Grouping (Fieldsets)**: To attach a description to a group of related elements (like `<input type="radio">` buttons), place `toolparamdescription` on the nearest parent `<fieldset>` element so it applies to the parameter group as a whole.
 
 ### Example
 

--- a/skills-drafts/webmcp/references/declarative.md
+++ b/skills-drafts/webmcp/references/declarative.md
@@ -36,15 +36,23 @@ document.querySelector('form').addEventListener('submit', (event) => {
   event.preventDefault();
 
   // Validate the form
-  if (!myFormIsValid()) {
-    if (event.agentInvoked) { 
-      event.respondWith(Promise.resolve({ error: "Validation failed" })); 
+  const formValidationErrors = myFormIsValid();
+
+  if (formValidationErrors.length > 0) {
+    if (event.agentInvoked) {
+      const errorString =
+        'Validation failed: ' +
+        formValidationErrors
+          .map((err) => `${err.field} (${err.message})`)
+          .join(', ');
+
+      event.respondWith(Promise.resolve(errorString));
     }
     return;
   }
 
   const resultPromise = performAsyncSearch(new FormData(event.target));
-  
+
   // Return the result directly to the agent without navigation
   if (event.agentInvoked) {
     event.respondWith(resultPromise);

--- a/skills-drafts/webmcp/references/imperative.md
+++ b/skills-drafts/webmcp/references/imperative.md
@@ -100,7 +100,7 @@ export function createInventoryTool(inventoryManager) {
 
 *   **annotations**: (Optional) A dictionary for tool metadata.
     *   **readOnlyHint**: (Optional) Set to `true` if the tool does not modify any state and only reads data. This helps agents decide when it is safe to call the tool.
-*   **Return Format**: The `execute` function can return any JSON-serializable value (object, array, string, number, boolean).
+*   **Return Format**: The `execute` function can return any JSON-serializable value (object, array, string, number, boolean). Select a structure that best serves your specific use case while ensuring the content is optimized for the LLM to process. The output may encompass raw data, specific error logs, or direct instructions to influence the agent's next action.
 *   **Secure Context**: WebMCP requires HTTPS.
 *   **Deprecated/Removed**: `unregisterTool()`, `provideContext()`, and `clearContext()` are no longer supported.
 

--- a/skills-drafts/webmcp/references/imperative.md
+++ b/skills-drafts/webmcp/references/imperative.md
@@ -20,7 +20,8 @@ navigator.modelContext.registerTool({
   execute() {
     const prefs = localStorage.getItem("user_prefs");
     return prefs ? JSON.parse(prefs) : { theme: "light" };
-  }
+  },
+  annotations: { readOnlyHint: true }
 }, { signal: controller.signal });
 
 // To unregister the tool (e.g., on component unmount):
@@ -46,7 +47,8 @@ navigator.modelContext.registerTool({
   execute(input) {
     // input is { width: 10, height: 20 }
     return input.width * input.height;
-  }
+  },
+  annotations: { readOnlyHint: true }
 });
 ```
 
@@ -88,13 +90,16 @@ export function createInventoryTool(inventoryManager) {
     inputSchema: { type: "object", properties: {} },
     execute() {
       return inventoryManager.getItems();
-    }
+    },
+    annotations: { readOnlyHint: true }
   };
 }
 ```
 
 ## API Notes
 
+*   **annotations**: (Optional) A dictionary for tool metadata.
+    *   **readOnlyHint**: (Optional) Set to `true` if the tool does not modify any state and only reads data. This helps agents decide when it is safe to call the tool.
 *   **Return Format**: The `execute` function can return any JSON-serializable value (object, array, string, number, boolean).
 *   **Secure Context**: WebMCP requires HTTPS.
 *   **Deprecated/Removed**: `unregisterTool()`, `provideContext()`, and `clearContext()` are no longer supported.

--- a/skills-drafts/webmcp/references/imperative.md
+++ b/skills-drafts/webmcp/references/imperative.md
@@ -1,0 +1,100 @@
+# WebMCP Imperative API
+
+The Imperative API uses `navigator.modelContext.registerTool()` to programmatically define JavaScript tools. This is ideal for Single Page Applications (SPAs) where tools need to be added or removed based on the current route or user state.
+
+## Registration and Lifecycle
+
+Tools are registered by passing a tool definition object and an optional options object containing an `AbortSignal`.
+
+### Lifecycle Handling with `AbortController`
+
+WebMCP does not provide an `unregisterTool()` method. To unregister a tool, you must pass an `AbortSignal` during registration and abort that signal when the tool is no longer needed.
+
+```javascript
+const controller = new AbortController();
+
+navigator.modelContext.registerTool({
+  name: "get_user_preferences",
+  description: "Retrieves the user's saved preferences.",
+  inputSchema: { type: "object", properties: {} },
+  execute() {
+    const prefs = localStorage.getItem("user_prefs");
+    return prefs ? JSON.parse(prefs) : { theme: "light" };
+  }
+}, { signal: controller.signal });
+
+// To unregister the tool (e.g., on component unmount):
+controller.abort();
+```
+
+## Defining Parameters
+
+Parameters (params) are defined using the `inputSchema` property. This must be a **JSON Schema** object that describes the structured data the tool expects.
+
+```javascript
+navigator.modelContext.registerTool({
+  name: "calculate_area",
+  description: "Calculates the area of a rectangle.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      width: { type: "number", description: "The width of the rectangle." },
+      height: { type: "number", description: "The height of the rectangle." }
+    },
+    required: ["width", "height"]
+  },
+  execute(input) {
+    // input is { width: 10, height: 20 }
+    return input.width * input.height;
+  }
+});
+```
+
+## Execution Patterns
+
+### When to use `async execute`
+Use `async` when the tool involves operations that return a Promise or take time to complete:
+- **Network calls**: Fetching data from an API.
+- **Asynchronous Storage**: Accessing IndexedDB.
+- **External Events**: Waiting for a specific state change or animation to finish.
+
+```javascript
+async execute(input) {
+  const response = await fetch(`/api/data/${input.id}`);
+  return await response.json();
+}
+```
+
+### When to use `execute` (Synchronous)
+Use a standard synchronous function for immediate operations:
+- **Pure logic**: Math, filtering, or sorting data already in memory.
+- **Synchronous state**: Reading from `localStorage` or a synchronous state manager.
+
+```javascript
+execute(input) {
+  return input.items.filter(item => item.active);
+}
+```
+
+## Tool Factory Pattern
+
+To pass context (like stores or application instances) to your tools, use factory functions.
+
+```javascript
+export function createInventoryTool(inventoryManager) {
+  return {
+    name: "get_inventory",
+    description: "Lists items in the inventory.",
+    inputSchema: { type: "object", properties: {} },
+    execute() {
+      return inventoryManager.getItems();
+    }
+  };
+}
+```
+
+## API Notes
+
+*   **Return Format**: The `execute` function can return any JSON-serializable value (object, array, string, number, boolean).
+*   **Secure Context**: WebMCP requires HTTPS.
+*   **Deprecated/Removed**: `unregisterTool()`, `provideContext()`, and `clearContext()` are no longer supported.

--- a/skills-drafts/webmcp/references/imperative.md
+++ b/skills-drafts/webmcp/references/imperative.md
@@ -103,3 +103,15 @@ export function createInventoryTool(inventoryManager) {
 *   **Return Format**: The `execute` function can return any JSON-serializable value (object, array, string, number, boolean).
 *   **Secure Context**: WebMCP requires HTTPS.
 *   **Deprecated/Removed**: `unregisterTool()`, `provideContext()`, and `clearContext()` are no longer supported.
+
+## Browser Support
+
+{{ BASELINE_STATUS("navigator-modelcontext") }}
+
+The WebMCP Imperative API should be used with feature detection to ensure compatibility with browsers that do not yet support WebMCP.
+
+```javascript
+if ('modelContext' in navigator && 'registerTool' in navigator.modelContext) {
+  // Register tools
+}
+```

--- a/skills-drafts/webmcp/references/implementation-status.md
+++ b/skills-drafts/webmcp/references/implementation-status.md
@@ -1,0 +1,8 @@
+# Implementation Status
+
+WebMCP is currently in early preview in Chrome browser:
+
+*   **Current Status**: Early preview.
+*   **Required Version**: Chrome `146.0.7672.0` or higher.
+*   **Activation**: Requires enabling the flag `chrome://flags/#enable-webmcp-testing`.
+*   **Specification**: Evolving [Draft Community Group specification](https://webmachinelearning.github.io/webmcp/); not yet a standards-track recommendation.


### PR DESCRIPTION
Adding first version of WebMCP skill (skill-draft). 

WebMCP is proposed web standard that is still being discussed in W3C group https://github.com/webmachinelearning/webmcp. 

We want to keep it lean for now as spec will definitely change going forward. Current early version of skill consists of implementation guides for Imperative and Declarative APIs, good and bad practices, and implementation status.