### PR TITLE
Adding additional guidance for WebMCP toolautosubmit

### DIFF
--- a/guides/webmcp/agentic-forms/guide.md
+++ b/guides/webmcp/agentic-forms/guide.md
@@ -108,6 +108,16 @@ The Declarative API is best for self-contained, standard forms. It is a poor cho
 * **Custom UI Components**: Forms relying on non-standard inputs (e.g., canvas, rich text editors) that don't auto-serialize values.
 * **Multi-Step Wizards**: Complex workflows requiring multiple form submissions. The Imperative API or standard DOM interaction is better suited here.
 
+## When to use toolautosubmit
+* **Read-Only Operations & Queries**: Searches, filters, fetching details, or checking status (e.g., a car model search, searching a directory, checking stock availability).
+* **Low-Risk, Reversible Actions**: Form actions that can easily be undone or refined by the user manually (e.g., adding items to a cart, applying a coupon code, saving a draft, or setting temporary layout options).
+
+## When to omit toolautosubmit
+* **Destructive or Irreversible Actions**: Deleting records, resetting system configurations, or clearing databases.
+* **Financial & Transactional Actions**: Submitting a checkout form, transferring funds, authorizing subscription payments, or final order placements.
+* **High-Impact User Communication**: Submitting a final job application, sending emails/messages to other real users, or publishing public-facing content.
+* **Sensitive Account Settings**: Changing passwords, modifying user roles/permissions, or updating billing/profile info.
+
 ## Fallback strategies
 
 {{ BASELINE_STATUS("declarative-webmcp") }}


### PR DESCRIPTION
Adding additional guidance for WebMCP toolautosubmit, tested with non-destructive actions like filtering, finding random movie.

Result of collaboration with @beaufortfrancois 