### PR TITLE
prepare for usage of npx and publish to npm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+      - run: git fetch --tags
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+      - run: git fetch --tags
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,23 +54,11 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: pnpm --filter serving run publish-skills
 
-      # =========================================================================
-      # Future: Enable these steps when ready to publish to npm publicly!
-      # =========================================================================
-      # - name: Setup Node with npm registry
-      #   uses: actions/setup-node@v6
-      #   with:
-      #     node-version: 24
-      #     registry-url: 'https://registry.npmjs.org'
-      # 
-      # - name: Publish to npm via OIDC Provenance
-      #   run: |
-      #     npm install -g npm@latest
-      #     cd dist/skills-cli
-      #     
-      #     # Run dry-run for safety or full publish
-      #     # npm publish --provenance --access public --registry https://registry.npmjs.org/
-      #     npm publish --dry-run --provenance --access public --registry https://registry.npmjs.org/
-      # =========================================================================
+      - name: Publish to npm via OIDC Provenance
+        run: |
+          npm install -g npm@latest
+          cd dist/skills-cli-npx
 
-
+          # Run dry-run for safety or full publish
+          # npm publish --provenance --access public --registry https://registry.npmjs.org/
+          npm publish --dry-run --provenance --access public --registry https://registry.npmjs.org/

--- a/serving/lib/practices.test.ts
+++ b/serving/lib/practices.test.ts
@@ -5,9 +5,9 @@ import { getGuide } from "./practices.ts";
 
 describe("getGuide", () => {
   it("should retrieve full guide when no section is provided", async () => {
-    const guide = await getGuide("batch-analytics-events");
+    const guide = await getGuide("accessible-error-announcement");
     assert.ok(guide);
-    assert.ok(guide.includes("# Debounce and batch multiple analytics events"));
+    assert.ok(guide.includes("Standard HTML5 validation provides visual feedback"));
   });
 
   it("should return null for non-existent guide", async () => {

--- a/serving/scripts/build-guides.ts
+++ b/serving/scripts/build-guides.ts
@@ -30,13 +30,42 @@ interface UseCase {
 async function processGuides() {
   const targetGuidePath = process.argv.slice(2).find(arg => !arg.startsWith("--"));
   const force = process.argv.includes("--force");
+  const subsetArg = process.argv.find(arg => arg.startsWith("--subset"));
 
   // Scan guides first to see if we even need to run
   let readyGuides = scanAllGuides().filter(inv => inv.hasGuide);
 
+  if (subsetArg) {
+    const limit = subsetArg.includes("=") ? parseInt(subsetArg.split("=")[1], 10) : 3;
+    readyGuides = readyGuides.slice(0, limit);
+    console.log(`Building a subset of ${readyGuides.length} guides.`);
+  }
+
   const VECTORS_FILE = path.join(ROOT_DIR, "lib/use-cases.vectors.gen.json.gz");
 
-  if (!targetGuidePath && !force && fs.existsSync(OUTPUT_FILE) && fs.existsSync(BUILD_GUIDES_DIR) && fs.existsSync(VECTORS_FILE)) {
+  let shouldSkip = !targetGuidePath && !force && fs.existsSync(OUTPUT_FILE) && fs.existsSync(BUILD_GUIDES_DIR) && fs.existsSync(VECTORS_FILE);
+
+  if (shouldSkip) {
+    // Also check if the count of files in BUILD_GUIDES_DIR matches readyGuides.length
+    const countFiles = (dir: string): number => {
+      let count = 0;
+      const entries = fs.readdirSync(dir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.isDirectory()) {
+          count += countFiles(path.join(dir, entry.name));
+        } else if (entry.name.endsWith(".md")) {
+          count++;
+        }
+      }
+      return count;
+    };
+
+    if (countFiles(BUILD_GUIDES_DIR) !== readyGuides.length) {
+      shouldSkip = false;
+    }
+  }
+
+  if (shouldSkip) {
     const outputFileMTime = Math.min(
       fs.statSync(OUTPUT_FILE).mtimeMs,
       fs.statSync(VECTORS_FILE).mtimeMs

--- a/serving/skills-cli/build-dist.ts
+++ b/serving/skills-cli/build-dist.ts
@@ -76,8 +76,8 @@ function convertSkillToUseNpx(skillDest: string) {
     skillText = skillText.replaceAll(from, to);
   }
 
-  replace(`node <modern-web-directory>/modern-web.mjs search "<query>"`, `npx -p modern-web@latest -- modern-web search "<query>"`);
-  replace(`node <modern-web-directory>/modern-web.mjs retrieve "<id>"`, `npx -p modern-web@latest -- modern-web retrieve "<id>"`);
+  replace(`node <modern-web-directory>/modern-web.mjs search "<query>"`, `npx -p modern-web-guidance@latest -- modern-web search "<query>"`);
+  replace(`node <modern-web-directory>/modern-web.mjs retrieve "<id>"`, `npx -p modern-web-guidance@latest -- modern-web retrieve "<id>"`);
   fs.writeFileSync(skillDest, skillText);
 }
 

--- a/serving/skills-cli/build-dist.ts
+++ b/serving/skills-cli/build-dist.ts
@@ -275,7 +275,13 @@ async function main(opts: {publishRoot: string, version?: string, npx?: boolean,
 
 function updateReadmeWithFeaturesAndUseCases(publishRoot: string) {
   console.log("Generating dynamic README content around features and use cases...");
-  const readyGuides = scanAllGuides().filter(inv => inv.hasGuide);
+  const guidesDir = path.join(publishRoot, 'skills/modern-web/guides');
+  const readyGuides = scanAllGuides().filter(inv => {
+    if (!inv.hasGuide) return false;
+
+    const guideBuildPath = path.join(guidesDir, inv.category, `${inv.name}.md`);
+    return fs.existsSync(guideBuildPath);
+  });
 
   const useCaseGroupMap = new Map<string, { features: { id: string; name: string }[]; useCases: { id: string; description: string }[] }>();
   const allFeatureIds = new Set<string>();

--- a/serving/skills-cli/build-dist.ts
+++ b/serving/skills-cli/build-dist.ts
@@ -81,8 +81,8 @@ function convertSkillToUseNpx(skillDest: string) {
   fs.writeFileSync(skillDest, skillText);
 }
 
-async function main(opts: {publishRoot: string, version?: string, npx?: boolean}): Promise<BuildResult | undefined> {
-  const {publishRoot, version, npx} = opts;
+async function main(opts: {publishRoot: string, version?: string, npx?: boolean, subset?: boolean | number}): Promise<BuildResult | undefined> {
+  const {publishRoot, version, npx, subset} = opts;
 
   fs.rmSync(publishRoot, { recursive: true, force: true });
   fs.mkdirSync(publishRoot, {recursive: true});
@@ -102,7 +102,8 @@ async function main(opts: {publishRoot: string, version?: string, npx?: boolean}
   // 1. Run build-guides.ts to update .modern-web-data and build/guides
   try {
     console.time("⏳ build-guides.ts");
-    execSync("node --experimental-strip-types scripts/build-guides.ts", {
+    const subsetFlag = subset ? (typeof subset === 'number' ? `--subset=${subset}` : '--subset') : '';
+    execSync(`node --experimental-strip-types scripts/build-guides.ts ${subsetFlag}`, {
       cwd: SERVING_DIR,
       stdio: "inherit",
     });
@@ -415,7 +416,7 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
     process.exit(1);
   });
 
-  main({publishRoot: path.join(ROOT_DIST_DIR, "skills-cli-npx"), version, npx: true}).catch((err) => {
+  main({publishRoot: path.join(ROOT_DIST_DIR, "skills-cli-npx"), version, npx: true, subset: 3}).catch((err) => {
     console.error(err);
     process.exit(1);
   });

--- a/serving/skills-cli/build-dist.ts
+++ b/serving/skills-cli/build-dist.ts
@@ -415,7 +415,13 @@ function getLatestVersion() {
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  const version = getLatestVersion();
+  let version;
+  // Not sure why but in CI the `git describe` command fails. Even though we fetched tags. shrug.
+  try {
+    version = getLatestVersion();
+  } catch (err) {
+    console.error(err);
+  }
 
   (async () => {
     try {

--- a/serving/skills-cli/build-dist.ts
+++ b/serving/skills-cli/build-dist.ts
@@ -417,15 +417,15 @@ function getLatestVersion() {
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
   const version = getLatestVersion();
 
-  main({publishRoot: path.join(ROOT_DIST_DIR, "skills-cli"), version}).catch((err) => {
-    console.error(err);
-    process.exit(1);
-  });
-
-  main({publishRoot: path.join(ROOT_DIST_DIR, "skills-cli-npx"), version, npx: true, subset: 3}).catch((err) => {
-    console.error(err);
-    process.exit(1);
-  });
+  (async () => {
+    try {
+      await main({publishRoot: path.join(ROOT_DIST_DIR, "skills-cli"), version});
+      await main({publishRoot: path.join(ROOT_DIST_DIR, "skills-cli-npx"), version, npx: true, subset: 3});
+    } catch (err) {
+      console.error(err);
+      process.exit(1);
+    }
+  })();
 }
 
 export { main as buildDist };

--- a/serving/skills-cli/build-dist.ts
+++ b/serving/skills-cli/build-dist.ts
@@ -10,9 +10,6 @@ import { rootDir } from "../../lib/paths.ts";
 
 const SERVING_DIR = path.join(rootDir, "serving");
 const ROOT_DIST_DIR = path.join(rootDir, "dist");
-const PUBLISH_ROOT = path.join(ROOT_DIST_DIR, "skills-cli");
-
-const DIST_DIR = path.join(PUBLISH_ROOT, "skills/modern-web");
 
 interface BuildResult {
   featuresCount: number;
@@ -68,7 +65,30 @@ function updateVersionsInDir(publishCliDir: string, newVersion: string) {
   console.log(`Updated ${marketplacePath}`);
 }
 
-async function main(version?: string): Promise<BuildResult | undefined> {
+function convertSkillToUseNpx(skillDest: string) {
+  let skillText = fs.readFileSync(skillDest, 'utf-8');
+
+  function replace(from: string, to: string) {
+    if (!skillText.includes(from)) {
+      throw new Error(`expected: '${from}', but not found`);
+    }
+
+    skillText = skillText.replaceAll(from, to);
+  }
+
+  replace(`node <modern-web-directory>/modern-web.mjs search "<query>"`, `npx -p modern-web@latest -- modern-web search "<query>"`);
+  replace(`node <modern-web-directory>/modern-web.mjs retrieve "<id>"`, `npx -p modern-web@latest -- modern-web retrieve "<id>"`);
+  fs.writeFileSync(skillDest, skillText);
+}
+
+async function main(opts: {publishRoot: string, version?: string, npx?: boolean}): Promise<BuildResult | undefined> {
+  const {publishRoot, version, npx} = opts;
+
+  fs.rmSync(publishRoot, { recursive: true, force: true });
+  fs.mkdirSync(publishRoot, {recursive: true});
+
+  const DIST_DIR = path.join(publishRoot, "skills/modern-web");
+
   fs.mkdirSync(ROOT_DIST_DIR, { recursive: true });
   const lockFilePath = path.join(ROOT_DIST_DIR, "build-dist.lock");
 
@@ -76,7 +96,7 @@ async function main(version?: string): Promise<BuildResult | undefined> {
 
   try {
     console.log("Ensuring dist/ output directory exists...");
-    fs.mkdirSync(PUBLISH_ROOT, { recursive: true });
+    fs.mkdirSync(publishRoot, { recursive: true });
 
   console.log("Generating guides and updating vector store...");
   // 1. Run build-guides.ts to update .modern-web-data and build/guides
@@ -95,11 +115,11 @@ async function main(version?: string): Promise<BuildResult | undefined> {
   // Placing modern-web.mjs inside the skill directory instead of bin/ for self-containment!
 
   console.log("Copying installation manifests and metadata for AI tools...");
-  fs.cpSync(path.join(SERVING_DIR, "skills-cli/template"), PUBLISH_ROOT, { recursive: true });
+  fs.cpSync(path.join(SERVING_DIR, "skills-cli/template"), publishRoot, { recursive: true });
 
   if (version) {
     console.log(`Updating version to ${version} in distribution files...`);
-    updateVersionsInDir(PUBLISH_ROOT, version);
+    updateVersionsInDir(publishRoot, version);
   }
 
 
@@ -147,7 +167,7 @@ async function main(version?: string): Promise<BuildResult | undefined> {
       bundle: true,
       platform: "node",
       format: "esm",
-      outfile: path.join(PUBLISH_ROOT, "skills/modern-web/search.mjs"),
+      outfile: path.join(publishRoot, "skills/modern-web/search.mjs"),
       banner: {
         js: `// @ts-nocheck\nimport { createRequire } from 'module';\nconst require = createRequire(import.meta.url);`,
       },
@@ -178,8 +198,8 @@ async function main(version?: string): Promise<BuildResult | undefined> {
         },
       }],
     });
-    fs.writeFileSync(path.join(PUBLISH_ROOT, "search.meta.json"), JSON.stringify(resultSearch.metafile, null, 2));
-    console.log(`Generated metafile for search.mjs at ${path.join(PUBLISH_ROOT, "search.meta.json")}`);
+    fs.writeFileSync(path.join(publishRoot, "search.meta.json"), JSON.stringify(resultSearch.metafile, null, 2));
+    console.log(`Generated metafile for search.mjs at ${path.join(publishRoot, "search.meta.json")}`);
 
     console.log("Bundling modern-web.mjs...");
     const resultModernWeb = await esbuild.build({
@@ -187,7 +207,7 @@ async function main(version?: string): Promise<BuildResult | undefined> {
       bundle: true,
       platform: "node",
       format: "esm",
-      outfile: path.join(PUBLISH_ROOT, "skills/modern-web/modern-web.mjs"),
+      outfile: path.join(publishRoot, "skills/modern-web/modern-web.mjs"),
       plugins: [{
         name: 'rewrite-search',
         setup(build) {
@@ -203,7 +223,7 @@ async function main(version?: string): Promise<BuildResult | undefined> {
     console.log("Generating THIRD_PARTY_NOTICES...");
     generateThirdPartyNotices(
       [resultSearch.metafile, resultModernWeb.metafile],
-      path.join(PUBLISH_ROOT, "THIRD_PARTY_NOTICES")
+      path.join(publishRoot, "THIRD_PARTY_NOTICES")
     );
 
   } catch (error) {
@@ -224,7 +244,7 @@ async function main(version?: string): Promise<BuildResult | undefined> {
   for (const candidate of candidates) {
     const skillSource = path.join(guidesDirInRoot, candidate, "SKILL.md");
     if (fs.existsSync(skillSource)) {
-      const skillDestDir = path.join(PUBLISH_ROOT, "skills", candidate);
+      const skillDestDir = path.join(publishRoot, "skills", candidate);
       const skillDest = path.join(skillDestDir, "SKILL.md");
       fs.mkdirSync(skillDestDir, { recursive: true });
       fs.copyFileSync(skillSource, skillDest);
@@ -233,9 +253,15 @@ async function main(version?: string): Promise<BuildResult | undefined> {
       skillNames.push(candidate);
     }
   }
+
+  if (npx) {
+    const skillDest = path.join(DIST_DIR, "SKILL.md");
+    convertSkillToUseNpx(skillDest);
+  }
+
   console.log(`Successfully copied ${skillsCount} skills to distribution.`);
 
-  const { featuresCount, useCasesCount } = updateReadmeWithFeaturesAndUseCases(PUBLISH_ROOT);
+  const { featuresCount, useCasesCount } = updateReadmeWithFeaturesAndUseCases(publishRoot);
 
   console.log("\nSuccess! standalone distribution generated in dist/skills-cli/");
   return { featuresCount, useCasesCount, skillsCount, skillNames };
@@ -374,8 +400,22 @@ function generateThirdPartyNotices(metafiles: esbuild.Metafile[], outputFilePath
   console.log(`Generated THIRD_PARTY_NOTICES at ${outputFilePath}`);
 }
 
+function getLatestVersion() {
+  const getLatestGitTag = () => execSync('git describe --tags --abbrev=0 --match="v*.*.*"', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim();
+  const tag = getLatestGitTag();
+  const version = tag.startsWith('v') ? tag.slice(1) : tag;
+  return version;
+}
+
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  main().catch((err) => {
+  const version = getLatestVersion();
+
+  main({publishRoot: path.join(ROOT_DIST_DIR, "skills-cli"), version}).catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+
+  main({publishRoot: path.join(ROOT_DIST_DIR, "skills-cli-npx"), version, npx: true}).catch((err) => {
     console.error(err);
     process.exit(1);
   });

--- a/serving/skills-cli/publish-skills.ts
+++ b/serving/skills-cli/publish-skills.ts
@@ -61,7 +61,7 @@ async function publishToNpm(newVersion: string) {
   console.log(`\nRebuilding distribution with version ${newVersion} for npm...`);
 
   const publishCliDir = path.join(DIST_DIR, "skills-cli-npx");
-  const result = await buildDist({publishRoot: publishCliDir, version: newVersion, npx: true});
+  const result = await buildDist({publishRoot: publishCliDir, version: newVersion, npx: true, subset: 3});
   if (!result) {
     throw new Error("Build failed or was already in progress.");
   }

--- a/serving/skills-cli/publish-skills.ts
+++ b/serving/skills-cli/publish-skills.ts
@@ -57,17 +57,13 @@ async function publishToDistributionRepo(publishCliDir: string, newVersion: stri
   console.log(`\n✅ Successfully published v${newVersion} to GoogleChrome/modern-web-guidance!`);
 }
 
-async function publishToNpm(newVersion: string) {
+async function buildForNpm(newVersion: string) {
   console.log(`\nRebuilding distribution with version ${newVersion} for npm...`);
 
   const publishCliDir = path.join(DIST_DIR, "skills-cli-npx");
   const result = await buildDist({publishRoot: publishCliDir, version: newVersion, npx: true, subset: 3});
   if (!result) {
     throw new Error("Build failed or was already in progress.");
-  }
-
-  if (isDryRun) {
-    return;
   }
 }
 
@@ -76,6 +72,7 @@ async function main() {
   const publishCliDir = path.join(DIST_DIR, "skills-cli");
 
   console.log(`\nRebuilding distribution with version ${newVersion}...`);
+  // TODO: when we release, this should be changed to `npx: true` to publish a npm-ready package.
   const result = await buildDist({publishRoot: publishCliDir, version: newVersion});
   if (!result) {
     throw new Error("Build failed or was already in progress.");
@@ -126,7 +123,7 @@ ${skillNames.map(skill => `  - ${skill}`).join('\n')}`.trim();
     console.log('\nPerhaps also:\n    pushd ~/code/skills-alpha && git pull gh && git push gob && popd');
   }
 
-  await publishToNpm(newVersion);
+  await buildForNpm(newVersion);
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/serving/skills-cli/publish-skills.ts
+++ b/serving/skills-cli/publish-skills.ts
@@ -17,7 +17,6 @@ function incrementVersion(version: string): string {
   return `${parts[0]}.${parts[1]}.${patch}`;
 }
 
-
 const getLatestGitTag = () => execSync('git describe --tags --abbrev=0 --match="v*.*.*"', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim();
 
 export async function getNextVersion(getLatestTag = getLatestGitTag): Promise<string> {
@@ -58,15 +57,26 @@ async function publishToDistributionRepo(publishCliDir: string, newVersion: stri
   console.log(`\n✅ Successfully published v${newVersion} to GoogleChrome/modern-web-guidance!`);
 }
 
+async function publishToNpm(newVersion: string) {
+  console.log(`\nRebuilding distribution with version ${newVersion} for npm...`);
+
+  const publishCliDir = path.join(DIST_DIR, "skills-cli-npx");
+  const result = await buildDist({publishRoot: publishCliDir, version: newVersion, npx: true});
+  if (!result) {
+    throw new Error("Build failed or was already in progress.");
+  }
+
+  if (isDryRun) {
+    return;
+  }
+}
+
 async function main() {
   const newVersion = await getNextVersion();
-  
   const publishCliDir = path.join(DIST_DIR, "skills-cli");
-  await fs.mkdir(publishCliDir, {recursive: true});
-  await fs.rm(publishCliDir, { recursive: true, force: true });
 
   console.log(`\nRebuilding distribution with version ${newVersion}...`);
-  const result = await buildDist(newVersion);
+  const result = await buildDist({publishRoot: publishCliDir, version: newVersion});
   if (!result) {
     throw new Error("Build failed or was already in progress.");
   }
@@ -115,6 +125,8 @@ ${skillNames.map(skill => `  - ${skill}`).join('\n')}`.trim();
 
     console.log('\nPerhaps also:\n    pushd ~/code/skills-alpha && git pull gh && git push gob && popd');
   }
+
+  await publishToNpm(newVersion);
 }
 
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/serving/skills-cli/template/package.json
+++ b/serving/skills-cli/template/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "modern-web-guidance",
+  "name": "modern-web",
   "displayName": "Modern Web Guidance",
   "private": true,
   "description": "Curated collection of agent skills for modern web development.",

--- a/serving/skills-cli/template/package.json
+++ b/serving/skills-cli/template/package.json
@@ -1,7 +1,6 @@
 {
   "name": "modern-web",
   "displayName": "Modern Web Guidance",
-  "private": true,
   "description": "Curated collection of agent skills for modern web development.",
   "version": "0.0.26",
   "publisher": "GoogleChrome",

--- a/serving/skills-cli/template/package.json
+++ b/serving/skills-cli/template/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "modern-web",
+  "name": "modern-web-guidance",
   "displayName": "Modern Web Guidance",
   "description": "Curated collection of agent skills for modern web development.",
   "version": "0.0.26",


### PR DESCRIPTION
ref b/508297009

This PR prepares the codebase for publishing the `modern-web-guidance` package to NPM by introducing a specialized build distribution and enabling the corresponding GitHub Actions workflow.

There is no impact on `GoogleChrome/modern-web-guidance` for now. Eventually, we will update the SKILL.md shipped there to use `npx`. We don't now b/c npm will only have a subset of guides until we are ready to go public.

* Updated the build process to generate a new `dist/skills-cli-npx` directory. This dist folder is specifically tailored for npx usage, replacing local execution paths with `npx -p modern-web-guidance@latest`.
* Added a --subset flag to the guide builder. This allows us to publish just a subset to npm for now.
* Enabled the OIDC-based NPM publishing step in the publish.yml workflow, targeting the new skills-cli-npx distribution.
