### PR TITLE
add cross-guide reference macro and build integration

### DIFF
--- a/eval-view/dashboard.js
+++ b/eval-view/dashboard.js
@@ -596,7 +596,7 @@ function renderGrid(data, testId) {
             if (!unguidedRuns && !guidedRuns) return; // Skip if neither exists
 
             const sampleRun = (unguidedRuns && unguidedRuns[0]) || (guidedRuns && guidedRuns[0]);
-            const isSkill = sampleRun ? sampleRun.isSkill : false;
+            const isDisciplineSkill = sampleRun ? (sampleRun.isDisciplineSkill !== undefined ? sampleRun.isDisciplineSkill : sampleRun.isSkill) : false;
 
             sortedScenarios.push(scenarioName);
 
@@ -629,8 +629,8 @@ function renderGrid(data, testId) {
                 <div class="task-accordion-header">
                     <div class="left-section">
                         <span class="chevron" style="display: inline-block; transition: transform 0.2s; margin-right: 10px;">▶</span>
-                        <span class="feature-chip">${escapeHtml(formatTestName(scenarioName, isSkill).split(': ')[0])}</span>
-                        <span class="task-title">${escapeHtml(formatTestName(scenarioName, isSkill).split(': ')[1] || '')}</span>
+                        <span class="feature-chip">${escapeHtml(formatTestName(scenarioName, isDisciplineSkill).split(': ')[0])}</span>
+                        <span class="task-title">${escapeHtml(formatTestName(scenarioName, isDisciplineSkill).split(': ')[1] || '')}</span>
                     </div>
                     <div class="right-section">
                         <div class="mini-dumbbell-track">
@@ -661,10 +661,10 @@ function renderGrid(data, testId) {
                 }
             };
 
-            const targetGrid = isSkill ? disciplineGrid : guideGrid;
+            const targetGrid = isDisciplineSkill ? disciplineGrid : guideGrid;
             if (targetGrid) {
                 targetGrid.appendChild(accordion);
-                if (isSkill) {
+                if (isDisciplineSkill) {
                     const section = document.getElementById('discipline-section');
                     if (section) section.style.display = 'block';
                 }
@@ -810,7 +810,8 @@ async function fillAccordionDetails(container, scenarioName, unguidedRuns, guide
             const hasExpectedPrefix = run.expectedToolPrefixes && run.expectedToolPrefixes.some(p => g.startsWith(p));
             const isGreen = isExpectedGuide || hasExpectedPrefix;
             
-            const isCorrespondingDiscipline = !run.isSkill && g === run.discipline;
+            const runIsDisciplineSkill = run.isDisciplineSkill !== undefined ? run.isDisciplineSkill : run.isSkill;
+            const isCorrespondingDiscipline = !runIsDisciplineSkill && g === run.discipline;
 
             let className = 'default-guide';
             let style = 'padding: 2px 4px; border-radius: 4px; font-family: monospace;';
@@ -900,7 +901,8 @@ async function fillAccordionDetails(container, scenarioName, unguidedRuns, guide
                              <div class="run-card-row-inner" style="flex-wrap: wrap;">
                                                                    ${toolsUsed.map(t => {
                                       const isCorrectTool = run.expectedToolPrefixes && run.expectedToolPrefixes.some(p => t.startsWith(p));
-                                      const isCorrespondingDiscipline = !run.isSkill && t === run.discipline;
+                                      const runIsDisciplineSkill = run.isDisciplineSkill !== undefined ? run.isDisciplineSkill : run.isSkill;
+                                       const isCorrespondingDiscipline = !runIsDisciplineSkill && t === run.discipline;
 
                                       let className = 'default-guide';
                                       let style = 'padding: 2px 4px; border-radius: 4px; font-family: monospace;';

--- a/eval-view/generate-manifests.js
+++ b/eval-view/generate-manifests.js
@@ -106,9 +106,9 @@ export async function generateGroupedTasksManifest(outputDir = '.') {
     for (const [key, info] of taskMap.entries()) {
         const [guide, task] = key.split('/');
         const parentDir = path.basename(path.dirname(info.guideDir));
-        const isSkill = parentDir === 'guides';
+        const isDisciplineSkill = parentDir === 'guides';
         
-        if (isSkill) {
+        if (isDisciplineSkill) {
             if (!disciplines[guide]) disciplines[guide] = [];
             disciplines[guide].push(task);
         } else {

--- a/eval-view/server.js
+++ b/eval-view/server.js
@@ -189,9 +189,9 @@ const server = http.createServer(async (req, res) => {
         const [guide, task] = key.split('/');
         
         const parentDir = path.basename(path.dirname(info.guideDir));
-        const isSkill = parentDir === 'guides';
+        const isDisciplineSkill = parentDir === 'guides';
         
-        if (isSkill) {
+        if (isDisciplineSkill) {
           if (!disciplines[guide]) disciplines[guide] = [];
           disciplines[guide].push(task);
         } else {

--- a/eval-view/utils.js
+++ b/eval-view/utils.js
@@ -115,7 +115,7 @@ export function calculateChartData(results) {
 }
 
 
-export function formatTestName(name, isSkill = false) {
+export function formatTestName(name, isDisciplineSkill = false) {
     if (!name) return name;
     const parts = name.split(' - ');
     if (parts.length >= 2) {
@@ -125,7 +125,7 @@ export function formatTestName(name, isSkill = false) {
         const featuresMap = window.__featuresMapping || {};
         let featureId = '';
         
-        if (isSkill) {
+        if (isDisciplineSkill) {
             // For skills, the first part is the discipline (e.g. performance)
             return `${appName}: ${guideName}`; // discipline: task
         }

--- a/guides/css/SKILL.md
+++ b/guides/css/SKILL.md
@@ -285,4 +285,6 @@ Keep CSS architecture clean by explicitly scoping styles to components.
     font-weight: bold;
   }
 }
+
+
 ```

--- a/guides/css/SKILL.md
+++ b/guides/css/SKILL.md
@@ -64,11 +64,11 @@ Modern CSS provides advanced effects for depth, textures, and non-rectangular ge
 ### Code Example: Advanced Visuals
 ```css
 .card {
-  box-shadow: 
-    0 1px 1px rgba(0,0,0,0.1), 
-    0 2px 2px rgba(0,0,0,0.1), 
+  box-shadow:
+    0 1px 1px rgba(0,0,0,0.1),
+    0 2px 2px rgba(0,0,0,0.1),
     0 4px 4px rgba(0,0,0,0.1); /* Layered shadow */
-    
+
   border-radius: 50px / 25px; /* Elliptical corners */
 }
 
@@ -107,19 +107,19 @@ Modern browser-native selectors reduce the need for preprocessors and complex st
 ```css
 .card {
   position: relative;
-  
+
   /* Accessible focus visible state */
   &:focus-visible {
     outline: 2px solid var(--accent);
     outline-offset: 4px; /* Separate ring from border */
   }
-  
+
   /* Conditional styling based on content */
   &:has(img) { padding: 0; }
-  
+
   /* State management without extra classes */
   &:has(input:checked) { border-color: var(--active); }
-  
+
   /* Shared styles without high specificity */
   :is(.title, .subtitle) {
     margin: 0;

--- a/guides/css/SKILL.md
+++ b/guides/css/SKILL.md
@@ -93,7 +93,7 @@ Modern browser-native selectors reduce the need for preprocessors and complex st
 
 ### DOs and DON'Ts
 - **DO** use native CSS nesting to group related styles (3 levels max).
-- **DO** use `:has()` to style parents based on child state (e.g., `.form-group:has(:invalid)`).
+- **DO** use `:has()` to style parents based on child state (e.g., `.form-group:has(:invalid)`). For more information, see the guides at {{ GUIDE_REF("child-state-based-styling") }} and {{ GUIDE_REF("content-based-styling") }}.
 - **DON'T** nest `:has()` or use pseudo-elements inside `:has()` (browser API limitation).
 - **DO** use Attribute selectors (e.g., `[disabled]`) to style elements based on their state or metadata.
 - **DO** use `:where()` for baseline styles you want to be easily overridable (0 specificity).

--- a/harness/lib/collection.ts
+++ b/harness/lib/collection.ts
@@ -203,9 +203,9 @@ export async function collectResults(resultsDir: string, suiteConfig: SuiteConfi
       }
 
       let taskCategory = path.basename(path.dirname(taskInfo.guideDir));
-      const isSkill = taskCategory === 'guides';
+      const isDisciplineSkill = taskCategory === 'guides';
       let expectedToolPrefixes = ['modern-web'].filter(Boolean);
-      if (isSkill) {
+      if (isDisciplineSkill) {
         taskCategory = path.basename(taskInfo.guideDir);
         expectedToolPrefixes = [taskCategory].filter(Boolean);
       }
@@ -263,7 +263,7 @@ export async function collectResults(resultsDir: string, suiteConfig: SuiteConfi
 
       // For skills, placing the discipline name (`guide`) first ensures it is correctly identified 
       // and displayed as the main category in the dashboard's transposed layout.
-      const testName = isSkill ? `${guide} - ${taskName} - ${runType}` : `${taskName} - ${guide} - ${runType}`;
+      const testName = isDisciplineSkill ? `${guide} - ${taskName} - ${runType}` : `${taskName} - ${guide} - ${runType}`;
       const actualBaseApp = taskInfo.baseApp;
 
       let totalTokens = 0;
@@ -355,7 +355,7 @@ export async function collectResults(resultsDir: string, suiteConfig: SuiteConfi
         fileReadGuides: fileReadGuides,
         guidanceToolsUsed: guidanceToolsUsedResult,
         discipline: taskCategory,
-        isSkill: isSkill,
+        isDisciplineSkill: isDisciplineSkill,
         expectedToolPrefixes: expectedToolPrefixes,
         guideName: guide,
         baseApp: actualBaseApp,

--- a/harness/lib/metrics.ts
+++ b/harness/lib/metrics.ts
@@ -12,7 +12,7 @@ export interface RunResult {
   guidanceToolsUsed?: string[];
   expectedToolPrefixes?: string[];
   guideName?: string;
-  isSkill?: boolean;
+  isDisciplineSkill?: boolean;
   taskName?: string;
   baseApp?: string;
   prompt?: string;
@@ -60,7 +60,7 @@ export interface Metrics {
     passedChecks: number;
     totalChecks: number;
 
-    isSkill?: boolean;
+    isDisciplineSkill?: boolean;
     earlyFailures?: number;
     avgTokens?: { total: number; cached: number };
   }>;
@@ -139,7 +139,7 @@ export function calculateMetrics(allResults: Record<string, RunResult[]>, runsPe
         const guidesUsed = run.guidesUsed || [];
         const expectedGuide = run.guideName;
         // For skills, we track guides used but there is no expected guide
-        if (!run.isSkill && expectedGuide && guidesUsed.includes(expectedGuide)) {
+        if (!run.isDisciplineSkill && expectedGuide && guidesUsed.includes(expectedGuide)) {
           guideUsageCount++;
         }
 
@@ -170,7 +170,7 @@ export function calculateMetrics(allResults: Record<string, RunResult[]>, runsPe
       runsUsingGuide: runType === 'guided' ? guideUsageCount : undefined,
       runsWithToolActivation: runType === 'guided' ? toolActivationCount : undefined,
       runCount: runs.length,
-      isSkill: runs[0]?.isSkill,
+      isDisciplineSkill: runs[0]?.isDisciplineSkill,
       passedChecks,
       totalChecks,
       earlyFailures,
@@ -226,7 +226,7 @@ export function calculateMetrics(allResults: Record<string, RunResult[]>, runsPe
           toolActivationCount += stats.runsWithToolActivation || 0;
           totalGuidedRuns += stats.runCount || 0;
 
-          if (!stats.isSkill) {
+          if (!stats.isDisciplineSkill) {
             totalGuidedNonDisciplineRuns += stats.runCount || 0;
             guidedNonDisciplineEarlyFailures += stats.earlyFailures || 0;
           }

--- a/lib/guide-validation.ts
+++ b/lib/guide-validation.ts
@@ -436,3 +436,16 @@ export function scanAllGuides(scanDir = guidesDir): GuideInventory[] {
   }
   return guides;
 }
+
+let cachedGuidesMap: Map<string, GuideInventory> | null = null;
+
+export function getGuidesMap(): Map<string, GuideInventory> {
+  if (!cachedGuidesMap) {
+    cachedGuidesMap = new Map(scanAllGuides().map(g => [g.name, g]));
+  }
+  return cachedGuidesMap;
+}
+
+export function resetGuidesMap() {
+  cachedGuidesMap = null;
+}

--- a/lib/guide-validation.ts
+++ b/lib/guide-validation.ts
@@ -275,6 +275,7 @@ export interface GuideInventory {
   hasGrader: boolean;
   hasTask: boolean;
   featureIds: string[];
+  isCategorySkill?: boolean;
 }
 
 export interface TaskInfo {
@@ -437,11 +438,44 @@ export function scanAllGuides(scanDir = guidesDir): GuideInventory[] {
   return guides;
 }
 
+export function scanCategorySkills(scanDir = guidesDir): GuideInventory[] {
+  const skills: GuideInventory[] = [];
+  if (!fs.existsSync(scanDir)) return skills;
+
+  const categories = fs.readdirSync(scanDir, { withFileTypes: true })
+    .filter(d => d.isDirectory() && !d.name.startsWith('.') && d.name !== 'node_modules')
+    .map(d => d.name);
+
+  for (const category of categories) {
+    const categoryDir = path.join(scanDir, category);
+    const skillPath = path.join(categoryDir, 'SKILL.md');
+    if (fs.existsSync(skillPath)) {
+      skills.push({
+        dir: categoryDir,
+        name: category,
+        category: category,
+        hasGuide: true,
+        isStub: false,
+        hasDemo: false,
+        hasExpectations: false,
+        expectationsEmpty: true,
+        hasNegativeDemo: false,
+        hasGrader: false,
+        hasTask: false,
+        featureIds: [],
+        isCategorySkill: true,
+      });
+    }
+  }
+  return skills;
+}
+
 let cachedGuidesMap: Map<string, GuideInventory> | null = null;
 
 export function getGuidesMap(): Map<string, GuideInventory> {
   if (!cachedGuidesMap) {
-    cachedGuidesMap = new Map(scanAllGuides().map(g => [g.name, g]));
+    const allItems = [...scanAllGuides(), ...scanCategorySkills()];
+    cachedGuidesMap = new Map(allItems.map(g => [g.name, g]));
   }
   return cachedGuidesMap;
 }

--- a/lib/guide-validation.ts
+++ b/lib/guide-validation.ts
@@ -275,7 +275,6 @@ export interface GuideInventory {
   hasGrader: boolean;
   hasTask: boolean;
   featureIds: string[];
-  isCategorySkill?: boolean;
 }
 
 export interface TaskInfo {
@@ -438,44 +437,11 @@ export function scanAllGuides(scanDir = guidesDir): GuideInventory[] {
   return guides;
 }
 
-export function scanCategorySkills(scanDir = guidesDir): GuideInventory[] {
-  const skills: GuideInventory[] = [];
-  if (!fs.existsSync(scanDir)) return skills;
-
-  const categories = fs.readdirSync(scanDir, { withFileTypes: true })
-    .filter(d => d.isDirectory() && !d.name.startsWith('.') && d.name !== 'node_modules')
-    .map(d => d.name);
-
-  for (const category of categories) {
-    const categoryDir = path.join(scanDir, category);
-    const skillPath = path.join(categoryDir, 'SKILL.md');
-    if (fs.existsSync(skillPath)) {
-      skills.push({
-        dir: categoryDir,
-        name: category,
-        category: category,
-        hasGuide: true,
-        isStub: false,
-        hasDemo: false,
-        hasExpectations: false,
-        expectationsEmpty: true,
-        hasNegativeDemo: false,
-        hasGrader: false,
-        hasTask: false,
-        featureIds: [],
-        isCategorySkill: true,
-      });
-    }
-  }
-  return skills;
-}
-
 let cachedGuidesMap: Map<string, GuideInventory> | null = null;
 
 export function getGuidesMap(): Map<string, GuideInventory> {
   if (!cachedGuidesMap) {
-    const allItems = [...scanAllGuides(), ...scanCategorySkills()];
-    cachedGuidesMap = new Map(allItems.map(g => [g.name, g]));
+    cachedGuidesMap = new Map(scanAllGuides().map(g => [g.name, g]));
   }
   return cachedGuidesMap;
 }

--- a/lib/guide-validation.ts
+++ b/lib/guide-validation.ts
@@ -275,7 +275,7 @@ export interface GuideInventory {
   hasGrader: boolean;
   hasTask: boolean;
   featureIds: string[];
-  isCategorySkill?: boolean;
+  isDisciplineSkill?: boolean;
 }
 
 export interface TaskInfo {
@@ -438,7 +438,7 @@ export function scanAllGuides(scanDir = guidesDir): GuideInventory[] {
   return guides;
 }
 
-export function scanCategorySkills(scanDir = guidesDir): GuideInventory[] {
+export function scanDisciplineSkills(scanDir = guidesDir): GuideInventory[] {
   const skills: GuideInventory[] = [];
   if (!fs.existsSync(scanDir)) return skills;
 
@@ -463,7 +463,7 @@ export function scanCategorySkills(scanDir = guidesDir): GuideInventory[] {
         hasGrader: false,
         hasTask: false,
         featureIds: [],
-        isCategorySkill: true,
+        isDisciplineSkill: true,
       });
     }
   }
@@ -474,7 +474,7 @@ let cachedGuidesMap: Map<string, GuideInventory> | null = null;
 
 export function getGuidesMap(): Map<string, GuideInventory> {
   if (!cachedGuidesMap) {
-    const allItems = [...scanAllGuides(), ...scanCategorySkills()];
+    const allItems = [...scanAllGuides(), ...scanDisciplineSkills()];
     cachedGuidesMap = new Map(allItems.map(g => [g.name, g]));
   }
   return cachedGuidesMap;

--- a/lib/guide-validation.ts
+++ b/lib/guide-validation.ts
@@ -275,6 +275,7 @@ export interface GuideInventory {
   hasGrader: boolean;
   hasTask: boolean;
   featureIds: string[];
+  isCategorySkill?: boolean;
 }
 
 export interface TaskInfo {
@@ -423,8 +424,8 @@ export function scanAllGuides(scanDir = guidesDir): GuideInventory[] {
   if (!fs.existsSync(guidesDir)) return guides;
 
   const categories = fs.readdirSync(scanDir, { withFileTypes: true })
-    .filter(d => d.isDirectory() && !d.name.startsWith('.') && d.name !== 'node_modules')
-    .map(d => d.name);
+     .filter(d => d.isDirectory() && !d.name.startsWith('.') && d.name !== 'node_modules')
+     .map(d => d.name);
 
   for (const category of categories) {
     const categoryDir = path.join(scanDir, category);
@@ -437,11 +438,44 @@ export function scanAllGuides(scanDir = guidesDir): GuideInventory[] {
   return guides;
 }
 
+export function scanCategorySkills(scanDir = guidesDir): GuideInventory[] {
+  const skills: GuideInventory[] = [];
+  if (!fs.existsSync(scanDir)) return skills;
+
+  const categories = fs.readdirSync(scanDir, { withFileTypes: true })
+    .filter(d => d.isDirectory() && !d.name.startsWith('.') && d.name !== 'node_modules')
+    .map(d => d.name);
+
+  for (const category of categories) {
+    const categoryDir = path.join(scanDir, category);
+    const skillPath = path.join(categoryDir, 'SKILL.md');
+    if (fs.existsSync(skillPath)) {
+      skills.push({
+        dir: categoryDir,
+        name: category,
+        category: category,
+        hasGuide: true,
+        isStub: false,
+        hasDemo: false,
+        hasExpectations: false,
+        expectationsEmpty: true,
+        hasNegativeDemo: false,
+        hasGrader: false,
+        hasTask: false,
+        featureIds: [],
+        isCategorySkill: true,
+      });
+    }
+  }
+  return skills;
+}
+
 let cachedGuidesMap: Map<string, GuideInventory> | null = null;
 
 export function getGuidesMap(): Map<string, GuideInventory> {
   if (!cachedGuidesMap) {
-    cachedGuidesMap = new Map(scanAllGuides().map(g => [g.name, g]));
+    const allItems = [...scanAllGuides(), ...scanCategorySkills()];
+    cachedGuidesMap = new Map(allItems.map(g => [g.name, g]));
   }
   return cachedGuidesMap;
 }

--- a/lib/paths.ts
+++ b/lib/paths.ts
@@ -6,8 +6,12 @@ import path from 'path';
  */
 export function getRootDir(): string {
   try {
+    const env = { ...process.env };
+    delete env.GIT_DIR;
+    delete env.GIT_WORK_TREE;
     return execSync('git rev-parse --show-toplevel', {
       encoding: 'utf-8',
+      env,
       stdio: ['pipe', 'pipe', 'pipe'],
     }).trim();
   } catch {

--- a/serving/lib/macros.test.ts
+++ b/serving/lib/macros.test.ts
@@ -58,18 +58,6 @@ describe('replaceMacros (Functional with real data)', () => {
       assert.ok(result.includes('`performance/break-up-long-tasks/guide.md`'));
     });
 
-    it('replaces macro with category-level skill path for local-dev', () => {
-      const content = '{{ GUIDE_REF("forms") }}';
-      const result = replaceMacros(content, 'test.md');
-      assert.ok(result.includes('`forms/SKILL.md`'));
-    });
-
-    it('replaces macro with category-level skill command for skills-cli', () => {
-      const content = '{{ GUIDE_REF("forms") }}';
-      const result = replaceMacros(content, 'test.md', { target: 'skills-cli' });
-      assert.ok(result.includes('`forms` (via `node <modern-web-directory>/modern-web.mjs retrieve "forms"`)'));
-    });
-
     it('throws error for non-existent guide', () => {
       const content = '{{ GUIDE_REF("non-existent-guide-xyz") }}';
       assert.throws(() => replaceMacros(content, 'test.md'), /Guide "non-existent-guide-xyz" not found/);

--- a/serving/lib/macros.test.ts
+++ b/serving/lib/macros.test.ts
@@ -58,6 +58,18 @@ describe('replaceMacros (Functional with real data)', () => {
       assert.ok(result.includes('`performance/break-up-long-tasks/guide.md`'));
     });
 
+    it('replaces macro with forms skill path', () => {
+      const content = '{{ GUIDE_REF("forms") }}';
+      const result = replaceMacros(content, 'test.md');
+      assert.ok(result.includes('`forms/SKILL.md`'));
+    });
+
+    it('replaces macro with category-level skill command for skills-cli', () => {
+      const content = '{{ GUIDE_REF("forms") }}';
+      const result = replaceMacros(content, 'test.md', { target: 'skills-cli' });
+      assert.ok(result.includes('`forms` (via `node <modern-web-directory>/modern-web.mjs retrieve "forms"`)'));
+    });
+
     it('throws error for non-existent guide', () => {
       const content = '{{ GUIDE_REF("non-existent-guide-xyz") }}';
       assert.throws(() => replaceMacros(content, 'test.md'), /Guide "non-existent-guide-xyz" not found/);

--- a/serving/lib/macros.test.ts
+++ b/serving/lib/macros.test.ts
@@ -50,4 +50,17 @@ describe('replaceMacros (Functional with real data)', () => {
     assert.ok(result.includes('Widely available'));
     assert.ok(result.includes('Baseline since'));
   });
+
+  describe('GUIDE_REF', () => {
+    it('replaces macro with guide path', () => {
+      const content = '{{ GUIDE_REF("break-up-long-tasks") }}';
+      const result = replaceMacros(content, 'test.md');
+      assert.ok(result.includes('guides/performance/break-up-long-tasks/guide.md'));
+    });
+
+    it('throws error for non-existent guide', () => {
+      const content = '{{ GUIDE_REF("non-existent-guide-xyz") }}';
+      assert.throws(() => replaceMacros(content, 'test.md'), /Guide "non-existent-guide-xyz" not found/);
+    });
+  });
 });

--- a/serving/lib/macros.test.ts
+++ b/serving/lib/macros.test.ts
@@ -58,6 +58,18 @@ describe('replaceMacros (Functional with real data)', () => {
       assert.ok(result.includes('`performance/break-up-long-tasks/guide.md`'));
     });
 
+    it('replaces macro with category-level skill path for local-dev', () => {
+      const content = '{{ GUIDE_REF("forms") }}';
+      const result = replaceMacros(content, 'test.md');
+      assert.ok(result.includes('`forms/SKILL.md`'));
+    });
+
+    it('replaces macro with category-level skill command for skills-cli', () => {
+      const content = '{{ GUIDE_REF("forms") }}';
+      const result = replaceMacros(content, 'test.md', { target: 'skills-cli' });
+      assert.ok(result.includes('`forms` (via `node <modern-web-directory>/modern-web.mjs retrieve "forms"`)'));
+    });
+
     it('throws error for non-existent guide', () => {
       const content = '{{ GUIDE_REF("non-existent-guide-xyz") }}';
       assert.throws(() => replaceMacros(content, 'test.md'), /Guide "non-existent-guide-xyz" not found/);

--- a/serving/lib/macros.test.ts
+++ b/serving/lib/macros.test.ts
@@ -55,7 +55,7 @@ describe('replaceMacros (Functional with real data)', () => {
     it('replaces macro with guide path', () => {
       const content = '{{ GUIDE_REF("break-up-long-tasks") }}';
       const result = replaceMacros(content, 'test.md');
-      assert.ok(result.includes('guides/performance/break-up-long-tasks/guide.md'));
+      assert.ok(result.includes('`performance/break-up-long-tasks/guide.md`'));
     });
 
     it('throws error for non-existent guide', () => {

--- a/serving/lib/macros.test.ts
+++ b/serving/lib/macros.test.ts
@@ -70,6 +70,12 @@ describe('replaceMacros (Functional with real data)', () => {
       assert.ok(result.includes('`forms` (via `node <modern-web-directory>/modern-web.mjs retrieve "forms"`)'));
     });
 
+    it('replaces macro with category-level skill command for skills-cli-npx', () => {
+      const content = '{{ GUIDE_REF("forms") }}';
+      const result = replaceMacros(content, 'test.md', { target: 'skills-cli-npx' });
+      assert.ok(result.includes('`forms` (via `npx -p modern-web-guidance@latest -- modern-web retrieve "forms"`)'));
+    });
+
     it('throws error for non-existent guide', () => {
       const content = '{{ GUIDE_REF("non-existent-guide-xyz") }}';
       assert.throws(() => replaceMacros(content, 'test.md'), /Guide "non-existent-guide-xyz" not found/);

--- a/serving/lib/macros.ts
+++ b/serving/lib/macros.ts
@@ -39,7 +39,8 @@ export function parseArguments(argsString: string): string[] {
   return args;
 }
 
-type MacroHandler = (args: string[], filePath: string) => string;
+type MacroHandler = (args: string[], filePath: string, options?: { target?: string }) => string;
+
 
 export class MacroError extends Error {
   constructor(message: string) {
@@ -98,7 +99,7 @@ const MACRO_HANDLERS: Record<string, MacroHandler> = {
 
     return status;
   },
-  GUIDE_REF: (args, filePath) => {
+  GUIDE_REF: (args, filePath, options) => {
     const [guideId] = args;
     if (!guideId) {
       throw new MacroError(`Missing guide ID in GUIDE_REF macro (${filePath}).`);
@@ -107,6 +108,13 @@ const MACRO_HANDLERS: Record<string, MacroHandler> = {
     const guidePath = getGuidePath(guideId);
     if (!guidePath) {
       throw new MacroError(`Guide "${guideId}" not found (referenced in GUIDE_REF macro in ${filePath}).`);
+    }
+
+    const target = options?.target || 'local-dev';
+    
+    if (target === 'skills-cli') {
+      // We can specialize here later if needed
+      return `For more information, see the guide at ${guidePath}`;
     }
 
     return `For more information, see the guide at ${guidePath}`;
@@ -152,10 +160,10 @@ export function validateMacros(content: string, filePath: string): string[] {
   return errors;
 }
 
-export function replaceMacros(content: string, filePath: string): string {
+export function replaceMacros(content: string, filePath: string, options: { target?: string } = {}): string {
   return processMacros(content, (handler, args, match) => {
     try {
-      return handler(args, filePath);
+      return handler(args, filePath, options);
     } catch (err: any) {
       if (err instanceof MacroError) {
         throw err;

--- a/serving/lib/macros.ts
+++ b/serving/lib/macros.ts
@@ -1,6 +1,7 @@
 import { validateFeature, getStatusMessage } from "./baseline.ts";
 import path from "node:path";
-import { scanAllGuides } from "../../lib/guide-validation.ts";
+import { scanAllGuides, type GuideInventory } from "../../lib/guide-validation.ts";
+
 
 
 
@@ -56,17 +57,14 @@ export class MacroError extends Error {
 export const MACRO_PATTERN = /{{\s*([A-Z_]+)\((.*?)\)\s*}}/g;
 
 
-let guideCache: Map<string, { path: string; category: string }> | null = null;
+let guideCache: Map<string, GuideInventory> | null = null;
 
-function getGuidePath(guideId: string): { path: string; category: string } | null {
+function getGuidePath(guideId: string): GuideInventory | null {
   if (!guideCache) {
     guideCache = new Map();
     const guides = scanAllGuides();
     for (const guide of guides) {
-      guideCache.set(guide.name, {
-        path: path.join('guides', guide.category, guide.name, 'guide.md'),
-        category: guide.category
-      });
+      guideCache.set(guide.name, guide);
     }
   }
   return guideCache.get(guideId) || null;

--- a/serving/lib/macros.ts
+++ b/serving/lib/macros.ts
@@ -114,7 +114,7 @@ const MACRO_HANDLERS: Record<string, MacroHandler> = {
     }
 
     const target = options?.target || 'local-dev';
-    
+
     if (target === 'skills-cli') {
       return `\`${guideId}\` (via \`node <modern-web-directory>/modern-web.mjs retrieve "${guideId}"\`)`;
     }

--- a/serving/lib/macros.ts
+++ b/serving/lib/macros.ts
@@ -53,9 +53,9 @@ export class MacroError extends Error {
 export const MACRO_PATTERN = /{{\s*([A-Z_]+)\((.*?)\)\s*}}/g;
 
 
-let guideCache: Map<string, string> | null = null;
+let guideCache: Map<string, { path: string; category: string }> | null = null;
 
-function getGuidePath(guideId: string): string | null {
+function getGuidePath(guideId: string): { path: string; category: string } | null {
   if (!guideCache) {
     guideCache = new Map();
     if (fs.existsSync(guidesDir)) {
@@ -68,7 +68,10 @@ function getGuidePath(guideId: string): string | null {
         if (!fs.existsSync(categoryDir)) continue;
         for (const entry of fs.readdirSync(categoryDir, { withFileTypes: true })) {
           if (entry.isDirectory()) {
-            guideCache.set(entry.name, path.join('guides', category, entry.name, 'guide.md'));
+            guideCache.set(entry.name, {
+              path: path.join('guides', category, entry.name, 'guide.md'),
+              category
+            });
           }
         }
       }
@@ -105,19 +108,18 @@ const MACRO_HANDLERS: Record<string, MacroHandler> = {
       throw new MacroError(`Missing guide ID in GUIDE_REF macro (${filePath}).`);
     }
 
-    const guidePath = getGuidePath(guideId);
-    if (!guidePath) {
+    const guideInfo = getGuidePath(guideId);
+    if (!guideInfo) {
       throw new MacroError(`Guide "${guideId}" not found (referenced in GUIDE_REF macro in ${filePath}).`);
     }
 
     const target = options?.target || 'local-dev';
     
     if (target === 'skills-cli') {
-      // We can specialize here later if needed
-      return `For more information, see the guide at ${guidePath}`;
+      return `\`${guideId}\` (via \`node modern-web.mjs retrieve "${guideId}"\`)`;
     }
 
-    return `For more information, see the guide at ${guidePath}`;
+    return `\`${guideInfo.category}/${guideId}/guide.md\``;
   }
 };
 

--- a/serving/lib/macros.ts
+++ b/serving/lib/macros.ts
@@ -39,7 +39,10 @@ export function parseArguments(argsString: string): string[] {
   return args;
 }
 
-type MacroHandler = (args: string[], filePath: string, options?: { target?: string }) => string;
+export type BuildTarget = 'skills-cli' | 'mcp-server' | 'megaskill' | 'local-dev';
+
+type MacroHandler = (args: string[], filePath: string, options?: { target?: BuildTarget }) => string;
+
 
 
 export class MacroError extends Error {
@@ -162,7 +165,7 @@ export function validateMacros(content: string, filePath: string): string[] {
   return errors;
 }
 
-export function replaceMacros(content: string, filePath: string, options: { target?: string } = {}): string {
+export function replaceMacros(content: string, filePath: string, options: { target?: BuildTarget } = {}): string {
   return processMacros(content, (handler, args, match) => {
     try {
       return handler(args, filePath, options);

--- a/serving/lib/macros.ts
+++ b/serving/lib/macros.ts
@@ -40,7 +40,7 @@ export function parseArguments(argsString: string): string[] {
   return args;
 }
 
-export type BuildTarget = 'skills-cli' | 'mcp-server' | 'megaskill' | 'local-dev';
+export type BuildTarget = 'skills-cli' | 'skills-cli-npx' | 'mcp-server' | 'megaskill' | 'local-dev';
 
 type MacroHandler = (args: string[], filePath: string, options?: { target?: BuildTarget }) => string;
 
@@ -96,6 +96,10 @@ const MACRO_HANDLERS: Record<string, MacroHandler> = {
 
     if (target === 'skills-cli') {
       return `\`${guideId}\` (via \`node <modern-web-directory>/modern-web.mjs retrieve "${guideId}"\`)`;
+    }
+
+    if (target === 'skills-cli-npx') {
+      return `\`${guideId}\` (via \`npx -p modern-web-guidance@latest -- modern-web retrieve "${guideId}"\`)`;
     }
 
     if (guideInfo.isDisciplineSkill) {

--- a/serving/lib/macros.ts
+++ b/serving/lib/macros.ts
@@ -1,4 +1,8 @@
 import { validateFeature, getStatusMessage } from "./baseline.ts";
+import fs from "node:fs";
+import path from "node:path";
+import { guidesDir } from "../../lib/paths.ts";
+
 
 /**
  * Parses macro arguments, respecting quotes and handling commas.
@@ -48,6 +52,30 @@ export class MacroError extends Error {
 export const MACRO_PATTERN = /{{\s*([A-Z_]+)\((.*?)\)\s*}}/g;
 
 
+let guideCache: Map<string, string> | null = null;
+
+function getGuidePath(guideId: string): string | null {
+  if (!guideCache) {
+    guideCache = new Map();
+    if (fs.existsSync(guidesDir)) {
+      const categories = fs.readdirSync(guidesDir, { withFileTypes: true })
+        .filter(d => d.isDirectory() && !d.name.startsWith('.') && d.name !== 'node_modules')
+        .map(d => d.name);
+
+      for (const category of categories) {
+        const categoryDir = path.join(guidesDir, category);
+        if (!fs.existsSync(categoryDir)) continue;
+        for (const entry of fs.readdirSync(categoryDir, { withFileTypes: true })) {
+          if (entry.isDirectory()) {
+            guideCache.set(entry.name, path.join('guides', category, entry.name, 'guide.md'));
+          }
+        }
+      }
+    }
+  }
+  return guideCache.get(guideId) || null;
+}
+
 const MACRO_HANDLERS: Record<string, MacroHandler> = {
   BASELINE_STATUS: (args, filePath) => {
     const [featureId, bcdKey] = args;
@@ -69,6 +97,19 @@ const MACRO_HANDLERS: Record<string, MacroHandler> = {
     }
 
     return status;
+  },
+  GUIDE_REF: (args, filePath) => {
+    const [guideId] = args;
+    if (!guideId) {
+      throw new MacroError(`Missing guide ID in GUIDE_REF macro (${filePath}).`);
+    }
+
+    const guidePath = getGuidePath(guideId);
+    if (!guidePath) {
+      throw new MacroError(`Guide "${guideId}" not found (referenced in GUIDE_REF macro in ${filePath}).`);
+    }
+
+    return `For more information, see the guide at ${guidePath}`;
   }
 };
 

--- a/serving/lib/macros.ts
+++ b/serving/lib/macros.ts
@@ -116,7 +116,7 @@ const MACRO_HANDLERS: Record<string, MacroHandler> = {
     const target = options?.target || 'local-dev';
     
     if (target === 'skills-cli') {
-      return `\`${guideId}\` (via \`node modern-web.mjs retrieve "${guideId}"\`)`;
+      return `\`${guideId}\` (via \`node <modern-web-directory>/modern-web.mjs retrieve "${guideId}"\`)`;
     }
 
     return `\`${guideInfo.category}/${guideId}/guide.md\``;

--- a/serving/lib/macros.ts
+++ b/serving/lib/macros.ts
@@ -98,6 +98,10 @@ const MACRO_HANDLERS: Record<string, MacroHandler> = {
       return `\`${guideId}\` (via \`node <modern-web-directory>/modern-web.mjs retrieve "${guideId}"\`)`;
     }
 
+    if (guideInfo.isCategorySkill) {
+      return `\`${guideInfo.category}/SKILL.md\``;
+    }
+
     return `\`${guideInfo.category}/${guideId}/guide.md\``;
   }
 };

--- a/serving/lib/macros.ts
+++ b/serving/lib/macros.ts
@@ -1,6 +1,7 @@
 import { validateFeature, getStatusMessage } from "./baseline.ts";
 import path from "node:path";
-import { scanAllGuides, type GuideInventory } from "../../lib/guide-validation.ts";
+import { scanAllGuides, type GuideInventory, getGuidesMap } from "../../lib/guide-validation.ts";
+
 
 
 
@@ -57,18 +58,7 @@ export class MacroError extends Error {
 export const MACRO_PATTERN = /{{\s*([A-Z_]+)\((.*?)\)\s*}}/g;
 
 
-let guideCache: Map<string, GuideInventory> | null = null;
 
-function getGuidePath(guideId: string): GuideInventory | null {
-  if (!guideCache) {
-    guideCache = new Map();
-    const guides = scanAllGuides();
-    for (const guide of guides) {
-      guideCache.set(guide.name, guide);
-    }
-  }
-  return guideCache.get(guideId) || null;
-}
 
 const MACRO_HANDLERS: Record<string, MacroHandler> = {
   BASELINE_STATUS: (args, filePath) => {
@@ -98,7 +88,7 @@ const MACRO_HANDLERS: Record<string, MacroHandler> = {
       throw new MacroError(`Missing guide ID in GUIDE_REF macro (${filePath}).`);
     }
 
-    const guideInfo = getGuidePath(guideId);
+    const guideInfo = getGuidesMap().get(guideId);
     if (!guideInfo) {
       throw new MacroError(`Guide "${guideId}" not found (referenced in GUIDE_REF macro in ${filePath}).`);
     }

--- a/serving/lib/macros.ts
+++ b/serving/lib/macros.ts
@@ -1,7 +1,5 @@
 import { validateFeature, getStatusMessage } from "./baseline.ts";
-import fs from "node:fs";
 import path from "node:path";
-import { guidesDir } from "../../lib/paths.ts";
 import { scanAllGuides } from "../../lib/guide-validation.ts";
 
 

--- a/serving/lib/macros.ts
+++ b/serving/lib/macros.ts
@@ -2,6 +2,8 @@ import { validateFeature, getStatusMessage } from "./baseline.ts";
 import fs from "node:fs";
 import path from "node:path";
 import { guidesDir } from "../../lib/paths.ts";
+import { scanAllGuides } from "../../lib/guide-validation.ts";
+
 
 
 /**
@@ -61,23 +63,12 @@ let guideCache: Map<string, { path: string; category: string }> | null = null;
 function getGuidePath(guideId: string): { path: string; category: string } | null {
   if (!guideCache) {
     guideCache = new Map();
-    if (fs.existsSync(guidesDir)) {
-      const categories = fs.readdirSync(guidesDir, { withFileTypes: true })
-        .filter(d => d.isDirectory() && !d.name.startsWith('.') && d.name !== 'node_modules')
-        .map(d => d.name);
-
-      for (const category of categories) {
-        const categoryDir = path.join(guidesDir, category);
-        if (!fs.existsSync(categoryDir)) continue;
-        for (const entry of fs.readdirSync(categoryDir, { withFileTypes: true })) {
-          if (entry.isDirectory()) {
-            guideCache.set(entry.name, {
-              path: path.join('guides', category, entry.name, 'guide.md'),
-              category
-            });
-          }
-        }
-      }
+    const guides = scanAllGuides();
+    for (const guide of guides) {
+      guideCache.set(guide.name, {
+        path: path.join('guides', guide.category, guide.name, 'guide.md'),
+        category: guide.category
+      });
     }
   }
   return guideCache.get(guideId) || null;

--- a/serving/lib/macros.ts
+++ b/serving/lib/macros.ts
@@ -98,7 +98,7 @@ const MACRO_HANDLERS: Record<string, MacroHandler> = {
       return `\`${guideId}\` (via \`node <modern-web-directory>/modern-web.mjs retrieve "${guideId}"\`)`;
     }
 
-    if (guideInfo.isCategorySkill) {
+    if (guideInfo.isDisciplineSkill) {
       return `\`${guideInfo.category}/SKILL.md\``;
     }
 

--- a/serving/lib/macros.ts
+++ b/serving/lib/macros.ts
@@ -98,10 +98,6 @@ const MACRO_HANDLERS: Record<string, MacroHandler> = {
       return `\`${guideId}\` (via \`node <modern-web-directory>/modern-web.mjs retrieve "${guideId}"\`)`;
     }
 
-    if (guideInfo.isCategorySkill) {
-      return `\`${guideInfo.category}/SKILL.md\``;
-    }
-
     return `\`${guideInfo.category}/${guideId}/guide.md\``;
   }
 };

--- a/serving/lib/macros.ts
+++ b/serving/lib/macros.ts
@@ -1,6 +1,5 @@
 import { validateFeature, getStatusMessage } from "./baseline.ts";
-import path from "node:path";
-import { scanAllGuides, type GuideInventory, getGuidesMap } from "../../lib/guide-validation.ts";
+import { getGuidesMap } from "../../lib/guide-validation.ts";
 
 
 

--- a/serving/lib/macros.ts
+++ b/serving/lib/macros.ts
@@ -72,21 +72,6 @@ const MACRO_HANDLERS: Record<string, MacroHandler> = {
     // will overflow the call stack. Add a visited set if it becomes a problem.
     return replaceMacros(result.content, result.absolutePath!);
   },
-};
-
-defineFeatureMacro("BASELINE_STATUS", {
-  content: (args, filePath) => {
-    const [featureId, bcdKey] = args;
-    const status = getStatusMessage(featureId, bcdKey);
-    if (!status) {
-      if (bcdKey) {
-        throw new MacroError(`BCD key "${bcdKey}" not found (referenced in ${filePath}).`);
-      }
-      throw new MacroError(`Status not found for feature "${featureId}" (referenced in ${filePath}).`);
-    }
-
-    return status;
-  },
   GUIDE_REF: (args, filePath, options) => {
     const [guideId] = args;
     if (!guideId) {
@@ -113,6 +98,21 @@ defineFeatureMacro("BASELINE_STATUS", {
     }
 
     return `\`${guideInfo.category}/${guideId}/guide.md\``;
+  }
+};
+
+defineFeatureMacro("BASELINE_STATUS", {
+  content: (args, filePath) => {
+    const [featureId, bcdKey] = args;
+    const status = getStatusMessage(featureId, bcdKey);
+    if (!status) {
+      if (bcdKey) {
+        throw new MacroError(`BCD key "${bcdKey}" not found (referenced in ${filePath}).`);
+      }
+      throw new MacroError(`Status not found for feature "${featureId}" (referenced in ${filePath}).`);
+    }
+
+    return status;
   }
 });
 

--- a/serving/lib/practices.test.ts
+++ b/serving/lib/practices.test.ts
@@ -14,4 +14,10 @@ describe("getGuide", () => {
     const guide = await getGuide("non-existent-id");
     assert.strictEqual(guide, null);
   });
+
+  it("should retrieve category skill when category name is provided", async () => {
+    const guide = await getGuide("forms");
+    assert.ok(guide);
+    assert.ok(guide.includes("Semantic Structure and Form Element"));
+  });
 });

--- a/serving/lib/practices.test.ts
+++ b/serving/lib/practices.test.ts
@@ -14,4 +14,11 @@ describe("getGuide", () => {
     const guide = await getGuide("non-existent-id");
     assert.strictEqual(guide, null);
   });
+
+  it("should retrieve category skill SKILL.md when category name is provided", async () => {
+    const guide = await getGuide("forms");
+    assert.ok(guide);
+    assert.ok(guide.includes("name: forms"));
+    assert.ok(guide.includes("description: Best practices for building accessible, secure, and user-friendly web forms"));
+  });
 });

--- a/serving/lib/practices.test.ts
+++ b/serving/lib/practices.test.ts
@@ -14,11 +14,4 @@ describe("getGuide", () => {
     const guide = await getGuide("non-existent-id");
     assert.strictEqual(guide, null);
   });
-
-  it("should retrieve category skill SKILL.md when category name is provided", async () => {
-    const guide = await getGuide("forms");
-    assert.ok(guide);
-    assert.ok(guide.includes("name: forms"));
-    assert.ok(guide.includes("description: Best practices for building accessible, secure, and user-friendly web forms"));
-  });
 });

--- a/serving/lib/practices.ts
+++ b/serving/lib/practices.ts
@@ -26,12 +26,27 @@ export function getUseCasesByCategory(category?: string): UseCase[] {
 }
 
 export async function getGuide(useCaseId: string): Promise<string | null> {
+  let filePath: string | null = null;
   const useCase = USE_CASES.find((u) => u.id === useCaseId);
-  if (!useCase) return null;
-  const devGuidesDir = path.resolve(import.meta.dirname, "../build/guides");
-  const prodGuidesDir = path.resolve(import.meta.dirname, "./guides");
-  const guidesDir = existsSync(devGuidesDir) ? devGuidesDir : prodGuidesDir;
-  const filePath = path.join(guidesDir, useCase.category, `${useCaseId}.md`);
+  
+  if (!useCase) {
+    // Fallback: Check if it is a high-level category skill.
+    const localSkillPath = path.resolve(import.meta.dirname, "../../guides", useCaseId, "SKILL.md");
+    const prodSkillPath = path.resolve(import.meta.dirname, "../", useCaseId, "SKILL.md");
+
+    if (existsSync(localSkillPath)) {
+      filePath = localSkillPath;
+    } else if (existsSync(prodSkillPath)) {
+      filePath = prodSkillPath;
+    } else {
+      return null;
+    }
+  } else {
+    const devGuidesDir = path.resolve(import.meta.dirname, "../build/guides");
+    const prodGuidesDir = path.resolve(import.meta.dirname, "./guides");
+    const guidesDir = existsSync(devGuidesDir) ? devGuidesDir : prodGuidesDir;
+    filePath = path.join(guidesDir, useCase.category, `${useCaseId}.md`);
+  }
 
   try {
     const content = await fs.readFile(filePath, "utf-8");

--- a/serving/lib/practices.ts
+++ b/serving/lib/practices.ts
@@ -26,27 +26,12 @@ export function getUseCasesByCategory(category?: string): UseCase[] {
 }
 
 export async function getGuide(useCaseId: string): Promise<string | null> {
-  let filePath: string | null = null;
   const useCase = USE_CASES.find((u) => u.id === useCaseId);
-  
-  if (!useCase) {
-    // Fallback: Check if it is a high-level category skill.
-    const localSkillPath = path.resolve(import.meta.dirname, "../../guides", useCaseId, "SKILL.md");
-    const prodSkillPath = path.resolve(import.meta.dirname, "../", useCaseId, "SKILL.md");
-
-    if (existsSync(localSkillPath)) {
-      filePath = localSkillPath;
-    } else if (existsSync(prodSkillPath)) {
-      filePath = prodSkillPath;
-    } else {
-      return null;
-    }
-  } else {
-    const devGuidesDir = path.resolve(import.meta.dirname, "../build/guides");
-    const prodGuidesDir = path.resolve(import.meta.dirname, "./guides");
-    const guidesDir = existsSync(devGuidesDir) ? devGuidesDir : prodGuidesDir;
-    filePath = path.join(guidesDir, useCase.category, `${useCaseId}.md`);
-  }
+  if (!useCase) return null;
+  const devGuidesDir = path.resolve(import.meta.dirname, "../build/guides");
+  const prodGuidesDir = path.resolve(import.meta.dirname, "./guides");
+  const guidesDir = existsSync(devGuidesDir) ? devGuidesDir : prodGuidesDir;
+  const filePath = path.join(guidesDir, useCase.category, `${useCaseId}.md`);
 
   try {
     const content = await fs.readFile(filePath, "utf-8");

--- a/serving/scripts/build-guides.ts
+++ b/serving/scripts/build-guides.ts
@@ -3,6 +3,8 @@ import path from "path";
 import zlib from "zlib";
 import matter from "gray-matter";
 import { marked } from "marked";
+import { parseArgs } from "node:util";
+
 export interface StoreUseCase {
   id: string;
   description: string;
@@ -277,13 +279,20 @@ async function processSingleGuideFile(
 
 // Only run automatically if executed directly
 if (process.argv[1] === import.meta.filename) {
-  const targetGuidePath = process.argv.slice(2).find(arg => !arg.startsWith("--"));
-  const force = process.argv.includes("--force");
-  const subsetArg = process.argv.find(arg => arg.startsWith("--subset"));
-  const subset = subsetArg ? (subsetArg.includes("=") ? parseInt(subsetArg.split("=")[1], 10) : 3) : undefined;
-  const modelArg = process.argv.find((arg) => arg.startsWith("--model="));
-  const modelName = modelArg ? modelArg.split("=")[1] : undefined;
-  const noChunking = process.argv.includes("--no-chunking");
+  const options = {
+    force: { type: 'boolean' as const },
+    subset: { type: 'string' as const },
+    model: { type: 'string' as const },
+    'no-chunking': { type: 'boolean' as const },
+  };
+
+  const { values, positionals } = parseArgs({ options, allowPositionals: true });
+
+  const targetGuidePath = positionals[0];
+  const force = values.force;
+  const noChunking = values['no-chunking'];
+  const modelName = values.model;
+  const subset = values.subset ? parseInt(values.subset, 10) : undefined;
 
   processGuides({
     outputDir: path.join(ROOT_DIR, "build"),

--- a/serving/scripts/build-guides.ts
+++ b/serving/scripts/build-guides.ts
@@ -123,11 +123,11 @@ export async function processGuides(opts: BuildOptions) {
   const storeUseCases: StoreUseCase[] = [];
 
   console.log("Initializing Embedder...");
-  
+
   if (modelName) {
     console.log(`Using custom embedding model: ${modelName}`);
   }
-  
+
   const { Embedder } = await import("../lib/transformers-embedder.ts");
   const embedder = Embedder.getInstance(modelName);
   await embedder.init();
@@ -163,7 +163,6 @@ export async function processGuides(opts: BuildOptions) {
     for (const candidate of candidates) {
       const skillSource = path.join(guidesDirInRoot, candidate, "SKILL.md");
       if (fs.existsSync(skillSource)) {
-        console.log(`Processing category skill: ${skillSource}`);
         await processSingleGuideFile(skillSource, candidate, candidate, useCases, storeUseCases, embedder);
       }
     }
@@ -249,7 +248,7 @@ async function processSingleGuideFile(
   });
 
   const chunks = IS_NO_CHUNKING
-    ? [`${frontmatter}\n\n${processedMarkdown}`] 
+    ? [`${frontmatter}\n\n${processedMarkdown}`]
     : [...chunkMarkdown(processedMarkdown), frontmatter];
 
   for (const chunk of chunks) {

--- a/serving/scripts/build-guides.ts
+++ b/serving/scripts/build-guides.ts
@@ -17,7 +17,6 @@ import { scanAllGuides, type GuideInventory } from "../../lib/guide-validation.t
 import { getFeatureName } from "../lib/baseline.ts";
 
 const ROOT_DIR = path.resolve(import.meta.dirname, "..");
-const BUILD_GUIDES_DIR = path.join(ROOT_DIR, "build/guides");
 const OUTPUT_FILE = path.join(ROOT_DIR, "lib/use-cases.gen.ts");
 
 interface UseCase {
@@ -27,21 +26,38 @@ interface UseCase {
   featuresUsed: string[];
 }
 
-async function processGuides() {
-  const targetGuidePath = process.argv.slice(2).find(arg => !arg.startsWith("--"));
-  const force = process.argv.includes("--force");
-  const subsetArg = process.argv.find(arg => arg.startsWith("--subset"));
+export interface BuildOptions {
+  outputDir: string;
+  isDistribution?: boolean;
+  subset?: number;
+  force?: boolean;
+  targetGuidePath?: string;
+  modelName?: string;
+  noChunking?: boolean;
+}
+
+// Global variables to be set by processGuides
+let BUILD_GUIDES_DIR: string;
+let VECTORS_FILE: string;
+let IS_NO_CHUNKING = false;
+
+export async function processGuides(opts: BuildOptions) {
+  const { outputDir, isDistribution, subset, force, targetGuidePath, modelName, noChunking } = opts;
+
+  BUILD_GUIDES_DIR = path.join(outputDir, "guides");
+  VECTORS_FILE = isDistribution
+    ? path.join(outputDir, "use-cases.vectors.gen.json.gz")
+    : path.join(ROOT_DIR, "lib/use-cases.vectors.gen.json.gz");
+  
+  IS_NO_CHUNKING = !!noChunking;
 
   // Scan guides first to see if we even need to run
   let readyGuides = scanAllGuides().filter(inv => inv.hasGuide);
 
-  if (subsetArg) {
-    const limit = subsetArg.includes("=") ? parseInt(subsetArg.split("=")[1], 10) : 3;
-    readyGuides = readyGuides.slice(0, limit);
+  if (subset) {
+    readyGuides = readyGuides.slice(0, subset);
     console.log(`Building a subset of ${readyGuides.length} guides.`);
   }
-
-  const VECTORS_FILE = path.join(ROOT_DIR, "lib/use-cases.vectors.gen.json.gz");
 
   let shouldSkip = !process.env.CI && !targetGuidePath && !force && fs.existsSync(OUTPUT_FILE) && fs.existsSync(BUILD_GUIDES_DIR) && fs.existsSync(VECTORS_FILE);
 
@@ -101,8 +117,6 @@ async function processGuides() {
   const storeUseCases: StoreUseCase[] = [];
 
   console.log("Initializing Embedder...");
-  const modelArg = process.argv.find((arg) => arg.startsWith("--model="));
-  const modelName = modelArg ? modelArg.split("=")[1] : undefined;
   
   if (modelName) {
     console.log(`Using custom embedding model: ${modelName}`);
@@ -228,8 +242,7 @@ async function processSingleGuideFile(
     featuresUsed,
   });
 
-  const isNoChunking = process.argv.includes("--no-chunking");
-  const chunks = isNoChunking 
+  const chunks = IS_NO_CHUNKING 
     ? [`${frontmatter}\n\n${processedMarkdown}`] 
     : [...chunkMarkdown(processedMarkdown), frontmatter];
 
@@ -260,5 +273,20 @@ async function processSingleGuideFile(
 
 // Only run automatically if executed directly
 if (process.argv[1] === import.meta.filename) {
-  processGuides().catch(console.error);
+  const targetGuidePath = process.argv.slice(2).find(arg => !arg.startsWith("--"));
+  const force = process.argv.includes("--force");
+  const subsetArg = process.argv.find(arg => arg.startsWith("--subset"));
+  const subset = subsetArg ? (subsetArg.includes("=") ? parseInt(subsetArg.split("=")[1], 10) : 3) : undefined;
+  const modelArg = process.argv.find((arg) => arg.startsWith("--model="));
+  const modelName = modelArg ? modelArg.split("=")[1] : undefined;
+  const noChunking = process.argv.includes("--no-chunking");
+
+  processGuides({
+    outputDir: path.join(ROOT_DIR, "build"),
+    force,
+    subset,
+    targetGuidePath,
+    modelName,
+    noChunking
+  }).catch(console.error);
 }

--- a/serving/scripts/build-guides.ts
+++ b/serving/scripts/build-guides.ts
@@ -28,7 +28,7 @@ interface UseCase {
 
 export interface BuildOptions {
   outputDir: string;
-  isDistribution?: boolean;
+  target?: 'skills-cli' | 'mcp-server' | 'megaskill' | 'local-dev';
   subset?: number;
   force?: boolean;
   targetGuidePath?: string;
@@ -40,16 +40,19 @@ export interface BuildOptions {
 let BUILD_GUIDES_DIR: string;
 let VECTORS_FILE: string;
 let IS_NO_CHUNKING = false;
+let TARGET = 'local-dev';
+
 
 export async function processGuides(opts: BuildOptions) {
-  const { outputDir, isDistribution, subset, force, targetGuidePath, modelName, noChunking } = opts;
+  const { outputDir, target, subset, force, targetGuidePath, modelName, noChunking } = opts;
 
   BUILD_GUIDES_DIR = path.join(outputDir, "guides");
-  VECTORS_FILE = isDistribution
+  VECTORS_FILE = (target === 'skills-cli')
     ? path.join(outputDir, "use-cases.vectors.gen.json.gz")
     : path.join(ROOT_DIR, "lib/use-cases.vectors.gen.json.gz");
   
   IS_NO_CHUNKING = !!noChunking;
+  TARGET = target || 'local-dev';
 
   // Scan guides first to see if we even need to run
   let readyGuides = scanAllGuides().filter(inv => inv.hasGuide);
@@ -230,7 +233,7 @@ async function processSingleGuideFile(
     return;
   }
 
-  const processedMarkdown = replaceMacros(markdownBody, filePath);
+  const processedMarkdown = replaceMacros(markdownBody, filePath, { target: TARGET });
 
   const featureIds: string[] = data['web-feature-ids'] || [];
   const featuresUsed = featureIds.map(getFeatureName);

--- a/serving/scripts/build-guides.ts
+++ b/serving/scripts/build-guides.ts
@@ -12,7 +12,8 @@ export interface StoreUseCase {
   vector?: number[];
   distance?: number;
 }
-import { replaceMacros } from "../lib/macros.ts";
+import { replaceMacros, type BuildTarget } from "../lib/macros.ts";
+
 import { scanAllGuides, type GuideInventory } from "../../lib/guide-validation.ts";
 import { getFeatureName } from "../lib/baseline.ts";
 
@@ -28,7 +29,7 @@ interface UseCase {
 
 export interface BuildOptions {
   outputDir: string;
-  target?: 'skills-cli' | 'mcp-server' | 'megaskill' | 'local-dev';
+  target?: BuildTarget;
   subset?: number;
   force?: boolean;
   targetGuidePath?: string;

--- a/serving/scripts/build-guides.ts
+++ b/serving/scripts/build-guides.ts
@@ -50,7 +50,7 @@ export async function processGuides(opts: BuildOptions) {
   VECTORS_FILE = (target === 'skills-cli')
     ? path.join(outputDir, "use-cases.vectors.gen.json.gz")
     : path.join(ROOT_DIR, "lib/use-cases.vectors.gen.json.gz");
-  
+
   IS_NO_CHUNKING = !!noChunking;
   TARGET = target || 'local-dev';
 
@@ -245,7 +245,7 @@ async function processSingleGuideFile(
     featuresUsed,
   });
 
-  const chunks = IS_NO_CHUNKING 
+  const chunks = IS_NO_CHUNKING
     ? [`${frontmatter}\n\n${processedMarkdown}`] 
     : [...chunkMarkdown(processedMarkdown), frontmatter];
 

--- a/serving/scripts/build-guides.ts
+++ b/serving/scripts/build-guides.ts
@@ -41,7 +41,7 @@ export interface BuildOptions {
 let BUILD_GUIDES_DIR: string;
 let VECTORS_FILE: string;
 let IS_NO_CHUNKING = false;
-let TARGET = 'local-dev';
+let TARGET: BuildTarget = 'local-dev';
 
 
 export async function processGuides(opts: BuildOptions) {

--- a/serving/skills-cli/build-dist.test.ts
+++ b/serving/skills-cli/build-dist.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import { processSkills } from './build-dist.ts';
+import { rootDir } from '../../lib/paths.ts';
+
+describe('processSkills', () => {
+  const testOutputDir = path.join(import.meta.dirname, 'test-output');
+  const testGuidesDir = path.join(rootDir, 'guides');
+  const dummySkillName = 'test-dummy-skill';
+  const dummySkillDir = path.join(testGuidesDir, dummySkillName);
+  
+  before(() => {
+    fs.mkdirSync(dummySkillDir, { recursive: true });
+    fs.writeFileSync(path.join(dummySkillDir, 'SKILL.md'), 'Test Skill with macro: {{ BASELINE_STATUS("grid") }}');
+    fs.mkdirSync(testOutputDir, { recursive: true });
+  });
+
+  after(() => {
+    fs.rmSync(dummySkillDir, { recursive: true, force: true });
+    fs.rmSync(testOutputDir, { recursive: true, force: true });
+  });
+
+  it('processes macros in SKILL.md', () => {
+    const publishRoot = testOutputDir;
+    const distDir = path.join(publishRoot, 'skills/modern-web');
+    
+    processSkills(publishRoot, distDir, false);
+    
+    const builtSkillPath = path.join(publishRoot, 'skills', dummySkillName, 'SKILL.md');
+    assert.ok(fs.existsSync(builtSkillPath), 'Built SKILL.md should exist');
+    
+    const content = fs.readFileSync(builtSkillPath, 'utf8');
+    assert.ok(!content.includes('{{ BASELINE_STATUS'), 'Macro should be resolved');
+    assert.ok(content.includes('Widely available') || content.includes('Baseline since'), 'Should contain baseline status');
+  });
+});

--- a/serving/skills-cli/build-dist.test.ts
+++ b/serving/skills-cli/build-dist.test.ts
@@ -35,4 +35,19 @@ describe('processSkills', () => {
     assert.ok(!content.includes('{{ BASELINE_STATUS'), 'Macro should be resolved');
     assert.ok(content.includes('Widely available') || content.includes('Baseline since'), 'Should contain baseline status');
   });
+
+  it('processes GUIDE_REF macros in real CSS SKILL.md', () => {
+    const publishRoot = testOutputDir;
+    const distDir = path.join(publishRoot, 'skills/modern-web');
+    
+    processSkills(publishRoot, distDir, false);
+    
+    const builtSkillPath = path.join(publishRoot, 'skills', 'css', 'SKILL.md');
+    assert.ok(fs.existsSync(builtSkillPath), 'Built CSS SKILL.md should exist');
+    
+    const content = fs.readFileSync(builtSkillPath, 'utf8');
+    assert.ok(!content.includes('{{ GUIDE_REF'), 'GUIDE_REF macro should be resolved');
+    assert.ok(content.includes('guides/user-experience/child-state-based-styling/guide.md'), 'Should contain path to child-state-based-styling');
+    assert.ok(content.includes('guides/user-experience/content-based-styling/guide.md'), 'Should contain path to content-based-styling');
+  });
 });

--- a/serving/skills-cli/build-dist.test.ts
+++ b/serving/skills-cli/build-dist.test.ts
@@ -12,7 +12,7 @@ describe('processSkills', () => {
   const testGuidesDir = path.join(rootDir, 'guides');
   const dummySkillName = 'test-dummy-skill';
   const dummySkillDir = path.join(testGuidesDir, dummySkillName);
-  
+
   before(() => {
     fs.mkdirSync(dummySkillDir, { recursive: true });
     fs.writeFileSync(path.join(dummySkillDir, 'SKILL.md'), 'Test Skill with macro: {{ BASELINE_STATUS("grid") }}');
@@ -27,12 +27,12 @@ describe('processSkills', () => {
   it('processes macros in SKILL.md', () => {
     const publishRoot = testOutputDir;
     const distDir = path.join(publishRoot, 'skills/modern-web');
-    
+
     processSkills(publishRoot, distDir, false);
-    
+
     const builtSkillPath = path.join(publishRoot, 'skills', dummySkillName, 'SKILL.md');
     assert.ok(fs.existsSync(builtSkillPath), 'Built SKILL.md should exist');
-    
+
     const content = fs.readFileSync(builtSkillPath, 'utf8');
     assert.ok(!content.includes('{{ BASELINE_STATUS'), 'Macro should be resolved');
     assert.ok(content.includes('Widely available') || content.includes('Baseline since'), 'Should contain baseline status');
@@ -41,12 +41,12 @@ describe('processSkills', () => {
   it('processes GUIDE_REF macros in real CSS SKILL.md', () => {
     const publishRoot = testOutputDir;
     const distDir = path.join(publishRoot, 'skills/modern-web');
-    
+
     processSkills(publishRoot, distDir, false);
-    
+
     const builtSkillPath = path.join(publishRoot, 'skills', 'css', 'SKILL.md');
     assert.ok(fs.existsSync(builtSkillPath), 'Built CSS SKILL.md should exist');
-    
+
     const content = fs.readFileSync(builtSkillPath, 'utf8');
     assert.ok(!content.includes('{{ GUIDE_REF'), 'GUIDE_REF macro should be resolved');
     assert.ok(content.includes('`child-state-based-styling` (via `node <modern-web-directory>/modern-web.mjs retrieve "child-state-based-styling"`)'), 'Should contain command for child-state-based-styling');
@@ -56,14 +56,14 @@ describe('processSkills', () => {
   it('uses the same command text as in modern-web/SKILL.md', () => {
     const skillFilePath = path.join(rootDir, 'guides/modern-web/SKILL.md');
     assert.ok(fs.existsSync(skillFilePath), 'modern-web/SKILL.md should exist');
-    
+
     const skillContent = fs.readFileSync(skillFilePath, 'utf8');
-    
+
     const expectedPattern = 'node <modern-web-directory>/modern-web.mjs retrieve "<id>"';
     assert.ok(skillContent.includes(expectedPattern), 'modern-web/SKILL.md should contain the expected command pattern');
-    
+
     const result = replaceMacros('{{ GUIDE_REF("break-up-long-tasks") }}', 'test.md', { target: 'skills-cli' });
-    
+
     assert.ok(result.includes('node <modern-web-directory>/modern-web.mjs retrieve "break-up-long-tasks"'), 'Macro output should match the pattern in SKILL.md');
   });
 });

--- a/serving/skills-cli/build-dist.test.ts
+++ b/serving/skills-cli/build-dist.test.ts
@@ -47,7 +47,7 @@ describe('processSkills', () => {
     
     const content = fs.readFileSync(builtSkillPath, 'utf8');
     assert.ok(!content.includes('{{ GUIDE_REF'), 'GUIDE_REF macro should be resolved');
-    assert.ok(content.includes('guides/user-experience/child-state-based-styling/guide.md'), 'Should contain path to child-state-based-styling');
-    assert.ok(content.includes('guides/user-experience/content-based-styling/guide.md'), 'Should contain path to content-based-styling');
+    assert.ok(content.includes('`child-state-based-styling` (via `node modern-web.mjs retrieve "child-state-based-styling"`)'), 'Should contain command for child-state-based-styling');
+    assert.ok(content.includes('`content-based-styling` (via `node modern-web.mjs retrieve "content-based-styling"`)'), 'Should contain command for content-based-styling');
   });
 });

--- a/serving/skills-cli/build-dist.test.ts
+++ b/serving/skills-cli/build-dist.test.ts
@@ -3,6 +3,8 @@ import assert from 'node:assert';
 import fs from 'node:fs';
 import path from 'node:path';
 import { processSkills } from './build-dist.ts';
+import { replaceMacros } from '../lib/macros.ts';
+
 import { rootDir } from '../../lib/paths.ts';
 
 describe('processSkills', () => {
@@ -47,7 +49,21 @@ describe('processSkills', () => {
     
     const content = fs.readFileSync(builtSkillPath, 'utf8');
     assert.ok(!content.includes('{{ GUIDE_REF'), 'GUIDE_REF macro should be resolved');
-    assert.ok(content.includes('`child-state-based-styling` (via `node modern-web.mjs retrieve "child-state-based-styling"`)'), 'Should contain command for child-state-based-styling');
-    assert.ok(content.includes('`content-based-styling` (via `node modern-web.mjs retrieve "content-based-styling"`)'), 'Should contain command for content-based-styling');
+    assert.ok(content.includes('`child-state-based-styling` (via `node <modern-web-directory>/modern-web.mjs retrieve "child-state-based-styling"`)'), 'Should contain command for child-state-based-styling');
+    assert.ok(content.includes('`content-based-styling` (via `node <modern-web-directory>/modern-web.mjs retrieve "content-based-styling"`)'), 'Should contain command for content-based-styling');
+  });
+
+  it('uses the same command text as in modern-web/SKILL.md', () => {
+    const skillFilePath = path.join(rootDir, 'guides/modern-web/SKILL.md');
+    assert.ok(fs.existsSync(skillFilePath), 'modern-web/SKILL.md should exist');
+    
+    const skillContent = fs.readFileSync(skillFilePath, 'utf8');
+    
+    const expectedPattern = 'node <modern-web-directory>/modern-web.mjs retrieve "<id>"';
+    assert.ok(skillContent.includes(expectedPattern), 'modern-web/SKILL.md should contain the expected command pattern');
+    
+    const result = replaceMacros('{{ GUIDE_REF("break-up-long-tasks") }}', 'test.md', { target: 'skills-cli' });
+    
+    assert.ok(result.includes('node <modern-web-directory>/modern-web.mjs retrieve "break-up-long-tasks"'), 'Macro output should match the pattern in SKILL.md');
   });
 });

--- a/serving/skills-cli/build-dist.test.ts
+++ b/serving/skills-cli/build-dist.test.ts
@@ -4,6 +4,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { processSkills } from './build-dist.ts';
 import { replaceMacros } from '../lib/macros.ts';
+import { resetGuidesMap } from '../../lib/guide-validation.ts';
+
 
 import { rootDir } from '../../lib/paths.ts';
 
@@ -17,6 +19,7 @@ describe('processSkills', () => {
     fs.mkdirSync(dummySkillDir, { recursive: true });
     fs.writeFileSync(path.join(dummySkillDir, 'SKILL.md'), 'Test Skill with macro: {{ BASELINE_STATUS("grid") }}');
     fs.mkdirSync(testOutputDir, { recursive: true });
+    resetGuidesMap();
   });
 
   after(() => {

--- a/serving/skills-cli/build-dist.test.ts
+++ b/serving/skills-cli/build-dist.test.ts
@@ -17,7 +17,7 @@ describe('processSkills', () => {
 
   before(() => {
     fs.mkdirSync(dummySkillDir, { recursive: true });
-    fs.writeFileSync(path.join(dummySkillDir, 'SKILL.md'), 'Test Skill with macro: {{ BASELINE_STATUS("grid") }}');
+    fs.writeFileSync(path.join(dummySkillDir, 'SKILL.md'), 'Test Skill with macro: {{ BASELINE_STATUS("grid") }} and guide ref: {{ GUIDE_REF("forms") }}');
     fs.mkdirSync(testOutputDir, { recursive: true });
     resetGuidesMap();
   });
@@ -39,6 +39,8 @@ describe('processSkills', () => {
     const content = fs.readFileSync(builtSkillPath, 'utf8');
     assert.ok(!content.includes('{{ BASELINE_STATUS'), 'Macro should be resolved');
     assert.ok(content.includes('Widely available') || content.includes('Baseline since'), 'Should contain baseline status');
+    assert.ok(!content.includes('{{ GUIDE_REF'), 'GUIDE_REF macro should be resolved');
+    assert.ok(content.includes('`forms` (via `node <modern-web-directory>/modern-web.mjs retrieve "forms"`)'), 'Should resolve forms skill reference');
   });
 
   it('processes GUIDE_REF macros in real CSS SKILL.md', () => {

--- a/serving/skills-cli/build-dist.ts
+++ b/serving/skills-cli/build-dist.ts
@@ -8,6 +8,8 @@ import { scanAllGuides } from "../../lib/guide-validation.ts";
 import { getFeatureName } from "../lib/baseline.ts";
 import { rootDir } from "../../lib/paths.ts";
 import { processGuides } from "../scripts/build-guides.ts";
+import { replaceMacros } from "../lib/macros.ts";
+
 
 
 const SERVING_DIR = path.join(rootDir, "serving");
@@ -234,8 +236,10 @@ async function main(opts: {publishRoot: string, version?: string, npx?: boolean,
       const skillDestDir = path.join(publishRoot, "skills", candidate);
       const skillDest = path.join(skillDestDir, "SKILL.md");
       fs.mkdirSync(skillDestDir, { recursive: true });
-      fs.copyFileSync(skillSource, skillDest);
-      console.log(`Copied skill ${candidate} (SKILL.md) to ${skillDestDir}`);
+      const skillContent = fs.readFileSync(skillSource, 'utf8');
+      const processedSkillContent = replaceMacros(skillContent, skillSource);
+      fs.writeFileSync(skillDest, processedSkillContent);
+      console.log(`Processed and copied skill ${candidate} (SKILL.md) to ${skillDestDir}`);
       skillsCount++;
       skillNames.push(candidate);
     }

--- a/serving/skills-cli/build-dist.ts
+++ b/serving/skills-cli/build-dist.ts
@@ -4,7 +4,7 @@ import { execSync } from "child_process";
 import { fileURLToPath } from "url";
 import matter from "gray-matter";
 import * as esbuild from "esbuild";
-import { scanAllGuides } from "../../lib/guide-validation.ts";
+import { scanAllGuides, scanDisciplineSkills } from "../../lib/guide-validation.ts";
 import { getFeatureName } from "../lib/baseline.ts";
 import { rootDir } from "../../lib/paths.ts";
 import { processGuides } from "../scripts/build-guides.ts";
@@ -87,19 +87,17 @@ function convertSkillToUseNpx(skillDest: string) {
 
 export function processSkills(publishRoot: string, distDir: string, npx: boolean) {
   console.log("Scanning for skills (SKILL.md) in guides/...");
-  const guidesDirInRoot = path.join(rootDir, "guides");
-  
-  // Find all SKILL.md files in top-level directories of guides/
-  const skillFiles = fs.globSync('*/SKILL.md', { cwd: guidesDirInRoot });
+  const skills = scanDisciplineSkills();
 
-  for (const relPath of skillFiles as string[]) {
-    const category = path.dirname(relPath);
-    const source = path.join(guidesDirInRoot, relPath);
+  for (const skill of skills) {
+    const category = skill.category;
+    const source = path.join(skill.dir, "SKILL.md");
     const skillDestDir = path.join(publishRoot, "skills", category);
     
     fs.mkdirSync(skillDestDir, { recursive: true });
     
-    const content = replaceMacros(fs.readFileSync(source, 'utf8'), source, { target: 'skills-cli' });
+    const target = npx ? 'skills-cli-npx' : 'skills-cli';
+    const content = replaceMacros(fs.readFileSync(source, 'utf8'), source, { target });
     fs.writeFileSync(path.join(skillDestDir, "SKILL.md"), content);
     
     console.log(`Processed and copied skill ${category} (SKILL.md) to ${skillDestDir}`);
@@ -110,8 +108,8 @@ export function processSkills(publishRoot: string, distDir: string, npx: boolean
     convertSkillToUseNpx(skillDest);
   }
 
-  console.log(`Successfully copied ${skillFiles.length} skills to distribution.`);
-  return { skillsCount: skillFiles.length, skillNames: skillFiles.map(f => path.dirname(f as string)) };
+  console.log(`Successfully copied ${skills.length} skills to distribution.`);
+  return { skillsCount: skills.length, skillNames: skills.map(s => s.category) };
 }
 
 async function main(opts: {publishRoot: string, version?: string, npx?: boolean, subset?: number}): Promise<BuildResult | undefined> {
@@ -136,7 +134,7 @@ async function main(opts: {publishRoot: string, version?: string, npx?: boolean,
     console.time("⏳ processGuides");
     await processGuides({
       outputDir: DIST_DIR,
-      target: 'skills-cli',
+      target: npx ? 'skills-cli-npx' : 'skills-cli',
       subset,
     });
     console.timeEnd("⏳ processGuides");

--- a/serving/skills-cli/build-dist.ts
+++ b/serving/skills-cli/build-dist.ts
@@ -85,6 +85,39 @@ function convertSkillToUseNpx(skillDest: string) {
   fs.writeFileSync(skillDest, skillText);
 }
 
+export function processSkills(publishRoot: string, distDir: string, npx: boolean) {
+  console.log("Scanning for skills (SKILL.md) in guides/...");
+  const guidesDirInRoot = path.join(rootDir, "guides");
+  const candidates = fs.readdirSync(guidesDirInRoot, { withFileTypes: true })
+    .filter(d => d.isDirectory() && !d.name.startsWith('.') && d.name !== 'node_modules')
+    .map(d => d.name);
+
+  let skillsCount = 0;
+  const skillNames: string[] = [];
+  for (const candidate of candidates) {
+    const skillSource = path.join(guidesDirInRoot, candidate, "SKILL.md");
+    if (fs.existsSync(skillSource)) {
+      const skillDestDir = path.join(publishRoot, "skills", candidate);
+      const skillDest = path.join(skillDestDir, "SKILL.md");
+      fs.mkdirSync(skillDestDir, { recursive: true });
+      const skillContent = fs.readFileSync(skillSource, 'utf8');
+      const processedSkillContent = replaceMacros(skillContent, skillSource);
+      fs.writeFileSync(skillDest, processedSkillContent);
+      console.log(`Processed and copied skill ${candidate} (SKILL.md) to ${skillDestDir}`);
+      skillsCount++;
+      skillNames.push(candidate);
+    }
+  }
+
+  if (npx) {
+    const skillDest = path.join(distDir, "SKILL.md");
+    convertSkillToUseNpx(skillDest);
+  }
+
+  console.log(`Successfully copied ${skillsCount} skills to distribution.`);
+  return { skillsCount, skillNames };
+}
+
 async function main(opts: {publishRoot: string, version?: string, npx?: boolean, subset?: boolean | number}): Promise<BuildResult | undefined> {
   const {publishRoot, version, npx, subset} = opts;
 
@@ -222,35 +255,7 @@ async function main(opts: {publishRoot: string, version?: string, npx?: boolean,
 
 
 
-  console.log("Scanning for skills (SKILL.md) in guides/...");
-  const guidesDirInRoot = path.join(rootDir, "guides");
-  const candidates = fs.readdirSync(guidesDirInRoot, { withFileTypes: true })
-    .filter(d => d.isDirectory() && !d.name.startsWith('.') && d.name !== 'node_modules')
-    .map(d => d.name);
-
-  let skillsCount = 0;
-  const skillNames: string[] = [];
-  for (const candidate of candidates) {
-    const skillSource = path.join(guidesDirInRoot, candidate, "SKILL.md");
-    if (fs.existsSync(skillSource)) {
-      const skillDestDir = path.join(publishRoot, "skills", candidate);
-      const skillDest = path.join(skillDestDir, "SKILL.md");
-      fs.mkdirSync(skillDestDir, { recursive: true });
-      const skillContent = fs.readFileSync(skillSource, 'utf8');
-      const processedSkillContent = replaceMacros(skillContent, skillSource);
-      fs.writeFileSync(skillDest, processedSkillContent);
-      console.log(`Processed and copied skill ${candidate} (SKILL.md) to ${skillDestDir}`);
-      skillsCount++;
-      skillNames.push(candidate);
-    }
-  }
-
-  if (npx) {
-    const skillDest = path.join(DIST_DIR, "SKILL.md");
-    convertSkillToUseNpx(skillDest);
-  }
-
-  console.log(`Successfully copied ${skillsCount} skills to distribution.`);
+  const { skillsCount, skillNames } = processSkills(publishRoot, DIST_DIR, !!npx);
 
   const { featuresCount, useCasesCount } = updateReadmeWithFeaturesAndUseCases(publishRoot);
 

--- a/serving/skills-cli/build-dist.ts
+++ b/serving/skills-cli/build-dist.ts
@@ -7,6 +7,8 @@ import * as esbuild from "esbuild";
 import { scanAllGuides } from "../../lib/guide-validation.ts";
 import { getFeatureName } from "../lib/baseline.ts";
 import { rootDir } from "../../lib/paths.ts";
+import { processGuides } from "../scripts/build-guides.ts";
+
 
 const SERVING_DIR = path.join(rootDir, "serving");
 const ROOT_DIST_DIR = path.join(rootDir, "dist");
@@ -99,15 +101,14 @@ async function main(opts: {publishRoot: string, version?: string, npx?: boolean,
     fs.mkdirSync(publishRoot, { recursive: true });
 
   console.log("Generating guides and updating vector store...");
-  // 1. Run build-guides.ts to update .modern-web-data and build/guides
   try {
-    console.time("⏳ build-guides.ts");
-    const subsetFlag = subset ? (typeof subset === 'number' ? `--subset=${subset}` : '--subset') : '';
-    execSync(`node --experimental-strip-types scripts/build-guides.ts ${subsetFlag}`, {
-      cwd: SERVING_DIR,
-      stdio: "inherit",
+    console.time("⏳ processGuides");
+    await processGuides({
+      outputDir: DIST_DIR,
+      isDistribution: true,
+      subset: typeof subset === 'number' ? subset : undefined,
     });
-    console.timeEnd("⏳ build-guides.ts");
+    console.timeEnd("⏳ processGuides");
   } catch (error) {
     console.error("Failed to build guides:", error);
     process.exit(1);
@@ -121,27 +122,6 @@ async function main(opts: {publishRoot: string, version?: string, npx?: boolean,
   if (version) {
     console.log(`Updating version to ${version} in distribution files...`);
     updateVersionsInDir(publishRoot, version);
-  }
-
-
-  console.log("Copying data files...");
-
-  // 4. Copy build/guides
-  const buildGuidesDir = path.join(SERVING_DIR, "build/guides");
-  const destBuildGuidesDir = path.join(DIST_DIR, "guides");
-  if (fs.existsSync(buildGuidesDir)) {
-    fs.cpSync(buildGuidesDir, destBuildGuidesDir, { recursive: true });
-    console.log(`Copied ${buildGuidesDir} to ${destBuildGuidesDir}`);
-  } else {
-    console.warn(`Warning: ${buildGuidesDir} does not exist.`);
-  }
-
-  console.log("Copying pure JS vector file...");
-  const vectorsFile = path.join(SERVING_DIR, "lib/use-cases.vectors.gen.json.gz");
-  const destVectorsFile = path.join(DIST_DIR, "use-cases.vectors.gen.json.gz");
-  if (fs.existsSync(vectorsFile)) {
-    fs.cpSync(vectorsFile, destVectorsFile);
-    console.log(`Copied ${vectorsFile} to ${destVectorsFile}`);
   }
 
   console.log("Copying TFJS model files...");

--- a/serving/skills-cli/build-dist.ts
+++ b/serving/skills-cli/build-dist.ts
@@ -114,7 +114,7 @@ export function processSkills(publishRoot: string, distDir: string, npx: boolean
   return { skillsCount: skillFiles.length, skillNames: skillFiles.map(f => path.dirname(f as string)) };
 }
 
-async function main(opts: {publishRoot: string, version?: string, npx?: boolean, subset?: boolean | number}): Promise<BuildResult | undefined> {
+async function main(opts: {publishRoot: string, version?: string, npx?: boolean, subset?: number}): Promise<BuildResult | undefined> {
   const {publishRoot, version, npx, subset} = opts;
 
   fs.rmSync(publishRoot, { recursive: true, force: true });
@@ -137,7 +137,7 @@ async function main(opts: {publishRoot: string, version?: string, npx?: boolean,
     await processGuides({
       outputDir: DIST_DIR,
       target: 'skills-cli',
-      subset: typeof subset === 'number' ? subset : undefined,
+      subset,
     });
     console.timeEnd("⏳ processGuides");
   } catch (error) {

--- a/serving/skills-cli/build-dist.ts
+++ b/serving/skills-cli/build-dist.ts
@@ -101,7 +101,7 @@ export function processSkills(publishRoot: string, distDir: string, npx: boolean
       const skillDest = path.join(skillDestDir, "SKILL.md");
       fs.mkdirSync(skillDestDir, { recursive: true });
       const skillContent = fs.readFileSync(skillSource, 'utf8');
-      const processedSkillContent = replaceMacros(skillContent, skillSource);
+      const processedSkillContent = replaceMacros(skillContent, skillSource, { target: 'skills-cli' });
       fs.writeFileSync(skillDest, processedSkillContent);
       console.log(`Processed and copied skill ${candidate} (SKILL.md) to ${skillDestDir}`);
       skillsCount++;

--- a/serving/skills-cli/build-dist.ts
+++ b/serving/skills-cli/build-dist.ts
@@ -207,6 +207,12 @@ async function main(opts: {publishRoot: string, version?: string, npx?: boolean,
       path.join(publishRoot, "THIRD_PARTY_NOTICES")
     );
 
+    const metaFile = path.join(publishRoot, "search.meta.json");
+    if (fs.existsSync(metaFile)) {
+      fs.unlinkSync(metaFile);
+      console.log(`Removed intermediate metafile ${metaFile}`);
+    }
+
   } catch (error) {
     console.error("Failed to bundle with esbuild:", error);
     process.exit(1);

--- a/serving/skills-cli/build-dist.ts
+++ b/serving/skills-cli/build-dist.ts
@@ -140,7 +140,7 @@ async function main(opts: {publishRoot: string, version?: string, npx?: boolean,
     console.time("⏳ processGuides");
     await processGuides({
       outputDir: DIST_DIR,
-      isDistribution: true,
+      target: 'skills-cli',
       subset: typeof subset === 'number' ? subset : undefined,
     });
     console.timeEnd("⏳ processGuides");

--- a/serving/skills-cli/build-dist.ts
+++ b/serving/skills-cli/build-dist.ts
@@ -88,25 +88,21 @@ function convertSkillToUseNpx(skillDest: string) {
 export function processSkills(publishRoot: string, distDir: string, npx: boolean) {
   console.log("Scanning for skills (SKILL.md) in guides/...");
   const guidesDirInRoot = path.join(rootDir, "guides");
-  const candidates = fs.readdirSync(guidesDirInRoot, { withFileTypes: true })
-    .filter(d => d.isDirectory() && !d.name.startsWith('.') && d.name !== 'node_modules')
-    .map(d => d.name);
+  
+  // Find all SKILL.md files in top-level directories of guides/
+  const skillFiles = fs.globSync('*/SKILL.md', { cwd: guidesDirInRoot });
 
-  let skillsCount = 0;
-  const skillNames: string[] = [];
-  for (const candidate of candidates) {
-    const skillSource = path.join(guidesDirInRoot, candidate, "SKILL.md");
-    if (fs.existsSync(skillSource)) {
-      const skillDestDir = path.join(publishRoot, "skills", candidate);
-      const skillDest = path.join(skillDestDir, "SKILL.md");
-      fs.mkdirSync(skillDestDir, { recursive: true });
-      const skillContent = fs.readFileSync(skillSource, 'utf8');
-      const processedSkillContent = replaceMacros(skillContent, skillSource, { target: 'skills-cli' });
-      fs.writeFileSync(skillDest, processedSkillContent);
-      console.log(`Processed and copied skill ${candidate} (SKILL.md) to ${skillDestDir}`);
-      skillsCount++;
-      skillNames.push(candidate);
-    }
+  for (const relPath of skillFiles as string[]) {
+    const category = path.dirname(relPath);
+    const source = path.join(guidesDirInRoot, relPath);
+    const skillDestDir = path.join(publishRoot, "skills", category);
+    
+    fs.mkdirSync(skillDestDir, { recursive: true });
+    
+    const content = replaceMacros(fs.readFileSync(source, 'utf8'), source, { target: 'skills-cli' });
+    fs.writeFileSync(path.join(skillDestDir, "SKILL.md"), content);
+    
+    console.log(`Processed and copied skill ${category} (SKILL.md) to ${skillDestDir}`);
   }
 
   if (npx) {
@@ -114,8 +110,8 @@ export function processSkills(publishRoot: string, distDir: string, npx: boolean
     convertSkillToUseNpx(skillDest);
   }
 
-  console.log(`Successfully copied ${skillsCount} skills to distribution.`);
-  return { skillsCount, skillNames };
+  console.log(`Successfully copied ${skillFiles.length} skills to distribution.`);
+  return { skillsCount: skillFiles.length, skillNames: skillFiles.map(f => path.dirname(f as string)) };
 }
 
 async function main(opts: {publishRoot: string, version?: string, npx?: boolean, subset?: boolean | number}): Promise<BuildResult | undefined> {

--- a/serving/skills-cli/install-gemini.test.ts
+++ b/serving/skills-cli/install-gemini.test.ts
@@ -18,7 +18,10 @@ test('Gemini CLI verifies extension install capability', { skip: !process.env.FU
             return;
         }
 
-        const helpOut = execSync(`${geminiBin} extensions --help`, { encoding: 'utf8' });
+        const helpOut = execSync(`${geminiBin} extensions --help`, { 
+            encoding: 'utf8',
+            env: { ...process.env, GEMINI_CLI_TRUST_WORKSPACE: '1' }
+        });
         assert.ok(helpOut.includes('install'), 'Gemini should have install command');
 
         console.log(`\nInstalling Gemini extension locally...`);
@@ -26,7 +29,7 @@ test('Gemini CLI verifies extension install capability', { skip: !process.env.FU
         execSync(`${geminiBin} extensions install ${distDir} --consent`, { 
             stdio: 'inherit',
             input: 'y\n',
-            env: { ...process.env, HOME: homeDir }
+            env: { ...process.env, HOME: homeDir, GEMINI_CLI_TRUST_WORKSPACE: 'true' }
         });
 
         console.log(`\nRunning Gemini prompt using the skill...`);
@@ -34,7 +37,7 @@ test('Gemini CLI verifies extension install capability', { skip: !process.env.FU
         const output = execSync(promptCmd, { 
             stdio: ['ignore', 'pipe', 'pipe'], 
             timeout: 90000,
-            env: { ...process.env, HOME: homeDir }
+            env: { ...process.env, HOME: homeDir, GEMINI_CLI_TRUST_WORKSPACE: 'true' }
         });
 
         console.log(`\nVerifying Gemini used the skill...`);

--- a/serving/skills-cli/install-gemini.test.ts
+++ b/serving/skills-cli/install-gemini.test.ts
@@ -18,26 +18,23 @@ test('Gemini CLI verifies extension install capability', { skip: !process.env.FU
             return;
         }
 
-        const helpOut = execSync(`${geminiBin} extensions --help`, { 
-            encoding: 'utf8',
-            env: { ...process.env, GEMINI_CLI_TRUST_WORKSPACE: '1' }
-        });
+        const helpOut = execSync(`${geminiBin} extensions --help`, { encoding: 'utf8' });
         assert.ok(helpOut.includes('install'), 'Gemini should have install command');
 
         console.log(`\nInstalling Gemini extension locally...`);
         // Use input: 'y\n' to answer the workspace trust prompt cleanly, and stdio: 'inherit' to see it
         execSync(`${geminiBin} extensions install ${distDir} --consent`, { 
-            stdio: 'inherit',
+            stdio: ['pipe', 'inherit', 'inherit'],
             input: 'y\n',
-            env: { ...process.env, HOME: homeDir, GEMINI_CLI_TRUST_WORKSPACE: 'true' }
+            env: { ...process.env, HOME: homeDir }
         });
 
         console.log(`\nRunning Gemini prompt using the skill...`);
-        const promptCmd = `${geminiBin} -p "use the modern-web skill and tell me best practices on implementing an address form" -o stream-json --yolo`;
+        const promptCmd = `${geminiBin} -p "use the modern-web skill and tell me best practices on implementing an address form" -o stream-json --yolo --skip-trust`;
         const output = execSync(promptCmd, { 
             stdio: ['ignore', 'pipe', 'pipe'], 
             timeout: 90000,
-            env: { ...process.env, HOME: homeDir, GEMINI_CLI_TRUST_WORKSPACE: 'true' }
+            env: { ...process.env, HOME: homeDir }
         });
 
         console.log(`\nVerifying Gemini used the skill...`);

--- a/serving/skills-cli/install-skills.test.ts
+++ b/serving/skills-cli/install-skills.test.ts
@@ -25,7 +25,7 @@ test('npx skills add from local path', { skip: !process.env.FULL }, async () => 
             try {
                 execSync(`${geminiBin} extensions uninstall googlechrome-skills`, {
                     stdio: 'ignore', 
-                    env: { ...process.env, HOME: homeDir, GEMINI_CLI_TRUST_WORKSPACE: 'true' }
+                    env: { ...process.env, HOME: homeDir }
                 });
             } catch {
                 // Ignore if not installed
@@ -40,11 +40,11 @@ test('npx skills add from local path', { skip: !process.env.FULL }, async () => 
 
         if (fs.existsSync(geminiBin)) {
             console.log(`\nVerifying Gemini can use the added skill...`);
-            const promptCmd = `${geminiBin} -p "use the modern-web skill and tell me best practices on implementing an address form" -o stream-json --yolo`;
+            const promptCmd = `${geminiBin} -p "use the modern-web skill and tell me best practices on implementing an address form" -o stream-json --yolo --skip-trust`;
             const output = execSync(promptCmd, { 
                 stdio: ['ignore', 'pipe', 'pipe'], 
                 timeout: 90000,
-                env: { ...process.env, HOME: homeDir, GEMINI_CLI_TRUST_WORKSPACE: 'true' }
+                env: { ...process.env, HOME: homeDir }
             });
 
             console.log(`\nVerifying Gemini used the skill...`);

--- a/serving/skills-cli/install-skills.test.ts
+++ b/serving/skills-cli/install-skills.test.ts
@@ -25,7 +25,7 @@ test('npx skills add from local path', { skip: !process.env.FULL }, async () => 
             try {
                 execSync(`${geminiBin} extensions uninstall googlechrome-skills`, {
                     stdio: 'ignore', 
-                    env: { ...process.env, HOME: homeDir }
+                    env: { ...process.env, HOME: homeDir, GEMINI_CLI_TRUST_WORKSPACE: 'true' }
                 });
             } catch {
                 // Ignore if not installed
@@ -44,7 +44,7 @@ test('npx skills add from local path', { skip: !process.env.FULL }, async () => 
             const output = execSync(promptCmd, { 
                 stdio: ['ignore', 'pipe', 'pipe'], 
                 timeout: 90000,
-                env: { ...process.env, HOME: homeDir }
+                env: { ...process.env, HOME: homeDir, GEMINI_CLI_TRUST_WORKSPACE: 'true' }
             });
 
             console.log(`\nVerifying Gemini used the skill...`);


### PR DESCRIPTION
### New `GUIDE_REF` macro

Allow guides and skills to reference other guides. It changes behavior depending on skillcli (cli references) vs local-dev (file paths).  Made this extensible a little early but this way it's prepared for any megaskill or mcp things we do. 



| Context | Markdown |
| :--- | :--- |
| **Input** | `... Also, see {{ GUIDE_REF("child-state-based-styling") }}.` |
| **Output (`skills-cli`)** | `... Also, see ˋchild-state-based-stylingˋ (via ˋnode modern-web.mjs retrieve "child-state-based-styling"ˋ).` |
| **Output (`local-dev`)** | `... Also, see ˋuser-experience/child-state-based-styling/guide.mdˋ.` |


### BASELINE_STATUS works in skills now. 

yup

### Build system mini-refactor.

Now build-guides exports a processGuides method.. rather than the shell-based execution.  And it accepts a `target` option in `BuildOptions` to direct output directly to the destination directory, avoiding the need for manual copying and preventing double builds.

### some gemini cli trust things 

`--skip-trust` and `GEMINI_CLI_TRUST_WORKSPACE='true'`.

### isSkill => isDisciplineSkill

some renames.
