### PR TITLE
Adds additional test-results patterns to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ dist/
 # Test artifacts
 eval-view/test-results/
 harness/results/
+harness/test-results/
+tasks/test-results/
 grade-report/
 test-app-results/
 


### PR DESCRIPTION
I noticed a couple of `test-results` folders that were not being ignored. Not sure if this is by design, but in case it's not, this PR adds two additional `test-results` folder patterns to `.gitignore`.