### PR TITLE
Add logging for runtime and improve eval latency

### DIFF
--- a/eval-view/dashboard.js
+++ b/eval-view/dashboard.js
@@ -287,6 +287,17 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 });
 
+function formatRuntime(ms) {
+    if (!ms) return '-';
+    const seconds = Math.floor(ms / 1000);
+    const minutes = Math.floor(seconds / 60);
+    const remainingSeconds = seconds % 60;
+    if (minutes > 0) {
+        return `${minutes}m ${remainingSeconds}s`;
+    }
+    return `${seconds}s`;
+}
+
 function renderTestHeader(testId, jetskiVersion, timestamp, data) {
     const container = $('#test-header');
     if (container) {
@@ -331,6 +342,7 @@ function renderTestHeader(testId, jetskiVersion, timestamp, data) {
                 <span>Agent: <strong>${escapeHtml(agent)}</strong></span>
                 <span>Model: <strong style="color: var(--text-secondary);">${escapeHtml(model)}</strong></span>
                 <span>Serving: <strong>${escapeHtml(serving)}</strong></span>
+                ${data.totalRuntime ? `<span>Total Runtime: <strong>${formatRuntime(data.totalRuntime)}</strong></span>` : ''}
             </div>`;
         }
 
@@ -464,6 +476,13 @@ function renderGrid(data, testId) {
                 const totalChecks = runData.reduce((acc, run) => acc + run.results.length, 0);
                 const avgRate = totalChecks > 0 ? Math.round((totalPassed / totalChecks) * 100) : 0;
 
+                // Calculate Average Runtime
+                const totalRuntime = runData.reduce((acc, run) => {
+                    const taskRun = run.runtime ? (run.runtime.agentRuntime || 0) + (run.runtime.graderRuntime || 0) : 0;
+                    return acc + taskRun;
+                }, 0);
+                const avgRuntime = runData.length > 0 ? totalRuntime / runData.length : 0;
+
                 let toolActivationHtml = '';
                 if (runType === 'guided' && testStats && testStats.runsWithToolActivation !== undefined) {
                     const count = testStats.runsWithToolActivation;
@@ -491,6 +510,7 @@ function renderGrid(data, testId) {
                 }
 
                 card.onclick = () => showDetails(testName, runData, testStats, testId);
+                card.style.position = 'relative';
                 card.innerHTML = `
                     <h3>${formatTestName(testName)}</h3>
                     <div class="pass-rate-bar">
@@ -500,6 +520,11 @@ function renderGrid(data, testId) {
                         <span>Average: ${avgRate}% <span style="opacity: 0.8">(${totalPassed}/${totalChecks})</span></span>
                         <span>Runs: ${runData.length}${testStats && testStats.earlyFailures ? ` (<span style="color: var(--accent-failure); font-weight: bold;">${testStats.earlyFailures} failed</span>)` : ''}</span>
                     </div>
+                    ${avgRuntime > 0 ? `
+                    <div style="position: absolute; bottom: 10px; right: 15px; font-size: 0.85em; color: var(--text-secondary);">
+                        Runtime (Average): <strong style="color: var(--text-primary);">${formatRuntime(avgRuntime)}</strong>
+                    </div>
+                    ` : ''}
                     ${toolActivationHtml}
                     ${guideUsageHtml}
                 `;
@@ -674,9 +699,12 @@ async function showDetails(testName, runs, stats, testId) {
 
         const runDetail = document.createElement('div');
         runDetail.className = 'run-detail';
+        const taskRuntime = run.runtime ? (run.runtime.agentRuntime || 0) + (run.runtime.graderRuntime || 0) : null;
+
         runDetail.innerHTML = `
             <div class="run-header">
                 <strong>Run ${run.runNumber}</strong>
+                ${taskRuntime ? `<span style="color: var(--text-secondary); font-size: 0.9em; margin-left: 10px;">(Runtime: ${formatRuntime(taskRuntime)})</span>` : ''}
                 <span style="color: ${getColor(s.rate)}; margin-left: auto; margin-right: 15px;">${s.rate}% Pass (${s.passed}/${s.total})</span>
                 <div class="run-actions">
                 </div>
@@ -731,6 +759,14 @@ async function showDetails(testName, runs, stats, testId) {
                     dropdown.appendChild(rawOpt);
                 }
 
+                const runtimeJson = files.find(f => f === 'runtime.json');
+                if (runtimeJson) {
+                    const runtimeOpt = document.createElement('option');
+                    runtimeOpt.value = 'runtime';
+                    runtimeOpt.textContent = 'Runtime Data';
+                    dropdown.appendChild(runtimeOpt);
+                }
+
                 if (sessionFile) {
                     const trajOpt = document.createElement('option');
                     trajOpt.value = 'trajectory';
@@ -756,6 +792,9 @@ async function showDetails(testName, runs, stats, testId) {
             } else if (val === 'raw') {
                 const rawPath = `${usedBasePath}/${guide}_results.json`;
                 viewContent(rawPath, rawPath);
+            } else if (val === 'runtime') {
+                const runtimePath = `${usedBasePath}/runtime.json`;
+                viewContent(runtimePath, runtimePath);
             }
         };
 

--- a/eval-view/eval-ui.css
+++ b/eval-view/eval-ui.css
@@ -444,7 +444,7 @@ tr:hover td {
 .btn-toggle-group {
   display: flex;
   gap: 0.5rem; /* smaller gap */
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   margin-top: 0.5rem;
 }
 
@@ -458,6 +458,7 @@ tr:hover td {
   font-weight: 500;
   cursor: pointer;
   transition: all 0.2s ease;
+  white-space: nowrap;
 }
 
 .btn-toggle:hover {

--- a/eval-view/eval-ui.html
+++ b/eval-view/eval-ui.html
@@ -34,15 +34,20 @@
                         <input type="text" id="name" placeholder="Leave empty for auto-generated name">
                     </div>
                     <div class="row">
-                        <div class="input-group">
+                        <div class="input-group" style="flex: 0 0 auto;">
                             <label for="numRuns">Number of Runs</label>
                             <input type="number" id="numRuns" value="1" min="1">
+                        </div>
+                        <div class="input-group" style="flex: 0 0 auto;">
+                            <label for="workerCount">Worker Count</label>
+                            <input type="number" id="workerCount" placeholder="Auto" min="1">
                         </div>
                         <div class="input-group">
                             <label>Agent</label>
                             <div class="btn-toggle-group" id="agent-group">
                                 <button type="button" class="btn-toggle active" data-value="gemini_cli">Gemini CLI</button>
                                 <button type="button" class="btn-toggle" data-value="jetski">Jetski</button>
+                                <button type="button" class="btn-toggle" data-value="jetski_cli">Jetski CLI</button>
                                 <button type="button" class="btn-toggle" data-value="claude_code">Claude Code</button>
                                 <button type="button" class="btn-toggle" data-value="codex_cli">Codex CLI</button>
                             </div>

--- a/eval-view/eval-ui.js
+++ b/eval-view/eval-ui.js
@@ -392,12 +392,14 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     const nameEl = document.getElementById('name');
     const numRunsEl = document.getElementById('numRuns');
+    const workerCountEl = document.getElementById('workerCount');
     const agentEl = document.getElementById('agent');
     const servingEl = document.getElementById('serving');
 
     const payload = {
       name: (nameEl instanceof HTMLInputElement) ? nameEl.value || null : null,
       numRuns: (numRunsEl instanceof HTMLInputElement) ? parseInt(numRunsEl.value) : 0,
+      workerCount: (workerCountEl instanceof HTMLInputElement && workerCountEl.value) ? parseInt(workerCountEl.value) : null,
       agent: (agentEl instanceof HTMLInputElement) ? agentEl.value : '',
       serving: (servingEl instanceof HTMLInputElement) ? servingEl.value : '',
       tasks: selectedTasks

--- a/guides/playwright.config.ts
+++ b/guides/playwright.config.ts
@@ -2,8 +2,8 @@ import { defineConfig, devices } from '@playwright/test';
 import * as path from 'path';
 
 export default defineConfig({
-  timeout: 10000,
-  expect: { timeout: 3000 },
+  timeout: 5000,
+  expect: { timeout: 2000 },
   // Forces Playwright to always search relative to this config file (the guides directory),
   // regardless of where you run it from (e.g., when run from within a specific results folder).
   testDir: import.meta.dirname,

--- a/guides/test-fixture.ts
+++ b/guides/test-fixture.ts
@@ -102,7 +102,7 @@ export const test = base.extend<{}, ServerWorkerFixtures>({
     if (serverProcess.pid) {
       try { process.kill(-serverProcess.pid); } catch (e) {}
     }
-  }, { scope: 'worker', timeout: 120000 }]
+  }, { scope: 'worker', timeout: 60000 }]
 });
 
 export { expect } from '@playwright/test';

--- a/harness/config.ts
+++ b/harness/config.ts
@@ -62,6 +62,7 @@ export const defaultSuiteConfig: SuiteConfig = {
   mcpServersToEnable: ['modern-web'],
   serving: Serving.SKILLS_CLI,
   agent: Agents.JETSKI_CLI,
+  workerCount: undefined,
 };
 
 export function mergeSuiteConfig(overrides: Partial<SuiteConfig>): SuiteConfig {
@@ -114,6 +115,7 @@ export interface SuiteConfig {
   mcpServersToEnable: string[];
   serving: Serving;
   agent: string;
+  workerCount?: number;
 }
 
 export const config = {

--- a/harness/evaluate.ts
+++ b/harness/evaluate.ts
@@ -34,7 +34,7 @@ export function mergeResults(oldResults: Record<string, any>, newResults: Record
   return { ...oldResults, ...newResults };
 }
 
-export async function evaluateSuite(suiteResultsDir: string, suiteName: string, totalRuntime?: number) {
+export async function evaluateSuite(suiteResultsDir: string, suiteName: string, suiteStartTime?: number) {
   console.log(`Evaluating suite: ${suiteName}`.cyan);
   console.log(`Results directory: ${suiteResultsDir}`.cyan);
 
@@ -87,9 +87,13 @@ export async function evaluateSuite(suiteResultsDir: string, suiteName: string, 
 
     const metrics = calculateMetrics(mergedResults, numRuns);
     const mdReport = generateMarkdownReport(metrics, mergedResults);
-    
     const model = extractModelFromResults(suiteResultsDir, suiteConfig.agent);
+    const totalRuntime = suiteStartTime ? Date.now() - suiteStartTime : undefined;
     const jsonReport = generateJsonReport(metrics, mergedResults, timestamp, numRuns, suiteConfig.agent, suiteConfig.serving, model, totalRuntime);
+
+    if (totalRuntime) {
+      console.log(`Total runtime: ${totalRuntime}ms`);
+    }
 
     saveReports(suiteResultsDir, mdReport, jsonReport);
 

--- a/harness/evaluate.ts
+++ b/harness/evaluate.ts
@@ -34,7 +34,7 @@ export function mergeResults(oldResults: Record<string, any>, newResults: Record
   return { ...oldResults, ...newResults };
 }
 
-export async function evaluateSuite(suiteResultsDir: string, suiteName: string) {
+export async function evaluateSuite(suiteResultsDir: string, suiteName: string, totalRuntime?: number) {
   console.log(`Evaluating suite: ${suiteName}`.cyan);
   console.log(`Results directory: ${suiteResultsDir}`.cyan);
 
@@ -89,7 +89,7 @@ export async function evaluateSuite(suiteResultsDir: string, suiteName: string) 
     const mdReport = generateMarkdownReport(metrics, mergedResults);
     
     const model = extractModelFromResults(suiteResultsDir, suiteConfig.agent);
-    const jsonReport = generateJsonReport(metrics, mergedResults, timestamp, numRuns, suiteConfig.agent, suiteConfig.serving, model);
+    const jsonReport = generateJsonReport(metrics, mergedResults, timestamp, numRuns, suiteConfig.agent, suiteConfig.serving, model, totalRuntime);
 
     saveReports(suiteResultsDir, mdReport, jsonReport);
 

--- a/harness/lib/collection.ts
+++ b/harness/lib/collection.ts
@@ -281,7 +281,10 @@ export async function collectResults(resultsDir: string, suiteConfig: SuiteConfi
         taskName: taskName,
         baseApp: actualBaseApp,
         prompt: taskInfo.prompt,
-        files: fs.readdirSync(dir).filter(f => !fs.statSync(path.join(dir, f)).isDirectory())
+        files: fs.readdirSync(dir).filter(f => !fs.statSync(path.join(dir, f)).isDirectory()),
+        runtime: fs.existsSync(path.join(dir, 'runtime.json')) 
+          ? JSON.parse(fs.readFileSync(path.join(dir, 'runtime.json'), 'utf-8'))
+          : null
       });
     }
   }

--- a/harness/lib/metrics.ts
+++ b/harness/lib/metrics.ts
@@ -68,6 +68,7 @@ export interface EvalsReport {
   agent: string;
   serving: string;
   model: string;
+  totalRuntime?: number;
 }
 
 export function calculateMetrics(allResults: Record<string, RunResult[]>, runsPerTest: number): Metrics {

--- a/harness/lib/reporting.ts
+++ b/harness/lib/reporting.ts
@@ -57,7 +57,7 @@ export function generateMarkdownReport(metrics: Metrics, allResults: Record<stri
   return md;
 }
 
-export function generateJsonReport(metrics: Metrics, allResults: Record<string, RunResult[]>, timestamp: string, runCount: number, agent: string, serving: string, model: string): EvalsReport {
+export function generateJsonReport(metrics: Metrics, allResults: Record<string, RunResult[]>, timestamp: string, runCount: number, agent: string, serving: string, model: string, totalRuntime?: number): EvalsReport {
   return {
     summary: metrics.summary,
     results: allResults,
@@ -66,7 +66,8 @@ export function generateJsonReport(metrics: Metrics, allResults: Record<string, 
     runCount,
     agent,
     serving,
-    model
+    model,
+    totalRuntime
   };
 }
 

--- a/harness/run_suite.ts
+++ b/harness/run_suite.ts
@@ -209,25 +209,10 @@ export async function runSuite(options: RunSuiteOptions = {}) {
     }
 
     if (!options.skipEval) {
-      await evaluateSuite(testDir, testID);
-      
-      const absoluteTotalRuntime = Date.now() - suiteStart;
-      console.log(`Total runtime: ${absoluteTotalRuntime}ms`);
-      
-      // Post-process evals.json to include the true total runtime
-      const evalsPath = path.join(testDir, 'evals.json');
-      if (fs.existsSync(evalsPath)) {
-        try {
-          const evals = JSON.parse(fs.readFileSync(evalsPath, 'utf-8'));
-          evals.totalRuntime = absoluteTotalRuntime;
-          fs.writeFileSync(evalsPath, JSON.stringify(evals, null, 2));
-        } catch (e) {
-          console.error('⚠️ Failed to update evals.json with total runtime:', e);
-        }
-      }
+      await evaluateSuite(testDir, testID, suiteStart);
     } else {
-      const absoluteTotalRuntime = Date.now() - suiteStart;
-      console.log(`Total runtime: ${absoluteTotalRuntime}ms`);
+      const totalRuntime = Date.now() - suiteStart;
+      console.log(`Total runtime: ${totalRuntime}ms`);
     }
 
     if (hasErrors) {

--- a/harness/run_suite.ts
+++ b/harness/run_suite.ts
@@ -104,6 +104,7 @@ export async function runSuite(options: RunSuiteOptions = {}) {
   // Setup logging to file
   const logFilePath = path.join(testDir, 'test_suite.log');
   const originalConsoleMethods = setupLogging(logFilePath);
+  const suiteStart = Date.now();
 
   console.log(`\n=== Test Suite Starting with ID: ${testID} ===`);
   console.log(`Results will be saved to: ${testDir}\n`);
@@ -117,7 +118,6 @@ export async function runSuite(options: RunSuiteOptions = {}) {
     console.log(`\nStarting execution for ${numRuns} runs`);
 
     for (let runNumber = 1; runNumber < endRun; runNumber++) {
-
       console.log(`\n${'='.repeat(60)}`);
       console.log(`>>> STARTING RUN ${runNumber} <<<`);
       console.log(`${'='.repeat(60)}\n`);
@@ -184,6 +184,8 @@ export async function runSuite(options: RunSuiteOptions = {}) {
           const pnpmArgs = ['-r', '--no-bail'];
           if (agent === Agents.JETSKI) {
             pnpmArgs.push('--workspace-concurrency', '1');
+          } else if (suiteConfig.workerCount) {
+            pnpmArgs.push('--workspace-concurrency', suiteConfig.workerCount.toString());
           }
           pnpmArgs.push('run-agent');
           const suiteConfigPath = path.resolve(testDir, 'suite_config.json');
@@ -208,6 +210,24 @@ export async function runSuite(options: RunSuiteOptions = {}) {
 
     if (!options.skipEval) {
       await evaluateSuite(testDir, testID);
+      
+      const absoluteTotalRuntime = Date.now() - suiteStart;
+      console.log(`Total runtime: ${absoluteTotalRuntime}ms`);
+      
+      // Post-process evals.json to include the true total runtime
+      const evalsPath = path.join(testDir, 'evals.json');
+      if (fs.existsSync(evalsPath)) {
+        try {
+          const evals = JSON.parse(fs.readFileSync(evalsPath, 'utf-8'));
+          evals.totalRuntime = absoluteTotalRuntime;
+          fs.writeFileSync(evalsPath, JSON.stringify(evals, null, 2));
+        } catch (e) {
+          console.error('⚠️ Failed to update evals.json with total runtime:', e);
+        }
+      }
+    } else {
+      const absoluteTotalRuntime = Date.now() - suiteStart;
+      console.log(`Total runtime: ${absoluteTotalRuntime}ms`);
     }
 
     if (hasErrors) {
@@ -403,14 +423,28 @@ const args = [
   workspaceBaseAppDir
 ])}
 ];
-const result = spawnSync(process.execPath, args, { stdio: 'inherit', cwd: ${JSON.stringify(process.cwd())} });
+const start = Date.now();
+const result = spawnSync(process.execPath, args, { stdio: 'inherit', cwd: ${JSON.stringify(process.cwd())}, timeout: 600000 });
+const runtime = Date.now() - start;
+
+let graderRuntime = null;
+let graderStatus = null;
 
 if (result.status === 0) {
-  console.log("Agent finished successfully. Running grader immediately...");
+  const gradeStart = Date.now();
   const gradeResult = spawnSync(process.execPath, ['grade.mjs'], { stdio: 'inherit', cwd: ${JSON.stringify(targetDir)} });
-  process.exit(gradeResult.status ?? 0);
+  graderRuntime = Date.now() - gradeStart;
+  graderStatus = gradeResult.status;
 }
-process.exit(result.status ?? 0);
+
+fs.writeFileSync(path.join(${JSON.stringify(targetDir)}, 'runtime.json'), JSON.stringify({
+  agentRuntime: runtime,
+  graderRuntime: graderRuntime,
+  agentStatus: result.status,
+  graderStatus: graderStatus
+}, null, 2));
+
+process.exit(graderStatus !== null ? graderStatus : result.status ?? 0);
 `.trim();
 
   fs.writeFileSync(path.join(targetDir, 'run.mjs'), runnerContent);


### PR DESCRIPTION
## The main latency changes made were:

1. Reduce Playwright timeouts.
2. Add "Worker Count" to config for setting concurrency in `run_suite.ts`.

Before changes- I ran 1 run of the full default task suite (66 tasks) with Gemini Flash 3, and this took __37 minutes__.

Afterwards, setting `Worker Count` to __20__, the same suite took __15 minutes__.

## Changes made:

Timeout Reductions:
- Lowered defaults to speed up failures: Test (5s), Expect (2s), and Worker Fixture (60s).

Latency Tracking:
- Captured per-task agent and grader execution times in a new runtime.json file.
- Aggregated task times and absolute total suite time into evals.json (via a post-process step).
- Updated console output to log the absolute total runtime.

Performance & Safety:
- Added support for workerCount in the suite configuration to control pnpm concurrency.
- Added a 10-minute safety timeout to agent execution to prevent indefinite hangs.

Dashboard UI:
- Surfaced Total Runtime in the detail page header.
- Surfaced Runtime (Average) on the outer test cards (bottom right).
- Surfaced specific Runtime per run inside the modal.
- Added runtime.json ("Runtime Data") to the Artifacts dropdown in the modal.

Other:
- Added "Jetski CLI" option and "Worker Count" input to the runner UI.

<img width="252" height="180" alt="Screenshot 2026-04-22 at 1 33 10 PM" src="https://github.com/user-attachments/assets/5b56db83-3c09-490a-8b59-a27aba99fc22" />

<img width="547" height="155" alt="Screenshot 2026-04-22 at 1 33 15 PM" src="https://github.com/user-attachments/assets/ac66043d-2868-41e3-8516-77c0363bbe08" />

<img width="189" height="66" alt="Screenshot 2026-04-22 at 1 33 33 PM" src="https://github.com/user-attachments/assets/6d4f34a5-5572-46ff-baa5-e80ecb4382b1" />

<img width="733" height="241" alt="Screenshot 2026-04-22 at 1 33 40 PM" src="https://github.com/user-attachments/assets/2903d031-fc59-403e-b4e7-dfeb0a5949e6" />