### PR TITLE
dashboard: make rows proper semantic links and polish data viz

### DIFF
--- a/eval-view/dashboard.css
+++ b/eval-view/dashboard.css
@@ -646,14 +646,15 @@ dialog#modal.diff-modal {
   border-radius: 50%;
   position: absolute;
   top: -2px;
+  transform: translateX(-50%);
 }
 
 .mini-dumbbell-track .dot.unguided {
-  background: transparent;
+  background: var(--card-bg);
   border: 1.5px solid var(--color-outline);
   width: 6px;
   height: 6px;
-  top: -1.5px;
+  top: -1px;
 }
 
 .mini-dumbbell-track .dot.guided {
@@ -1027,14 +1028,14 @@ dialog#modal.diff-modal {
   width: 6px;
   height: 6px;
   border-width: 1.5px;
-  top: 0px;
+  top: -1px;
   transform: none; /* Reset vertical centered transform if needed or adjust */
 }
 
 .sparkline-dot.guided.small {
   width: 8px;
   height: 8px;
-  top: -1px;
+  top: -2px;
   transform: none;
 }
 
@@ -1048,7 +1049,7 @@ dialog#modal.diff-modal {
 
 .sparkline-range.small {
   height: 2px;
-  top: 2px;
+  top: 1px;
   transform: none;
 }
 

--- a/eval-view/dashboard.js
+++ b/eval-view/dashboard.js
@@ -398,6 +398,23 @@ function renderTestHeader(testId, jetskiVersion, timestamp, data) {
     }
 }
 
