### PR TITLE
centralize redundant fallbacks transclusion

### DIFF
--- a/features/auth-forms.md
+++ b/features/auth-forms.md
@@ -1,0 +1,88 @@
+# Authentication Forms
+
+## Own Form Element { #auth-own-form }
+
+Always use the `<form>` element when you're getting users to enter data.
+
+Don't wrap inputs in a `<div>` and handle input data submission purely with JavaScript. It's generally better to use a `<form>` element. This makes your site accessible to screenreaders and other assistive devices, enables a range of built-in browser features, makes it simpler to build basic functional authentication for older browsers, and can still work even if JavaScript fails.
+
+## Don't Double Up Inputs { #auth-dont-double-up }
+
+Some sites force users to enter emails or passwords twice. That might reduce errors for a few users, but causes extra work for all users, and increases abandonment rates. Asking twice also makes no sense where browsers autofill email addresses or suggest strong passwords. It's better to enable users to confirm their email address (you'll need to do that anyway) and make it easy for them to reset their password if necessary.
+
+## Password Privacy & Show Password { #auth-keep-passwords-private }
+
+Passwords inputs should have `type="password"` to hide password text and help the browser understand that the input is for passwords. (Note that browsers use a variety of techniques to understand input roles and decide whether or not to offer to save passwords.)
+
+You should add a **Show password** toggle to enable users to check the text they've entered—and don't forget to add a **Forgot password** link.
+
+## Mobile Keyboards { #auth-mobile-keyboard }
+
+Use `<input type="email">` to give mobile users an appropriate keyboard and enable basic built-in email address validation by the browser… no JavaScript required!
+
+If you need to use a telephone number instead of an email address, `<input type="tel">` enables a telephone keypad on mobile. You can also use the `inputmode` attribute where necessary: `inputmode="numeric"` is ideal for PIN numbers.
+
+## Re-entering Credentials { #auth-avoid-re-entering }
+
+You can help browsers store data correctly and autofill inputs, so users don't have to remember to enter email and password values. This is particularly important on mobile, and crucial for email inputs, which get high abandonment rates. There are two parts to this:
+
+1. The `autocomplete`, `name`, `id`, and `type` attributes help browsers understand the role of inputs in order to store data that can later be used for autofill. To allow data to be stored for autofill, modern browsers also require inputs to have a stable `name` or `id` value (not randomly generated on each page load or site deployment), and to be in a `<form>` element with a `submit` button.
+2. The `autocomplete` attribute helps browsers correctly autofill inputs using stored data.
+
+For email inputs use `autocomplete="username"`, since `username` is recognized by password managers in modern browsers—even though you should use `type="email"` and you may want to use `id="email"` and `name="email"`. For password inputs, use the appropriate `autocomplete` and `id` values to help browsers differentiate between new and current passwords.
+
+
+
+## Allow Password Pasting { #auth-allow-password-pasting }
+
+Some sites don't allow text to be pasted into password inputs.
+
+Disallowing password pasting annoys users, encourages passwords that are memorable (and therefore may be easier to compromise) and, according to organizations such as the UK National Cyber Security Centre, may actually reduce security. Users only become aware that pasting is disallowed after they try to paste their password, so disallowing password pasting doesn't avoid clipboard vulnerabilities.
+
+## Registration Form Security and Layout { #auth-registration-practices }
+
+### Put sign-up in its own `<form>` element
+
+Always use the `<form>` element when you're getting users to enter data.
+
+Don't wrap inputs in a `<div>` and handle input data submission purely with JavaScript. It's generally better to use a `<form>` element. This makes your site accessible to screenreaders and other assistive devices, enables a range of built-in browser features, makes it simpler to build basic functional authentication for older browsers, and can still work even if JavaScript fails.
+
+### Don't double up inputs
+
+Some sites force users to enter emails or passwords twice. That might reduce errors for a few users, but causes extra work for all users, and increases abandonment rates. Asking twice also makes no sense where browsers autofill email addresses or suggest strong passwords. It's better to enable users to confirm their email address (you'll need to do that anyway) and make it easy for them to reset their password if necessary.
+
+### Keep passwords private—but enable users to see them if they want
+
+Passwords inputs should have `type="password"` to hide password text and help the browser understand that the input is for passwords. (Note that browsers use a variety of techniques to understand input roles and decide whether or not to offer to save passwords.)
+
+You should add a **Show password** toggle to enable users to check the text they've entered—and don't forget to add a **Forgot password** link.
+
+### Give mobile users the right keyboard
+
+Use `<input type="email">` to give mobile users an appropriate keyboard and enable basic built-in email address validation by the browser… no JavaScript required!
+
+If you need to use a telephone number instead of an email address, `<input type="tel">` enables a telephone keypad on mobile. You can also use the `inputmode` attribute where necessary: `inputmode="numeric"` is ideal for PIN numbers.
+
+## Sign-In Form Security and Layout { #auth-signin-practices }
+
+### Put sign-in in its own `<form>` element
+
+Always use the `<form>` element when you're getting users to enter data.
+
+Don't wrap inputs in a `<div>` and handle input data submission purely with JavaScript. It's generally better to use a `<form>` element. This makes your site accessible to screenreaders and other assistive devices, enables a range of built-in browser features, makes it simpler to build basic functional authentication for older browsers, and can still work even if JavaScript fails.
+
+### Don't double up inputs
+
+Some sites force users to enter emails or passwords twice. That might reduce errors for a few users, but causes extra work for all users, and increases abandonment rates. Asking twice also makes no sense where browsers autofill email addresses or suggest strong passwords. It's better to enable users to confirm their email address (you'll need to do that anyway) and make it easy for them to reset their password if necessary.
+
+### Keep passwords private—but enable users to see them if they want
+
+Passwords inputs should have `type="password"` to hide password text and help the browser understand that the input is for passwords. (Note that browsers use a variety of techniques to understand input roles and decide whether or not to offer to save passwords.)
+
+You should add a **Show password** toggle to enable users to check the text they've entered—and don't forget to add a **Forgot password** link.
+
+### Give mobile users the right keyboard
+
+Use `<input type="email">` to give mobile users an appropriate keyboard and enable basic built-in email address validation by the browser… no JavaScript required!
+
+If you need to use a telephone number instead of an email address, `<input type="tel">` enables a telephone keypad on mobile. You can also use the `inputmode` attribute where necessary: `inputmode="numeric"` is ideal for PIN numbers.

