### PR TITLE
Add macros for selective content transclusion from other md files

### DIFF
--- a/.agents/skills/project-guides/SKILL.md
+++ b/.agents/skills/project-guides/SKILL.md
@@ -64,12 +64,31 @@ sources:
 
 ### 5. Fallback Strategies
 * You **MUST** include a "Fallback strategies" section regardless of Baseline status, as developers may have older baseline targets.
-* **MANDATORY**: The `{{ BASELINE_STATUS("feature-id") }}` macro must *always* be placed as the first, standalone line inside the "Fallback strategies" section. Do not place it at the top of the document.
-* **OPTIONAL** provide an optional second argument for specific BCD keys: `{{ BASELINE_STATUS("feature-id", "bcd.key") }}`. This is useful when a critical sub-feature's status differs from the overall feature status.
+* **MANDATORY**: The first, standalone line inside that section must be either `{{ FEATURE_FALLBACKS("feature-id") }}` (preferred) or `{{ BASELINE_STATUS("feature-id") }}`. Do not place either at the top of the document.
+  * Prefer `FEATURE_FALLBACKS` even when no `features/<feature-id>.md` exists yet — it gracefully degrades to just the baseline status, and any shared fallback content added later flows in automatically without a guide-side edit.
+  * Use `BASELINE_STATUS` directly only when you need the BCD-key second argument: `{{ BASELINE_STATUS("feature-id", "bcd.key") }}`. This is useful when a critical sub-feature's status differs from the overall feature status.
 * **MANDATORY**: You MUST explicitly describe the fallback experience for unsupported browsers. Explain if the feature is a progressive enhancement (and what the base experience looks like), or show explicit code for feature detection (e.g., `CSS.supports()`, `if ('feature' in window)`) and graceful degradation techniques.
 * When recommending feature detection, prefer checking `HTMLElement.prototype` (e.g., `'onbeforematch' in HTMLElement.prototype`) over `window` or `document`, as it is more reliable.
 * When recommending a polyfill, ALWAYS show how to conditionally load it only for browsers that need it. Do not instruct agents to unconditionally load polyfills.
 * **DO NOT** recommend polyfills from polyfill.io.
+
+### 6. Build-time macros
+
+| Macro | What it emits |
+|---|---|
+| `{{ BASELINE_STATUS("feature-id"[, "bcd.key"]) }}` | `"Baseline since YYYY-MM-DD"` or `"limited availability"`. |
+| `{{ INCLUDE("path[#section]") }}` | Whole markdown file (frontmatter + leading `# H1` stripped) or one section (its heading dropped). Bare paths resolve from repo root; `./`/`../` resolve relative to the calling file. |
+| `{{ FEATURE("feature-id", "section") }}` | Sugar for `INCLUDE("features/<feature-id>.md#<section>")`. |
+| `{{ FEATURE_FALLBACKS("feature-id") }}` | `### Fallbacks & browser support for <Feature name>` + `BASELINE_STATUS` + the `#fallbacks` section. If `#fallbacks` is empty, emits only `BASELINE_STATUS` (no heading). |
+| `{{ FEATURE_ISSUES("feature-id") }}` | `### Issues to be aware of when using <Feature name>` + the `#issues` section. Returns `""` if `#issues` is empty/missing. |
+
+* **Errors**: invalid feature ID or missing required argument → `MacroError` (build fails loudly). Missing referenced *content* (file or section) → silent `""`, so guides can reference content that doesn't exist yet.
+* **Section IDs**: slugified heading text (`### Fallback strategies` → `fallback-strategies`), or an explicit `{#id}` suffix on the heading.
+* **Recursion**: macros inside transcluded content expand normally. No cycle detection — don't write self-referential includes.
+
+### 7. Reusing per-feature content via `features/`
+
+When the same feature-level content (intro, fallback patterns, a11y, gotchas) applies to multiple guides, extract it into `features/<feature-id>.md` and pull it in with the macros above. Rule of thumb: extract if two or more guides cover the same `web-feature-id` and repeat the same advice. Standard section names: `## Fallbacks` (used by `FEATURE_FALLBACKS`), `## Issues` (used by `FEATURE_ISSUES`); add others as needed and pull them with `FEATURE`. Verify your include resolved by inspecting the build output (`serving/build/guides/<category>/<id>.md`) — silent misses won't fail the build.
 
 ## Authoring `expectations.md` and  `demo.html`
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -282,6 +282,10 @@ Guides are read by AI coding agents, not humans directly. Key requirements:
 - Short, commented code snippets with directives in code comments
 - Fallback strategies section if the feature is not Baseline Widely Available
 - Use `{{ BASELINE_STATUS("feature-id") }}` macro for browser support display
+- Use `{{ INCLUDE("path[#section]") }}` to transclude a whole markdown file or one section. Bare paths resolve from repo root; `./`/`../` resolve relative to the calling file
+- Use `{{ FEATURE("feature-id", "section") }}` as a shorthand for `INCLUDE("features/<feature-id>.md#<section>")`
+- Use `{{ FEATURE_FALLBACKS("feature-id") }}` (preferred) inside the "Fallback strategies" section — emits a sub-heading, `BASELINE_STATUS`, and the `#fallbacks` section from `features/<feature-id>.md` if it exists
+- Use `{{ FEATURE_ISSUES("feature-id") }}` to surface known gotchas from `features/<feature-id>.md#issues`, or `""` if no such section exists
 
 ### Writing expectations.md
 

