### PR TITLE
Recommend `:is()` instead of duplicate CSS rules

### DIFF
--- a/guides/user-experience/declarative-dialog-popover-control/demo.html
+++ b/guides/user-experience/declarative-dialog-popover-control/demo.html
@@ -25,7 +25,7 @@
     }
 
     /* Native & polyfill styling for open popover */
-    [popover]:is(:popover-open, \:popover-open) {
+    [popover]:is(:popover-open, .\:popover-open) {
       /* Example of styling an open popover */
       background-color: #f9f9f9;
     }

--- a/guides/user-experience/declarative-dialog-popover-control/demo.html
+++ b/guides/user-experience/declarative-dialog-popover-control/demo.html
@@ -23,18 +23,13 @@
       border-radius: 4px;
       box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
     }
-    
-    /* Native styling for open popover */
-    [popover]:popover-open {
+
+    /* Native & polyfill styling for open popover */
+    [popover]:is(:popover-open, \:popover-open) {
       /* Example of styling an open popover */
       background-color: #f9f9f9;
     }
 
-    /* Polyfill styling for open popover (must be a separate rule) */
-    [popover].\:popover-open {
-      background-color: #f9f9f9;
-    }
-    
     dialog {
       padding: 1.5rem;
       border: none;

--- a/guides/user-experience/declarative-dialog-popover-control/demo.html
+++ b/guides/user-experience/declarative-dialog-popover-control/demo.html
@@ -9,14 +9,14 @@
       font-family: system-ui, sans-serif;
       padding: 2rem;
     }
-    
+
     button {
       padding: 0.5rem 1rem;
       font-size: 1rem;
       cursor: pointer;
       margin-bottom: 1rem;
     }
-    
+
     [popover] {
       padding: 1rem;
       border: 1px solid #ccc;
@@ -41,7 +41,7 @@
       border-radius: 8px;
       box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
     }
-    
+
     dialog::backdrop {
       background: rgba(0, 0, 0, 0.5);
     }
@@ -49,14 +49,14 @@
 </head>
 <body>
   <h1>Declarative Controls</h1>
-  
+
   <section>
     <h2>Popover Toggle</h2>
     <!-- Invoker button to toggle the popover -->
     <button commandfor="my-popover" command="toggle-popover">
       Toggle Popover
     </button>
-    
+
     <!-- The popover target -->
     <div id="my-popover" popover>
       <p>This popover was toggled declaratively without writing custom JS for supported browsers.</p>
@@ -73,7 +73,7 @@
     <!-- The explicit popover target -->
     <div id="my-explicit-popover" popover>
       <p>This popover uses explicit show and hide commands rather than toggle.</p>
-      
+
       <!-- Invoker button to exclusively hide the popover -->
       <button commandfor="my-explicit-popover" command="hide-popover">
         Hide Popover
@@ -87,12 +87,12 @@
     <button commandfor="my-dialog" command="show-modal">
       Open Dialog
     </button>
-    
+
     <!-- The dialog target -->
     <dialog id="my-dialog">
       <h2>Confirmation</h2>
       <p>Are you sure you want to proceed with this action?</p>
-      
+
       <!-- Invoker button inside the dialog to close it -->
       <button commandfor="my-dialog" command="close">
         Close Dialog

--- a/guides/user-experience/declarative-dialog-popover-control/expectations.md
+++ b/guides/user-experience/declarative-dialog-popover-control/expectations.md
@@ -12,4 +12,4 @@
 - The `invokers-polyfill` is only loaded if `'commandForElement' in HTMLButtonElement.prototype` is false.
 - The document includes a fallback script that conditionally loads a `popover` polyfill.
 - The `popover` polyfill is only loaded if `'popover' in HTMLElement.prototype` is false.
-- If the open state of a popover is styled, there are separate CSS rules for `:popover-open` and the polyfill class `.\:popover-open`.
+- If the open state of a popover is styled, `:popover-open` is not used by itself, combined with the polyfill class `.\:popover-open` via `:is()` or `:where()`

--- a/guides/user-experience/declarative-dialog-popover-control/guide.md
+++ b/guides/user-experience/declarative-dialog-popover-control/guide.md
@@ -5,7 +5,7 @@ web-feature-ids:
   - invoker-commands
   - popover
   - dialog
-sources: 
+sources:
   - https://developer.chrome.com/blog/command-and-commandfor
   - https://developer.mozilla.org/en-US/docs/Web/API/Invoker_Commands_API
   - https://open-ui.org/components/invokers.explainer/
@@ -46,7 +46,7 @@ If you need to control opening and closing with separate buttons, you can use th
 
 <div id="my-explicit-popover" popover>
   <p>This popover is explicitly opened and closed by separate buttons.</p>
-  
+
   <!-- MANDATORY: Use 'hide-popover' to explicitly close the targeted popover. -->
   <button commandfor="my-explicit-popover" command="hide-popover">
     Hide Popover
@@ -67,7 +67,7 @@ Unlike popovers, modal dialogs typically use separate buttons for opening and cl
 
 <dialog id="confirm-dialog">
   <p>Are you sure you want to proceed?</p>
-  
+
   <!-- MANDATORY: Use command="close" to dismiss the dialog safely. -->
   <button commandfor="confirm-dialog" command="close">
     Cancel
@@ -111,7 +111,7 @@ If you are not using a package manager, dynamically import the polyfill directly
 ```
 
 **Invokers Polyfill Limitations**
-Unlike the native Invoker Commands API, `invokers-polyfill` does not automatically handle ARIA attributes (such as `aria-expanded`) on the command button. 
+Unlike the native Invoker Commands API, `invokers-polyfill` does not automatically handle ARIA attributes (such as `aria-expanded`) on the command button.
 
 MANDATORY: You MUST manually manage these ARIA states to ensure your site remains fully accessible to screen readers in browsers relying on the polyfill.
 

--- a/guides/user-experience/declarative-dialog-popover-control/guide.md
+++ b/guides/user-experience/declarative-dialog-popover-control/guide.md
@@ -149,20 +149,10 @@ If you are not using a package manager, dynamically import the polyfill directly
 ```
 
 **Popover Polyfill Limitations & Styling Caveats**
-MANDATORY: When styling the open state of a popover, you must provide a separate CSS declaration for the polyfill's CSS class (`.\:popover-open`).
+MANDATORY: Use `:is()` or `:where()` to combine `:popover-open` with the corresponding polyfill class, otherwise browsers that do not support `:popover-open` will throw away the entire rule.
 
 ```css
-/* DO NOT combine these into a single comma-separated list.
-   If a browser does not understand the native :popover-open pseudo-class,
-   it will throw away the entire rule, breaking the polyfill styling. */
-
-[popover]:popover-open {
-  /* Native styling */
-  display: block;
-}
-
-[popover].\:popover-open {
-  /* Polyfill styling */
+[popover]:is(:popover-open, \:popover-open) {
   display: block;
 }
 ```

--- a/guides/user-experience/declarative-dialog-popover-control/guide.md
+++ b/guides/user-experience/declarative-dialog-popover-control/guide.md
@@ -152,7 +152,7 @@ If you are not using a package manager, dynamically import the polyfill directly
 MANDATORY: Use `:is()` or `:where()` to combine `:popover-open` with the corresponding polyfill class, otherwise browsers that do not support `:popover-open` will throw away the entire rule.
 
 ```css
-[popover]:is(:popover-open, \:popover-open) {
+[popover]:is(:popover-open, .\:popover-open) {
   display: block;
 }
 ```


### PR DESCRIPTION
Fix one of the [review](https://github.com/GoogleChrome/guidance/issues/332#issuecomment-4283244943) points, namely the one about needing duplicate CSS rules (recommend `:is()` instead).

Also removed some trailing whitespace in these files.

`grader.ts` still needs to be regenerated.