--- a/features/forms.md
+++ b/features/forms.md
@@ -1,0 +1,40 @@
+# Forms
+
+## Semantic Foundation { #forms-markup-best-practices }
+
+### Use meaningful, valid HTML
+
+Make the most of the elements and attributes built for creating forms:
+
+- `<form>`, `<input>`, `<label>`, and `<button>`
+- `type`, `autocomplete`, and `inputmode`
+
+These enable built-in browser functionality, improve accessibility, and add meaning to markup.
+
+### Use the `<label>` element to label form fields for data entry
+
+To label an `<input>`, `<select>`, or `<textarea>`, use a `<label>`. Associate a label with an input by giving the label's `for` attribute the same value as the input's `id`.
+
+## HTML Attributes - Intro { #forms-html-attributes-intro }
+
+Make it easy for users to enter data, by using the appropriate `<input>` element `<type>` attribute to provide the right keyboard on mobile and enable basic built-in validation by the browser.
+
+Always use `type="email"` for email addresses and `type="tel"` for phone numbers.
+
+## HTML Attributes - Conclusion { #forms-html-attributes-conclusion }
+
+Every `<input>`, `<select>`, and `<textarea>` element SHOULD have an appropriate `autocomplete` attribute, to improve accessibility and help users avoid re-entering data.
+
+## Buttons { #forms-button-element }
+
+Use `<button>` for buttons. You can also use `<input type="submit">`, but don't use a `div` or some other random element acting as a button. Button elements provide accessible behaviour, built-in form submission functionality, and can easily be styled.
+
+## Single Name Input { #forms-single-name }
+
+Allow your users to enter their name using a single input, unless you have a good reason for separately storing given names, family names, honorifics, or other name parts. Using a single name input makes forms less complex, enables cut-and-paste, and makes autofill simpler.
+
+Allow international names. For validation, avoid using regular expressions that only match Latin characters. Latin-only excludes users with names or addresses that include characters that aren't in the Latin alphabet. Allow Unicode letter matching instead—and ensure your backend supports Unicode securely as both input and output. Unicode in regular expressions is well supported by modern browsers.
+
+## Enterkeyhint { #forms-enterkeyhint }
+
+Use the `enterkeyhint` attribute on form inputs to set the mobile keyboard enter key label. For example, use `enterkeyhint="previous"` and `enterkeyhint="next"` within a multi-page form, `enterkeyhint="done"` for the final input in the form, and `enterkeyhint="search"` for a search input.

