### PR TITLE
build: fix publish-skills CI failure + minor fixes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          cd dist/skills-cli-npx
+          cd dist/skills-cli
           npm publish --access public
 
       # - name: Publish to npm via OIDC Provenance

--- a/serving/scripts/build-guides.ts
+++ b/serving/scripts/build-guides.ts
@@ -99,6 +99,7 @@ function restoreFromCache(paths: CachePaths, outputDir: string, target: string):
     fs.mkdirSync(outputDir, { recursive: true });
     fs.copyFileSync(paths.cachedVectors, path.join(outputDir, "use-cases.vectors.gen.json.gz"));
     fs.cpSync(paths.cachedGuides, path.join(outputDir, "guides"), { recursive: true });
+    fs.copyFileSync(paths.cachedTs, OUTPUT_FILE);
   } else {
     fs.mkdirSync(path.join(ROOT_DIR, "lib"), { recursive: true });
     fs.mkdirSync(path.join(ROOT_DIR, "build"), { recursive: true });

--- a/serving/skills-cli/build-dist.test.ts
+++ b/serving/skills-cli/build-dist.test.ts
@@ -2,7 +2,7 @@ import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert';
 import fs from 'node:fs';
 import path from 'node:path';
-import { processSkills } from './build-dist.ts';
+import { processSkills, buildDist } from './build-dist.ts';
 import { replaceMacros } from '../lib/macros.ts';
 import { resetGuidesMap } from '../../lib/guide-validation.ts';
 
@@ -64,5 +64,21 @@ describe('processSkills', () => {
     const result = replaceMacros('{{ GUIDE_REF("break-up-long-tasks") }}', 'test.md', { target: 'skills-cli' });
 
     assert.ok(result.includes('npx -y modern-web-guidance@latest retrieve "break-up-long-tasks"'), 'Macro output should match the pattern in SKILL.md');
+  });
+
+  it('builds distribution successfully with buildDist', async () => {
+    const publishRoot = path.join(testOutputDir, 'full-dist');
+    
+    // Ensure clean state for this test
+    fs.rmSync(publishRoot, { recursive: true, force: true });
+
+    const result = await buildDist({ publishRoot, version: '1.0.0' });
+    
+    assert.ok(result, 'buildDist should return a result');
+    assert.ok(result.skillsCount > 0, 'Should have processed skills');
+    
+    // Verify that esbuild outputs exist
+    assert.ok(fs.existsSync(path.join(publishRoot, 'skills/modern-web-guidance/modern-web.mjs')), 'modern-web.mjs should exist');
+    assert.ok(fs.existsSync(path.join(publishRoot, 'skills/modern-web-guidance/search.mjs')), 'search.mjs should exist');
   });
 });

