### PR TITLE
add install command

### DIFF
--- a/serving/bin/modern-web.ts
+++ b/serving/bin/modern-web.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node --experimental-strip-types
 
 import { parseArgs } from "util";
+import { spawnSync } from "child_process";
 import { retrieveUseCase } from "../lib/retrieve.ts";
 
 const { values, positionals } = parseArgs({
@@ -9,6 +10,7 @@ const { values, positionals } = parseArgs({
     help: { type: "boolean", short: "h" },
   },
   allowPositionals: true,
+  strict: false,
 });
 
 function printUsage() {
@@ -18,6 +20,7 @@ Usage: modern-web <command> [args]
 Commands:
   search <query>          Search use cases by query
   retrieve <ids>          Retrieve use case(s) by ID(s), comma-separated
+  install                 Install skills
 
 Options:
   -h, --help              Show this help
@@ -75,6 +78,16 @@ async function main() {
         process.exit(1);
       }
     }
+  } else if (command === "install") {
+    const extraArgs = process.argv.slice(3);
+    const result = spawnSync("npx", ["skills", "add", "GoogleChrome/modern-web-guidance", ...extraArgs], {
+      stdio: "inherit",
+    });
+    if (result.error) {
+      console.error("Install failed:", result.error);
+      process.exit(1);
+    }
+    process.exit(result.status ?? 0);
   } else {
     console.error(`Unknown command: ${command}`);
     printUsage();

--- a/serving/skills-cli/template/README.md
+++ b/serving/skills-cli/template/README.md
@@ -4,6 +4,10 @@ This curated collection of skills, tools, and AI-ready documentation injects Chr
 
 ## Installation
 
+```bash
+npx modern-web-guidance install
+```
+
 ### 🍦 Universal Skills Pack
 Consult your coding agent's documentation for installation instructions. You can also use Vercel's `skills` CLI:
 ```bash


### PR DESCRIPTION
adds `npx modern-web-guidance install` for installing these skills

for now, we defer to `npx skills`. But in the future we may switch this out.

ref https://docs.google.com/document/d/1AGcHNZyAOUHYubwabjJeNg7fFh1zPTUFZ5hX8nkyLTw/edit?usp=sharing&resourcekey=0-GIG327JksHNmwZ6bObP-LQ (paul and i brainstormed and this is our notes docs)