### PR TITLE
feat: skill for web component

### DIFF
--- a/guides/html/web-components/accessible-web-components/demo.html
+++ b/guides/html/web-components/accessible-web-components/demo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Accessible Web Components: ElementInternals roles and state</title>
+  <style>
+    toggle-switch:not(:defined) { visibility: hidden; }
+    toggle-switch {
+      display: inline-block; inline-size: 3rem; block-size: 1.5rem;
+      border-radius: 1rem; background: #ccc; cursor: pointer;
+    }
+    /* ARIA state lives in the accessibility tree; a non-ARIA data hook drives styling. */
+    toggle-switch[data-checked] { background: seagreen; }
+    toggle-switch:focus-visible { outline: 2px solid #06f; outline-offset: 2px; }
+  </style>
+</head>
+<body>
+  <label id="wifi-label">Wi-Fi</label>
+  <toggle-switch aria-labelledby="wifi-label"></toggle-switch>
+
+  <script>
+    class ToggleSwitch extends HTMLElement {
+      #internals;
+
+      constructor() {
+        super();
+        this.#internals = this.attachInternals();
+        // Default role + state via the ARIA mixin; no host ARIA attributes needed,
+        // and consumers can still override with attributes in the Light DOM.
+        this.#internals.role = 'switch';
+        this.#internals.ariaChecked = 'false';
+      }
+
+      connectedCallback() {
+        // Make the host keyboard-focusable and operable like a native control.
+        if (!this.hasAttribute('tabindex')) this.tabIndex = 0;
+        this.addEventListener('click', () => this.toggle());
+        this.addEventListener('keydown', (e) => {
+          if (e.key === ' ' || e.key === 'Enter') { e.preventDefault(); this.toggle(); }
+        });
+      }
+
+      toggle() {
+        const on = this.#internals.ariaChecked !== 'true';
+        // Canonical state for the accessibility tree; no host ARIA attribute.
+        this.#internals.ariaChecked = String(on);
+        // Separate non-ARIA hook purely so CSS can target the state.
+        this.toggleAttribute('data-checked', on);
+      }
+    }
+
+    customElements.define('toggle-switch', ToggleSwitch);
+  </script>
+</body>
+</html>

--- a/guides/html/web-components/accessible-web-components/guide.md
+++ b/guides/html/web-components/accessible-web-components/guide.md
@@ -1,0 +1,54 @@
+---
+name: accessible-web-components
+description: Make custom elements accessible by default, setting roles and ARIA state via the ElementInternals ARIA mixin, managing focus with delegatesFocus, and keeping ARIA relationships within a single shadow root.
+web-feature-ids:
+  - aria-attribute-reflection
+  - shadow-dom
+---
+
+# Accessible Web Components
+
+A shadow boundary changes how semantics and ARIA work. Two failures dominate: missing semantics inside the shadow tree, and ARIA references that silently break because they cannot cross shadow roots.
+
+Start from semantic markup: use real `<button>`, `<nav>`, `<ul>` inside the template so most semantics come for free, and reserve `ElementInternals`/ARIA for the gaps.
+
+## Default semantics via the ElementInternals ARIA mixin
+
+Set a custom element's role and ARIA state in JS through `ElementInternals`, rather than writing ARIA attributes onto the host. This keeps the semantics as defaults the component owns, while still letting a consumer override them with attributes in the Light DOM.
+
+```javascript
+class ToggleSwitch extends HTMLElement {
+  #internals;
+  constructor() {
+    super();
+    this.#internals = this.attachInternals();
+    this.#internals.role = 'switch';          // default role, no host attribute needed
+    this.#internals.ariaChecked = 'false';    // exposed to the accessibility tree
+  }
+  toggle() {
+    const on = this.#internals.ariaChecked !== 'true';
+    this.#internals.ariaChecked = String(on);
+  }
+}
+customElements.define('toggle-switch', ToggleSwitch);
+```
+
+This avoids polluting the DOM with ARIA attributes and prevents consumers from accidentally clobbering them, while the accessibility tree still sees the correct role and state.
+
+## Focus management and `delegatesFocus`
+
+- Attach the shadow root with `delegatesFocus: true` when the component wraps focusable controls. Focusing the host then forwards focus to the first focusable child, and `:focus`/label clicks behave as users expect.
+- For roving focus or moving focus into a newly revealed region, give the target `tabindex="-1"` and call `.focus()`; make programmatically-focusable targets explicit rather than relying on tab order.
+
+## ARIA relationships cannot cross shadow roots
+
+- **MANDATORY**: an `id` referenced by `aria-labelledby`, `aria-describedby`, `aria-controls`, etc. must live in the **same** tree as the referencing element. An attribute in the Light DOM cannot point at an `id` inside the shadow tree, and vice versa; the reference is silently ignored.
+- Keep each ARIA relationship within one root. If a label in the shadow tree must describe a slotted Light DOM element, move the relationship into one tree (e.g. render the label in the Light DOM, or use `aria-label` text instead of an `id` reference).
+- For element-to-element references that genuinely must cross roots, the emerging **Reference Target** mechanism is the standards direction, but it is not yet broadly available; design to keep references within a single tree today.
+- The reflected ARIA *element* properties — `ariaLabelledByElements`, `ariaDescribedByElements`, and siblings — let you set these relationships to actual element references in JS, with no `id` needed. Browser support is still limited and the rules for referencing across shadow roots are constrained and evolving, so verify before relying on them; today, treat them mainly as a cleaner way to wire *same-tree* relationships without minting ids.
+
+## Fallback strategies
+
+{{ BASELINE_STATUS("aria-attribute-reflection") }}
+
+Where the `ElementInternals` ARIA mixin is unavailable, set the role and ARIA state as attributes on the host instead (`this.setAttribute('role', 'switch')`). It works everywhere, at the cost of putting attributes in the DOM that a consumer could override.

--- a/guides/html/web-components/custom-elements/demo.html
+++ b/guides/html/web-components/custom-elements/demo.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Custom Elements: attribute/property reflection and custom states</title>
+  <style>
+    /* Hide the elements until their definitions have upgraded them (no FOUC). */
+    my-counter:not(:defined),
+    async-button:not(:defined) { visibility: hidden; }
+
+    /* Consumer-facing styling hook: a custom state, not an attribute. */
+    async-button:state(success) { outline: 2px solid seagreen; }
+    async-button:state(error)   { outline: 2px solid firebrick; }
+
+    body { font-family: system-ui, sans-serif; display: grid; gap: 1.5rem; padding: 1rem; }
+  </style>
+</head>
+<body>
+  <!-- The attribute is present before the script runs: the element upgrades and
+       reads its initial state from the attribute in connectedCallback. -->
+  <my-counter count="3"></my-counter>
+
+  <!-- Transient lifecycle state (busy/success/error) is internal and runtime-only,
+       so it lives as a custom state rather than a reflected attribute. -->
+  <async-button>Save changes</async-button>
+
+  <script>
+    // Build the shadow tree once, then update only the text node that changes.
+    const counterTemplate = document.createElement('template');
+    counterTemplate.innerHTML = `
+      <style>
+        :host { display: inline-flex; gap: .5rem; align-items: center;
+                padding: 1rem; border: 1px solid #ccc; border-radius: 8px; }
+        button { cursor: pointer; }
+      </style>
+      <span>Count: <output id="value">0</output></span>
+      <button type="button" id="inc">Increment</button>
+    `;
+
+    class MyCounter extends HTMLElement {
+      static observedAttributes = ['count'];
+
+      constructor() {
+        super(); // MANDATORY: first statement, before touching `this`.
+        this.attachShadow({ mode: 'open' });
+        this.shadowRoot.append(counterTemplate.content.cloneNode(true));
+        this.#output = this.shadowRoot.getElementById('value');
+        this.shadowRoot.getElementById('inc')
+          .addEventListener('click', () => { this.count += 1; });
+      }
+
+      #output;
+
+      // Attribute values are always strings; coerce to a number.
+      get count() { return Number(this.getAttribute('count')) || 0; }
+      set count(v) { this.setAttribute('count', String(v)); }
+
+      connectedCallback() { this.#render(); }
+
+      attributeChangedCallback(name, oldVal, newVal) {
+        if (oldVal !== newVal) this.#render(); // guard against reflection loops
+      }
+
+      #render() { this.#output.textContent = String(this.count); }
+    }
+
+    customElements.define('my-counter', MyCounter);
+
+    // --- Custom states: a button that reflects its async lifecycle ---
+
+    const buttonTemplate = document.createElement('template');
+    buttonTemplate.innerHTML = `
+      <style>
+        button { padding: .5em 1em; cursor: pointer; }
+        .spinner { display: none; }
+        /* The component styles its OWN states from inside the shadow tree. */
+        :host(:state(busy)) button    { opacity: .6; pointer-events: none; }
+        :host(:state(busy)) .spinner  { display: inline; }
+        :host(:state(success)) button { background: seagreen; color: white; }
+      </style>
+      <button type="button"><span class="spinner">⏳</span> <slot>Run</slot></button>
+    `;
+
+    class AsyncButton extends HTMLElement {
+      #internals;
+      // Demo action: resolves after a short delay to simulate a network call.
+      #action = () => new Promise((resolve) => setTimeout(resolve, 1200));
+
+      constructor() {
+        super();
+        this.#internals = this.attachInternals();
+        this.attachShadow({ mode: 'open' });
+        this.shadowRoot.append(buttonTemplate.content.cloneNode(true));
+      }
+
+      // The host supplies the work to perform.
+      set action(fn) { this.#action = fn; }
+
+      connectedCallback() {
+        this.shadowRoot.querySelector('button')
+          .addEventListener('click', () => this.run());
+      }
+
+      async run() {
+        if (this.#internals.states.has('busy')) return; // guard re-entry
+        this.#internals.states.add('busy');
+        this.#internals.states.delete('success');
+        this.#internals.states.delete('error');
+        try {
+          await this.#action();
+          this.#internals.states.add('success'); // CustomStateSet composes states
+        } catch {
+          this.#internals.states.add('error');
+        } finally {
+          this.#internals.states.delete('busy');
+        }
+      }
+    }
+
+    customElements.define('async-button', AsyncButton);
+  </script>
+</body>
+</html>

--- a/guides/html/web-components/custom-elements/guide.md
+++ b/guides/html/web-components/custom-elements/guide.md
@@ -1,0 +1,125 @@
+---
+name: custom-elements
+description: Define, register, and manage the lifecycle of autonomous custom elements, covering constructor rules, lifecycle callbacks, upgrade timing, attribute/property reflection, and naming conventions.
+web-feature-ids:
+  - autonomous-custom-elements
+---
+
+# Custom Elements
+
+A custom element is a class registered against a tag name via `customElements.define()`. Registration and basic lifecycle are well understood; the rules below target the parts routinely implemented incorrectly.
+
+## Lifecycle: the parts that get implemented wrong
+
+The callbacks themselves are well documented; these are the misconceptions that cause bugs:
+
+- **`connectedCallback` can run more than once.** It fires on every insertion, so moving the element re-runs it. Make setup idempotent — don't assume a single first run.
+- **`connectedMoveCallback` skips the disconnect/reconnect pair on a move.** When an element is relocated with `Node.moveBefore()`, this callback fires *instead of* `disconnectedCallback` → `connectedCallback`, so state, focus, and iframe/media playback survive the move. Define it when your setup or teardown is expensive or observably re-runs.
+- **Tear down in `disconnectedCallback`.** Remove global listeners, timers, and observers or you leak; but the element may be re-inserted, so don't treat teardown as permanent.
+- **Do not depend on the full DOM being present in the constructor.** Attributes are usually (but not always) present; long lists of children may not have finished parsing. Use `connectedCallback` for one-shot initialization, `slotchange` to monitor direct children, and `attributeChangedCallback` to monitor attributes. `connectedCallback` may still fire before all children are parsed, so do not ignore subsequent `slotchange` / `attributeChangedCallback` calls.
+- **`attributeChangedCallback` fires only for `observedAttributes`,** and should stay cheap for attributes that don't affect output.
+- **Lifecycle hooks and `observedAttributes` are snapshotted at registration.** `customElements.define()` reads both once; adding a hook or extending `observedAttributes` on the class *after* the call is silently ignored. In particular, `attributeChangedCallback` never fires unless `observedAttributes` was already present at `define()` time.
+
+## Upgrade timing and `:defined`
+
+An element can exist in the DOM *before* its class is registered (in server-rendered HTML, or when the script loads late). Until defined it is an inert `HTMLElement` with none of your behavior; when `customElements.define()` runs, the browser **upgrades** every matching element already in the document, running its constructor and `connectedCallback` then.
+
+Two consequences models routinely miss:
+
+1. **Attributes and children may already be present** when your constructor/`connectedCallback` runs on upgrade. Read existing attributes in `connectedCallback` to sync initial state, and never assume the element started empty.
+2. **Children may still be missing** even in `connectedCallback` — the HTML parser can yield mid-parse of long child lists, so the callback sometimes runs before every child is attached. See the constructor bullet in *Lifecycle* above for the pattern (`slotchange` + `attributeChangedCallback`).
+
+Hide undefined elements to avoid a flash of unstyled content — but **fail open**, so the content stays reachable if the script never loads. Animate `opacity` with a delay rather than hard-hiding with `visibility: hidden`, so the element reveals itself after a timeout even when it is never upgraded:
+
+```css
+my-element:not(:defined) {
+  opacity: 0;
+  /* Reveal anyway after 2s, so a failed or slow script never hides content for good. */
+  animation: defined-fallback 0.2s 2s forwards;
+}
+@keyframes defined-fallback { to { opacity: 1; } }
+```
+
+Scope these guards to the elements that need them — or to a specific subtree via `:has(:not(:defined))` — rather than the whole `body`. One slow, non-critical widget (a share button, say) should not delay paint for the entire page.
+
+## Attribute ⇄ property reflection
+
+Keep the HTML attribute and the JS property in sync so the element is usable from both markup and script. Attribute values are **always strings**; coerce them.
+
+```javascript
+class MyToggle extends HTMLElement {
+  static observedAttributes = ['label', 'disabled'];
+
+  // String attribute reflected via getter/setter.
+  get label() { return this.getAttribute('label') ?? ''; }
+  set label(v) {
+    v ? this.setAttribute('label', v) : this.removeAttribute('label');
+  }
+
+  // Boolean attribute: present = true, absent = false. Never set it to "false".
+  get disabled() { return this.hasAttribute('disabled'); }
+  set disabled(on) { this.toggleAttribute('disabled', !!on); }
+
+  attributeChangedCallback(name, oldVal, newVal) {
+    if (oldVal !== newVal) this.render();
+  }
+}
+```
+
+### Where the value lives
+
+The example above keeps the **DOM as the source of truth** — each getter reads `getAttribute`. That's the right default for a handful of simple, string-ish attributes: there is only one place the state can live, so it can't desync.
+
+For richer components, keep the **source of truth in a JS field** and reflect *outward* to an attribute only when something else must see it — CSS targeting, or a consumer reading it. Reading a field is far cheaper than parsing and coercing an attribute on every access, and non-string values never round-trip through serialization. This is why libraries like Lit hold state in JS and reflect selectively rather than treating attributes as storage: reflect only what the outside world must observe, not every property.
+
+Pitfalls:
+
+- **`observedAttributes` discipline**: list only attributes whose change must re-render or trigger a side effect. Observing everything adds a callback to every mutation for no benefit.
+- **Reflection loops**: a setter that writes an attribute will re-enter `attributeChangedCallback`. Guard with an `oldVal !== newVal` check, as above.
+- **Style-only state**: for internal state that exists only to drive styling (loading, active, expanded), prefer **custom states** over reflecting a synthetic attribute — see [Custom states](#custom-states) below. Reflect to an attribute only when consumers must be able to set the state from markup.
+
+## Custom states
+
+Custom states are boolean flags an element exposes *about itself* for CSS to target, set through `ElementInternals` and matched with the `:state()` pseudo-class. Use them for internal, runtime UI state — `busy`, `expanded`, `invalid` — instead of reflecting a synthetic attribute: they can't collide with a consumer's attributes, never appear in the DOM, and are read-only from outside (a consumer can *style* `:state()` but can't forge it).
+
+```javascript
+class AsyncButton extends HTMLElement {
+  #internals;
+  #action = async () => {};
+
+  constructor() {
+    super();
+    this.#internals = this.attachInternals();
+  }
+
+  set action(fn) { this.#action = fn; } // host supplies the work to run
+
+  async run() {
+    if (this.#internals.states.has('busy')) return; // guard re-entry
+    this.#internals.states.add('busy');
+    this.#internals.states.delete('success');
+    try {
+      await this.#action();
+      this.#internals.states.add('success');
+    } catch {
+      this.#internals.states.add('error');
+    } finally {
+      this.#internals.states.delete('busy');
+    }
+  }
+}
+```
+
+`CustomStateSet` is a set, so independent states compose (`busy` plus `error`) without inventing a combined `data-status` enum.
+
+**Custom state is runtime-only.** It is not serialized to the DOM, so it does not survive a reload, the element being re-created, or server rendering. If the state must be set declaratively in markup or persist across loads, that is a job for an **attribute** (see [Where the value lives](#where-the-value-lives)) — restore it in `connectedCallback` from your source of truth. Rule of thumb: custom state for what the component derives and owns at runtime and only needs to *style*; an attribute for what must be set from markup or serialized.
+
+For styling these states — both inside the component and from a consumer's stylesheet — see {{ GUIDE_REF("web-components/styling-web-components") }}.
+
+## Naming conventions
+
+- True-private state: native `#` fields (`#count`) for hard encapsulation; a `_` prefix only when subclasses must still reach it. Note `#` fields are not inherited — a subclass cannot see a base class's private fields.
+- Symbol-keyed properties are a middle ground: hidden from ordinary enumeration, but reachable by any code holding the symbol (export it, or expose it as a `static` field on the class). Because each symbol is unique, two symbols sharing a description never collide — handy when a subclass or sibling needs controlled access that `#` fields can't provide.
+- Do **not** shadow global attributes (`style`, `class`, `id`, `slot`, `part`, `title`, `lang`, `dir`) with your own properties; doing so breaks their built-in behavior. Note `disabled` is only global on form controls; on other elements you must implement its effect yourself.
+
+When naming a new API surface, follow the platform's own conventions — see the [W3C naming principles](https://www.w3.org/TR/design-principles/#naming-is-hard).

--- a/guides/html/web-components/form-associated-custom-elements/demo.html
+++ b/guides/html/web-components/form-associated-custom-elements/demo.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Form-Associated Custom Elements: a custom control in a form</title>
+  <style>
+    rating-input:not(:defined) { visibility: hidden; }
+    rating-input { display: inline-flex; gap: .25rem; }
+    rating-input:invalid { outline: 2px solid crimson; }
+    button[part] { all: unset; cursor: pointer; font-size: 1.5rem; line-height: 1; }
+  </style>
+</head>
+<body>
+  <form id="review">
+    <label for="score">Rating (required)</label>
+    <rating-input id="score" name="rating" required></rating-input>
+    <button type="submit">Submit</button>
+  </form>
+  <output id="result"></output>
+
+  <script>
+    class RatingInput extends HTMLElement {
+      // MANDATORY: opt in, or the attachInternals() form APIs are unavailable.
+      static formAssociated = true;
+
+      #internals;
+      #value = '';
+
+      constructor() {
+        super();
+        this.#internals = this.attachInternals();
+        this.attachShadow({ mode: 'open', delegatesFocus: true });
+        this.shadowRoot.innerHTML = [1, 2, 3, 4, 5]
+          .map(n => `<button type="button" part="star" data-value="${n}" tabindex="${n === 1 ? 0 : -1}">★</button>`)
+          .join('');
+        this.shadowRoot.addEventListener('click', (e) => {
+          const star = e.target.closest('[data-value]');
+          if (star) this.value = star.dataset.value;
+        });
+        this.#validate();
+      }
+
+      get value() { return this.#value; }
+      set value(v) {
+        this.#value = v;
+        this.#internals.setFormValue(v);        // submits without a hidden input
+        this.#validate();
+      }
+
+      #validate() {
+        if (this.hasAttribute('required') && !this.#value) {
+          this.#internals.setValidity(
+            { valueMissing: true },
+            'Please choose a rating.',
+            this.shadowRoot.querySelector('[data-value]'),
+          );
+        } else {
+          this.#internals.setValidity({}); // clear
+        }
+      }
+
+      formResetCallback() { this.value = ''; }
+      formDisabledCallback(disabled) { this.toggleAttribute('disabled', disabled); }
+      formStateRestoreCallback(state) { this.value = state; }
+    }
+
+    customElements.define('rating-input', RatingInput);
+
+    document.getElementById('review').addEventListener('submit', (e) => {
+      e.preventDefault();
+      const data = new FormData(e.target);
+      document.getElementById('result').textContent = `Submitted rating: ${data.get('rating')}`;
+    });
+  </script>
+</body>
+</html>

--- a/guides/html/web-components/form-associated-custom-elements/guide.md
+++ b/guides/html/web-components/form-associated-custom-elements/guide.md
@@ -1,0 +1,67 @@
+---
+name: form-associated-custom-elements
+description: Make a custom control participate natively in forms with formAssociated and ElementInternals, submitting its own value, integrating with constraint validation, and reacting to reset, disable, and state-restore.
+web-feature-ids:
+  - form-associated-custom-elements
+---
+
+# Form-Associated Custom Elements
+
+Do not fall back to a hidden `<input>` to surface a custom control's value to a form. Use **Form-Associated Custom Elements** (FACE): with `formAssociated` and `ElementInternals`, the element submits its own value, participates in validation, and reflects form state natively.
+
+```javascript
+class RatingInput extends HTMLElement {
+  // MANDATORY: opt in. Without this, attachInternals() form APIs are unavailable.
+  static formAssociated = true;
+
+  #internals;
+  #value = '';
+
+  constructor() {
+    super();
+    this.#internals = this.attachInternals();
+    this.attachShadow({ mode: 'open' });
+  }
+
+  get value() { return this.#value; }
+  set value(v) {
+    this.#value = v;
+    // Push the value into the owning <form> for submission.
+    this.#internals.setFormValue(v);
+    this.#validate();
+  }
+
+  #validate() {
+    if (this.hasAttribute('required') && !this.#value) {
+      // Mark invalid and supply the native validation message + anchor.
+      this.#internals.setValidity(
+        { valueMissing: true },
+        'Please choose a rating.',
+        this.shadowRoot.querySelector('[tabindex]'),
+      );
+    } else {
+      this.#internals.setValidity({}); // clear
+    }
+  }
+
+  // Optional FACE lifecycle hooks:
+  formResetCallback() { this.value = ''; }
+  formDisabledCallback(disabled) { this.toggleAttribute('disabled', disabled); }
+  formStateRestoreCallback(state) { this.value = state; }
+}
+customElements.define('rating-input', RatingInput);
+```
+
+Key points:
+
+- `static formAssociated = true` is **MANDATORY**; it unlocks the form-related `ElementInternals` methods and the `formXxxCallback` lifecycle.
+- `setFormValue(value)` is what submits, with no hidden input required. Pass a `FormData` for multi-value controls.
+- `setValidity(flags, message, anchor)` integrates with native constraint validation: the form won't submit while invalid, `:invalid`/`:valid` apply, and the anchor element receives focus on report. Call `setValidity({})` to clear. The interaction-aware `:user-valid`/`:user-invalid` pseudo-classes are *not* consistently wired up for form-associated elements across browsers — verify support before relying on them rather than assuming they track user interaction the way they do for native controls.
+- Implement `formResetCallback`, `formDisabledCallback`, and `formStateRestoreCallback` so the element behaves like a native control on reset, `fieldset[disabled]`, and back/forward autofill restore.
+- Follow platform conventions for dispatched events and prefer the built-in `input` and `change` events over custom ones. `input` fires when the value changes as a direct result of user action (typing, dragging a slider); `change` fires once per stream of changes, when the user commits (releasing the slider, blurring the field). Construct them with `InputEvent` and `Event` respectively.
+
+## Fallback strategies
+
+{{ BASELINE_STATUS("form-associated-custom-elements") }}
+
+Feature-detect with `static formAssociated` support before relying on it: `'attachInternals' in HTMLElement.prototype && 'setFormValue' in ElementInternals.prototype`. Where it is unavailable, fall back to a visually-hidden native `<input>` synced to the control's value so the form still submits — the one case where the hidden-input pattern is justified.

--- a/guides/html/web-components/prerendering-custom-elements/demo.html
+++ b/guides/html/web-components/prerendering-custom-elements/demo.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Declarative Shadow DOM: server-rendered, hydrated in place</title>
+</head>
+<body>
+  <!-- This markup represents server output: the shadow root and its styles ship
+       as HTML, so the component is correct on first paint, before any JS runs. -->
+  <my-card>
+    <template shadowrootmode="open">
+      <style>
+        :host { display: block; max-inline-size: 24rem; }
+        .card { border: 1px solid #ccc; border-radius: 8px; padding: 1rem; }
+        button { cursor: pointer; }
+      </style>
+      <div class="card">
+        <slot name="header"></slot>
+        <div class="body"><slot></slot></div>
+        <button type="button" id="toggle">Toggle details</button>
+      </div>
+    </template>
+
+    <h2 slot="header">Server-rendered title</h2>
+    <p>Visible and styled before JS loads.</p>
+  </my-card>
+
+  <script>
+    class MyCard extends HTMLElement {
+      constructor() {
+        super();
+        // Reuse the server-rendered shadow root; only create one if it is absent.
+        if (!this.shadowRoot) {
+          this.attachShadow({ mode: 'open' });
+          // (Client-only path would clone a template here.)
+        }
+      }
+
+      connectedCallback() {
+        // Hydrate in place: wire behavior to existing markup. Do NOT re-render;
+        // that would discard the server's DOM and cause a flash.
+        this.shadowRoot.getElementById('toggle')
+          ?.addEventListener('click', () => {
+            this.toggleAttribute('open');
+          });
+      }
+    }
+
+    customElements.define('my-card', MyCard);
+  </script>
+</body>
+</html>

--- a/guides/html/web-components/prerendering-custom-elements/guide.md
+++ b/guides/html/web-components/prerendering-custom-elements/guide.md
@@ -1,0 +1,67 @@
+---
+name: prerendering-custom-elements
+description: Server-render a custom element, then hydrate it in place without re-rendering or a flash of unstyled content.
+web-feature-ids:
+  - declarative-shadow-dom
+---
+
+# Pre-rendering custom elements
+
+Pre-rendering means shipping a custom element's markup — including its shadow tree — from the server, so the component is styled and structured *before* any JavaScript runs. The main platform primitive for this is **Declarative Shadow DOM (DSD)**: the parser attaches the shadow root from HTML alone, and the element is later upgraded ("hydrated") by its class if one is registered. Use this pattern for server-side rendering, streaming, and avoiding a flash of unstyled content (FOUC).
+
+## Authoring a declarative shadow root
+
+Nest a `<template>` with the `shadowrootmode` attribute as the first child of the host. The parser attaches its content as a shadow root and removes the template; no script needed.
+
+```html
+<my-card>
+  <template shadowrootmode="open">
+    <style>
+      .card { border: 1px solid; border-radius: 8px; padding: 1rem; }
+    </style>
+    <div class="card">
+      <slot name="header"></slot>
+      <div class="body"><slot></slot></div>
+    </div>
+  </template>
+
+  <!-- Light DOM children are projected into the slots above. -->
+  <h2 slot="header">Server-rendered title</h2>
+  <p>Visible and styled before JS loads.</p>
+</my-card>
+```
+
+## Hydration timing
+
+When the matching class is registered, the browser upgrades the host. Because the shadow root **already exists**, the constructor must not blindly create a second one:
+
+```javascript
+class MyCard extends HTMLElement {
+  constructor() {
+    super();
+    // Reuse the server-rendered shadow root if present; only create one if absent.
+    if (!this.shadowRoot) {
+      this.attachShadow({ mode: 'open' });
+      this.shadowRoot.append(template.content.cloneNode(true));
+    }
+    // Otherwise hydrate in place: wire up listeners against existing markup,
+    // and do NOT re-render; that would discard the server's DOM and flash.
+  }
+}
+```
+
+Set `shadowrootmode="open"` (not `closed`) for almost all cases, so scripts and tools can reach `this.shadowRoot` to hydrate. To serialize an existing shadow root back to HTML on the server or in tests, use `getHTML({ serializableShadowRoots: true })` and attach the root with `serializable: true`.
+
+## Avoiding FOUC
+
+DSD renders correctly on first paint only if styles ship inside the declarative template. To preserve that:
+
+- Put component CSS **inside** the `<template shadowrootmode>` (a `<style>` tag or a `<link>`), not in a separate script-loaded sheet.
+- Pair with `my-card:not(:defined) { … }` only for styles that must wait for JS — typically page-level guard rules like a fade-out on client-rendered instances that miss the SSR pass. These live in the light-DOM (page) stylesheet, since the shadow root doesn't yet exist there and `:host` selectors don't apply from outside. Structural styles inside the DSD template need no such guard.
+- Do not re-render the shadow tree on hydration. Treat the server markup as authoritative and attach behavior to it.
+
+## Fallback strategies
+
+{{ BASELINE_STATUS("declarative-shadow-dom") }}
+
+In engines that don't parse `shadowrootmode`, the template is inert and its content is not attached as a shadow root. Detect this (`HTMLTemplateElement.prototype.hasOwnProperty('shadowRootMode')`) and, if absent, attach the shadow root imperatively from the same markup during upgrade so the component still renders.

--- a/guides/html/web-components/shadow-dom/demo.html
+++ b/guides/html/web-components/shadow-dom/demo.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Shadow DOM: template, slots, and a shared stylesheet</title>
+  <style>
+    my-card:not(:defined) { visibility: hidden; }
+  </style>
+</head>
+<body>
+  <my-card>
+    <h2 slot="header">Title</h2>
+    <p>Body content goes to the default slot.</p>
+    <small slot="footer">Footer</small>
+  </my-card>
+
+  <script>
+    // One template, cloned per instance; far cheaper than re-parsing innerHTML.
+    const template = document.createElement('template');
+    template.innerHTML = `
+      <div class="card">
+        <header><slot name="header"></slot></header>
+        <div class="body"><slot></slot></div>
+        <footer><slot name="footer"></slot></footer>
+      </div>
+    `;
+
+    // One shared CSSStyleSheet reused by every instance; no per-instance parse.
+    const sheet = new CSSStyleSheet();
+    sheet.replaceSync(`
+      :host { display: block; max-inline-size: 24rem; }
+      .card { border: 1px solid #ccc; border-radius: 8px; padding: 1rem; }
+      .body { margin-block: .5rem; }
+    `);
+
+    class MyCard extends HTMLElement {
+      constructor() {
+        super();
+        this.attachShadow({ mode: 'open' });
+        this.shadowRoot.adoptedStyleSheets = [sheet];
+        // Deep-clone so each instance gets its own nodes.
+        this.shadowRoot.append(template.content.cloneNode(true));
+
+        // Reflect whether the header slot is filled, for styling/state.
+        const header = this.shadowRoot.querySelector('slot[name="header"]');
+        header.addEventListener('slotchange', (e) => {
+          this.toggleAttribute('has-header', e.target.assignedElements().length > 0);
+        });
+      }
+    }
+
+    customElements.define('my-card', MyCard);
+  </script>
+</body>
+</html>

--- a/guides/html/web-components/shadow-dom/guide.md
+++ b/guides/html/web-components/shadow-dom/guide.md
@@ -1,0 +1,87 @@
+---
+name: shadow-dom
+description: Encapsulate a component's DOM and styles with Shadow DOM, construct the tree efficiently with HTML templates, and project consumer content with slots.
+web-feature-ids:
+  - shadow-dom
+  - slot
+---
+
+# Shadow DOM, Templates & Slots
+
+A shadow root is an encapsulated DOM subtree attached to a host element: styles inside it do not leak out, and page styles do not leak in (except inherited properties). Templates construct the tree efficiently; slots project Light DOM content into it.
+
+## Attaching a shadow root
+
+```javascript
+this.attachShadow({ mode: 'open', delegatesFocus: true });
+```
+
+`delegatesFocus: true` makes focusing the host move focus to the first focusable element inside the shadow tree, and routes `:focus` styling to the host. Set it whenever the component wraps focusable controls; it is required for label-click and keyboard accessibility. (Use `mode: 'open'` in almost all cases — see the cross-cutting rules in {{ GUIDE_REF("web-components") }}.)
+
+## Templates: construct the tree efficiently
+
+Define a `<template>` **once** (module scope or a static field) and clone it per instance. Cloning a parsed fragment is far faster than re-parsing an `innerHTML` string on every construction.
+
+```javascript
+const template = document.createElement('template');
+template.innerHTML = `
+  <div class="card">
+    <slot name="header"></slot>
+    <div class="body"><slot></slot></div>
+    <slot name="footer"></slot>
+  </div>
+`;
+
+class MyCard extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+    // MANDATORY: deep-clone the template content so each instance gets its own nodes.
+    this.shadowRoot.append(template.content.cloneNode(true));
+  }
+}
+customElements.define('my-card', MyCard);
+```
+
+Keep templates lean. Deeply nested "div soup" and many levels of nested shadow roots both add measurable style-resolution and layout cost, a major performance hit at scale. Prefer a flat structure and semantic elements.
+
+## Slots: the parts that surprise people
+
+Default vs. named slots work as documented; these are the behaviors that bite:
+
+- **Whitespace counts.** Text nodes between elements (including pure whitespace) are assigned to the default slot, so a default slot is rarely truly "empty."
+- **DOM order is preserved, not slot order.** Projected nodes keep their original Light DOM order for `:first-child`/`:last-child` purposes, regardless of which slot they fill. A `::slotted(*:first-child)` rule targets the first *DOM* child, not the first child of that slot, so it often will not match what you expect.
+- **`slotchange` is the upgrade-timing signal.** It fires when assigned nodes change (including initial assignment) and is the reliable way to know Light DOM children have arrived after an upgrade, when they may not have existed during `connectedCallback`.
+
+```javascript
+this.shadowRoot.querySelector('slot[name="header"]')
+  .addEventListener('slotchange', (e) => {
+    const nodes = e.target.assignedElements();
+    this.toggleAttribute('has-header', nodes.length > 0);
+  });
+```
+
+## Loading stylesheets into a shadow root
+
+| Method | Pros | Cons |
+| :--- | :--- | :--- |
+| `<style>` in the template | Simple, fully encapsulated, works without JS. | Duplicated per instance; bloats the DOM at scale. |
+| `<link rel="stylesheet">` | Cacheable external file. | Extra request; risks a flash of unstyled content. |
+| `adoptedStyleSheets` | One shared `CSSStyleSheet` across all instances; fastest at scale. | Requires JS; constructed sheets don't support `@import`. |
+
+For many instances of one component, prefer a shared constructed stylesheet:
+
+```javascript
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(`:host { display: block; }`);
+
+class MyCard extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+    // The same sheet object is reused by every instance; no per-instance parse.
+    this.shadowRoot.adoptedStyleSheets = [sheet];
+  }
+}
+```
+

--- a/guides/html/web-components/styling-web-components/demo.html
+++ b/guides/html/web-components/styling-web-components/demo.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Styling Web Components: custom properties, ::part theming, and :state()</title>
+  <style>
+    my-card:not(:defined),
+    favorite-button:not(:defined) { visibility: hidden; }
+
+    /* Theme from outside via inherited custom properties (they cross the boundary). */
+    body { --card-bg: #f6f8fa; --card-fg: #111; font-family: system-ui, sans-serif; }
+
+    /* Unrestricted styling of an exposed internal, without knowing the structure. */
+    my-card::part(action) {
+      background: navy;
+      color: white;
+      border: 0;
+      border-radius: 6px;
+      padding: .4rem .8rem;
+    }
+
+    /* :state() is a read-only public styling hook — the consumer can style the
+       component's own state but cannot set or forge it. */
+    favorite-button:state(favorited) { filter: drop-shadow(0 0 4px crimson); }
+  </style>
+</head>
+<body>
+  <my-card>
+    <span slot="title">Themed card</span>
+  </my-card>
+
+  <favorite-button></favorite-button>
+
+  <script>
+    const cardTemplate = document.createElement('template');
+    cardTemplate.innerHTML = `
+      <style>
+        :host { container-type: inline-size; display: block; max-inline-size: 28rem; }
+        .card {
+          /* Consumers override these from outside; fallbacks keep it usable. */
+          background: var(--card-bg, white);
+          color: var(--card-fg, black);
+          border-radius: 8px;
+          padding: 1rem;
+          display: grid;
+          gap: .75rem;
+        }
+        /* A component should respond to its own size, not the viewport. */
+        @container (min-width: 24rem) {
+          .card { grid-template-columns: 1fr auto; align-items: center; }
+        }
+      </style>
+      <div class="card">
+        <strong><slot name="title">Card</slot></strong>
+        <button type="button" part="action">Action</button>
+      </div>
+    `;
+
+    class MyCard extends HTMLElement {
+      constructor() {
+        super();
+        this.attachShadow({ mode: 'open' });
+        this.shadowRoot.append(cardTemplate.content.cloneNode(true));
+      }
+    }
+
+    customElements.define('my-card', MyCard);
+
+    // --- :state() as a styling channel: a like/favorite toggle ---
+
+    const favTemplate = document.createElement('template');
+    favTemplate.innerHTML = `
+      <style>
+        button { border: 0; background: none; cursor: pointer; font-size: 2rem; line-height: 1; }
+        .icon { color: #999; }
+        /* The component styles its own state from inside the shadow tree. */
+        :host(:state(favorited)) .icon { color: crimson; }
+      </style>
+      <button type="button" aria-pressed="false" aria-label="Favorite">
+        <span class="icon">&#9829;</span>
+      </button>
+    `;
+
+    class FavoriteButton extends HTMLElement {
+      #internals;
+
+      constructor() {
+        super();
+        this.#internals = this.attachInternals();
+        this.attachShadow({ mode: 'open' });
+        this.shadowRoot.append(favTemplate.content.cloneNode(true));
+      }
+
+      connectedCallback() {
+        // The inner native <button> provides role, focus, and keyboard activation;
+        // the host does not re-declare button semantics.
+        this.shadowRoot.querySelector('button')
+          .addEventListener('click', () => this.toggle());
+      }
+
+      get favorited() { return this.#internals.states.has('favorited'); }
+      set favorited(on) {
+        // CustomStateSet is setlike: add/delete, no toggle() — no DOM attribute involved.
+        if (on) this.#internals.states.add('favorited');
+        else this.#internals.states.delete('favorited');
+        this.shadowRoot.querySelector('button')
+          .setAttribute('aria-pressed', String(!!on));
+      }
+
+      toggle() {
+        this.favorited = !this.favorited;
+        // Follow platform conventions: dispatch a built-in change event.
+        this.dispatchEvent(new Event('change', { bubbles: true }));
+      }
+    }
+
+    customElements.define('favorite-button', FavoriteButton);
+  </script>
+</body>
+</html>

--- a/guides/html/web-components/styling-web-components/guide.md
+++ b/guides/html/web-components/styling-web-components/guide.md
@@ -1,0 +1,132 @@
+---
+name: styling-web-components
+description: Style across the shadow boundary with :host selectors, inherited and custom properties for theming, ::slotted and ::part, and cascade layers and container queries inside components.
+web-feature-ids:
+  - shadow-parts
+  - host-context
+  - cascade-layers
+  - container-queries
+---
+
+# Styling Web Components
+
+Shadow DOM is a style boundary: page rules don't reach in and component rules don't leak out, except **inherited** properties (including custom properties). Cross it deliberately through the channels below.
+
+## `:host`, `:host()`, `:host-context()`
+
+```css
+/* The component's own host element, styled from inside its shadow tree. */
+:host { display: block; }
+
+/* Only when the host matches a selector (e.g. a reflected state attribute). */
+:host([disabled]) { opacity: 0.5; pointer-events: none; }
+
+/* Based on an ancestor in the Light DOM; useful for theming. */
+:host-context([theme="dark"]) { background: #111; color: #eee; }
+```
+
+**Avoid `:host-context()`.** It reaches *outside* the boundary to test ancestors, but Firefox and Safari have declined to ship it and the CSSWG is leaning toward not developing it further — treat it as a Chromium-only dead end, not a forward-looking option. Theme through an inherited CSS custom property instead (below): the consumer sets the property on an ancestor and the component reads it across the boundary, which works everywhere and keeps both sides decoupled.
+
+## Inherited properties and custom properties cross the boundary
+
+Inherited CSS properties (`color`, `font-family`, `line-height`, and CSS custom properties) **do** pass through the shadow boundary. This makes custom properties the primary theming API: expose them with sensible fallbacks.
+
+```css
+:host {
+  /* Consumers override --card-bg from outside; the fallback keeps it usable. */
+  background: var(--card-bg, white);
+  color: var(--card-fg, black);
+}
+```
+
+A custom property *defined* on `:host` can only be overridden by rules targeting the host element specifically. To let it inherit and be overridable from anywhere up the tree, leave the public property unset on `:host` and rely on the fallback in each `var()`; do not seed the public property on `:host`.
+
+To keep the fallback declared once rather than repeated at every `var()`, define a private "shadow" property on `:host` that reads the public one, and reference the private property internally:
+
+```css
+:host {
+  --_card-bg: var(--card-bg, white);
+  --_card-fg: var(--card-fg, black);
+}
+.card { background: var(--_card-bg); color: var(--_card-fg); }
+```
+
+Consumers still override `--card-bg` from outside; the leading underscore signals the alias is internal, and the fallback lives in exactly one place.
+
+## `::slotted()`: styling projected Light DOM
+
+`::slotted(selector)` targets the **top-level** nodes assigned to a slot. It cannot reach their descendants, and it loses to any Light DOM rule (the consumer owns their own content), so use it for light touch-ups, not control. `::slotted(...) !important` can beat consumer rules, but doing so overrides styling the consumer is entitled to own — reserve it for structural fixes, not aesthetic overrides.
+
+```css
+/* Matches a slotted <p>, but NOT a <p> nested inside a slotted <div>. */
+::slotted(p) { margin: 0; }
+```
+
+## `::part()` and `exportparts`: expose internals for theming
+
+Mark an internal element with `part="name"` to let consumers style it with any property, without learning your internal structure.
+
+```html
+<!-- inside the shadow template -->
+<button part="submit">Submit</button>
+```
+
+```css
+/* consumer stylesheet */
+my-card::part(submit) { background: navy; color: white; }
+```
+
+Expose a few **high-level** parts (button, input, label), not every `<div>`; broad part surfaces become a brittle API. To re-expose a nested component's parts upward through your own component, forward them with `exportparts`:
+
+```html
+<inner-widget exportparts="submit: card-submit"></inner-widget>
+```
+
+Choose between the two channels deliberately: **custom properties** for a constrained, design-system-safe set of values; **parts** for unrestricted styling of a specific element.
+
+## Forwarding styles to a wrapped native element
+
+When a custom element wraps a native control (`<my-button>` around a real `<button>`), three things routinely trip people up:
+
+- **Form controls don't inherit typography.** `color` and custom properties cross the boundary, but `<button>`, `<input>`, and `<select>` take `font` and friends from the UA stylesheet, which does *not* inherit. The wrapped control therefore renders in the platform font, not the page font, until you set `font: inherit` (and usually `color: inherit`) on it inside the shadow tree. This is the single most common miss.
+- **`:host` styles don't reach the inner element.** Setting `background`/`border`/`padding` on `:host` styles the host box, not the control inside it. Forward deliberately: expose the control as a `::part` for open-ended styling, or pipe a fixed set of values through custom properties — a `:host` rule does not cascade into the wrapped element.
+- **`display: contents` + `all: inherit` is a real tradeoff, not a shortcut.** Collapsing the host with `display: contents` and resetting the inner control with `all: inherit` is currently the only generic way to pass arbitrary styles through to a wrapped native element without consumers learning per-component parts or custom properties — and removing the host's own box is usually *the point* of the pattern (composition compensating for a missing built-in inheritance). Two real caveats: `all: inherit` wipes UA defaults, so scope to specific properties or use `revert` when you want defaults back; and the concrete blocker — `getBoundingClientRect()` and `getClientRects()` return zero for `display: contents` elements, so anchor positioning against the host is broken. Reach for `::part` or custom properties when those tradeoffs don't fit.
+
+## `:state()`: style the component's own states
+
+A custom element can expose internal boolean states through `ElementInternals` (see {{ GUIDE_REF("custom-elements") }} for setting them), and those states become a styling channel across the boundary — like `::part` and custom properties, but for *state* rather than structure or values. Match them inside the shadow tree with `:host(:state(name))`, and from a consumer's stylesheet with `tag-name:state(name)`:
+
+```css
+/* Inside the component's shadow tree. */
+:host(:state(busy)) button { opacity: 0.6; pointer-events: none; }
+
+/* From the consumer's stylesheet — a read-only public hook. */
+favorite-button:state(favorited) { filter: drop-shadow(0 0 4px crimson); }
+```
+
+Unlike a reflected attribute, a custom state is **read-only to the outside**: consumers can style it but cannot set or forge it, so the component stays the sole writer. Prefer it over a `data-*` attribute whenever the state is owned by the component and only needs to be styled.
+
+## `@layer` and container queries inside components
+
+- **Cascade layers** (`@layer`) work inside a shadow root and are scoped to it; a layer name in the shadow tree is independent of a same-named layer in the page. Use them to order your own component styles (e.g. `@layer base, theme;`) so consumer overrides via custom properties and `::part` still win predictably.
+- **Container queries** are the right tool for responsive components: a component should respond to the space it's given, not the viewport. Declare the host or a wrapper as a container and query it, so the same component adapts in a sidebar or a full-width region.
+
+```css
+:host { container-type: inline-size; }
+
+@container (min-width: 30rem) {
+  .card { grid-template-columns: 1fr 2fr; }
+}
+```
+
+## Fallback strategies
+
+{{ BASELINE_STATUS("shadow-parts") }}
+
+{{ BASELINE_STATUS("cascade-layers") }}
+
+{{ BASELINE_STATUS("container-queries") }}
+
+{{ BASELINE_STATUS("host-context") }}
+
+`::part`, cascade layers, and container queries are broadly available; theme primarily through inherited custom properties, which work even where these don't. As noted above, do **not** rely on `:host-context()` — it is effectively Chromium-only and not a forward-looking option.

--- a/guides/html/web-components/web-components/guide.md
+++ b/guides/html/web-components/web-components/guide.md
@@ -1,0 +1,59 @@
+---
+name: web-components
+description: Orientation and cross-cutting principles for authoring and using Web Components, covering Custom Elements, Shadow DOM, templates and slots, Declarative Shadow DOM, styling across the shadow boundary, Form-Associated Custom Elements, and accessibility requirements. Use this guide when building reusable UI components, design systems, or server-rendered custom elements.
+web-feature-ids:
+  - autonomous-custom-elements
+  - shadow-dom
+  - declarative-shadow-dom
+---
+
+# Web Components Orientation Guide
+
+Web Components are Custom Elements, Shadow DOM, and HTML Templates: the platform primitives for reusable, framework-agnostic components whose markup and styles are encapsulated from the document. Use them for design systems, embeddable widgets, and self-contained UI.
+
+The rules below are cross-cutting. Retrieve the specific guide for the task at hand; each restates the context it needs and documents the APIs and pitfalls unique to it.
+
+## Decide whether you even need a custom element
+
+Reach for a custom element only when you need encapsulated behavior, lifecycle, or a reusable JS-backed API on a tag. Do **not** build one when:
+
+- A plain HTML element with CSS would do. A styled `<button>` or `<details>` is more accessible and cheaper than a re-implementation.
+- The thing is purely presentational with no behavior. A class on a native element is more performant, and scopable with `@layer` or `@scope`.
+- You only need style scoping on the server with no interactivity; a scoped stylesheet or Declarative Shadow DOM (without an upgrade) may be enough.
+
+Rebuilding native semantics (a custom `<my-button>` that re-creates focus, activation, and ARIA) is the most common misuse: you inherit the platform's accessibility for free only if you reuse the native element. When a `<my-button>`-style wrapper *is* warranted — usually for shared styling hooks, extra markup, or behavior a native element can't express — wrap the real `<button>` rather than re-implementing it (see {{ GUIDE_REF("styling-web-components") }} for forwarding styles to an internal native element).
+
+The test is whether you need **encapsulated state, a scriptable API, or behavior the native element can't express** — not merely a different look. A like/favorite toggle qualifies: it carries latched domain state, exposes that state as a styling hook for the surrounding page, and dispatches its own `change` event — none of which a styled `<button>` gives you. A button that only changes color when pressed does not: reach for `<button>` + CSS. When you do build it, model its state with a custom state or attribute as appropriate (see {{ GUIDE_REF("custom-elements") }}).
+
+## Match the tool to the codebase
+
+Whether something *should* be a custom element depends on what the project already uses. Agents tend to over-abstract and reach for a new element too eagerly — when in doubt, the lighter option (native element, CSS, a server template) is usually right, and you can promote to a custom element later if reuse or behavior actually demands it. Heuristics, in rough priority:
+
+- **The codebase already has a component model (React, Vue, Svelte, …).** Default to that framework's component for in-app UI. Reach for a custom element only when the thing must escape or outlive the framework: a design-system primitive shared across apps or frameworks, a widget dropped into markup the framework doesn't control, or output that must work as plain HTML (email, CMS, SSR fragments). Don't stand up a parallel component system for ordinary in-app views.
+- **No tooling, mostly static markup.** Prefer plain HTML + CSS, or a server template/partial. A custom element earns its keep only where you genuinely need behavior, lifecycle, or a JS-backed API on the tag — not merely to share markup, which a server include or `<template>` does without shipping any JS.
+- **Static site generator with islands of interactivity.** Render the markup statically; reserve the custom element for the interactive part. For "lots of markup, a little interactivity," keep the markup in Light DOM (or Declarative Shadow DOM) and let a small custom element progressively enhance it, rather than re-rendering everything from JS.
+- **You could push a built-in element further instead.** Taking a native element as far as it goes (CSS, a few listeners, the occasional pseudo-element) is usually preferable to a custom element, because you keep the platform's accessibility and behavior for free. Cross over to a custom element when the workarounds stop being maintainable — when you'd be fighting the element's built-in behavior, or the authoring experience becomes worse than a clean component API would be. Needing a little JS on a built-in element is not, by itself, a reason to replace it.
+
+## Cross-cutting rules
+
+These hold across every guide below:
+
+- **MANDATORY**: the tag name must be kebab-case with at least one hyphen (e.g. `my-element`). This is what distinguishes custom elements from current and future built-ins.
+- **MANDATORY**: call `super()` first in the constructor, before touching `this`; calling it after any statement that reads or writes `this` throws.
+- **MANDATORY**: use semantic elements (`<button>`, `<nav>`, `<ul>`) inside shadow templates. Most accessibility failures in shadow trees come from non-semantic markup; a slot does not change the role of what it projects.
+- **MANDATORY**: ARIA `id` references (`aria-labelledby`, `aria-describedby`, `aria-controls`) cannot cross a shadow boundary; the referencing element and the `id` it points to must live in the same tree.
+- Prefer `attachShadow({ mode: 'open' })` so dev tools, page scripts, and server hydration can reach `element.shadowRoot`. Use `'closed'` only when you must hide internal structure from page scripts.
+- Avoid *customized built-in elements* (`extends HTMLButtonElement` with `is="…"`); Safari has permanently declined to ship them.
+
+## Use-case guide matrix
+
+Identify the task and retrieve its guide:
+
+| If you need to… | Retrieve |
+| :--- | :--- |
+| Define a new semantic tag with behavior and lifecycle | {{ GUIDE_REF("custom-elements") }} |
+| Scope styles and markup to a component, and project consumer content into it | {{ GUIDE_REF("shadow-dom") }} |
+| Render a component's shadow tree on the server (SSR) without a flash of unstyled content | {{ GUIDE_REF("prerendering-custom-elements") }} |
+| Style across the shadow boundary (theming, `::part`, custom properties) | {{ GUIDE_REF("styling-web-components") }} |
+| Submit a custom control's value to a surrounding `<form>` | {{ GUIDE_REF("form-associated-custom-elements") }} |
+| Make a custom element accessible (roles, focus, ARIA across shadow roots) | {{ GUIDE_REF("accessible-web-components") }} |


### PR DESCRIPTION
## Summary

Aligned the output with the approach taken for passkeys - an orientation page linking to specific and focused guides.

Guides were broken into the following topics:

- accessible-web-components
- custom-elements
- declarative-shadow-dom
- form-associated-custom-elements
- shadow-dom
- styling-web-components