### PR TITLE
[#365] calculate-total-foreground-time guidance

### DIFF
--- a/guides/performance/calculate-total-foreground-time/demo.html
+++ b/guides/performance/calculate-total-foreground-time/demo.html
@@ -61,12 +61,12 @@
   <div class="card">
     <h1>Total Foreground Time</h1>
     <p>This demo accurately measures how long you've spent actively viewing this page using the <code>VisibilityStateEntry</code> API.</p>
-    
+
     <div class="metric">
       <span class="label">Total Foreground Time</span>
       <span id="foreground-time" class="value">0ms</span>
     </div>
-    
+
     <div class="metric">
       <span class="label">Total Page Time (Elapsed)</span>
       <span id="total-time" class="value">0ms</span>
@@ -86,15 +86,19 @@
   <script>
     /**
      * Calculates total time the page was in the visible state.
-     * 
+     *
+     * This function uses the VisibilityStateEntry API via performance.getEntriesByType
+     * to reconstruct the visibility history of the page.
+     *
      * @returns {number} Total foreground time in milliseconds.
      */
     function getTotalForegroundTime() {
       // MANDATORY: Query the visibility-state entries from the performance timeline.
+      // This retrieves all VisibilityStateEntry objects recorded since the page loaded.
       const entries = performance.getEntriesByType('visibility-state');
 
-      // Fallback: If the browser does not support VisibilityStateEntry, 
-      // the API will gracefully return an empty array.
+      // Fallback: If the browser does not support VisibilityStateEntry,
+      // the array will be empty.
       if (entries.length === 0) {
         // Return total time since navigation start as a fallback.
         return performance.now();
@@ -103,16 +107,16 @@
       let totalForegroundTime = 0;
 
       for (let i = 0; i < entries.length; i++) {
-        // Only calculate duration for periods where the state was 'visible'
+        // Only accumulate time for 'visible' periods.
         if (entries[i].name === 'visible') {
           const start = entries[i].startTime;
-          
-          // The end time is the start time of the next state change, 
-          // or the current time if this is the final entry.
+
+          // The end of this state is the start of the next state change,
+          // or the current time if this is the most recent entry.
           const end = i + 1 < entries.length
               ? entries[i + 1].startTime
               : performance.now();
-              
+
           totalForegroundTime += (end - start);
         }
       }
@@ -124,10 +128,10 @@
       const foregroundTime = getTotalForegroundTime();
       const totalTime = performance.now();
       const state = document.visibilityState;
-      
+
       document.getElementById('foreground-time').textContent = `${Math.round(foregroundTime)}ms`;
       document.getElementById('total-time').textContent = `${Math.round(totalTime)}ms`;
-      
+
       const stateEl = document.getElementById('current-state');
       stateEl.textContent = state;
       stateEl.className = `status-badge status-${state}`;
@@ -135,7 +139,7 @@
       // Check for API support and update status
       const modeEl = document.getElementById('api-mode');
       const entries = performance.getEntriesByType('visibility-state');
-      
+
       if (entries.length > 0) {
         modeEl.textContent = 'VisibilityStateEntry API';
         modeEl.className = 'status-badge status-visible';

--- a/guides/performance/calculate-total-foreground-time/expectations.md
+++ b/guides/performance/calculate-total-foreground-time/expectations.md
@@ -1,3 +1,3 @@
-- The application requires that the total time the browser tab is visible (total foreground time) be measured across the life of the page.
+- The application wants to record the total time the page was visible (total foreground time) across the life of the page.
 - Total foreground time _must_ be measured using the `VisibilityStateEntry` API, which uses `PerformanceObserver`.
-- If a fallback is necessary, the application _must_ first check if `VisibilityStateEntry` API is available. If not, `performance.now()` can be used instead.
+- If a fallback is necessary, the application _must_ first check if `VisibilityStateEntry` API is available. If not, `performance.now()` can be used instead with the caveat that it will include background time in it's results.

--- a/guides/performance/calculate-total-foreground-time/grader.ts
+++ b/guides/performance/calculate-total-foreground-time/grader.ts
@@ -1,0 +1,90 @@
+import { test, expect } from '@playwright/test';
+
+const targetFile = process.env.TARGET_FILE || 'demo.html';
+
+test.describe('Total Foreground Time Grader', () => {
+  test.beforeEach(async ({ page }) => {
+    // We mock performance.getEntriesByType and PerformanceObserver to detect usage
+    await page.addInitScript(() => {
+      (window as any)._visibilityAPIUsed = false;
+      
+      const originalGetEntriesByType = performance.getEntriesByType.bind(performance);
+      performance.getEntriesByType = function(type: string) {
+        if (type === 'visibility-state') {
+          (window as any)._visibilityAPIUsed = true;
+          // Return some mock data to test the logic
+          // 0-500: visible
+          // 500-1500: hidden
+          // 1500-now: visible
+          return [
+            { name: 'visible', startTime: 0, entryType: 'visibility-state', duration: 0, toJSON: () => {} },
+            { name: 'hidden', startTime: 500, entryType: 'visibility-state', duration: 0, toJSON: () => {} },
+            { name: 'visible', startTime: 1500, entryType: 'visibility-state', duration: 0, toJSON: () => {} }
+          ];
+        }
+        return originalGetEntriesByType(type);
+      };
+
+      // Also mock PerformanceObserver
+      const OriginalPerformanceObserver = window.PerformanceObserver;
+      (window as any).PerformanceObserver = function(callback: any) {
+        (window as any)._visibilityAPIUsed = true; // Simple detection
+        return new (OriginalPerformanceObserver as any)(callback);
+      };
+      (window as any).PerformanceObserver.supportedEntryTypes = OriginalPerformanceObserver.supportedEntryTypes;
+    });
+
+    await page.goto(`file://${targetFile}`);
+  });
+
+  test('should use VisibilityStateEntry API (via getEntriesByType or PerformanceObserver)', async ({ page }) => {
+    // Wait for the app to initialize and potentially call the API
+    await page.waitForFunction(() => (window as any)._visibilityAPIUsed === true || performance.now() > 2000);
+    const used = await page.evaluate(() => (window as any)._visibilityAPIUsed);
+    expect(used).toBe(true);
+  });
+
+  test('should correctly calculate foreground time excluding hidden periods', async ({ page }) => {
+    // In our mock: 0-500 (v), 500-1500 (h), 1500-now (v)
+    // Foreground time should be 500 + (now - 1500) = now - 1000.
+    
+    // Wait until performance.now() is safely past 1500ms
+    await page.waitForFunction(() => performance.now() > 2000);
+    
+    // Give the UI time to update
+    await page.waitForTimeout(500);
+
+    const values = await page.evaluate(() => {
+      const results: { value: number, now: number }[] = [];
+      const elements = Array.from(document.querySelectorAll('*'));
+      for (const el of elements) {
+        if (el.children.length === 0 && el.textContent?.includes('ms')) {
+          const match = el.textContent.match(/(\d+)\s*ms/);
+          if (match) {
+            results.push({
+              value: parseInt(match[1]),
+              now: performance.now()
+            });
+          }
+        }
+      }
+      return results;
+    });
+
+    expect(values.length).toBeGreaterThan(0);
+    
+    // At least one of the values should be close to now - 1000
+    const foregroundTimeFound = values.some(v => Math.abs(v.value - (v.now - 1000)) < 200);
+    expect(foregroundTimeFound).toBe(true);
+  });
+
+  test('should check for VisibilityStateEntry support before falling back', async ({ page }) => {
+    // This is hard to test without seeing the code, but we can check if it 
+    // at least tried to call getEntriesByType or checked supportedEntryTypes.
+    
+    const checked = await page.evaluate(() => {
+      return (window as any)._visibilityAPIUsed;
+    });
+    expect(checked).toBe(true);
+  });
+});

--- a/guides/performance/calculate-total-foreground-time/guide.md
+++ b/guides/performance/calculate-total-foreground-time/guide.md
@@ -7,9 +7,13 @@ sources:
     - https://developer.mozilla.org/en-US/docs/Web/API/VisibilityStateEntry
 ---
 
-This guide details how to accurately calculate the total time a user spends actively viewing a page. Traditional metrics like time-on-page often incorrectly include time spent with the tab in the background. By using the `VisibilityStateEntry` API, you can measure only the "foreground time," providing a better metric of user engagement.
+# Calculate total foreground time
 
-### Implementing foreground time calculation
+This guide details how to accurately calculate the total time a user spends actively viewing a page. Traditional metrics like time-on-page often incorrectly include time spent with the page in the background. By using the `VisibilityStateEntry` API, you can measure only the "foreground time," providing a better metric of user engagement.
+
+{{ BASELINE_STATUS("page-visibility-state") }}
+
+## Implementing foreground time calculation
 
 The `PerformanceTimeline` API exposes visibility state changes as performance entries. Rather than reacting to `visibilitychange` events and manually accumulating time throughout a session, you can query the entire visibility history at any time.
 
@@ -18,14 +22,14 @@ MANDATORY: You must query the `visibility-state` performance entries to calculat
 ```javascript
 /**
  * Calculates total time the page was in the visible state.
- * 
+ *
  * @returns {number} Total foreground time in milliseconds.
  */
 function getTotalForegroundTime() {
   // MANDATORY: Query the visibility-state entries from the performance timeline.
   const entries = performance.getEntriesByType('visibility-state');
 
-  // Fallback: If the browser does not support VisibilityStateEntry, 
+  // Fallback: If the browser does not support VisibilityStateEntry,
   // the API will gracefully return an empty array.
   if (entries.length === 0) {
     // Return total time since navigation start as a fallback.
@@ -38,13 +42,13 @@ function getTotalForegroundTime() {
     // Only calculate duration for periods where the state was 'visible'
     if (entries[i].name === 'visible') {
       const start = entries[i].startTime;
-      
-      // The end time is the start time of the next state change, 
+
+      // The end time is the start time of the next state change,
       // or the current time if this is the final entry.
       const end = i + 1 < entries.length
           ? entries[i + 1].startTime
           : performance.now();
-          
+
       totalForegroundTime += (end - start);
     }
   }
@@ -53,21 +57,22 @@ function getTotalForegroundTime() {
 }
 ```
 
-### Fallback strategies
+## Fallbacks & browser support
 
-{{ BASELINE_STATUS("page-visibility-state") }}
+{{ FEATURE_FALLBACKS("page-visibility-state") }}
 
-The `VisibilityStateEntry` API has limited availability and is currently unsupported in several major browsers. 
+The `VisibilityStateEntry` API is a modern addition to the Performance Timeline and may not be supported in all browsers.
 
-Because `performance.getEntriesByType('visibility-state')` will return an empty array in browsers that do not support it, feature detection is straightforward and built directly into the execution flow. You must always check if the returned array is empty before attempting to calculate foreground time.
+Because `performance.getEntriesByType('visibility-state')` returns an empty array in unsupported browsers, feature detection is built into the calculation flow. You should always check if entries are returned before proceeding.
 
-If it is empty, the recommended fallback strategy is to gracefully degrade to standard time-on-page analytics by returning `performance.now()`. This represents the total time elapsed since the page was loaded, ensuring a valid duration is still recorded without throwing runtime errors.
+If the API is unsupported, the recommended fallback is to return `performance.now()`. This represents the total time since navigation, which serves as a reasonable upper bound for engagement time when visibility state history is unavailable.
 
 ```javascript
 const entries = performance.getEntriesByType('visibility-state');
 
-// Empty array means unsupported
+// If the array is empty, the API is likely unsupported.
 if (entries.length === 0) {
-  return performance.now(); // Fallback
+  // Fallback: Return total time since page load.
+  return performance.now();
 }
 ```

--- a/guides/performance/calculate-total-foreground-time/guide.md
+++ b/guides/performance/calculate-total-foreground-time/guide.md
@@ -3,8 +3,6 @@ name: calculate-total-foreground-time
 description: Calculate the total time a user actually spent viewing a page, excluding periods when the tab was in the background.
 web-feature-ids:
     - page-visibility-state
-sources:
-    - https://developer.mozilla.org/en-US/docs/Web/API/VisibilityStateEntry
 ---
 
 # Calculate total foreground time

--- a/guides/performance/calculate-total-foreground-time/guide.md
+++ b/guides/performance/calculate-total-foreground-time/guide.md
@@ -9,8 +9,6 @@ web-feature-ids:
 
 This guide details how to accurately calculate the total time a user spends actively viewing a page. Traditional metrics like time-on-page often incorrectly include time spent with the page in the background. By using the `VisibilityStateEntry` API, you can measure only the "foreground time," providing a better metric of user engagement.
 
-{{ BASELINE_STATUS("page-visibility-state") }}
-
 ## Implementing foreground time calculation
 
 The `PerformanceTimeline` API exposes visibility state changes as performance entries. Rather than reacting to `visibilitychange` events and manually accumulating time throughout a session, you can query the entire visibility history at any time.

--- a/guides/performance/calculate-total-foreground-time/negative-demo.html
+++ b/guides/performance/calculate-total-foreground-time/negative-demo.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Incorrect Foreground Time Calculation (Negative Demo)</title>
+  <style>
+    body { font-family: system-ui, sans-serif; padding: 2rem; }
+    .error { color: #991b1b; background: #fee2e2; padding: 1rem; border-radius: 8px; }
+  </style>
+</head>
+<body>
+  <div class="error">
+    <h1>Total Foreground Time (Incorrect)</h1>
+    <p>This demo incorrectly calculates foreground time by just using <code>performance.now()</code>, failing to exclude time spent in the background.</p>
+    <div id="time">0ms</div>
+  </div>
+
+  <script>
+    // INCORRECT: This function just returns total elapsed time,
+    // ignoring whether the tab was actually in the foreground.
+    function getTotalForegroundTime() {
+      return performance.now();
+    }
+
+    function updateUI() {
+      document.getElementById('time').textContent = `${Math.round(getTotalForegroundTime())}ms`;
+    }
+
+    setInterval(updateUI, 100);
+  </script>
+</body>
+</html>

--- a/guides/performance/calculate-total-foreground-time/tasks/task.md
+++ b/guides/performance/calculate-total-foreground-time/tasks/task.md
@@ -1,0 +1,6 @@
+---
+base_app: analytics-dashboard
+---
+- i want to track how long users are actually looking at the page. can you add a function to calculate the total foreground time?
+- add a metric to my dashboard that shows total time spent in the visible state, excluding background time.
+- create a screensaver effect on a page that is triggered after the user has been inactive for a certain amount of time.


### PR DESCRIPTION
Progress on https://github.com/GoogleChrome/guidance/issues/365

## Summary
- Finalized guidance for calculating total foreground time using the `VisibilityStateEntry` API.
- Added `tasks/task.md` with realistic developer prompts.
- Added `negative-demo.html` for evaluation calibration.
- Updated `expectations.md` and `demo.html` with minor refinements.

## Test plan
- Verified `demo.html` correctly implements the logic.
- Verified `negative-demo.html` demonstrates the incorrect approach.
- Followed modern web guidance standards for the `guide.md`.