--- a/guides/guides-integrity.test.ts
+++ b/guides/guides-integrity.test.ts
@@ -7,6 +7,7 @@ import { marked } from 'marked';
 
 // Import shared utilities
 import { scanAllGuides, processGuideInventory } from '../lib/guide-validation.ts';
+import { MACRO_PATTERN, replaceMacros } from '../serving/lib/macros.ts';
 
 const REPO_ROOT = path.resolve(import.meta.dirname, '..');
 
@@ -69,6 +70,32 @@ describe('Guides Validation (Single Source of Truth)', () => {
       for (const marker of conflictMarkers) {
         if (content.includes(marker)) {
           assert.fail(`File contains git conflict marker "${marker}" in ${relativeDir}`);
+        }
+      }
+    });
+
+    // Transclusion macros silently return "" for missing files/sections, which
+    // validateMacros (error-throw based) does not catch. Guard against
+    // accidentally referencing a path/section that doesn't exist.
+    //
+    // Excluded macros:
+    // - FEATURE_ISSUES: "" is its documented return when #issues is empty/missing,
+    //   so an empty result is not a bug.
+    // - BASELINE_STATUS: not a transclusion macro; it either returns content or
+    //   throws (already caught by validateMacros), so a non-empty check is redundant.
+    it(`validates transclusion macros for ${relativeDir}`, () => {
+      const guidePath = path.join(guide.dir, 'guide.md');
+      if (!fs.existsSync(guidePath)) return;
+
+      const { content: body } = matter(fs.readFileSync(guidePath, 'utf8'));
+      const REQUIRED = new Set(['INCLUDE', 'FEATURE', 'FEATURE_FALLBACKS']);
+
+      for (const match of body.matchAll(MACRO_PATTERN)) {
+        const [full, name] = match;
+        if (!REQUIRED.has(name)) continue;
+        const result = replaceMacros(full, guidePath);
+        if (!result.trim()) {
+          assert.fail(`${full} in ${relativeDir} returned empty content (file or section not found).`);
         }
       }
     });

--- a/serving/lib/include.ts
+++ b/serving/lib/include.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import path from "path";
 import matter from "gray-matter";
+import { marked, type Token, type Tokens } from "marked";
 import { rootDir } from "../../lib/paths.ts";
 
 /**
@@ -41,85 +42,73 @@ export function resolveInclude(rawArg: string, callerPath: string): IncludeResol
     return { isValid: false, errorMessage: `Absolute paths are not allowed (got "${rawArg}")` };
   }
 
-  const hashIdx = rawArg.indexOf("#");
-  const rawPath = hashIdx === -1 ? rawArg : rawArg.slice(0, hashIdx);
-  const sectionId = hashIdx === -1 ? "" : rawArg.slice(hashIdx + 1);
-
+  const [rawPath, ...rest] = rawArg.split("#");
+  const sectionId = rest.join("#");
   const absolutePath = rawPath.startsWith("./") || rawPath.startsWith("../")
     ? path.resolve(path.dirname(callerPath), rawPath)
     : path.resolve(rootDir, rawPath);
 
-  loadBody(absolutePath); // populate cache (or mark missing as "")
-  const content = sectionId
-    ? loadSection(absolutePath, sectionId)
-    : fileCache.get(absolutePath)![""];
-
+  const file = loadFile(absolutePath);
+  const content = sectionId ? extractSection(file, sectionId) : file.body;
   return { isValid: true, content, absolutePath };
 }
 
-// File cache: absolutePath -> { "" -> post-frontmatter, post-h1 body, ...sectionId -> section body }
-const fileCache = new Map<string, Record<string, string>>();
+interface ParsedFile {
+  /** File body with frontmatter and a leading H1 stripped. "" for missing files. */
+  body: string;
+  /** Lexed body. Joined `.raw` is lossless, so sections slice cleanly. */
+  tokens: Token[];
+  /** Memoized section bodies by id. "" for misses. */
+  sections: Map<string, string>;
+}
 