--- a/guides/forms/autofill-address-form/guide.md
+++ b/guides/forms/autofill-address-form/guide.md
@@ -13,24 +13,11 @@ Create a form that makes it as easy as possible for users to enter address data 
 
 Outlined below are the most important guidelines for building successful address forms.
 
-### Use meaningful, valid HTML
-
-Make the most of the elements and attributes built for creating forms:
-
--   `<form>`, `<input>`, `<label>`, and `<button>`
--   `type`, `autocomplete`, and `inputmode`
-
-These enable built-in browser functionality, improve accessibility, and add meaning to markup.
-
-### Use the `<label>` element to label form fields for data entry
-
-To label an `<input>`, `<select>`, or `<textarea>`, use a `<label>`. Associate a label with an input by giving the label's `for` attribute the same value as the input's `id`.
+{{ INCLUDE("features/forms.md#forms-markup-best-practices") }}
 
 ### Make the most of HTML attributes
 
-Make it easy for users to enter data, by using the appropriate `<input>` element `<type>` attribute to provide the right keyboard on mobile and enable basic built-in validation by the browser.
-
-Always use `type="email"` for email addresses and `type="tel"` for phone numbers.
+{{ INCLUDE("features/forms.md#forms-html-attributes-intro") }}
 
 ```html
 <!-- type="email"/"tel" gives mobile users the right keyboard and enables built-in validation -->
@@ -38,19 +25,17 @@ Always use `type="email"` for email addresses and `type="tel"` for phone numbers
 <input type="tel" id="phone" name="phone" autocomplete="tel">
 ```
 
-Every `<input>`, `<select>`, and `<textarea>` element SHOULD have an appropriate `autocomplete` attribute, to improve accessibility and help users avoid re-entering data.
+{{ INCLUDE("features/forms.md#forms-html-attributes-conclusion") }}
 
 ### Make buttons helpful
 
-Use `<button>` for buttons. You can also use `<input type="submit">`, but don't use a `div` or some other random element acting as a button. Button elements provide accessible behaviour, built-in form submission functionality, and can easily be styled.
+{{ INCLUDE("features/forms.md#forms-button-element") }}
 
 Give each form submit button a value that says what it does. For each step towards checkout, use a descriptive call-to-action that shows progress and makes the next step obvious. For example, label the submit button on your delivery address form **Proceed to Payment** rather than **Continue** or **Save**.
 
 ### Use a single name input where possible
 
-Allow your users to enter their name using a single input, unless you have a good reason for separately storing given names, family names, honorifics, or other name parts. Using a single name input makes forms less complex, enables cut-and-paste, and makes autofill simpler.
-
-Allow international names. For validation, avoid using regular expressions that only match Latin characters. Latin-only excludes users with names or addresses that include characters that aren't in the Latin alphabet. Allow Unicode letter matching instead—and ensure your backend supports Unicode securely as both input and output. Unicode in regular expressions is well supported by modern browsers.
+{{ INCLUDE("features/forms.md#forms-single-name") }}
 
 ### Allow for a variety of address formats
 