--- a/serving/skills-cli/build-dist.ts
+++ b/serving/skills-cli/build-dist.ts
@@ -116,10 +116,6 @@ async function main(opts: { publishRoot: string, version?: string}): Promise<Bui
   await acquireLock(lockFilePath);
 
   try {
-    fs.mkdirSync(publishRoot, { recursive: true });
-
-
-
     fs.cpSync(path.join(SERVING_DIR, "skills-cli/template"), publishRoot, { recursive: true });
 
     if (version) {

--- a/serving/skills-cli/publish-skills.ts
+++ b/serving/skills-cli/publish-skills.ts
@@ -17,7 +17,7 @@ const GH_PUBLISH_PATTERNS = [
   '!**/tfjs_model_minilm/**',
   '!**/*.{js,mjs,ts,bin,map,gz}',
   '!THIRD_PARTY_NOTICES',
-  '!skills/modern-web/package.json',
+  '!skills/modern-web-guidance/package.json',
 ];
 
 const isDryRun = process.argv.includes('--dry-run');

--- a/serving/skills-cli/test-dist.test.ts
+++ b/serving/skills-cli/test-dist.test.ts
@@ -22,11 +22,11 @@ export function assertSearchResults(output: string) {
 }
 
 const ROOT_DIR = path.resolve(import.meta.dirname, "../.."); // guidance/
-const DIST_DIR = path.join(ROOT_DIR, "dist/skills-cli");
+const STAGING_DIR = path.join(ROOT_DIR, "dist/skills-cli");
 
 
 test('Claude Plugin Config in Dist', async () => {
-  const marketplaceJsonRaw = await fs.readFile(path.join(DIST_DIR, '.claude-plugin/marketplace.json'), 'utf8');
+  const marketplaceJsonRaw = await fs.readFile(path.join(STAGING_DIR, '.claude-plugin/marketplace.json'), 'utf8');
   const marketplaceJson = JSON.parse(marketplaceJsonRaw);
   assert.strictEqual(marketplaceJson.name, 'googlechrome', 'marketplace.json name should be googlechrome');
   assert.strictEqual(marketplaceJson.owner.name, 'Google Chrome', 'marketplace.json owner should be Google Chrome');
@@ -35,18 +35,18 @@ test('Claude Plugin Config in Dist', async () => {
   assert.strictEqual(marketplaceJson.plugins[0].name, 'modern-web-guidance');
   assert.strictEqual(marketplaceJson.plugins[0].source, './');
 
-  const pluginJsonRaw = await fs.readFile(path.join(DIST_DIR, '.claude-plugin/plugin.json'), 'utf8');
+  const pluginJsonRaw = await fs.readFile(path.join(STAGING_DIR, '.claude-plugin/plugin.json'), 'utf8');
   const pluginJson = JSON.parse(pluginJsonRaw);
   assert.strictEqual(pluginJson.name, 'modern-web-guidance', 'plugin.json name should match');
   assert.strictEqual(pluginJson.author.name, 'Google Chrome', 'plugin.json author should be Google Chrome');
 });
 
 test('Gemini and VS Code manifests', async () => {
-  const geminiJson = JSON.parse(await fs.readFile(path.join(DIST_DIR, 'gemini-extension.json'), 'utf8'));
+  const geminiJson = JSON.parse(await fs.readFile(path.join(STAGING_DIR, 'gemini-extension.json'), 'utf8'));
   assert.strictEqual(geminiJson.name, 'modern-web-guidance');
   assert.strictEqual(geminiJson.author.name, 'Google Chrome');
 
-  const pkgJsonRaw = await fs.readFile(path.join(DIST_DIR, 'package.json'), 'utf8');
+  const pkgJsonRaw = await fs.readFile(path.join(STAGING_DIR, 'package.json'), 'utf8');
   const pkgJson = JSON.parse(pkgJsonRaw);
   assert.strictEqual(pkgJson.publisher, 'GoogleChrome');
   assert.ok(pkgJson.contributes?.chatSkills, 'Must contribute chatSkills');
@@ -54,7 +54,7 @@ test('Gemini and VS Code manifests', async () => {
 });
 
 test('SKILL.md validations', async () => {
-  const skillPath = path.join(DIST_DIR, 'skills/modern-web-guidance/SKILL.md');
+  const skillPath = path.join(STAGING_DIR, 'skills/modern-web-guidance/SKILL.md');
   await assert.doesNotReject(fs.access(skillPath), `Missing SKILL.md in modern-web-guidance`);
 
   const content = await fs.readFile(skillPath, 'utf8');
@@ -65,7 +65,7 @@ test('SKILL.md validations', async () => {
 
 test('Discipline guides present (forms, performance)', async () => {
   const checkGuide = async (name: string) => {
-    const guidesDir = path.join(DIST_DIR, 'skills/modern-web-guidance/guides');
+    const guidesDir = path.join(STAGING_DIR, 'skills/modern-web-guidance/guides');
     const guidePath = path.join(guidesDir, name, `${name}.md`);
     await assert.doesNotReject(fs.access(guidePath), `Missing guide file in ${name}`);
   };
@@ -76,27 +76,27 @@ test('Discipline guides present (forms, performance)', async () => {
 
 test('Manifest source paths resolve relative to dist directory', async () => {
   // Claude Code source
-  const marketplaceJsonRaw = await fs.readFile(path.join(DIST_DIR, '.claude-plugin/marketplace.json'), 'utf8');
+  const marketplaceJsonRaw = await fs.readFile(path.join(STAGING_DIR, '.claude-plugin/marketplace.json'), 'utf8');
   const marketplaceJson = JSON.parse(marketplaceJsonRaw);
   const claudeSourcePath = marketplaceJson.plugins[0].source;
-  const resolvedClaudePath = path.join(DIST_DIR, claudeSourcePath);
+  const resolvedClaudePath = path.join(STAGING_DIR, claudeSourcePath);
   await assert.doesNotReject(fs.access(resolvedClaudePath), `Claude source path ${claudeSourcePath} must resolve to a valid directory`);
   
   // Claude plugin resolution logic mapping
-  // If source is './', the plugin resides precisely at DIST_DIR/.claude-plugin/plugin.json
+  // If source is './', the plugin resides precisely at STAGING_DIR/.claude-plugin/plugin.json
   const expectedPluginJsonPath = path.join(resolvedClaudePath, '.claude-plugin/plugin.json');
   await assert.doesNotReject(fs.access(expectedPluginJsonPath), `Claude Plugin must be resolving from the source pointer`);
 
   // VS Code Extension source
-  const pkgJsonRaw = await fs.readFile(path.join(DIST_DIR, 'package.json'), 'utf8');
+  const pkgJsonRaw = await fs.readFile(path.join(STAGING_DIR, 'package.json'), 'utf8');
   const pkgJson = JSON.parse(pkgJsonRaw);
   const vscodePath = pkgJson.contributes.chatSkills[0].path;
-  const resolvedVsCodePath = path.join(DIST_DIR, vscodePath);
+  const resolvedVsCodePath = path.join(STAGING_DIR, vscodePath);
   await assert.doesNotReject(fs.access(resolvedVsCodePath), `VS Code skill path ${vscodePath} must resolve to an existing SKILL.md`);
 });
 
 test('README dynamic Skill Coverage content', async () => {
-  const readmeRaw = await fs.readFile(path.join(DIST_DIR, 'README.md'), 'utf8');
+  const readmeRaw = await fs.readFile(path.join(STAGING_DIR, 'README.md'), 'utf8');
   
   // Verify it contains the new headers and format
   assert.match(readmeRaw, /#### Skill Coverage in `v\d+\.\d+\.\d+`/, 'README should contain the Skill Coverage header with the version');
@@ -108,7 +108,7 @@ test('README dynamic Skill Coverage content', async () => {
 });
 
 test('modern-web CLI search and retrieve', async () => {
-  const binaryPath = path.join(DIST_DIR, 'skills/modern-web-guidance/modern-web.mjs');
+  const binaryPath = path.join(STAGING_DIR, 'skills/modern-web-guidance/modern-web.mjs');
   
   // 1. Validate search
   const searchOut = execSync(`node "${binaryPath}" search "address form"`, { encoding: 'utf8' });
@@ -120,8 +120,8 @@ test('modern-web CLI search and retrieve', async () => {
 });
 
 test('modern-web CLI version flags', async () => {
-  const binaryPath = path.join(DIST_DIR, 'skills/modern-web-guidance/modern-web.mjs');
-  const pkgJsonRaw = await fs.readFile(path.join(DIST_DIR, 'package.json'), 'utf8');
+  const binaryPath = path.join(STAGING_DIR, 'skills/modern-web-guidance/modern-web.mjs');
+  const pkgJsonRaw = await fs.readFile(path.join(STAGING_DIR, 'package.json'), 'utf8');
   const pkgJson = JSON.parse(pkgJsonRaw);
   const expectedVersion = pkgJson.version;
 
@@ -138,7 +138,7 @@ test('modern-web CLI version flags', async () => {
 
 // TODO: this has been failing locally from publish-skills.ts
 test.skip('THIRD_PARTY_NOTICES validation', async () => {
-  const noticesPath = path.join(DIST_DIR, 'THIRD_PARTY_NOTICES');
+  const noticesPath = path.join(STAGING_DIR, 'THIRD_PARTY_NOTICES');
   await assert.doesNotReject(fs.access(noticesPath), `Missing THIRD_PARTY_NOTICES in dist`);
 
   const content = await fs.readFile(noticesPath, 'utf8');


### PR DESCRIPTION
- **Fixed CI failure**: Made sure `use-cases.gen.ts` is copied to `lib/` for the `skills-cli` target so `esbuild` can resolve it.
- **Workflow update**: Switched `publish.yml` to use `dist/skills-cli` instead of the dead `npx` target.
- **Added test**: Added a real integration test for `buildDist` to catch missing dependency errors earlier.
- **Cleanups**: Fixed a typo in `publish-skills.ts` patterns, renamed confusing `DIST_DIR` variable in tests, and removed a redundant `mkdirSync` call in `build-dist.ts`.

