### PR TITLE
use expected syntax in package.json bin

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "private": true,
   "bin": {
-    "gd": "./bin/gd.ts"
+    "gd": "bin/gd.ts"
   },
   "scripts": {
     "test": "pnpm -r test",

--- a/serving/skills-cli/template/package.json
+++ b/serving/skills-cli/template/package.json
@@ -20,6 +20,6 @@
     ]
   },
   "bin": {
-    "modern-web": "./skills/modern-web/modern-web.mjs"
+    "modern-web": "skills/modern-web/modern-web.mjs"
   }
 }

--- a/serving/skills-cli/template/skills/modern-web/package.json
+++ b/serving/skills-cli/template/skills/modern-web/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "type": "module",
   "bin": {
-    "modern-web": "./modern-web.mjs"
+    "modern-web": "modern-web.mjs"
   }
 }


### PR DESCRIPTION
apparently, `./` is not liked by npm. they fix that when packages are published, but to get rid of the warning I'll fix it on our end.

```
npm warn publish errors corrected:                                                                                                                                          
npm warn publish "bin[modern-web]" script name was cleaned     
```