### PR TITLE
tag version in modern-web-guidance release repo

### DIFF
--- a/serving/skills-cli/publish-skills.ts
+++ b/serving/skills-cli/publish-skills.ts
@@ -86,6 +86,7 @@ async function main() {
       repo: 'git@github.com:GoogleChrome/modern-web-guidance.git',
       dotfiles: true,
       message: `Release v${newVersion}`,
+      tag: `v${newVersion}`,
       remove: "**/*"
     });
 


### PR DESCRIPTION
This should make GitHub tag + generate a zip file for us in the Releases page.