+function renderSparkline(uRate, gRate, isSmall = false, uTitle = '', gTitle = '') {
+    const barClass = isSmall ? 'sparkline-bar small' : 'sparkline-bar';
+    const dotClass = isSmall ? 'sparkline-dot small' : 'sparkline-dot';
+    const rangeClass = isSmall ? 'sparkline-range small' : 'sparkline-range';
+    const min = Math.min(uRate, gRate);
+    const abs = Math.abs(gRate - uRate);
+    const leftOffset = uRate < gRate ? 3 : 4;
+    
+    return `
+        <div class="${barClass}">
+            <div class="${dotClass} unguided" style="left: calc(${uRate}% - 3px);" title="${escapeHtml(uTitle)}"></div>
+            <div class="${dotClass} guided" style="left: calc(${gRate}% - 4px);" title="${escapeHtml(gTitle)}"></div>
+            <div class="${rangeClass}" style="left: calc(${min}% + ${leftOffset}px); width: calc(${abs}% - 7px);"></div>
+        </div>
+    `;
+}
+
 function renderSummary(data) {
     const container = document.getElementById('summary-side-panel');
     if (!container) return;
@@ -465,11 +482,7 @@ function renderSummary(data) {
                 <span class="meta-value-highlight">+${upliftDelta}%</span>
             </div>
             <div class="sparkline-container">
-                                <div class="sparkline-bar">
-                    <div class="sparkline-dot unguided" style="left: calc(${unguidedPassRate}% - 3px);" title="Unguided: ${unguidedPassRate}%"></div>
-                    <div class="sparkline-dot guided" style="left: calc(${guidedPassRate}% - 4px);" title="Guided: ${guidedPassRate}%"></div>
-                    <div class="sparkline-range" style="left: calc(${Math.min(unguidedPassRate, guidedPassRate)}% + ${unguidedPassRate < guidedPassRate ? 3 : 4}px); width: calc(${Math.abs(guidedPassRate - unguidedPassRate)}% - 7px);"></div>
-                </div>
+                    ${renderSparkline(unguidedPassRate, guidedPassRate, false, `Unguided: ${unguidedPassRate}%`, `Guided: ${guidedPassRate}%`)}
                 <span class="sparkline-labels">${unguidedPassRate}% → <span>${guidedPassRate}%</span></span>
             </div>
             ${summary.expectedTotalRuns !== undefined ? `
@@ -492,17 +505,11 @@ function renderSummary(data) {
                 <span class="meta-label">Assertions Passed</span>
             </div>
             <div class="sparkline-container">
-                <div class="sparkline-bar small">
                     ${(() => {
                         const uPct = (totalUnguidedPassed / Math.max(totalUnguidedChecks, totalGuidedChecks)) * 100;
                         const gPct = (totalGuidedPassed / Math.max(totalUnguidedChecks, totalGuidedChecks)) * 100;
-                        return `
-                            <div class="sparkline-dot unguided small" style="left: calc(${uPct}% - 3px);" title="Unguided Count: ${totalUnguidedPassed}"></div>
-                            <div class="sparkline-dot guided small" style="left: calc(${gPct}% - 4px);" title="Guided Count: ${totalGuidedPassed}"></div>
-                            <div class="sparkline-range small" style="left: calc(${Math.min(uPct, gPct)}% + ${uPct < gPct ? 3 : 4}px); width: calc(${Math.abs(gPct - uPct)}% - 7px);"></div>
-                        `;
+                        return renderSparkline(uPct, gPct, true, `Unguided Count: ${totalUnguidedPassed}`, `Guided Count: ${totalGuidedPassed}`);
                     })()}
-                </div>
                 <span class="sparkline-labels-small">${totalUnguidedPassed} → <span>${totalGuidedPassed}</span> <span>/ ${Math.max(totalUnguidedChecks, totalGuidedChecks)}</span></span>
             </div>
         </div>

--- a/eval-view/dashboard.js
+++ b/eval-view/dashboard.js
@@ -466,9 +466,9 @@ function renderSummary(data) {
             </div>
             <div class="sparkline-container">
                                 <div class="sparkline-bar">
-                    <div class="sparkline-dot unguided" style="left: calc(${unguidedPassRate}% - 6px);" title="Unguided: ${unguidedPassRate}%"></div>
-                    <div class="sparkline-dot guided" style="left: calc(${guidedPassRate}% - 8px);" title="Guided: ${guidedPassRate}%"></div>
-                    <div class="sparkline-range" style="left: calc(${Math.min(unguidedPassRate, guidedPassRate)}% + 4px); width: calc(${Math.abs(guidedPassRate - unguidedPassRate)}% - 8px);"></div>
+                    <div class="sparkline-dot unguided" style="left: calc(${unguidedPassRate}% - 3px);" title="Unguided: ${unguidedPassRate}%"></div>
+                    <div class="sparkline-dot guided" style="left: calc(${guidedPassRate}% - 4px);" title="Guided: ${guidedPassRate}%"></div>
+                    <div class="sparkline-range" style="left: calc(${Math.min(unguidedPassRate, guidedPassRate)}% + ${unguidedPassRate < guidedPassRate ? 3 : 4}px); width: calc(${Math.abs(guidedPassRate - unguidedPassRate)}% - 7px);"></div>
                 </div>
                 <span class="sparkline-labels">${unguidedPassRate}% → <span>${guidedPassRate}%</span></span>
             </div>
@@ -493,9 +493,15 @@ function renderSummary(data) {
             </div>
             <div class="sparkline-container">
                 <div class="sparkline-bar small">
-                    <div class="sparkline-dot unguided small" style="left: calc(${(totalUnguidedPassed / Math.max(totalUnguidedChecks, totalGuidedChecks)) * 100}% - 3px);" title="Unguided Count: ${totalUnguidedPassed}"></div>
-                    <div class="sparkline-dot guided small" style="left: calc(${(totalGuidedPassed / Math.max(totalUnguidedChecks, totalGuidedChecks)) * 100}% - 4px);" title="Guided Count: ${totalGuidedPassed}"></div>
-                    <div class="sparkline-range small" style="left: calc(${Math.min((totalUnguidedPassed / Math.max(totalUnguidedChecks, totalGuidedChecks)) * 100, (totalGuidedPassed / Math.max(totalUnguidedChecks, totalGuidedChecks)) * 100)}% + 2px); width: calc(${Math.abs((totalGuidedPassed / Math.max(totalUnguidedChecks, totalGuidedChecks)) * 100 - (totalUnguidedPassed / Math.max(totalUnguidedChecks, totalGuidedChecks)) * 100)}% - 4px);"></div>
+                    ${(() => {
+                        const uPct = (totalUnguidedPassed / Math.max(totalUnguidedChecks, totalGuidedChecks)) * 100;
+                        const gPct = (totalGuidedPassed / Math.max(totalUnguidedChecks, totalGuidedChecks)) * 100;
+                        return `
+                            <div class="sparkline-dot unguided small" style="left: calc(${uPct}% - 3px);" title="Unguided Count: ${totalUnguidedPassed}"></div>
+                            <div class="sparkline-dot guided small" style="left: calc(${gPct}% - 4px);" title="Guided Count: ${totalGuidedPassed}"></div>
+                            <div class="sparkline-range small" style="left: calc(${Math.min(uPct, gPct)}% + ${uPct < gPct ? 3 : 4}px); width: calc(${Math.abs(gPct - uPct)}% - 7px);"></div>
+                        `;
+                    })()}
                 </div>
                 <span class="sparkline-labels-small">${totalUnguidedPassed} → <span>${totalGuidedPassed}</span> <span>/ ${Math.max(totalUnguidedChecks, totalGuidedChecks)}</span></span>
             </div>

--- a/eval-view/dashboard.js
+++ b/eval-view/dashboard.js
@@ -622,9 +622,8 @@ function renderGrid(data, testId) {
             accordion.className = 'task-accordion';
             accordion.id = `item-${scenarioName.replace(/\s+/g, '-').toLowerCase()}`;
 
-            // Draw mini dumbbell slider track
-            const leftDot = Math.min(unguidedAvg, guidedAvg) + 2;
-            const rightDot = Math.max(unguidedAvg, guidedAvg);
+            const minVal = Math.min(unguidedAvg, guidedAvg);
+            const maxVal = Math.max(unguidedAvg, guidedAvg);
             const trackWidth = 250; // matches css
             const scale = (val) => (val / 100) * trackWidth;
 
@@ -637,7 +636,7 @@ function renderGrid(data, testId) {
                     </div>
                     <div class="right-section">
                         <div class="mini-dumbbell-track">
-                            <div class="connector" style="left: ${scale(leftDot)}px; width: ${scale(rightDot - leftDot)}px;"></div>
+                            <div class="connector" style="left: ${scale(minVal)}px; width: ${scale(maxVal - minVal)}px;"></div>
                             <div class="dot unguided" style="left: ${scale(unguidedAvg)}px;"></div>
                             <div class="dot guided" style="left: ${scale(guidedAvg)}px;"></div>
                         </div>

--- a/eval-view/dashboard.js
+++ b/eval-view/dashboard.js
@@ -417,6 +417,11 @@ function renderSummary(data) {
     let guidedRunsCount = 0;
 
 
+    let unguidedTaskRatesSum = 0;
+    let unguidedTaskCount = 0;
+    let guidedTaskRatesSum = 0;
+    let guidedTaskCount = 0;
+
     const baseKeys = new Set();
     const tasksWithTools = new Set();
     const tasksWithGuides = new Set();
@@ -429,6 +434,9 @@ function renderSummary(data) {
         const isGuided = key.endsWith(' - guided');
         if (isGuided) guidedRunsCount += runs.length;
 
+        let taskPassed = 0;
+        let taskTotal = 0;
+
         runs.forEach(run => {
             const hasTools = run.guidanceToolsUsed && run.guidanceToolsUsed.length > 0;
             const hasGuides = (run.guidesUsed && run.guidesUsed.length > 0) || (run.guideUsed && typeof run.guideUsed === 'object' && run.guideUsed.guidesUsed && run.guideUsed.guidesUsed.length > 0);
@@ -437,20 +445,32 @@ function renderSummary(data) {
             if (isGuided && hasGuides) tasksWithGuides.add(base);
 
             const stats = getRunStats(run.results);
+            taskPassed += stats.passed;
+            taskTotal += stats.total;
+
             if (isGuided) {
                 totalGuidedPassed += stats.passed;
                 totalGuidedChecks += stats.total;
-
             } else {
                 totalUnguidedPassed += stats.passed;
                 totalUnguidedChecks += stats.total;
             }
         });
+
+        if (taskTotal > 0) {
+            if (isGuided) {
+                guidedTaskRatesSum += (taskPassed / taskTotal) * 100;
+                guidedTaskCount++;
+            } else {
+                unguidedTaskRatesSum += (taskPassed / taskTotal) * 100;
+                unguidedTaskCount++;
+            }
+        }
     });
 
     const tasksCount = baseKeys.size;
-    const unguidedPassRate = totalUnguidedChecks > 0 ? Math.round((totalUnguidedPassed / totalUnguidedChecks) * 100) : 0;
-    const guidedPassRate = totalGuidedChecks > 0 ? Math.round((totalGuidedPassed / totalGuidedChecks) * 100) : 0;
+    const unguidedPassRate = unguidedTaskCount > 0 ? Math.round(unguidedTaskRatesSum / unguidedTaskCount) : 0;
+    const guidedPassRate = guidedTaskCount > 0 ? Math.round(guidedTaskRatesSum / guidedTaskCount) : 0;
     const toolActivationRate = tasksCount > 0 ? Math.round((tasksWithTools.size / tasksCount) * 100) : 0;
     const guideUsageRate = tasksCount > 0 ? Math.round((tasksWithGuides.size / tasksCount) * 100) : 0;
 

--- a/eval-view/dashboard.js
+++ b/eval-view/dashboard.js
@@ -417,11 +417,6 @@ function renderSummary(data) {
     let guidedRunsCount = 0;
 
 
-    let unguidedTaskRatesSum = 0;
-    let unguidedTaskCount = 0;
-    let guidedTaskRatesSum = 0;
-    let guidedTaskCount = 0;
-
     const baseKeys = new Set();
     const tasksWithTools = new Set();
     const tasksWithGuides = new Set();
@@ -434,9 +429,6 @@ function renderSummary(data) {
         const isGuided = key.endsWith(' - guided');
         if (isGuided) guidedRunsCount += runs.length;
 
-        let taskPassed = 0;
-        let taskTotal = 0;
-
         runs.forEach(run => {
             const hasTools = run.guidanceToolsUsed && run.guidanceToolsUsed.length > 0;
             const hasGuides = (run.guidesUsed && run.guidesUsed.length > 0) || (run.guideUsed && typeof run.guideUsed === 'object' && run.guideUsed.guidesUsed && run.guideUsed.guidesUsed.length > 0);
@@ -445,32 +437,20 @@ function renderSummary(data) {
             if (isGuided && hasGuides) tasksWithGuides.add(base);
 
             const stats = getRunStats(run.results);
-            taskPassed += stats.passed;
-            taskTotal += stats.total;
-
             if (isGuided) {
                 totalGuidedPassed += stats.passed;
                 totalGuidedChecks += stats.total;
+
             } else {
                 totalUnguidedPassed += stats.passed;
                 totalUnguidedChecks += stats.total;
             }
         });
-
-        if (taskTotal > 0) {
-            if (isGuided) {
-                guidedTaskRatesSum += (taskPassed / taskTotal) * 100;
-                guidedTaskCount++;
-            } else {
-                unguidedTaskRatesSum += (taskPassed / taskTotal) * 100;
-                unguidedTaskCount++;
-            }
-        }
     });
 
     const tasksCount = baseKeys.size;
-    const unguidedPassRate = unguidedTaskCount > 0 ? Math.round(unguidedTaskRatesSum / unguidedTaskCount) : 0;
-    const guidedPassRate = guidedTaskCount > 0 ? Math.round(guidedTaskRatesSum / guidedTaskCount) : 0;
+    const unguidedPassRate = totalUnguidedChecks > 0 ? Math.round((totalUnguidedPassed / totalUnguidedChecks) * 100) : 0;
+    const guidedPassRate = totalGuidedChecks > 0 ? Math.round((totalGuidedPassed / totalGuidedChecks) * 100) : 0;
     const toolActivationRate = tasksCount > 0 ? Math.round((tasksWithTools.size / tasksCount) * 100) : 0;
     const guideUsageRate = tasksCount > 0 ? Math.round((tasksWithGuides.size / tasksCount) * 100) : 0;
 

--- a/eval-view/dumbbell-chart.js
+++ b/eval-view/dumbbell-chart.js
@@ -10,6 +10,7 @@ export class DumbbellChart {
       title: options.title || '',
       hideZeros: options.hideZeros || false,
       height: options.height || null,
+      maxHeight: options.maxHeight || null,
       hideSeparators: options.hideSeparators || false,
       hideLabels: options.hideLabels || false,
       ...options

--- a/eval-view/dumbbell-chart.js
+++ b/eval-view/dumbbell-chart.js
@@ -90,38 +90,34 @@ export class DumbbellChart {
 
     const featureNames = Object.keys(groups).sort();
     
-    // Calculate total height dynamically based on the number of stacked dumbbells per feature
-    let totalHeight = this.options.margin.top;
+    // Calculate natural CONTENT height (excluding margins)
+    let naturalContentHeight = 0;
     featureNames.forEach(f => {
         const count = groups[f].length;
-        totalHeight += this.options.rowHeight + (count - 1) * offsetStep;
+        naturalContentHeight += this.options.rowHeight + (count - 1) * offsetStep;
     });
-    totalHeight += this.options.margin.bottom;
 
-    if (this.options.maxHeight && totalHeight > this.options.maxHeight) {
-        const available = this.options.maxHeight - this.options.margin.top - this.options.margin.bottom;
-        const natural = totalHeight - this.options.margin.top - this.options.margin.bottom;
-        if (natural > 0) {
-            const factor = available / natural;
-            this.options.rowHeight *= factor;
-            offsetStep *= factor;
-            totalHeight = this.options.maxHeight;
-        }
+    const verticalMargins = this.options.margin.top + this.options.margin.bottom;
+    let totalNaturalHeight = verticalMargins + naturalContentHeight;
+    let finalSvgHeight = totalNaturalHeight;
+
+    if (this.options.maxHeight && totalNaturalHeight > this.options.maxHeight && naturalContentHeight > 0) {
+        const availableContentHeight = this.options.maxHeight - verticalMargins;
+        const compressionFactor = availableContentHeight / naturalContentHeight;
+        this.options.rowHeight *= compressionFactor;
+        offsetStep *= compressionFactor;
+        finalSvgHeight = this.options.maxHeight;
     }
 
-    const height = totalHeight;
+    // If an explicit height is passed (like dashboard), use it. Otherwise use our tightly bounded finalSvgHeight.
+    const height = this.options.height || finalSvgHeight;
 
     this.svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     this.svg.setAttribute("width", "100%");
-    let svgHeight = this.options.height || height;
-    const cWidth = this.container.clientWidth;
-    if (cWidth > 0 && cWidth < width) {
-        svgHeight = Math.min(svgHeight, cWidth * (height / width));
-    }
-    this.svg.setAttribute("height", svgHeight.toString());
+    this.svg.setAttribute("height", `${height}px`);
     this.svg.setAttribute("viewBox", `0 0 ${width} ${height}`);
-    // If fixed height is forced, we want it to stretch to fill it!
-    this.svg.setAttribute("preserveAspectRatio", this.options.height ? "none" : "xMidYMin meet");
+    // If we have a maxHeight constraint (like tooltip), use 'none' so it locks to width without downscaling. Otherwise use meet.
+    this.svg.setAttribute("preserveAspectRatio", (this.options.maxHeight || this.options.height) ? "none" : "xMidYMin meet");
     
     // Add Gradients in defs
     const defs = document.createElementNS("http://www.w3.org/2000/svg", "defs");

--- a/eval-view/dumbbell-chart.js
+++ b/eval-view/dumbbell-chart.js
@@ -113,7 +113,12 @@ export class DumbbellChart {
 
     this.svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
     this.svg.setAttribute("width", "100%");
-    this.svg.setAttribute("height", this.options.height || height);
+    let svgHeight = this.options.height || height;
+    const cWidth = this.container.clientWidth;
+    if (cWidth > 0 && cWidth < width) {
+        svgHeight = Math.min(svgHeight, cWidth * (height / width));
+    }
+    this.svg.setAttribute("height", svgHeight.toString());
     this.svg.setAttribute("viewBox", `0 0 ${width} ${height}`);
     // If fixed height is forced, we want it to stretch to fill it!
     this.svg.setAttribute("preserveAspectRatio", this.options.height ? "none" : "xMidYMin meet");

--- a/eval-view/dumbbell-chart.js
+++ b/eval-view/dumbbell-chart.js
@@ -32,7 +32,7 @@ export class DumbbellChart {
   }
 
   render(data) {
-    const offsetStep = 8;
+    let offsetStep = 8;
     this.init();
 
     const labels = data.labels || [];
@@ -97,6 +97,17 @@ export class DumbbellChart {
         totalHeight += this.options.rowHeight + (count - 1) * offsetStep;
     });
     totalHeight += this.options.margin.bottom;
+
+    if (this.options.maxHeight && totalHeight > this.options.maxHeight) {
+        const available = this.options.maxHeight - this.options.margin.top - this.options.margin.bottom;
+        const natural = totalHeight - this.options.margin.top - this.options.margin.bottom;
+        if (natural > 0) {
+            const factor = available / natural;
+            this.options.rowHeight *= factor;
+            offsetStep *= factor;
+            totalHeight = this.options.maxHeight;
+        }
+    }
 
     const height = totalHeight;
 

--- a/eval-view/landing.css
+++ b/eval-view/landing.css
@@ -85,6 +85,7 @@
   transition: background-color 0.2s;
 }
 
+/* Stretched link: expands the clickable area of the first column's <a> tag to cover the entire row (<tr>). */
 .suite-link::after {
   content: '';
   position: absolute;

--- a/eval-view/landing.css
+++ b/eval-view/landing.css
@@ -64,20 +64,18 @@
 }
 
 .insight-dumbbell-track {
-  height: 10px;
+  height: 4px;
   background: var(--border-color);
-  border-radius: 5px;
+  border-radius: 2px;
   position: relative;
-  padding: 1px;
   width: 130px;
 }
 
 .suite-dumbbell-track {
-  height: 12px;
+  height: 4px;
   background: var(--border-color);
-  border-radius: 6px;
+  border-radius: 2px;
   position: relative;
-  padding: 2px;
 }
 
 .suites-table {

--- a/eval-view/landing.css
+++ b/eval-view/landing.css
@@ -645,6 +645,11 @@
   display: block;
 }
 
+#tooltip-chart {
+  max-height: 300px;
+  overflow-y: auto;
+}
+
 .tooltip-title {
   font-size: 0.9em;
   font-weight: 700;

--- a/eval-view/landing.css
+++ b/eval-view/landing.css
@@ -85,6 +85,10 @@
   transition: background-color 0.2s;
 }
 
+.suite-table-row.faulty {
+  opacity: 0.2;
+}
+
 /* Stretched link: expands the clickable area of the first column's <a> tag to cover the entire row (<tr>). */
 .suite-link::after {
   content: '';

--- a/eval-view/landing.css
+++ b/eval-view/landing.css
@@ -58,6 +58,20 @@
   background: rgba(255, 255, 255, 0.05);
 }
 
+.insight-dumbbell-cell {
+  width: 150px;
+  vertical-align: middle;
+}
+
+.insight-dumbbell-track {
+  height: 10px;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 5px;
+  position: relative;
+  padding: 1px;
+  width: 130px;
+}
+
 .suites-table {
   width: 100%;
   border-collapse: collapse;

--- a/eval-view/landing.css
+++ b/eval-view/landing.css
@@ -65,11 +65,19 @@
 
 .insight-dumbbell-track {
   height: 10px;
-  background: rgba(255, 255, 255, 0.05);
+  background: var(--border-color);
   border-radius: 5px;
   position: relative;
   padding: 1px;
   width: 130px;
+}
+
+.suite-dumbbell-track {
+  height: 12px;
+  background: var(--border-color);
+  border-radius: 6px;
+  position: relative;
+  padding: 2px;
 }
 
 .suites-table {

--- a/eval-view/landing.css
+++ b/eval-view/landing.css
@@ -623,11 +623,11 @@
   position: fixed;
   z-index: 2000;
   max-width: 300px;
-  background: rgba(13, 17, 23, 0.95);
+  background: var(--card-bg);
   backdrop-filter: blur(8px);
   border: 1px solid var(--border-color);
   border-radius: 12px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.15);
   pointer-events: none;
   padding: 15px;
   transition: opacity 0.2s ease, transform 0.2s ease;

--- a/eval-view/landing.css
+++ b/eval-view/landing.css
@@ -76,9 +76,23 @@
   text-align: center;
 }
 
+.suite-table-row {
+  position: relative;
+}
+
 .suite-table-row:hover {
   background-color: var(--bg-tertiary);
   transition: background-color 0.2s;
+}
+
+.suite-link::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1;
 }
 
 .header-filter-select {

--- a/eval-view/landing.css
+++ b/eval-view/landing.css
@@ -646,8 +646,8 @@
 }
 
 #tooltip-chart {
-  max-height: 300px;
-  overflow-y: auto;
+  max-height: 250px;
+  overflow: hidden;
 }
 
 .tooltip-title {

--- a/eval-view/landing.css
+++ b/eval-view/landing.css
@@ -78,6 +78,70 @@
   position: relative;
 }
 
+.agent-badge {
+  margin-right: 4px;
+}
+.agent-badge.gemini {
+  color: #8B5CF6;
+}
+.agent-badge.openai {
+  color: #10A37F;
+}
+.agent-badge.claude {
+  color: #E06A3B;
+}
+
+.insight-dumbbell-track .dot,
+.suite-dumbbell-track .dot {
+  position: absolute;
+  border-radius: 50%;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.insight-dumbbell-track .dot.unguided,
+.suite-dumbbell-track .dot.unguided {
+  border: 1.5px solid #8b949e;
+  background: transparent;
+}
+
+.insight-dumbbell-track .dot.guided,
+.suite-dumbbell-track .dot.guided {
+  background: var(--color-primary);
+}
+
+.insight-dumbbell-track .connector,
+.suite-dumbbell-track .connector {
+  position: absolute;
+  background: var(--color-primary);
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.insight-dumbbell-track .dot.unguided {
+  width: 4px;
+  height: 4px;
+}
+.insight-dumbbell-track .dot.guided {
+  width: 6px;
+  height: 6px;
+}
+.insight-dumbbell-track .connector {
+  height: 1.5px;
+}
+
+.suite-dumbbell-track .dot.unguided {
+  width: 6px;
+  height: 6px;
+}
+.suite-dumbbell-track .dot.guided {
+  width: 8px;
+  height: 8px;
+}
+.suite-dumbbell-track .connector {
+  height: 2px;
+}
+
 .suites-table {
   width: 100%;
   border-collapse: collapse;

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -505,8 +505,8 @@ function renderSuites() {
         const gStats = calculateGroupTotalStats(results, 'guided');
         const uStats = calculateGroupTotalStats(results, 'unguided');
 
-        const gRate = gStats.rate;
-        const uRate = uStats.rate;
+        const gRate = gStats.total > 0 ? Math.round((gStats.passed / gStats.total) * 100) : 0;
+        const uRate = uStats.total > 0 ? Math.round((uStats.passed / uStats.total) * 100) : 0;
 
         const localLink = `dashboard.html?testId=${testId}&source=${testInfo.source}`;
         const timeAgoStr = timeAgo(_date);
@@ -723,33 +723,23 @@ function getAgentBadge(agentName) {
 }
 
 function calculateGroupTotalStats(results, groupType) {
-    let globalPassed = 0;
-    let globalTotal = 0;
-    let taskRatesSum = 0;
-    let taskCount = 0;
+    let passed = 0;
+    let total = 0;
 
-    if (!results) return { passed: 0, total: 0, rate: 0 };
+    if (!results) return { passed, total }; // Guard against missing results
 
     Object.keys(results).forEach(key => {
+        // key format: "scenario - prompt - agent"
         if (key.endsWith(` - ${groupType}`)) {
-            let taskPassed = 0;
-            let taskTotal = 0;
             results[key].forEach(run => {
                 const s = getRunStats(run.results);
-                taskPassed += s.passed;
-                taskTotal += s.total;
-                globalPassed += s.passed;
-                globalTotal += s.total;
+                passed += s.passed;
+                total += s.total;
             });
-            if (taskTotal > 0) {
-                taskRatesSum += (taskPassed / taskTotal) * 100;
-                taskCount++;
-            }
         }
     });
 
-    const rate = taskCount > 0 ? Math.round(taskRatesSum / taskCount) : 0;
-    return { passed: globalPassed, total: globalTotal, rate };
+    return { passed, total };
 }
 
 function getSortedTestIds() {
@@ -776,8 +766,8 @@ function renderPivotInsights() {
         const data = testInfo.data;
         const gStats = calculateGroupTotalStats(data.results, 'guided');
         const uStats = calculateGroupTotalStats(data.results, 'unguided');
-        const gRate = gStats.rate;
-        const uRate = uStats.rate;
+        const gRate = gStats.total > 0 ? Math.round((gStats.passed / gStats.total) * 100) : 0;
+        const uRate = uStats.total > 0 ? Math.round((uStats.passed / uStats.total) * 100) : 0;
         const uplift = gRate - uRate;
 
         if (!grouped.agent[testInfo.agent]) grouped.agent[testInfo.agent] = [];

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -611,7 +611,7 @@ function showTooltipChart(testInfo, x, y, compoundKey) {
 
     if (!tooltipChartInstance) {
         tooltipChartInstance = new DumbbellChart('tooltip-chart', {
-            size: 400, rowHeight: 20, margin: { top: 15, right: 15, bottom: 15, left: 15 }, hideLegend: true, hideLabels: true, hideSeparators: true, hideZeros: true, hideAxes: true
+            size: 400, maxHeight: 250, rowHeight: 20, margin: { top: 15, right: 15, bottom: 15, left: 15 }, hideLegend: true, hideLabels: true, hideSeparators: true, hideZeros: true, hideAxes: true
         });
     }
 

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -518,24 +518,28 @@ function renderSuites() {
         scenarioKeys.forEach(k => { if (data.results[k].length > maxRuns) maxRuns = data.results[k].length; });
 
         html += `
-            <tr class="suite-table-row" onclick="window.location.href='${localLink}'" style="cursor: pointer;">
+            <tr class="suite-table-row">
                 <td style="text-align: left; font-weight: 600;">
-                    <div style="color: var(--text-primary); font-size: 0.95rem;">${testId}</div>
-                    <div style="font-size: 0.8rem; font-weight: 400; color: var(--text-secondary); margin-top: 4px;">${timeAgoStr} • <span style="font-size: 0.75rem;">${displayTimestamp}</span></div>
+                    <a href="${localLink}" class="suite-link" style="color: inherit; text-decoration: none;">
+                        <div style="color: var(--text-primary); font-size: 0.95rem;">${testId}</div>
+                        <div style="font-size: 0.8rem; font-weight: 400; color: var(--text-secondary); margin-top: 4px;">${timeAgoStr} • <span style="font-size: 0.75rem;">${displayTimestamp}</span></div>
+                    </a>
                 </td>
                 <td>${testInfo.agent}</td>
                 <td>${servingDisplayNames[testInfo.serving] || testInfo.serving}</td>
                 <td style="font-size: 0.85rem; color: var(--text-secondary); word-break: break-word; width: 120px;">${escapeHtml(testInfo.model).replaceAll('-', '-&shy;')}</td>
                 <td style="font-weight: 600;">${taskCount} ${maxRuns > 1 ? `<span style="color: var(--text-secondary); font-size: 0.8rem; font-weight: 400;">×${maxRuns}</span>` : ''}</td>
-                <td class="uplift-cell" data-compound-key="${compoundKey}" style="width: 200px; padding: 10px 15px; vertical-align: middle;">
-                    <div style="height: 12px; background: rgba(255,255,255,0.05); border-radius: 6px; position: relative; padding: 2px;">
-                        <div style="position: absolute; left: calc(${uRate}% - 3px); width: 6px; height: 6px; border: 1.5px solid #8b949e; background: transparent; border-radius: 50%; top: 50%; transform: translateY(-50%);"></div>
-                        <div style="position: absolute; left: calc(${gRate}% - 4px); width: 8px; height: 8px; background: var(--color-primary); border-radius: 50%; top: 50%; transform: translateY(-50%);"></div>
-                        <div style="position: absolute; left: calc(${Math.min(uRate, gRate)}% + 2px); width: calc(${Math.abs(gRate - uRate)}% - 4px); height: 2px; background: var(--color-primary); top: 50%; transform: translateY(-50%);"></div>
-                    </div>
-                    <div style="font-size: 0.85rem; color: var(--text-secondary); margin-top: 4px; text-align: center;">
-                        <span style="font-weight: bold; color: var(--text-primary);">${gRate - uRate >= 0 ? '+' : ''}${gRate - uRate}%</span>
-                    </div>
+                <td class="uplift-cell" data-compound-key="${compoundKey}" style="width: 200px; padding: 0; vertical-align: middle; position: relative; z-index: 2;">
+                    <a href="${localLink}" style="display: block; color: inherit; text-decoration: none; padding: 10px 15px;">
+                        <div style="height: 12px; background: rgba(255,255,255,0.05); border-radius: 6px; position: relative; padding: 2px;">
+                            <div style="position: absolute; left: calc(${uRate}% - 3px); width: 6px; height: 6px; border: 1.5px solid #8b949e; background: transparent; border-radius: 50%; top: 50%; transform: translateY(-50%);"></div>
+                            <div style="position: absolute; left: calc(${gRate}% - 4px); width: 8px; height: 8px; background: var(--color-primary); border-radius: 50%; top: 50%; transform: translateY(-50%);"></div>
+                            <div style="position: absolute; left: calc(${Math.min(uRate, gRate)}% + 2px); width: calc(${Math.abs(gRate - uRate)}% - 4px); height: 2px; background: var(--color-primary); top: 50%; transform: translateY(-50%);"></div>
+                        </div>
+                        <div style="font-size: 0.85rem; color: var(--text-secondary); margin-top: 4px; text-align: center;">
+                            <span style="font-weight: bold; color: var(--text-primary);">${gRate - uRate >= 0 ? '+' : ''}${gRate - uRate}%</span>
+                        </div>
+                    </a>
                 </td>
                 ${isRemoteDashboard() ? '' : `<td style="text-transform: capitalize;">${testInfo.source}</td>`}
             </tr>

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -505,8 +505,8 @@ function renderSuites() {
         const gStats = calculateGroupTotalStats(results, 'guided');
         const uStats = calculateGroupTotalStats(results, 'unguided');
 
-        const gRate = gStats.total > 0 ? Math.round((gStats.passed / gStats.total) * 100) : 0;
-        const uRate = uStats.total > 0 ? Math.round((uStats.passed / uStats.total) * 100) : 0;
+        const gRate = gStats.rate;
+        const uRate = uStats.rate;
 
         const localLink = `dashboard.html?testId=${testId}&source=${testInfo.source}`;
         const timeAgoStr = timeAgo(_date);
@@ -723,23 +723,33 @@ function getAgentBadge(agentName) {
 }
 
 function calculateGroupTotalStats(results, groupType) {
-    let passed = 0;
-    let total = 0;
+    let globalPassed = 0;
+    let globalTotal = 0;
+    let taskRatesSum = 0;
+    let taskCount = 0;
 
-    if (!results) return { passed, total }; // Guard against missing results
+    if (!results) return { passed: 0, total: 0, rate: 0 };
 
     Object.keys(results).forEach(key => {
-        // key format: "scenario - prompt - agent"
         if (key.endsWith(` - ${groupType}`)) {
+            let taskPassed = 0;
+            let taskTotal = 0;
             results[key].forEach(run => {
                 const s = getRunStats(run.results);
-                passed += s.passed;
-                total += s.total;
+                taskPassed += s.passed;
+                taskTotal += s.total;
+                globalPassed += s.passed;
+                globalTotal += s.total;
             });
+            if (taskTotal > 0) {
+                taskRatesSum += (taskPassed / taskTotal) * 100;
+                taskCount++;
+            }
         }
     });
 
-    return { passed, total };
+    const rate = taskCount > 0 ? Math.round(taskRatesSum / taskCount) : 0;
+    return { passed: globalPassed, total: globalTotal, rate };
 }
 
 function getSortedTestIds() {
@@ -766,8 +776,8 @@ function renderPivotInsights() {
         const data = testInfo.data;
         const gStats = calculateGroupTotalStats(data.results, 'guided');
         const uStats = calculateGroupTotalStats(data.results, 'unguided');
-        const gRate = gStats.total > 0 ? Math.round((gStats.passed / gStats.total) * 100) : 0;
-        const uRate = uStats.total > 0 ? Math.round((uStats.passed / uStats.total) * 100) : 0;
+        const gRate = gStats.rate;
+        const uRate = uStats.rate;
         const uplift = gRate - uRate;
 
         if (!grouped.agent[testInfo.agent]) grouped.agent[testInfo.agent] = [];

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -537,9 +537,9 @@ function renderSuites() {
                 <td class="uplift-cell" data-compound-key="${compoundKey}" style="width: 200px; padding: 0; vertical-align: middle; position: relative; z-index: 2;">
                     <a href="${localLink}" style="display: block; color: inherit; text-decoration: none; padding: 10px 15px;">
                         <div class="suite-dumbbell-track">
-                            <div style="position: absolute; left: calc(${uRate}% - 3px); width: 6px; height: 6px; border: 1.5px solid #8b949e; background: transparent; border-radius: 50%; top: 50%; transform: translateY(-50%);"></div>
-                            <div style="position: absolute; left: calc(${gRate}% - 4px); width: 8px; height: 8px; background: var(--color-primary); border-radius: 50%; top: 50%; transform: translateY(-50%);"></div>
-                            <div style="position: absolute; left: calc(${Math.min(uRate, gRate)}% + 2px); width: calc(${Math.abs(gRate - uRate)}% - 4px); height: 2px; background: var(--color-primary); top: 50%; transform: translateY(-50%);"></div>
+                            <div class="connector" style="left: calc(${Math.min(uRate, gRate)}% + 2px); width: calc(${Math.abs(gRate - uRate)}% - 4px);"></div>
+                            <div class="dot unguided" style="left: calc(${uRate}% - 3px);"></div>
+                            <div class="dot guided" style="left: calc(${gRate}% - 4px);"></div>
                         </div>
                         <div style="font-size: 0.85rem; color: var(--text-secondary); margin-top: 4px; text-align: center;">
                             <span style="font-weight: bold; color: var(--text-primary);">${gRate - uRate >= 0 ? '+' : ''}${gRate - uRate}%</span>
@@ -711,13 +711,13 @@ function formatSuiteLabel(testInfo) {
 function getAgentBadge(agentName) {
     const name = (agentName || '').toLowerCase();
     if (name.includes('gemini') || name.includes('jetski')) {
-        return '<span style="color: #8B5CF6; margin-right: 4px;">✦</span>';
+        return '<span class="agent-badge gemini">✦</span>';
     }
     if (name.includes('codex') || name.includes('openai')) {
-        return '<span style="color: #10A37F; margin-right: 4px;">❂</span>';
+        return '<span class="agent-badge openai">❂</span>';
     }
     if (name.includes('claude')) {
-        return '<span style="color: #E06A3B; margin-right: 4px;">✱</span>';
+        return '<span class="agent-badge claude">✱</span>';
     }
     return '';
 }
@@ -804,9 +804,9 @@ function renderPivotInsights() {
                     </td>
                     <td class="insight-dumbbell-cell">
                         <div class="insight-dumbbell-track">
-                            <div style="position: absolute; left: calc(${uRate}% - 2px); width: 4px; height: 4px; border: 1px solid #8b949e; background: transparent; border-radius: 50%; top: 50%; transform: translateY(-50%);"></div>
-                            <div style="position: absolute; left: calc(${gRate}% - 3px); width: 6px; height: 6px; background: var(--color-primary); border-radius: 50%; top: 50%; transform: translateY(-50%);"></div>
-                            <div style="position: absolute; left: calc(${Math.min(uRate, gRate)}% + 1px); width: calc(${Math.abs(gRate - uRate)}% - 2px); height: 1.5px; background: var(--color-primary); top: 50%; transform: translateY(-50%);"></div>
+                            <div class="connector" style="left: calc(${Math.min(uRate, gRate)}% + 1px); width: calc(${Math.abs(gRate - uRate)}% - 2px);"></div>
+                            <div class="dot unguided" style="left: calc(${uRate}% - 2px);"></div>
+                            <div class="dot guided" style="left: calc(${gRate}% - 3px);"></div>
                         </div>
                         <div style="font-size: 0.8rem; color: var(--text-secondary); text-align: center; margin-top: 2px;">${medUplift >= 0 ? '+' : ''}${medUplift}%</div>
                     </td>

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -527,7 +527,7 @@ function renderSuites() {
                 <td style="text-align: left; font-weight: 600;">
                     <a href="${localLink}" class="suite-link" style="color: inherit; text-decoration: none;">
                         <div style="color: var(--text-primary); font-size: 0.95rem;" title="${escapeHtml(testId)}">${escapeHtml(label)}</div>
-                        <div style="font-size: 0.8rem; font-weight: 400; color: var(--text-secondary); margin-top: 4px;">${timeAgoStr} • <span style="font-size: 0.75rem;">${displayTimestamp}</span>${ldap ? ` • <span style="font-weight: 600;">${escapeHtml(ldap)}</span>` : ''}</div>
+                        <div style="font-size: 0.8rem; font-weight: 400; color: var(--text-secondary); margin-top: 4px;">${timeAgoStr} • <span style="font-size: 0.75rem;">${displayTimestamp}</span>${ldap ? ` • <span>${escapeHtml(ldap)}</span>` : ''}</div>
                     </a>
                 </td>
                 <td>${testInfo.agent}</td>

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -614,7 +614,7 @@ function showTooltipChart(testInfo, x, y, compoundKey) {
 
     if (!tooltipChartInstance) {
         tooltipChartInstance = new DumbbellChart('tooltip-chart', {
-            size: 400, maxHeight: 250, rowHeight: 20, margin: { top: 15, right: 15, bottom: 15, left: 15 }, hideLegend: true, hideLabels: true, hideSeparators: true, hideZeros: true, hideAxes: true
+            size: 270, maxHeight: 250, rowHeight: 20, margin: { top: 15, right: 15, bottom: 15, left: 15 }, hideLegend: true, hideLabels: true, hideSeparators: true, hideZeros: true, hideAxes: true
         });
     }
 

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -530,7 +530,7 @@ function renderSuites() {
                         <div style="font-size: 0.8rem; font-weight: 400; color: var(--text-secondary); margin-top: 4px;">${timeAgoStr} • <span style="font-size: 0.75rem;">${displayTimestamp}</span>${ldap ? ` • <span>${escapeHtml(ldap)}</span>` : ''}</div>
                     </a>
                 </td>
-                <td>${testInfo.agent}</td>
+                <td>${getAgentBadge(testInfo.agent)}${escapeHtml(testInfo.agent)}</td>
                 <td>${servingDisplayNames[testInfo.serving] || testInfo.serving}</td>
                 <td style="font-size: 0.85rem; color: var(--text-secondary); word-break: break-word; width: 120px;">${escapeHtml(testInfo.model).replaceAll('-', '-&shy;')}</td>
                 <td style="font-weight: 600;">${taskCount} ${maxRuns > 1 ? `<span style="color: var(--text-secondary); font-size: 0.8rem; font-weight: 400;">×${maxRuns}</span>` : ''}</td>
@@ -706,6 +706,20 @@ function formatSuiteLabel(testInfo) {
     }
     
     return { label: finalLabel, ldap };
+}
+
+function getAgentBadge(agentName) {
+    const name = (agentName || '').toLowerCase();
+    if (name.includes('gemini') || name.includes('jetski')) {
+        return '<span style="color: #8B5CF6; margin-right: 4px;">✦</span>';
+    }
+    if (name.includes('codex') || name.includes('openai')) {
+        return '<span style="color: #10A37F; margin-right: 4px;">❂</span>';
+    }
+    if (name.includes('claude')) {
+        return '<span style="color: #E06A3B; margin-right: 4px;">✱</span>';
+    }
+    return '';
 }
 
 function calculateGroupTotalStats(results, groupType) {

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -611,7 +611,7 @@ function showTooltipChart(testInfo, x, y, compoundKey) {
 
     if (!tooltipChartInstance) {
         tooltipChartInstance = new DumbbellChart('tooltip-chart', {
-            size: 400, height: 300, rowHeight: 20, margin: { top: 15, right: 15, bottom: 15, left: 15 }, hideLegend: true, hideLabels: true, hideSeparators: true, hideZeros: true, hideAxes: true
+            size: 400, rowHeight: 20, margin: { top: 15, right: 15, bottom: 15, left: 15 }, hideLegend: true, hideLabels: true, hideSeparators: true, hideZeros: true, hideAxes: true
         });
     }
 

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -524,7 +524,7 @@ function renderSuites() {
             <tr class="suite-table-row ${isFaulty ? 'faulty' : ''}">
                 <td style="text-align: left; font-weight: 600;">
                     <a href="${localLink}" class="suite-link" style="color: inherit; text-decoration: none;">
-                        <div style="color: var(--text-primary); font-size: 0.95rem;">${testId}</div>
+                        <div style="color: var(--text-primary); font-size: 0.95rem;" title="${escapeHtml(testId)}">${escapeHtml(formatSuiteLabel(testInfo))}</div>
                         <div style="font-size: 0.8rem; font-weight: 400; color: var(--text-secondary); margin-top: 4px;">${timeAgoStr} • <span style="font-size: 0.75rem;">${displayTimestamp}</span></div>
                     </a>
                 </td>
@@ -662,6 +662,44 @@ function hideTooltipChart() {
 // HELPERS
 // ==========================================
 
+function formatSuiteLabel(testInfo) {
+    const { testId, agent, serving } = testInfo;
+    if (!testId) return 'Evaluation Run';
+
+    const timeRegex = /[-_]?\b\d{4}-\d{2}-\d{2}(?:[T_]\d{2}-\d{2}-\d{2})?\b[-_]?/;
+    const parts = testId.split(timeRegex);
+    
+    let prefix = parts[0] || '';
+    let suffix = parts[1] || '';
+    
+    prefix = prefix.replace(/^[-_]+|[-_]+$/g, '');
+    suffix = suffix.replace(/^[-_]+|[-_]+$/g, '');
+    
+    let runType = prefix || 'Evaluation Run';
+    runType = runType.split('-').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+    
+    if (!suffix) return runType;
+    
+    const normalize = s => (s || '').toLowerCase().replace(/[-_]+/g, '');
+    const normAgent = normalize(agent);
+    const normServing = normalize(serving);
+    
+    const suffixParts = suffix.split('-');
+    const meaningfulParts = suffixParts.filter(part => {
+        const normPart = normalize(part);
+        if (normPart === normAgent || normPart === normServing) return false;
+        if (normPart === 'cli' || normPart === 'run') return false;
+        return true;
+    });
+    
+    if (meaningfulParts.length > 0) {
+        const userOrTag = meaningfulParts.join('-');
+        return `${runType} • ${userOrTag}`;
+    }
+    
+    return runType;
+}
+
 function calculateGroupTotalStats(results, groupType) {
     let passed = 0;
     let total = 0;
@@ -742,8 +780,8 @@ function renderPivotInsights() {
                         <div style="font-weight: 600;">${filterKey === 'serving' ? (servingDisplayNames[key] || key) : key}</div>
                         <div style="font-size: 0.75rem; color: var(--text-secondary);">${items.length} trials</div>
                     </td>
-                    <td style="width: 120px; vertical-align: middle;">
-                        <div style="height: 10px; background: rgba(255,255,255,0.05); border-radius: 5px; position: relative; padding: 1px; width: 100px;">
+                    <td class="insight-dumbbell-cell">
+                        <div class="insight-dumbbell-track">
                             <div style="position: absolute; left: calc(${uRate}% - 2px); width: 4px; height: 4px; border: 1px solid #8b949e; background: transparent; border-radius: 50%; top: 50%; transform: translateY(-50%);"></div>
                             <div style="position: absolute; left: calc(${gRate}% - 3px); width: 6px; height: 6px; background: var(--color-primary); border-radius: 50%; top: 50%; transform: translateY(-50%);"></div>
                             <div style="position: absolute; left: calc(${Math.min(uRate, gRate)}% + 1px); width: calc(${Math.abs(gRate - uRate)}% - 2px); height: 1.5px; background: var(--color-primary); top: 50%; transform: translateY(-50%);"></div>

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -536,7 +536,7 @@ function renderSuites() {
                 <td style="font-weight: 600;">${taskCount} ${maxRuns > 1 ? `<span style="color: var(--text-secondary); font-size: 0.8rem; font-weight: 400;">×${maxRuns}</span>` : ''}</td>
                 <td class="uplift-cell" data-compound-key="${compoundKey}" style="width: 200px; padding: 0; vertical-align: middle; position: relative; z-index: 2;">
                     <a href="${localLink}" style="display: block; color: inherit; text-decoration: none; padding: 10px 15px;">
-                        <div style="height: 12px; background: rgba(255,255,255,0.05); border-radius: 6px; position: relative; padding: 2px;">
+                        <div class="suite-dumbbell-track">
                             <div style="position: absolute; left: calc(${uRate}% - 3px); width: 6px; height: 6px; border: 1.5px solid #8b949e; background: transparent; border-radius: 50%; top: 50%; transform: translateY(-50%);"></div>
                             <div style="position: absolute; left: calc(${gRate}% - 4px); width: 8px; height: 8px; background: var(--color-primary); border-radius: 50%; top: 50%; transform: translateY(-50%);"></div>
                             <div style="position: absolute; left: calc(${Math.min(uRate, gRate)}% + 2px); width: calc(${Math.abs(gRate - uRate)}% - 4px); height: 2px; background: var(--color-primary); top: 50%; transform: translateY(-50%);"></div>

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -517,8 +517,11 @@ function renderSuites() {
         let maxRuns = 1;
         scenarioKeys.forEach(k => { if (data.results[k].length > maxRuns) maxRuns = data.results[k].length; });
 
+        const earlyFailureRate = data.summary?.unguidedEarlyFailureRate || 0;
+        const isFaulty = earlyFailureRate === 100;
+
         html += `
-            <tr class="suite-table-row">
+            <tr class="suite-table-row ${isFaulty ? 'faulty' : ''}">
                 <td style="text-align: left; font-weight: 600;">
                     <a href="${localLink}" class="suite-link" style="color: inherit; text-decoration: none;">
                         <div style="color: var(--text-primary); font-size: 0.95rem;">${testId}</div>

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -520,12 +520,14 @@ function renderSuites() {
         const earlyFailureRate = data.summary?.unguidedEarlyFailureRate || 0;
         const isFaulty = earlyFailureRate === 100;
 
+        const { label, ldap } = formatSuiteLabel(testInfo);
+
         html += `
             <tr class="suite-table-row ${isFaulty ? 'faulty' : ''}">
                 <td style="text-align: left; font-weight: 600;">
                     <a href="${localLink}" class="suite-link" style="color: inherit; text-decoration: none;">
-                        <div style="color: var(--text-primary); font-size: 0.95rem;" title="${escapeHtml(testId)}">${escapeHtml(formatSuiteLabel(testInfo))}</div>
-                        <div style="font-size: 0.8rem; font-weight: 400; color: var(--text-secondary); margin-top: 4px;">${timeAgoStr} • <span style="font-size: 0.75rem;">${displayTimestamp}</span></div>
+                        <div style="color: var(--text-primary); font-size: 0.95rem;" title="${escapeHtml(testId)}">${escapeHtml(label)}</div>
+                        <div style="font-size: 0.8rem; font-weight: 400; color: var(--text-secondary); margin-top: 4px;">${timeAgoStr} • <span style="font-size: 0.75rem;">${displayTimestamp}</span>${ldap ? ` • <span style="font-weight: 600;">${escapeHtml(ldap)}</span>` : ''}</div>
                     </a>
                 </td>
                 <td>${testInfo.agent}</td>
@@ -664,7 +666,7 @@ function hideTooltipChart() {
 
 function formatSuiteLabel(testInfo) {
     const { testId, agent, serving } = testInfo;
-    if (!testId) return 'Evaluation Run';
+    if (!testId) return { label: 'evaluation-run', ldap: '' };
 
     const timeRegex = /[-_]?\b\d{4}-\d{2}-\d{2}(?:[T_]\d{2}-\d{2}-\d{2})?\b[-_]?/;
     const parts = testId.split(timeRegex);
@@ -675,29 +677,35 @@ function formatSuiteLabel(testInfo) {
     prefix = prefix.replace(/^[-_]+|[-_]+$/g, '');
     suffix = suffix.replace(/^[-_]+|[-_]+$/g, '');
     
-    let runType = prefix || 'Evaluation Run';
-    runType = runType.split('-').map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+    const label = prefix || 'evaluation-run';
     
-    if (!suffix) return runType;
+    if (!suffix) return { label, ldap: '' };
     
     const normalize = s => (s || '').toLowerCase().replace(/[-_]+/g, '');
     const normAgent = normalize(agent);
     const normServing = normalize(serving);
     
     const suffixParts = suffix.split('-');
-    const meaningfulParts = suffixParts.filter(part => {
+    let ldap = '';
+    const otherTags = [];
+    
+    suffixParts.forEach(part => {
         const normPart = normalize(part);
-        if (normPart === normAgent || normPart === normServing) return false;
-        if (normPart === 'cli' || normPart === 'run') return false;
-        return true;
+        if (normPart === normAgent || normPart === normServing) return;
+        if (normPart === 'cli' || normPart === 'run' || normPart === 'skills') return;
+        otherTags.push(part);
     });
     
-    if (meaningfulParts.length > 0) {
-        const userOrTag = meaningfulParts.join('-');
-        return `${runType} • ${userOrTag}`;
+    if (otherTags.length > 0) {
+        ldap = otherTags.pop();
     }
     
-    return runType;
+    let finalLabel = label;
+    if (otherTags.length > 0) {
+        finalLabel += '-' + otherTags.join('-');
+    }
+    
+    return { label: finalLabel, ldap };
 }
 
 function calculateGroupTotalStats(results, groupType) {


### PR DESCRIPTION
because i want to rightclick/ctrlclick rows in the dashboard

* **Semantic Navigation**: Converted table rows from inline `onclick` handlers to standard `<a>` tags with stretched links (`::after`), enabling native browser behaviors like Cmd+Click for new tabs.
* **Information Architecture**: Simplified verbose suite IDs into scannable `[Run Type] • [LDAP]` display labels and injected Unicode brand logos (`✦`, `❂`, `✱`) for Gemini, OpenAI, and Claude.
* **DataViz Alignment**: Eliminated SVG scaling distortion in dumbbell tooltips by bounding canvas height and applying `preserveAspectRatio="none"`. Corrected sparkline dot centering (`translateX(-50%)`) and range bar connection offsets across all cards.
* **Visual Polish**: Added slim (`4px`) solid gray tracks behind dumbbells for reliable light-mode contrast and dimmed suites with 100% generation errors (`opacity: 0.2`).

<img width="1094" height="565" alt="image" src="https://github.com/user-attachments/assets/683c7c89-ae3d-451c-ae1e-defff5dae09e" />