@@ -73,7 +58,7 @@ Add the `required` attribute to mandatory fields.
 <input type="text" id="city" name="city" autocomplete="address-level2" required>
 ```
 
-### Fallback strategies
+## Fallback strategies
 
 {{ BASELINE_STATUS("autofill") }}
 

--- a/guides/forms/autofill-payment-form/guide.md
+++ b/guides/forms/autofill-payment-form/guide.md
@@ -17,24 +17,11 @@ Create a form that makes it as easy as possible for users to enter payment detai
 
 Outlined below are the most important guidelines for building successful payment forms.
 
-### Use meaningful, valid HTML
-
-Make the most of the elements and attributes built for creating forms:
-
--   `<form>`, `<input>`, `<label>`, and `<button>`
--   `type`, `autocomplete`, and `inputmode`
-
-These enable built-in browser functionality, improve accessibility, and add meaning to markup.
-
-### Use the `<label>` element to label form fields for data entry
-
-To label an `<input>`, `<select>`, or `<textarea>`, use a `<label>`. Associate a label with an input by giving the label's `for` attribute the same value as the input's `id`.
+{{ INCLUDE("features/forms.md#forms-markup-best-practices") }}
 
 ### Make the most of HTML attributes
 
-Make it easy for users to enter data, by using the appropriate `<input>` element `<type>` attribute to provide the right keyboard on mobile and enable basic built-in validation by the browser.
-
-Always use `type="email"` for email addresses and `type="tel"` for phone numbers.
+{{ INCLUDE("features/forms.md#forms-html-attributes-intro") }}
 
 ```html
 <!-- type="email"/"tel" gives mobile users the right keyboard and enables built-in validation -->
