### PR TITLE
harness: intercept npx commands during evals via TS template shim

### DIFF
--- a/harness/npx-intercept.template.ts
+++ b/harness/npx-intercept.template.ts
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'child_process';
+import path from 'path';
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+
+const args = process.argv.slice(2);
+
+if (args[0] === '-y' && args[1] === 'modern-web-guidance@latest') {
+  const remainingArgs = args.slice(2);
+  const localCliPath = "__LOCAL_CLI_PATH__";
+
+  // Execute the local CLI instead of fetching from registry
+  const result = spawnSync(process.execPath, [localCliPath, ...remainingArgs], { stdio: 'inherit' });
+  process.exit(result.status ?? 0);
+}
+
+// Fallback to real npx
+const currentDir = fs.realpathSync(path.dirname(fileURLToPath(import.meta.url)));
+
+// Find all npx in PATH
+const npxPaths = spawnSync('which', ['-a', 'npx'], { encoding: 'utf8' }).stdout.split('\n').filter(Boolean);
+
+// Find the first one that does not resolve to our shim path
+const realNpx = npxPaths.find(p => {
+  try {
+    return fs.realpathSync(p) !== path.join(currentDir, 'npx');
+  } catch {
+    return false;
+  }
+});
+
+if (!realNpx) {
+  console.error("Could not find real npx");
+  process.exit(1);
+}
+
+const env = { ...process.env };
+if (env.PATH) {
+  const pathDirs = env.PATH.split(path.delimiter);
+  env.PATH = pathDirs.filter(d => d !== currentDir).join(path.delimiter);
+}
+
+const result = spawnSync(realNpx, args, { stdio: 'inherit', env });
+process.exit(result.status ?? 0);

--- a/harness/npx-intercept.template.ts
+++ b/harness/npx-intercept.template.ts
@@ -1,5 +1,14 @@
 #!/usr/bin/env node
 
+/**
+ * @file npx-intercept.template.ts
+ * @description This script acts as a shim for `npx` during evaluations.
+ * It intercepts calls to `npx -y modern-web-guidance@latest` and redirects them
+ * to the local build in `dist/skills-cli`, ensuring that agents use the fresh
+ * local guides instead of fetching the published package from the npm registry.
+ * All other `npx` calls fall back to the real system `npx`.
+ */
+
 import { spawnSync } from 'child_process';
 import path from 'path';
 import fs from 'fs';

