### PR TITLE
Prevent build-guides from skipping in CI

### DIFF
--- a/serving/scripts/build-guides.ts
+++ b/serving/scripts/build-guides.ts
@@ -43,7 +43,7 @@ async function processGuides() {
 
   const VECTORS_FILE = path.join(ROOT_DIR, "lib/use-cases.vectors.gen.json.gz");
 
-  let shouldSkip = !targetGuidePath && !force && fs.existsSync(OUTPUT_FILE) && fs.existsSync(BUILD_GUIDES_DIR) && fs.existsSync(VECTORS_FILE);
+  let shouldSkip = !process.env.CI && !targetGuidePath && !force && fs.existsSync(OUTPUT_FILE) && fs.existsSync(BUILD_GUIDES_DIR) && fs.existsSync(VECTORS_FILE);
 
   if (shouldSkip) {
     // Also check if the count of files in BUILD_GUIDES_DIR matches readyGuides.length

--- a/serving/skills-cli/build-dist.ts
+++ b/serving/skills-cli/build-dist.ts
@@ -425,8 +425,8 @@ if (process.argv[1] === fileURLToPath(import.meta.url)) {
 
   (async () => {
     try {
-      await main({publishRoot: path.join(ROOT_DIST_DIR, "skills-cli"), version});
       await main({publishRoot: path.join(ROOT_DIST_DIR, "skills-cli-npx"), version, npx: true, subset: 3});
+      await main({publishRoot: path.join(ROOT_DIST_DIR, "skills-cli"), version});
     } catch (err) {
       console.error(err);
       process.exit(1);


### PR DESCRIPTION
### The Issue
* Parallel `harness test` and `serving test` suites run concurrently on CI.
* `harness test` generates a 3-guide subset vector database to limit embedding generation overhead, saving these files to the CI cache.
* `serving test` restores the cached 3-guide subset and skips regenerating the full 95-guide database because files already exist in the filesystem (`shouldSkip === true`).
* The addition of the `built-in-ai` category in #652 alphabetically shifted `autofill-address-form` out of the first 3 guides sliced for the subset. 
* `lib/search.test.ts` failed because it searched the stale 3-guide subset database where `autofill-address-form` was no longer present.

### The Fix
* Appended `!process.env.CI` to the `shouldSkip` conditional check in `serving/scripts/build-guides.ts`.
* This forces a fresh, full guide and vector database regeneration on every CI execution regardless of cached filesystem states.