@@ -42,19 +29,17 @@ Always use `type="email"` for email addresses and `type="tel"` for phone numbers
 <input type="tel" id="phone" name="phone" autocomplete="tel">
 ```
 
-Every `<input>`, `<select>`, and `<textarea>` element SHOULD have an appropriate `autocomplete` attribute, to improve accessibility and help users avoid re-entering data.
+{{ INCLUDE("features/forms.md#forms-html-attributes-conclusion") }}
 
 ### Make buttons helpful
 
-Use `<button>` for buttons. You can also use `<input type="submit">`, but don't use a `div` or some other random element acting as a button. Button elements provide accessible behaviour, built-in form submission functionality, and can easily be styled.
+{{ INCLUDE("features/forms.md#forms-button-element") }}
 
 Give each form submit button a value that says what it does. For each step towards checkout, use a descriptive call-to-action that shows progress and makes the next step obvious. For example, label the submit button on your delivery address form **Proceed to Payment** rather than **Continue** or **Save**.
 
 ### Use a single name input where possible
 
-Allow your users to enter their name using a single input, unless you have a good reason for separately storing given names, family names, honorifics, or other name parts. Using a single name input makes forms less complex, enables cut-and-paste, and makes autofill simpler.
-
-Allow international names. For validation, avoid using regular expressions that only match Latin characters. Latin-only excludes users with names or addresses that include characters that aren't in the Latin alphabet. Allow Unicode letter matching instead—and ensure your backend supports Unicode securely as both input and output. Unicode in regular expressions is well supported by modern browsers.
+{{ INCLUDE("features/forms.md#forms-single-name") }}
 
 ### Allow for a variety of address formats
 
@@ -78,7 +63,7 @@ Use appropriate autocomplete values for the billing address, just as you do for 
 
 For each step towards payment, use page headings and descriptive button values that make it clear what needs to be done now, and what checkout step is next.
 
-Use the `enterkeyhint` attribute on form inputs to set the mobile keyboard enter key label. For example, use `enterkeyhint="previous"` and `enterkeyhint="next"` within a multi-page form, `enterkeyhint="done"` for the final input in the form, and `enterkeyhint="search"` for a search input.
+{{ INCLUDE("features/forms.md#forms-enterkeyhint") }}
 
 ### Help users avoid re-entering payment data
 

--- a/guides/forms/autofill-sign-in-form/guide.md
+++ b/guides/forms/autofill-sign-in-form/guide.md
@@ -16,44 +16,29 @@ If users ever need to sign in to your site, then good sign-in form design is cri
 
 Outlined below are the most important guidelines for building successful sign-in forms.
 
-### Use meaningful, valid HTML
-
-Make the most of the elements and attributes built for creating forms:
-
-- `<form>`, `<input>`, `<label>`, and `<button>`
-- `type`, `autocomplete`, and `inputmode`
-
-These enable built-in browser functionality, improve accessibility, and add meaning to markup.
-
-### Use the `<label>` element to label form fields for data entry
-
-To label an `<input>`, `<select>`, or `<textarea>`, use a `<label>`. Associate a label with an input by giving the label's `for` attribute the same value as the input's `id`.
+{{ INCLUDE("features/forms.md#forms-markup-best-practices") }}
 
 ### Make the most of HTML attributes
 
-Make it easy for users to enter data, by using the appropriate `<input>` element `<type>` attribute to provide the right keyboard on mobile and enable basic built-in validation by the browser.
+{{ INCLUDE("features/forms.md#forms-html-attributes-intro") }}
 
-Always use `type="email"` for email addresses and `type="tel"` for phone numbers.
-
-Every `<input>`, `<select>`, and `<textarea>` element SHOULD have an appropriate `autocomplete` attribute, to improve accessibility and help users avoid re-entering data.
+{{ INCLUDE("features/forms.md#forms-html-attributes-conclusion") }}
 
 ### Make buttons helpful
 
-Use `<button>` for buttons. You can also use `<input type="submit">`, but don't use a `div` or some other random element acting as a button. Button elements provide accessible behaviour, built-in form submission functionality, and can easily be styled.
+{{ INCLUDE("features/forms.md#forms-button-element") }}
 
 Give each form submit button a value that says what it does. Use a clear, recognizable label. For example, use **Sign In** rather than **Continue** or **Submit**.
 
 ### Use a single name input where possible
 
-Allow your users to enter their name using a single input, unless you have a good reason for separately storing given names, family names, honorifics, or other name parts. Using a single name input makes forms less complex, enables cut-and-paste, and makes autofill simpler.
-
-Allow international names. For validation, avoid using regular expressions that only match Latin characters. Latin-only excludes users with names or addresses that include characters that aren't in the Latin alphabet. Allow Unicode letter matching instead—and ensure your backend supports Unicode securely as both input and output. Unicode in regular expressions is well supported by modern browsers.
+{{ INCLUDE("features/forms.md#forms-single-name") }}
 
 ### Show sign-in progress
 
 For each step towards sign-in, use page headings and descriptive button values that make it clear what needs to be done now, and what the next step is.
 
-Use the `enterkeyhint` attribute on form inputs to set the mobile keyboard enter key label. For example, use `enterkeyhint="previous"` and `enterkeyhint="next"` within a multi-page form, `enterkeyhint="done"` for the final input in the form, and `enterkeyhint="search"` for a search input.
+{{ INCLUDE("features/forms.md#forms-enterkeyhint") }}
 
 ### Help users avoid re-entering sign-in data
 
@@ -65,27 +50,7 @@ This enables browsers to help users by securely storing sign-in details and corr
 
 Validate data entry both in realtime and before form submission. Use `type="email"` for email inputs — the browser will validate the format automatically. Add the `required` attribute to mandatory fields to prevent empty submissions.
 
-### Put sign-in in its own `<form>` element
-
-Always use the `<form>` element when you're getting users to enter data
-
-Don't wrap inputs in a `<div>` and handle input data submission purely with JavaScript. It's generally better to use a `<form>` element. This makes your site accessible to screenreaders and other assistive devices, enables a range of built-in browser features, makes it simpler to build basic functional sign-in for older browsers, and can still work even if JavaScript fails.
-
-### Don't double up inputs
-
-Some sites force users to enter emails or passwords twice. That might reduce errors for a few users, but causes extra work for all users, and increases abandonment rates. Asking twice also makes no sense where browsers autofill email addresses or suggest strong passwords. It's better to enable users to confirm their email address (you'll need to do that anyway) and make it easy for them to reset their password if necessary.
-
-### Keep passwords private—but enable users to see them if they want
-
-Passwords inputs should have `type="password"` to hide password text and help the browser understand that the input is for passwords. (Note that browsers use a variety of techniques to understand input roles and decide whether or not to offer to save passwords.)
-
-You should add a **Show password** toggle to enable users to check the text they've entered—and don't forget to add a **Forgot password** link.
-
-### Give mobile users the right keyboard
-
-Use `<input type="email">` to give mobile users an appropriate keyboard and enable basic built-in email address validation by the browser… no JavaScript required!
-
-If you need to use a telephone number instead of an email address, `<input type="tel">` enables a telephone keypad on mobile. You can also use the `inputmode` attribute where necessary: `inputmode="numeric"` is ideal for PIN numbers.
+{{ INCLUDE("features/auth-forms.md#auth-signin-practices") }}
 
 ### Prevent mobile keyboard from obstructing the Sign in button
 
@@ -95,12 +60,7 @@ Where possible, avoid this by displaying only the email (or phone) and password 
 
 ### Help users to avoid re-entering data
 
-You can help browsers store data correctly and autofill inputs, so users don't have to remember to enter email and password values. This is particularly important on mobile, and crucial for email inputs, which get high abandonment rates. There are two parts to this:
-
-1.  The `autocomplete`, `name`, `id`, and `type` attributes help browsers understand the role of inputs in order to store data that can later be used for autofill. To allow data to be stored for autofill, modern browsers also require inputs to have a stable `name` or `id` value (not randomly generated on each page load or site deployment), and to be in a `<form>` element with a `submit` button.
-1.  The `autocomplete` attribute helps browsers correctly autofill inputs using stored data.
-
-For email inputs use `autocomplete="username"`, since `username` is recognized by password managers in modern browsers—even though you should use `type="email"` and you may want to use `id="email"` and `name="email"`. For password inputs, use the appropriate `autocomplete` and `id` values to help browsers differentiate between new and current passwords.
+{{ INCLUDE("features/auth-forms.md#auth-avoid-re-entering") }}
 
 ### Use autocomplete="current-password" and id="current-password" for an existing password
 
@@ -108,15 +68,9 @@ MANDATORY: Use `autocomplete="current-password"` and `id="current-password"` for
 
 For a sign-in form:
 
+```html
+<input type="password" autocomplete="current-password" id="current-password" required>
 ```
-<input type="password" autocomplete="current-password" id="current-password" …>
-```
-
-### Enable the browser to suggest a strong password
-
-Modern browsers use heuristics to decide when to show the password manager UI and suggest a strong password.
-
-Built-in browser password generators mean users and developers don't need to work out what a "strong password" is. Since browsers can securely store passwords and autofill them as necessary, there's no need for users to remember or enter passwords. Encouraging users to take advantage of built-in browser password generators also means they're more likely to use a unique, strong password on your site, and less likely to reuse a password that could be compromised elsewhere.
 
 ### Help save users from accidentally missing inputs
 
