### PR TITLE
Nightly fix: enforce package.json

### DIFF
--- a/harness/lib/collection.ts
+++ b/harness/lib/collection.ts
@@ -144,7 +144,7 @@ export async function collectResults(resultsDir: string, suiteConfig: SuiteConfi
           console.warn("Failed to parse existing package.json, overwriting...");
         }
       }
-      pkgJsonObj.scripts["run-grader"] = `node grade.mjs --id ${relativeId}`;
+      pkgJsonObj.scripts["run-grader"] = `node --experimental-strip-types grade.mjs --id ${relativeId}`;
       fs.writeFileSync(targetPkgJson, JSON.stringify(pkgJsonObj, null, 2));
 
       pnpmWorkspacePackages.push(relativeId);
@@ -153,14 +153,31 @@ export async function collectResults(resultsDir: string, suiteConfig: SuiteConfi
 
   // --- PASS 1.5: Execute the accumulated grading runs in parallel ---
   if (pnpmWorkspacePackages.length > 0) {
-    console.log(`\n>>> Discovered ${pnpmWorkspacePackages.length} un-graded tasks. Running parallel grading with pnpm -r run-grader...`);
+    const rootPkgJsonPath = path.join(resultsDir, 'package.json');
+    let wroteRootPkgJson = false;
+    if (!fs.existsSync(rootPkgJsonPath)) {
+      fs.writeFileSync(rootPkgJsonPath, JSON.stringify({
+        name: "evaluation-suite-workspace",
+        private: true
+      }, null, 2));
+      wroteRootPkgJson = true;
+    }
+
     const pnpmWorkspacePath = path.join(resultsDir, 'pnpm-workspace.yaml');
     fs.writeFileSync(pnpmWorkspacePath, 'packages:\n  - \'**\'\n');
+
     try {
+      console.log(`\n>>> Bootstrapping dependencies inside results workspace with pnpm install...`);
+      spawnSync('pnpm', ['install', '--no-frozen-lockfile'], { cwd: resultsDir, stdio: 'inherit' });
+
+      console.log(`\n>>> Discovered ${pnpmWorkspacePackages.length} un-graded tasks. Running parallel grading with pnpm -r run-grader...`);
       spawnSync('pnpm', ['-r', 'run-grader'], { cwd: resultsDir, stdio: 'inherit' });
     } finally {
       if (fs.existsSync(pnpmWorkspacePath)) {
         fs.unlinkSync(pnpmWorkspacePath);
+      }
+      if (wroteRootPkgJson && fs.existsSync(rootPkgJsonPath)) {
+        fs.unlinkSync(rootPkgJsonPath);
       }
     }
     console.log(`✅ Completed parallel grading pass\n`);

--- a/harness/run_suite.ts
+++ b/harness/run_suite.ts
@@ -438,7 +438,7 @@ let graderStatus = null;
 
 if (result.status === 0) {
   const gradeStart = Date.now();
-  const gradeResult = spawnSync(process.execPath, ['grade.mjs'], { stdio: 'inherit', cwd: ${JSON.stringify(targetDir)} });
+  const gradeResult = spawnSync(process.execPath, ['--experimental-strip-types', 'grade.mjs'], { stdio: 'inherit', cwd: ${JSON.stringify(targetDir)} });
   graderRuntime = Date.now() - gradeStart;
   graderStatus = gradeResult.status;
 }


### PR DESCRIPTION
Nightly builds failed again with 0% eval data (agents were run, but failed at grading step).

Fixed and re-ran nightly and successfully generated data on 5/12.