### PR TITLE
fix ghpages publish missing some files

### DIFF
--- a/serving/skills-cli/publish-skills.ts
+++ b/serving/skills-cli/publish-skills.ts
@@ -81,7 +81,7 @@ async function main() {
     console.log(`\nPublishing new dist/skills-cli/ to GoogleChrome/modern-web-guidance (main branch)...`);
     
     await ghpages.publish(publishCliDir, {
-      src: ['**/*'], // No longer vendor node_modules! Users will install via npx -y!
+      src: ['**/*', 'README.md', 'package.json'], // No longer vendor node_modules! Users will install via npx -y!
       branch: 'main',
       repo: 'git@github.com:GoogleChrome/modern-web-guidance.git',
       dotfiles: true,

--- a/serving/skills-cli/publish-skills.ts
+++ b/serving/skills-cli/publish-skills.ts
@@ -81,7 +81,6 @@ async function main() {
     console.log(`\nPublishing new dist/skills-cli/ to GoogleChrome/modern-web-guidance (main branch)...`);
     
     await ghpages.publish(publishCliDir, {
-      src: ['**/*', 'README.md', 'package.json'], // No longer vendor node_modules! Users will install via npx -y!
       branch: 'main',
       repo: 'git@github.com:GoogleChrome/modern-web-guidance.git',
       dotfiles: true,


### PR DESCRIPTION
That glob excludes files in the root folder. ~~Maybe should just remove `src:` entirely but I don't know what else is in the folder...~~ should be fine to remove it.

This was preventing the version numbers in package.json and README.md from being updated