@@ -129,9 +83,7 @@ MANDATORY: Add the `required` attribute to both email and password fields. Moder
 
 ### Allow password pasting
 
-Some sites don't allow text to be pasted into password inputs.
-
-Disallowing password pasting annoys users, encourages passwords that are memorable (and therefore may be easier to compromise) and, according to organizations such as the UK National Cyber Security Centre, may actually reduce security. Users only become aware that pasting is disallowed after they try to paste their password, so disallowing password pasting doesn't avoid clipboard vulnerabilities.
+{{ INCLUDE("features/auth-forms.md#auth-allow-password-pasting") }}
 
 ### Fallback strategies
 

--- a/guides/forms/autofill-sign-up-form/guide.md
+++ b/guides/forms/autofill-sign-up-form/guide.md
@@ -16,44 +16,29 @@ If users ever need to sign up to your site, then good sign-up form design is cri
 
 Outlined below are the most important guidelines for building successful sign-up forms.
 
-### Use meaningful, valid HTML
-
-Make the most of the elements and attributes built for creating forms:
-
--   `<form>`, `<input>`, `<label>`, and `<button>`
--   `type`, `autocomplete`, and `inputmode`
-
-These enable built-in browser functionality, improve accessibility, and add meaning to markup.
-
-### Use the `<label>` element to label form fields for data entry
-
-To label an `<input>`, `<select>`, or `<textarea>`, use a `<label>`. Associate a label with an input by giving the label's `for` attribute the same value as the input's `id`.
+{{ INCLUDE("features/forms.md#forms-markup-best-practices") }}
 
 ### Make the most of HTML attributes
 
