### PR TITLE
Build serving before deploying dashboard (CI workflow)

### DIFF
--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Build serving package
+        run: pnpm --filter serving build
+
       - name: Deploy Dashboard
         run: |
           git config --global user.name "github-actions[bot]"


### PR DESCRIPTION
The latest dashboard deployment in CI workflow failed: https://github.com/GoogleChrome/guidance/actions/runs/24751086138/job/72414120337