### PR TITLE
fix STATIC=true gd dashboard

### DIFF
--- a/eval-view/api.js
+++ b/eval-view/api.js
@@ -30,7 +30,13 @@ export class ApiClient {
             }
             return url;
         } else {
-            return `${path}?source=${this.source}`;
+            let fullPath = path;
+            // Prepend results/ for local results in static mode
+            if (this.source === 'static' && !path.startsWith('results/') && !path.startsWith('base_apps/') && !path.startsWith('tasks/')) {
+                fullPath = `results/${path}`;
+            }
+            const separator = fullPath.includes('?') ? '&' : '?';
+            return `${fullPath}${separator}source=${this.source}`;
         }
     }
 

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -255,6 +255,7 @@ async function loadLocalTests() {
     try {
         let response = await fetch(`/api/suites?t=${Date.now()}`);
         let manifest;
+        let useResultsPrefix = false;
 
         if (!response.ok) {
             // Try fetching suites.gen.json as fallback for static mode
@@ -263,6 +264,7 @@ async function loadLocalTests() {
             const suites = await staticRes.json();
             // convert array of strings to expected format [{id: string, source: 'local'}]
             manifest = { suites: suites.map(id => ({ id, source: 'local', timestamp: new Date().toISOString() })) };
+            useResultsPrefix = true;
         } else {
             manifest = await response.json();
         }
@@ -278,10 +280,11 @@ async function loadLocalTests() {
             const testId = suite.id;
             const suiteTimestamp = suite.timestamp;
             try {
-                const response = await fetch(`${testId}/evals.json?source=local&t=${Date.now()}`);
+                const fetchPath = useResultsPrefix ? `results/${testId}/evals.json` : `${testId}/evals.json`;
+                const response = await fetch(`${fetchPath}?source=local&t=${Date.now()}`);
                 if (response.ok) {
                     const parsed = await response.json();
-                    registerTestData(testId, 'local', parsed, suiteTimestamp);
+                    registerTestData(testId, useResultsPrefix ? 'static' : 'local', parsed, suiteTimestamp);
                 }
             } catch (e) {
                 console.warn(`Failed to load local test ${testId}:`, e);

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -253,9 +253,19 @@ async function loadLocalTests() {
     }
     
     try {
-        const response = await fetch(`/api/suites?t=${Date.now()}`);
-        if (!response.ok) return; // Silent fail for local if we are on gh-pages
-        const manifest = await response.json();
+        let response = await fetch(`/api/suites?t=${Date.now()}`);
+        let manifest;
+
+        if (!response.ok) {
+            // Try fetching suites.gen.json as fallback for static mode
+            const staticRes = await fetch(`/suites.gen.json?t=${Date.now()}`);
+            if (!staticRes.ok) return; // Silent fail if both fail
+            const suites = await staticRes.json();
+            // convert array of strings to expected format [{id: string, source: 'local'}]
+            manifest = { suites: suites.map(id => ({ id, source: 'local', timestamp: new Date().toISOString() })) };
+        } else {
+            manifest = await response.json();
+        }
 
         if (manifest.suites && manifest.suites.length > 0) {
             document.getElementById('empty-state').style.display = 'none';

--- a/eval-view/server.js
+++ b/eval-view/server.js
@@ -4,6 +4,7 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import { exec, spawn } from 'child_process';
+import { runAllManifests } from './generate-manifests.js';
 
 const PORT = process.env.PORT || 8081;
 const STATIC = process.env.STATIC === 'true';
@@ -12,6 +13,10 @@ if (STATIC) {
   console.log('🌐 Running in STATIC mode via statikk. Dynamic APIs will be unavailable.');
   
   const distDir = path.resolve('../dist/dashboard');
+  
+  console.log('🔄 Generating manifests for static mode...');
+  await runAllManifests({ outputDir: distDir });
+
   if (fs.existsSync(distDir)) {
     fs.rmSync(distDir, { recursive: true, force: true });
   }

--- a/eval-view/server.js
+++ b/eval-view/server.js
@@ -13,9 +13,6 @@ if (STATIC) {
   console.log('🌐 Running in STATIC mode via statikk. Dynamic APIs will be unavailable.');
   
   const distDir = path.resolve('../dist/dashboard');
-  
-  console.log('🔄 Generating manifests for static mode...');
-  await runAllManifests({ outputDir: distDir });
 
   if (fs.existsSync(distDir)) {
     fs.rmSync(distDir, { recursive: true, force: true });
@@ -48,6 +45,9 @@ if (STATIC) {
       console.error(`Failed to create symlink for ${link.name}:`, message);
     }
   }
+
+  console.log('🔄 Generating manifests for static mode...');
+  await runAllManifests({ outputDir: distDir });
 
   console.log(`🚀 Spawning statikk on port ${PORT} serving ../dist/dashboard...`);
   const p = spawn('pnpm', ['dlx', 'statikk', '--port', PORT.toString(), '../dist/dashboard'], { stdio: 'inherit' });

--- a/eval-view/tsconfig.json
+++ b/eval-view/tsconfig.json
@@ -16,6 +16,7 @@
     "node_modules",
     "test-results",
     "mock-results",
-    "features_mapping.gen.js"
+    "features_mapping.gen.js",
+    "**/grade-report"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
     "**/node_modules",
     "**/dist",
     "**/build",
+    "**/grade-report",
     "**/test-app-results/**",
     "harness/results/",
     "**/eval-view",


### PR DESCRIPTION
i thought i did all this in https://github.com/GoogleChrome/guidance/pull/632 but nope.

anyway now `STATIC=true gd dashboard` works and doesnt use any local server.js apis... which lets you test how things work on the proper deployment.