-Make it easy for users to enter data, by using the appropriate `<input>` element `<type>` attribute to provide the right keyboard on mobile and enable basic built-in validation by the browser.
+{{ INCLUDE("features/forms.md#forms-html-attributes-intro") }}
 
-Always use `type="email"` for email addresses and `type="tel"` for phone numbers.
-
-Every `<input>`, `<select>`, and `<textarea>` element SHOULD have an appropriate `autocomplete` attribute, to improve accessibility and help users avoid re-entering data.
+{{ INCLUDE("features/forms.md#forms-html-attributes-conclusion") }}
 
 ### Make buttons helpful
 
-Use `<button>` for buttons. You can also use `<input type="submit">`, but don't use a `div` or some other random element acting as a button. Button elements provide accessible behaviour, built-in form submission functionality, and can easily be styled.
+{{ INCLUDE("features/forms.md#forms-button-element") }}
 
 Give each form submit button a value that says what it does. Use a clear, recognizable label. For example, use **Create account** or **Sign up** rather than **Continue** or **Submit**.
 
 ### Use a single name input where possible
 
-Allow your users to enter their name using a single input, unless you have a good reason for separately storing given names, family names, honorifics, or other name parts. Using a single name input makes forms less complex, enables cut-and-paste, and makes autofill simpler.
-
-Allow international names. For validation, avoid using regular expressions that only match Latin characters. Latin-only excludes users with names or addresses that include characters that aren't in the Latin alphabet. Allow Unicode letter matching instead—and ensure your backend supports Unicode securely as both input and output. Unicode in regular expressions is well supported by modern browsers.
+{{ INCLUDE("features/forms.md#forms-single-name") }}
 
 ### Show sign-up progress
 
 For each step towards sign-up, use page headings and descriptive button values that make it clear what needs to be done now, and what the next step is.
 
-Use the `enterkeyhint` attribute on form inputs to set the mobile keyboard enter key label. For example, use `enterkeyhint="previous"` and `enterkeyhint="next"` within a multi-page form, `enterkeyhint="done"` for the final input in the form, and `enterkeyhint="search"` for a search input.
+{{ INCLUDE("features/forms.md#forms-enterkeyhint") }}
 
 ### Help users avoid re-entering sign-up data
 
@@ -65,27 +50,7 @@ This enables browsers to help users by securely storing sign-up details and corr
 
 Validate data entry both in realtime and before form submission. Use `type="email"` for email inputs — the browser will validate the format automatically. For passwords, use a `pattern` attribute to enforce strength requirements and provide clear error messages when validation fails. Add the `required` attribute to mandatory fields to prevent empty submissions.
 