--- a/harness/npx-intercept.test.ts
+++ b/harness/npx-intercept.test.ts
@@ -1,0 +1,68 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import fs from 'fs';
+import path from 'path';
+import os from 'node:os';
+import { spawnSync } from 'child_process';
+
+test('npx interception via shim', async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'npx-intercept-test-'));
+  const templatePath = path.resolve(import.meta.dirname, 'npx-intercept.template.ts');
+
+  assert.ok(fs.existsSync(templatePath), 'Template should exist');
+
+  // Create a dummy CLI script that creates a file when called
+  const dummyCliPath = path.join(tempDir, 'dummy-cli.js');
+  fs.writeFileSync(dummyCliPath, `#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+fs.writeFileSync(path.join(__dirname, 'called.txt'), 'yes');
+`);
+  fs.chmodSync(dummyCliPath, 0o755);
+
+  // Read template and replace path
+  let templateContent = fs.readFileSync(templatePath, 'utf8');
+  templateContent = templateContent.replace('__LOCAL_CLI_PATH__', dummyCliPath);
+
+  const npxShimPath = path.join(tempDir, 'npx');
+  fs.writeFileSync(npxShimPath, templateContent);
+  fs.chmodSync(npxShimPath, 0o755);
+
+  try {
+    // Run a command that should be intercepted
+    // We need to make sure we use the shim npx by setting PATH
+    const env = { ...process.env, PATH: `${tempDir}:${process.env.PATH}` };
+
+    console.log(`Running intercepted command with PATH=${tempDir}...`);
+    const result = spawnSync('npx', ['-y', 'modern-web-guidance@latest', 'search', 'foo'], {
+      cwd: tempDir,
+      stdio: 'inherit',
+      env,
+      timeout: 10000
+    });
+
+    assert.strictEqual(result.status, 0, 'Intercepted command should succeed');
+
+    const calledFile = path.join(tempDir, 'called.txt');
+    assert.ok(fs.existsSync(calledFile), 'Dummy CLI should have been called');
+    assert.strictEqual(fs.readFileSync(calledFile, 'utf8'), 'yes', 'Dummy CLI should have written yes');
+
+    // Clean up called file
+    fs.unlinkSync(calledFile);
+
+    // Run a command that should NOT be intercepted (fallback)
+    console.log(`Running fallback command with PATH=${tempDir}...`);
+    const resultFallback = spawnSync('npx', ['--version'], {
+      cwd: tempDir,
+      stdio: 'inherit',
+      env,
+      timeout: 10000
+    });
+
+    assert.strictEqual(resultFallback.status, 0, 'Fallback command should succeed');
+    assert.ok(!fs.existsSync(calledFile), 'Dummy CLI should NOT have been called for fallback');
+
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/harness/run_suite.ts
+++ b/harness/run_suite.ts
@@ -56,9 +56,9 @@ export async function runAgent(templateDirRaw: string, promptContentRaw: string,
 
     const suiteConfigPath = path.resolve(targetDir, 'suite_config.json');
     await runCommand('node', [
-      '--experimental-strip-types', 
-      agentScript, 
-      JSON.stringify(promptContent), 
+      '--experimental-strip-types',
+      agentScript,
+      JSON.stringify(promptContent),
       'guided', // Default to guided for ad-hoc tool execution
       targetDir,
       templateDir
@@ -160,7 +160,7 @@ export async function runSuite(options: RunSuiteOptions = {}) {
         const guideFolder = path.join(runDir, guideName);
         const taskFolder = path.join(guideFolder, taskName);
         const graderPath = path.join(taskInfo.guideDir, 'grader.ts');
-        
+
         for (const runType of runTypesToRun) {
           const targetDir = path.join(taskFolder, runType);
           generateTransientPackage(targetDir, agentScript, promptContent, runType, workspaceBaseAppDir, taskName, guideName, graderPath);
@@ -389,6 +389,22 @@ function generateTransientPackage(
   const gradeScript = getGraderScriptContent(targetDir, graderPath, guideName);
   fs.writeFileSync(path.join(targetDir, 'grade.mjs'), gradeScript);
 
+  // Create npx wrapper to intercept modern-web-guidance calls during evals
+  const rootDir = path.resolve(harnessDir, '..');
+  const templatePath = path.join(harnessDir, 'npx-intercept.template.ts');
+  const localCliPath = path.join(rootDir, 'dist', 'skills-cli', 'skills/modern-web-guidance/modern-web.mjs');
+
+  if (fs.existsSync(templatePath)) {
+    let templateContent = fs.readFileSync(templatePath, 'utf8');
+    templateContent = templateContent.replace('__LOCAL_CLI_PATH__', localCliPath);
+
+    const npxWrapperPath = path.join(targetDir, 'npx');
+    fs.writeFileSync(npxWrapperPath, templateContent);
+    fs.chmodSync(npxWrapperPath, 0o755); // Make executable
+  } else {
+    console.warn(`Warning: npx-intercept.template.ts not found at ${templatePath}`);
+  }
+
   // Generate runner script
   // HACK: To get nice aggregated, prefix-multiplexed output for parallel runs,
   // we trick pnpm into thinking each test run is a package in a pnpm workspace.
@@ -408,8 +424,13 @@ const args = [
   workspaceBaseAppDir
 ])}
 ];
+
+// Intercept npx by prepending targetDir to PATH
+const env = { ...process.env };
+env.PATH = \`${targetDir}:\${env.PATH}\`;
+
 const start = Date.now();
-const result = spawnSync(process.execPath, args, { stdio: 'inherit', cwd: ${JSON.stringify(process.cwd())}, timeout: 600000 });
+const result = spawnSync(process.execPath, args, { stdio: 'inherit', cwd: ${JSON.stringify(process.cwd())}, timeout: 600000, env });
 const runtime = Date.now() - start;
 
 let graderRuntime = null;

--- a/lib/paths.ts
+++ b/lib/paths.ts
@@ -4,9 +4,9 @@ import path from 'path';
  * Returns the repository root directory.
  * 
  * NOTE: We used to use \`git rev-parse --show-toplevel\` here to support git worktrees.
- * However, that failed when evaluations were run from a directory that was itself
- * inside a DIFFERENT git repository (like \`guidance-evals\`), causing it to resolve
- * to that repo's root instead of this project's root.
+ * However, that failed when processes were spawned from directories resolved outside 
+ * the project (e.g. via symlinks into another git repository), causing it to incorrectly 
+ * resolve to that external repository's root instead of this project's root.
  * 
  * Using \`import.meta.dirname\` is robust and works correctly regardless of the current
  * working directory or surrounding git repositories.

--- a/lib/paths.ts
+++ b/lib/paths.ts
@@ -1,26 +1,17 @@
-import { execSync } from 'child_process';
 import path from 'path';
-/**
- * Returns the repository root directory. Uses `git rev-parse --show-toplevel`
- * so that the correct root is returned even when running from a git worktree.
- */
-export function getRootDir(): string {
-  try {
-    const env = { ...process.env };
-    delete env.GIT_DIR;
-    delete env.GIT_WORK_TREE;
-    return execSync('git rev-parse --show-toplevel', {
-      encoding: 'utf-8',
-      env,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }).trim();
-  } catch {
-    // Fallback to import.meta.dirname-based resolution (e.g. outside a git repo).
-    return path.resolve(import.meta.dirname, '..');
-  }
-}
 
-export const rootDir = getRootDir();
+/**
+ * Returns the repository root directory.
+ * 
+ * NOTE: We used to use \`git rev-parse --show-toplevel\` here to support git worktrees.
+ * However, that failed when evaluations were run from a directory that was itself
+ * inside a DIFFERENT git repository (like \`guidance-evals\`), causing it to resolve
+ * to that repo's root instead of this project's root.
+ * 
+ * Using \`import.meta.dirname\` is robust and works correctly regardless of the current
+ * working directory or surrounding git repositories.
+ */
+export const rootDir = path.resolve(import.meta.dirname, '..');
 
 export const guidesDir = path.join(rootDir, 'guides');
 export const harnessDir = path.join(rootDir, 'harness');


### PR DESCRIPTION
My #760 broke things for evals.. since the default switched to running with npx... it means that locally when we run evals... it was still using whatever was published to NPM. 

and thats no good because we need to eval what's on disk.

---

this fixes that with a little `npx` command shim that is preferred over the real `npx` command in PATH. 

with the intercept we can handle any `npx` stuff however we want.. but in particular we need it to run our local `modern-web.mjs`