-/**
- * Read a markdown file's body (frontmatter + leading H1 stripped, trimmed).
- * Returns "" if the file doesn't exist. Cached per absolute path.
- */
-function loadBody(absolutePath: string): string {
-  let record = fileCache.get(absolutePath);
-  if (!record) {
-    record = {};
-    fileCache.set(absolutePath, record);
-    if (!fs.existsSync(absolutePath)) {
-      record[""] = "";
-    } else {
-      const raw = fs.readFileSync(absolutePath, "utf-8");
-      let body = matter(raw).content.trim();
-      // Strip a leading "# Title" line — redundant when transcluded.
-      const firstNL = body.indexOf("\n");
-      const firstLine = firstNL === -1 ? body : body.slice(0, firstNL);
-      if (/^#\s+/.test(firstLine)) {
-        body = firstNL === -1 ? "" : body.slice(firstNL + 1).trim();
-      }
-      record[""] = body;
-    }
-  }
-  return record[""];
+const fileCache = new Map<string, ParsedFile>();
+
+function loadFile(absolutePath: string): ParsedFile {
+  let file = fileCache.get(absolutePath);
+  if (file) return file;
+
+  const raw = fs.existsSync(absolutePath) ? fs.readFileSync(absolutePath, "utf-8") : "";
+  // Strip frontmatter and a leading "# Title" line — redundant when transcluded.
+  const body = matter(raw).content.trim().replace(/^#\s+[^\n]*\n?/, "").trim();
+  file = { body, tokens: marked.lexer(body), sections: new Map() };
+  fileCache.set(absolutePath, file);
+  return file;
+}
+
+const isHeading = (t: Token): t is Tokens.Heading => t.type === "heading";
+
+// `{#id}` heading-suffix syntax. Not standard CommonMark, and no installed
+// marked plugin handles it, so we match it on the heading text ourselves.
+const HEADING_ID = /\s*\{\s*#([\w-]+)\s*\}\s*$/;
+
+function matchesHeading({ text, depth }: Tokens.Heading, sectionId: string): boolean {
+  if (depth < 2) return false; // H1s are document titles, not section anchors.
+  const explicit = HEADING_ID.exec(text);
+  return explicit
+    ? explicit[1] === sectionId
+    : slugify(text) === sectionId;
 }
 
 /**
  * Extract a section by id, dropping the heading itself. A heading matches
  * when its `{#id}` suffix equals `sectionId` or its text slugifies to it.
  * Section ends at the next heading of equal or shallower depth.
- * Cached per (file, sectionId).
- *
- * Heading detection is regex-based and skips H1 to avoid clashing with
- * document titles. Known limitation: a `### foo` line inside a fenced code
- * block is treated as a real heading.
  */
-function loadSection(absolutePath: string, sectionId: string): string {
-  const record = fileCache.get(absolutePath)!;
-  if (sectionId in record) return record[sectionId];
+function extractSection(file: ParsedFile, sectionId: string): string {
+  let result = file.sections.get(sectionId);
+  if (result !== undefined) return result;
 
-  const body = record[""];
-  let result = "";
-  if (body) {
-    const headings = [...body.matchAll(/^(#{2,})\s+(.+?)(?:\s*\{\s*#([\w-]+)\s*\})?\s*$/gm)];
-    for (let i = 0; i < headings.length; i++) {
-      const [match, hashes, text, explicitId] = headings[i];
-      if (explicitId !== sectionId && slugify(text) !== sectionId) continue;
-
-      const start = headings[i].index! + match.length;
-      let end = body.length;
-      for (let j = i + 1; j < headings.length; j++) {
-        if (headings[j][1].length <= hashes.length) {
-          end = headings[j].index!;
-          break;
-        }
-      }
-      result = body.slice(start, end).trim();
-      break;
-    }
+  const { tokens } = file;
+  const heading = tokens.find((t): t is Tokens.Heading => isHeading(t) && matchesHeading(t, sectionId));
+  if (!heading) {
+    result = "";
+  } else {
+    const start = tokens.indexOf(heading);
+    const end = tokens.findIndex((t, i) => i > start && isHeading(t) && t.depth <= heading.depth);
+    const stop = end === -1 ? tokens.length : end;
+    result = tokens.slice(start + 1, stop).map(t => t.raw).join("").trim();
   }
-  record[sectionId] = result;
+  file.sections.set(sectionId, result);
   return result;
 }

--- a/serving/lib/include.ts
+++ b/serving/lib/include.ts
@@ -78,16 +78,36 @@ function loadFile(absolutePath: string): ParsedFile {
 
 const isHeading = (t: Token): t is Tokens.Heading => t.type === "heading";
 
+/**
+ * Plain-text projection of a list of marked tokens (block or inline), in the
+ * spirit of DOM `Node.textContent`. Strips markdown syntax and HTML tags,
+ * keeping only visible content; for links, keeps the visible text and drops
+ * the URL. Inline `html` tokens (the tag syntax itself) are skipped, since
+ * the visible text between tags lives in adjacent `text` tokens. Block-level
+ * HTML is also dropped — its content isn't exposed as child tokens.
+ */
+function textContent(tokens: Token[] | undefined): string {
+  return tokens?.map(t => {
+    if ("tokens" in t && t.tokens) return textContent(t.tokens);
+    if (t.type === "br") return "\n";
+    if (t.type === "html") return "";
+    return "text" in t ? t.text : "";
+  }).join("") ?? "";
+}
+
 // `{#id}` heading-suffix syntax. Not standard CommonMark, and no installed
 // marked plugin handles it, so we match it on the heading text ourselves.
 const HEADING_ID = /\s*\{\s*#([\w-]+)\s*\}\s*$/;
 
-function matchesHeading({ text, depth }: Tokens.Heading, sectionId: string): boolean {
-  if (depth < 2) return false; // H1s are document titles, not section anchors.
+function matchesHeading(heading: Tokens.Heading, sectionId: string): boolean {
+  if (heading.depth < 2) return false; // H1s are document titles, not section anchors.
+  let text = textContent(heading.tokens);
   const explicit = HEADING_ID.exec(text);
-  return explicit
-    ? explicit[1] === sectionId
-    : slugify(text) === sectionId;
+  if (explicit) {
+    if (explicit[1] === sectionId) return true;
+    text = text.slice(0, explicit.index);
+  }
+  return slugify(text) === sectionId;
 }
 
 /**

--- a/serving/lib/include.ts
+++ b/serving/lib/include.ts
@@ -1,0 +1,125 @@
+import fs from "fs";
+import path from "path";
+import matter from "gray-matter";
+import { rootDir } from "../../lib/paths.ts";
+
+/**
+ * Result of resolving an INCLUDE argument. Mirrors the result-object
+ * pattern used by `validateFeature` in baseline.ts.
+ */
+export interface IncludeResolution {
+  isValid: boolean;
+  errorMessage?: string;
+  /** Resolved content. May be "" for a silent miss (missing file or section). */
+  content?: string;
+  /** Absolute path of the resolved file, used as the caller path for nested expansion. */
+  absolutePath?: string;
+}
+
+// NOTE: simple slugify, not a full GitHub-compatible algorithm. Adequate for
+// the predictable ASCII section names we use in features/*.md. Upgrade to a
+// package if we hit Unicode or duplicate-heading edge cases.
+export function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, "")
+    .trim()
+    .replace(/\s+/g, "-");
+}
+
+/**
+ * Resolve and load an INCLUDE argument. Returns `{ isValid: false, errorMessage }`
+ * for programmer errors (currently: absolute paths). Returns
+ * `{ isValid: true, content, absolutePath }` otherwise; `content` is "" for a
+ * silent miss when the file or section does not exist.
+ *
+ * Path resolution: `./` / `../` paths resolve relative to `callerPath`'s
+ * directory; bare paths resolve relative to repo root.
+ */
+export function resolveInclude(rawArg: string, callerPath: string): IncludeResolution {
+  if (rawArg.startsWith("/")) {
+    return { isValid: false, errorMessage: `Absolute paths are not allowed (got "${rawArg}")` };
+  }
+
+  const hashIdx = rawArg.indexOf("#");
+  const rawPath = hashIdx === -1 ? rawArg : rawArg.slice(0, hashIdx);
+  const sectionId = hashIdx === -1 ? "" : rawArg.slice(hashIdx + 1);
+
+  const absolutePath = rawPath.startsWith("./") || rawPath.startsWith("../")
+    ? path.resolve(path.dirname(callerPath), rawPath)
+    : path.resolve(rootDir, rawPath);
+
+  loadBody(absolutePath); // populate cache (or mark missing as "")
+  const content = sectionId
+    ? loadSection(absolutePath, sectionId)
+    : fileCache.get(absolutePath)![""];
+
+  return { isValid: true, content, absolutePath };
+}
+
+// File cache: absolutePath -> { "" -> post-frontmatter, post-h1 body, ...sectionId -> section body }
+const fileCache = new Map<string, Record<string, string>>();
+
+/**
+ * Read a markdown file's body (frontmatter + leading H1 stripped, trimmed).
+ * Returns "" if the file doesn't exist. Cached per absolute path.
+ */
+function loadBody(absolutePath: string): string {
+  let record = fileCache.get(absolutePath);
+  if (!record) {
+    record = {};
+    fileCache.set(absolutePath, record);
+    if (!fs.existsSync(absolutePath)) {
+      record[""] = "";
+    } else {
+      const raw = fs.readFileSync(absolutePath, "utf-8");
+      let body = matter(raw).content.trim();
+      // Strip a leading "# Title" line — redundant when transcluded.
+      const firstNL = body.indexOf("\n");
+      const firstLine = firstNL === -1 ? body : body.slice(0, firstNL);
+      if (/^#\s+/.test(firstLine)) {
+        body = firstNL === -1 ? "" : body.slice(firstNL + 1).trim();
+      }
+      record[""] = body;
+    }
+  }
+  return record[""];
+}
+
+/**
+ * Extract a section by id, dropping the heading itself. A heading matches
+ * when its `{#id}` suffix equals `sectionId` or its text slugifies to it.
+ * Section ends at the next heading of equal or shallower depth.
+ * Cached per (file, sectionId).
+ *
+ * Heading detection is regex-based and skips H1 to avoid clashing with
+ * document titles. Known limitation: a `### foo` line inside a fenced code
+ * block is treated as a real heading.
+ */
+function loadSection(absolutePath: string, sectionId: string): string {
+  const record = fileCache.get(absolutePath)!;
+  if (sectionId in record) return record[sectionId];
+
+  const body = record[""];
+  let result = "";
+  if (body) {
+    const headings = [...body.matchAll(/^(#{2,})\s+(.+?)(?:\s*\{\s*#([\w-]+)\s*\})?\s*$/gm)];
+    for (let i = 0; i < headings.length; i++) {
+      const [match, hashes, text, explicitId] = headings[i];
+      if (explicitId !== sectionId && slugify(text) !== sectionId) continue;
+
+      const start = headings[i].index! + match.length;
+      let end = body.length;
+      for (let j = i + 1; j < headings.length; j++) {
+        if (headings[j][1].length <= hashes.length) {
+          end = headings[j].index!;
+          break;
+        }
+      }
+      result = body.slice(start, end).trim();
+      break;
+    }
+  }
+  record[sectionId] = result;
+  return result;
+}

--- a/serving/lib/macros.test.ts
+++ b/serving/lib/macros.test.ts
@@ -1,6 +1,11 @@
-import { describe, it } from 'node:test';
+import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { replaceMacros } from './macros.ts';
+import { slugify } from './include.ts';
+import { rootDir } from '../../lib/paths.ts';
 
 describe('replaceMacros (Functional with real data)', () => {
   describe('BASELINE_STATUS', () => {
@@ -49,5 +54,214 @@ describe('replaceMacros (Functional with real data)', () => {
     assert.ok(result.includes('grid'));
     assert.ok(result.includes('Widely available'));
     assert.ok(result.includes('Baseline since'));
+  });
+});
+
+describe('slugify', () => {
+  it('lowercases and replaces whitespace with hyphens', () => {
+    assert.equal(slugify('Fallback strategies'), 'fallback-strategies');
+  });
+
+  it('trims surrounding whitespace', () => {
+    assert.equal(slugify('  Foo Bar  '), 'foo-bar');
+  });
+
+  it('strips punctuation', () => {
+    assert.equal(slugify('Hello, World!'), 'hello-world');
+  });
+
+  it('preserves hyphens', () => {
+    assert.equal(slugify('multi-word section'), 'multi-word-section');
+  });
+});
+
+describe('INCLUDE', () => {
+  let tmpDir: string;
+  let FIXTURE_CALLER: string;
+  let repoFixtureDir: string;
+  let repoFixtureRelPath: string;
+
+  before(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'macros-test-'));
+    FIXTURE_CALLER = path.join(tmpDir, 'caller.md');
+    // A second tmp dir inside the repo root, so we can test bare-path resolution
+    // (which always resolves from rootDir).
+    repoFixtureDir = fs.mkdtempSync(path.join(rootDir, 'macros-test-'));
+    repoFixtureRelPath = `${path.basename(repoFixtureDir)}/repo-root-fixture.md`;
+    fs.writeFileSync(
+      path.join(repoFixtureDir, 'repo-root-fixture.md'),
+      '# Repo Root Fixture\n\nThis fixture lives inside the repo root.\n'
+    );
+
+    fs.writeFileSync(
+      path.join(tmpDir, 'sibling.md'),
+      '# Sibling Fixture\n\nSibling content.\n'
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'with-frontmatter.md'),
+      '---\ntitle: With Frontmatter\n---\n\n# Heading One\n\nBody content after frontmatter.\n\n### Section Alpha\n\nAlpha section text.\n'
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'multi-section.md'),
+      '# Multi-section\n\n### First\n\nFirst section content. UNIQUE_FIRST.\n\n#### Nested\n\nNested content stays inside First.\n\n### Second\n\nSecond section content. UNIQUE_SECOND.\n'
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'explicit-id.md'),
+      '# Explicit ID\n\n### A long renamed heading {#stable-id}\n\nExplicit-ID section content. UNIQUE_EXPLICIT.\n\n### Plain heading\n\nPlain section content.\n'
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'with-baseline.md'),
+      '# With Baseline\n\n### Fallbacks\n\nBaseline status: {{ BASELINE_STATUS("grid") }}\n'
+    );
+  });
+
+  after(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(repoFixtureDir, { recursive: true, force: true });
+  });
+
+  describe('whole-file include', () => {
+    it('strips frontmatter and leading h1 from the included body', () => {
+      const result = replaceMacros('{{ INCLUDE("./with-frontmatter.md") }}', FIXTURE_CALLER);
+      assert.ok(!result.includes('---'));
+      assert.ok(!result.includes('# Heading One'));
+      assert.ok(result.includes('Body content after frontmatter.'));
+      assert.ok(result.includes('### Section Alpha'));
+    });
+
+    it('expands BASELINE_STATUS inside the included content (recursive)', () => {
+      const result = replaceMacros('{{ INCLUDE("./with-baseline.md") }}', FIXTURE_CALLER);
+      assert.ok(!result.includes('{{ BASELINE_STATUS'));
+      assert.ok(/Baseline|limited availability/.test(result));
+    });
+  });
+
+  describe('section include', () => {
+    it('returns section body, dropping the section heading itself', () => {
+      const result = replaceMacros(
+        '{{ INCLUDE("./multi-section.md#first") }}',
+        FIXTURE_CALLER
+      );
+      assert.ok(result.includes('UNIQUE_FIRST'));
+      assert.ok(!result.includes('### First'));
+    });
+
+    it('stops at the next heading of the same depth (and includes deeper sub-headings)', () => {
+      const result = replaceMacros('{{ INCLUDE("./multi-section.md#first") }}', FIXTURE_CALLER);
+      assert.ok(result.includes('UNIQUE_FIRST'));
+      assert.ok(result.includes('Nested content stays inside First.'));
+      assert.ok(!result.includes('UNIQUE_SECOND'));
+    });
+
+    it('matches an explicit `{#id}` suffix on the heading', () => {
+      const result = replaceMacros('{{ INCLUDE("./explicit-id.md#stable-id") }}', FIXTURE_CALLER);
+      assert.ok(result.includes('UNIQUE_EXPLICIT'));
+      assert.ok(!result.includes('Plain section content'));
+    });
+
+    it('still matches by slugified heading text when no `{#id}` is set', () => {
+      const result = replaceMacros('{{ INCLUDE("./explicit-id.md#plain-heading") }}', FIXTURE_CALLER);
+      assert.ok(result.includes('Plain section content'));
+    });
+
+    it('trims output so a section can be inlined cleanly', () => {
+      const result = replaceMacros(
+        '* prelude {{ INCLUDE("./sibling.md") }} postlude',
+        FIXTURE_CALLER
+      );
+      assert.ok(/prelude Sibling content[^\n]* postlude/.test(result));
+    });
+  });
+
+  describe('path resolution', () => {
+    it('resolves bare paths from repo root regardless of caller location', () => {
+      const result = replaceMacros(
+        `{{ INCLUDE("${repoFixtureRelPath}") }}`,
+        '/some/unrelated/path/test.md'
+      );
+      assert.ok(result.includes('This fixture lives inside the repo root.'));
+    });
+
+    it('resolves ./ paths relative to the caller', () => {
+      const result = replaceMacros('{{ INCLUDE("./sibling.md") }}', FIXTURE_CALLER);
+      assert.ok(result.includes('Sibling content'));
+    });
+
+    it('resolves ../ paths relative to the caller', () => {
+      const deeperCaller = path.join(tmpDir, 'subdir', 'caller.md');
+      const result = replaceMacros('{{ INCLUDE("../sibling.md") }}', deeperCaller);
+      assert.ok(result.includes('Sibling content'));
+    });
+
+    it('rejects absolute paths', () => {
+      assert.throws(
+        () => replaceMacros('{{ INCLUDE("/etc/passwd") }}', 'test.md'),
+        /Absolute paths are not allowed/
+      );
+    });
+  });
+
+  describe('error handling', () => {
+    it('throws on missing argument', () => {
+      assert.throws(
+        () => replaceMacros('{{ INCLUDE() }}', 'test.md'),
+        /Missing path in INCLUDE/
+      );
+    });
+  });
+
+  describe('silent miss', () => {
+    it('returns empty string for missing file', () => {
+      const result = replaceMacros(
+        'before {{ INCLUDE("features/does-not-exist-xyz.md") }} after',
+        'test.md'
+      );
+      assert.equal(result, 'before  after');
+    });
+
+    it('returns empty string for missing section', () => {
+      const result = replaceMacros(
+        'before {{ INCLUDE("./multi-section.md#nonexistent-section-xyz") }} after',
+        FIXTURE_CALLER
+      );
+      assert.equal(result, 'before  after');
+    });
+  });
+
+  describe('FEATURE_FALLBACKS wrapper', () => {
+    it('throws on missing feature ID', () => {
+      assert.throws(
+        () => replaceMacros('{{ FEATURE_FALLBACKS() }}', 'test.md'),
+        /Missing feature ID in FEATURE_FALLBACKS/
+      );
+    });
+
+    it('throws on unknown feature ID', () => {
+      assert.throws(
+        () => replaceMacros('{{ FEATURE_FALLBACKS("nonexistent-feature") }}', 'test.md'),
+        /Web feature ID "nonexistent-feature" not found/
+      );
+    });
+  });
+
+  describe('caching', () => {
+    it('returns consistent results across multiple includes of the same file and section', () => {
+      const result = replaceMacros(
+        `{{ INCLUDE("./multi-section.md#first") }}\n---\n{{ INCLUDE("./multi-section.md#first") }}`,
+        FIXTURE_CALLER
+      );
+      const [first, second] = result.split('\n---\n');
+      assert.equal(first, second);
+      assert.ok(first.length > 0);
+    });
+
+    it('shares the file read across whole-file and section requests', () => {
+      const wholeFile = replaceMacros('{{ INCLUDE("./multi-section.md") }}', FIXTURE_CALLER);
+      const section = replaceMacros('{{ INCLUDE("./multi-section.md#first") }}', FIXTURE_CALLER);
+      assert.ok(wholeFile.length > 0);
+      assert.ok(section.length > 0);
+      assert.ok(wholeFile.includes('UNIQUE_FIRST'));
+      assert.ok(section.includes('UNIQUE_FIRST'));
+    });
   });
 });

--- a/serving/lib/macros.test.ts
+++ b/serving/lib/macros.test.ts
@@ -113,6 +113,15 @@ describe('INCLUDE', () => {
       path.join(tmpDir, 'with-baseline.md'),
       '# With Baseline\n\n### Fallbacks\n\nBaseline status: {{ BASELINE_STATUS("grid") }}\n'
     );
+    fs.writeFileSync(
+      path.join(tmpDir, 'formatted-headings.md'),
+      '# Formatted Headings\n\n' +
+      '### Foo **bar** <em>baz</em>\n\nUNIQUE_BOLD_HTML\n\n' +
+      '### A [link](https://example.com) here\n\nUNIQUE_LINK\n\n' +
+      '### `code` in heading\n\nUNIQUE_CODE\n\n' +
+      '### *Italic* heading {#renamed}\n\nUNIQUE_RENAMED\n\n' +
+      'Setext Foo  \nBar\n----------\n\nUNIQUE_BR\n'
+    );
   });
 
   after(() => {
@@ -162,6 +171,33 @@ describe('INCLUDE', () => {
     it('still matches by slugified heading text when no `{#id}` is set', () => {
       const result = replaceMacros('{{ INCLUDE("./explicit-id.md#plain-heading") }}', FIXTURE_CALLER);
       assert.ok(result.includes('Plain section content'));
+    });
+
+    it('matches headings with bold and inline HTML by visible text', () => {
+      const result = replaceMacros('{{ INCLUDE("./formatted-headings.md#foo-bar-baz") }}', FIXTURE_CALLER);
+      assert.ok(result.includes('UNIQUE_BOLD_HTML'));
+    });
+
+    it('matches headings with links by visible text only (URL not in slug)', () => {
+      const result = replaceMacros('{{ INCLUDE("./formatted-headings.md#a-link-here") }}', FIXTURE_CALLER);
+      assert.ok(result.includes('UNIQUE_LINK'));
+    });
+
+    it('matches headings with inline code', () => {
+      const result = replaceMacros('{{ INCLUDE("./formatted-headings.md#code-in-heading") }}', FIXTURE_CALLER);
+      assert.ok(result.includes('UNIQUE_CODE'));
+    });
+
+    it('treats a hard line break in a setext heading as a word boundary', () => {
+      const result = replaceMacros('{{ INCLUDE("./formatted-headings.md#setext-foo-bar") }}', FIXTURE_CALLER);
+      assert.ok(result.includes('UNIQUE_BR'));
+    });
+
+    it('matches a heading with both formatting and {#id}, by either id or slug', () => {
+      const byId = replaceMacros('{{ INCLUDE("./formatted-headings.md#renamed") }}', FIXTURE_CALLER);
+      assert.ok(byId.includes('UNIQUE_RENAMED'));
+      const bySlug = replaceMacros('{{ INCLUDE("./formatted-headings.md#italic-heading") }}', FIXTURE_CALLER);
+      assert.ok(bySlug.includes('UNIQUE_RENAMED'));
     });
 
     it('trims output so a section can be inlined cleanly', () => {

--- a/serving/lib/macros.ts
+++ b/serving/lib/macros.ts
@@ -1,4 +1,5 @@
-import { validateFeature, getStatusMessage } from "./baseline.ts";
+import { validateFeature, getStatusMessage, getFeatureName } from "./baseline.ts";
+import { resolveInclude } from "./include.ts";
 
 /**
  * Parses macro arguments, respecting quotes and handling commas.
@@ -47,19 +48,28 @@ export class MacroError extends Error {
 // Matches {{ NAME(ARGS) }} where NAME is uppercase and ARGS can be anything
 export const MACRO_PATTERN = /{{\s*([A-Z_]+)\((.*?)\)\s*}}/g;
 
-
 const MACRO_HANDLERS: Record<string, MacroHandler> = {
-  BASELINE_STATUS: (args, filePath) => {
-    const [featureId, bcdKey] = args;
-    if (!featureId) {
-      throw new MacroError(`Missing feature ID in BASELINE_STATUS macro (${filePath}).`);
+  INCLUDE: (args, filePath) => {
+    const [rawArg] = args;
+    if (!rawArg) {
+      throw new MacroError(`Missing path in INCLUDE macro (${filePath}).`);
     }
 
-    const result = validateFeature(featureId);
+    const result = resolveInclude(rawArg, filePath);
     if (!result.isValid) {
-      throw new MacroError(`${result.errorMessage} (referenced in BASELINE_STATUS macro in ${filePath}).`);
+      throw new MacroError(`${result.errorMessage} (referenced in INCLUDE macro in ${filePath}).`);
     }
+    if (!result.content) return ""; // silent miss: file or section not found
 
+    // NOTE: no cycle detection. If files INCLUDE each other in a loop, this
+    // will overflow the call stack. Add a visited set if it becomes a problem.
+    return replaceMacros(result.content, result.absolutePath!);
+  },
+};
+
+defineFeatureMacro("BASELINE_STATUS", {
+  content: (args, filePath) => {
+    const [featureId, bcdKey] = args;
     const status = getStatusMessage(featureId, bcdKey);
     if (!status) {
       if (bcdKey) {
@@ -70,7 +80,75 @@ const MACRO_HANDLERS: Record<string, MacroHandler> = {
 
     return status;
   }
-};
+});
+
+
+defineFeatureMacro("FEATURE", {
+  content: (args, filePath) => {
+    const [featureId, section] = args;
+    let url = `features/${featureId}.md`;
+    if (section) {
+      url += `#${section}`;
+    }
+    return MACRO_HANDLERS.INCLUDE([url], filePath);
+  }
+});
+
+defineFeatureMacro("FEATURE_FALLBACKS", {
+  content: (args, filePath) => {
+    const [featureId] = args;
+    const fallbacks = MACRO_HANDLERS.FEATURE([featureId, "fallbacks"], filePath);
+    const baselineStatus = MACRO_HANDLERS.BASELINE_STATUS([featureId], filePath);
+    if (!fallbacks) {
+      return baselineStatus;
+    }
+
+    return [
+      `### Fallbacks & browser support for ${getFeatureName(featureId)}`,
+      baselineStatus,
+      fallbacks
+    ].join("\n\n");
+  }
+});
+
+defineFeatureMacro("FEATURE_ISSUES", {
+  content: (args, filePath) => {
+    const [featureId] = args;
+    const included = MACRO_HANDLERS.FEATURE([featureId, "issues"], filePath);
+    if (!included) return "";
+    return [
+      `### Issues to be aware of when using ${getFeatureName(featureId)}`,
+      included
+    ].join("\n\n");
+  }
+});
+
+function defineFeatureMacro(name: string, {
+  recursive,
+  content,
+}: {
+  recursive?: boolean;
+  // Producer: may return anything; we coerce to string below.
+  content: (args: string[], filePath: string) => any;
+}): MacroHandler {
+  const fn: MacroHandler = (args, filePath) => {
+    const [featureId] = args;
+    if (!featureId) {
+      throw new MacroError(`Missing feature ID in ${name} macro (${filePath}).`);
+    }
+    const validation = validateFeature(featureId);
+    if (!validation.isValid) {
+      throw new MacroError(`${validation.errorMessage} (referenced in ${name} macro in ${filePath}).`);
+    }
+
+    let result = content(args, filePath);
+    if (!result && result !== 0) return "";
+    if (typeof result !== "string") result = String(result);
+    if (recursive) result = replaceMacros(result, filePath);
+    return result.trim();
+  };
+  return (MACRO_HANDLERS[name] = fn);
+}
 
 /**
  * Internal helper to iterate over macros and call a processor.


### PR DESCRIPTION
Closes #591. 

After seeing the Nth[^1] case of repeated content that was not fully in sync, I figured I'd get an agent to prototype this idea, just to get a feel of how difficult it would be to have this functionality. Turns out, it was much easier than I thought, kudos to whomever set up the macros infrastructure! In fact, I ended up generalizing it to _any_ kind of content transclusion, that way guides can share related content from each other as needed, without needing to set up a project wide feature for that specific type of content. I did add higher level shortcuts for features however, since that's by far the most common case.

[^1]:  Where N → +∞ — ok ok I'm exaggerating _juuust_ a tad for effect 😅

This PR uses the existing macro machinery that `BASELINE_STATUS` was already using to add several macros for including content from arbitrary or predefined Markdown files to minimize duplication (see #591).

It also introduces a `defineFeatureMacro()` abstraction for more easily defining macros that take a feature id, and rewrites `BASELINE_STATUS` to use it.

Example usage in #718 . 

## Macros added, from lowest level to highest level

For all macros below, unless otherwise specified:
- **Errors**: Generally, author errors fail loudly, missing content fails silently. For feature macros, if the feature is not found, it throws a `MacroError`. If the *file* or *section* is not found, it fails silently (just outputs `""`) so that references can be added independently of referenced content, if we anticipate certain referenced content.
- Recursive: individual macros still work within the referenced content.
- Content is trimmed. so it can become part of. a list, a table etc

Out of scope for now, but we can add easily:
- Cycle detection for recursive macros
- Proper Markdown parsing (code uses a regexp and assumes hash heading syntax)
- A slugify package (currently using a GitHub-style helper)

### `INCLUDE`

#### `INCLUDE("path/to/file.md")`: Include whole file

Transcludes an entire markdown file, ignoring any frontmatter and level 1 heading (so that they can also be used independently).

Path resolution is repo-root-relative for bare paths (e.g. `features/foo.md` is resolved from the repo root), but caller-relative for `./` and `../.` (so that files can include relative to themselves).

#### `INCLUDE("path/to/file.md#section")`: Include section content

Transcludes an individual section, ignoring its heading. If section is not found, outputs `""` silently.

Section IDs match either an explicit `{ #id }` suffix or the slugified heading text (slugify function implemented ad hoc to be similar to GitHub's).

### `FEATURE("feature-id", "section")`

Wrapper around `INCLUDE("features/feature-id.md", "#section")` to make the common case of feature-related content nicer. Compare:

```
{{ FEATURE("user-pseudos", "aria-invalid") }}
{{ INCLUDE("features/user-pseudos.md", "#aria-invalid") }}
```

### `FEATURE_ISSUES("feature-id")`

Prints out a heading like `### Issues to be aware of when using [feature name]` plus the content of the `#issues` section for that feature, iff there is one. If there is no issues section, the entire macro returns `""`

### `FEATURE_FALLBACKS("feature-id")`

Prints out:
1. A heading like `### Fallbacks & browser support for [Feature name]`
2. `BASELINE_STATUS("feature-id")`
3. `FEATURE("feature-id", "fallbacks")`

If 3 is empty, it only prints out 2, so that it can replace `BASELINE_STATUS` in guides even when we *anticipate* fallbacks to be documented in the future, before they exist.