-### Put sign-up in its own `<form>` element
-
-Always use the `<form>` element when you're getting users to enter data
-
-Don't wrap inputs in a `<div>` and handle input data submission purely with JavaScript. It's generally better to use a `<form>` element. This makes your site accessible to screenreaders and other assistive devices, enables a range of built-in browser features, makes it simpler to build basic functional sign-up for older browsers, and can still work even if JavaScript fails.
-
-### Don't double up inputs
-
-Some sites force users to enter emails or passwords twice. That might reduce errors for a few users, but causes extra work for all users, and increases abandonment rates. Asking twice also makes no sense where browsers autofill email addresses or suggest strong passwords. It's better to enable users to confirm their email address (you'll need to do that anyway) and make it easy for them to reset their password if necessary.
-
-### Keep passwords private—but enable users to see them if they want
-
-Passwords inputs should have `type="password"` to hide password text and help the browser understand that the input is for passwords. (Note that browsers use a variety of techniques to understand input roles and decide whether or not to offer to save passwords.)
-
-You should add a **Show password** toggle to enable users to check the text they've entered—and don't forget to add a **Forgot password** link.
-
-### Give mobile users the right keyboard
-
-Use `<input type="email">` to give mobile users an appropriate keyboard and enable basic built-in email address validation by the browser… no JavaScript required!
-
-If you need to use a telephone number instead of an email address, `<input type="tel">` enables a telephone keypad on mobile. You can also use the `inputmode` attribute where necessary: `inputmode="numeric"` is ideal for PIN numbers.
+{{ INCLUDE("features/auth-forms.md#auth-registration-practices") }}
 
 ### Prevent mobile keyboard from obstructing the Sign up button
 
@@ -95,12 +60,7 @@ Where possible, avoid this by displaying only the email (or phone) and password 
 
 ### Help users to avoid re-entering data
 
-You can help browsers store data correctly and autofill inputs, so users don't have to remember to enter email and password values. This is particularly important on mobile, and crucial for email inputs, which get high abandonment rates. There are two parts to this:
-
-1.  The `autocomplete`, `name`, `id`, and `type` attributes help browsers understand the role of inputs in order to store data that can later be used for autofill. To allow data to be stored for autofill, modern browsers also require inputs to have a stable `name` or `id` value (not randomly generated on each page load or site deployment), and to be in a `<form>` element with a `submit` button.
-1.  The `autocomplete` attribute helps browsers correctly autofill inputs using stored data.
-
-For email inputs use `autocomplete="username"`, since `username` is recognized by password managers in modern browsers—even though you should use `type="email"` and you may want to use `id="email"` and `name="email"`. For password inputs, use the appropriate `autocomplete` and `id` values to help browsers differentiate between new and current passwords.
+{{ INCLUDE("features/auth-forms.md#auth-avoid-re-entering") }}
 
 ### Use autocomplete="new-password" and id="new-password" for a new password
 
@@ -123,9 +83,7 @@ Add the `required` attribute to both email and password fields. Modern browsers 
 
 ### Allow password pasting
 
-Some sites don't allow text to be pasted into password inputs.
-
-Disallowing password pasting annoys users, encourages passwords that are memorable (and therefore may be easier to compromise) and, according to organizations such as the UK National Cyber Security Centre, may actually reduce security. Users only become aware that pasting is disallowed after they try to paste their password, so disallowing password pasting doesn't avoid clipboard vulnerabilities.
+{{ INCLUDE("features/auth-forms.md#auth-allow-password-pasting") }}
 
 ### Offer third-party login
 


### PR DESCRIPTION
thx to #717  we can apply this technique more broadly.

the general approach (IMO) is to have less text floating around making it easier to review and maintain. also lower chance of inconsistencies.

cc @LeaVerou 

this is what this did

<img width="954" height="563" alt="image" src="https://github.com/user-attachments/assets/f7a8eabd-ba34-44eb-a850-8f5fafcaecf2" />

## macro-expansion diffs!

and I have a script which illuminates the effect of all macros:

look at [the "Summary" page of the "CI" workflow](https://github.com/GoogleChrome/guidance/actions/runs/25611989708?pr=751).. for a markdown summary of exactly what changed in the BUILT guides (which is kinda hard to tell because macros)

eg
<img width="975" height="1375" alt="image" src="https://github.com/user-attachments/assets/67bf2938-2db1-4264-a2e6-b96b72b02c9d" />

## forms changes

Notably.. in this batch of forms things... there is this diff:

<img width="1808" height="882" alt="image" src="https://github.com/user-attachments/assets/24ef70b2-77e3-43ae-a726-4b06cdeac44f" />


But.. I decided that "suggest a strong password" stuff shouldnt be on the sign-IN form.. only on the sign-up form (where it remains). So.. yeah

## followups

- i can do another followup for UX/perf guides... (it was a lot of stuff when i had them included)