### PR TITLE
build: publish-skills dry-run in CI & other fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
           TEST_REPORTER: spec
         run: pnpm run preflight
 
+      - name: Verify publish-skills (Dry Run)
+        run: pnpm --filter serving run publish-skills --dry-run
 
       # Fail if any changes were written to any source files or generated untracked files
       - run: git add -A && git diff --cached --exit-code

--- a/guides/guides-integrity.test.ts
+++ b/guides/guides-integrity.test.ts
@@ -2,6 +2,7 @@ import test, { describe, it } from 'node:test';
 import assert from 'node:assert';
 import path from 'node:path';
 import fs from 'node:fs';
+import { execSync } from 'node:child_process';
 import matter from 'gray-matter';
 import { marked } from 'marked';
 
@@ -100,4 +101,33 @@ describe('Guides Validation (Single Source of Truth)', () => {
       }
     });
   }
+
+  it('checks all tracked files for conflict markers', () => {
+    const files = execSync('git ls-files', { encoding: 'utf8' }).trim().split('\n');
+    const extensions = ['.md', '.html', '.txt', '.yaml', '.yml'];
+    const conflictMarkers = ['<<<<<<<', '=======', '>>>>>>>'];
+    const failedFiles: string[] = [];
+
+    for (const file of files) {
+      const ext = path.extname(file);
+      if (!extensions.includes(ext)) continue;
+
+      const filePath = path.resolve(REPO_ROOT, file);
+      try {
+        const content = fs.readFileSync(filePath, 'utf8');
+        for (const marker of conflictMarkers) {
+          if (content.includes(marker)) {
+            failedFiles.push(`${file} (contains "${marker}")`);
+            break;
+          }
+        }
+      } catch (e) {
+        // Ignore files that cannot be read
+      }
+    }
+
+    if (failedFiles.length > 0) {
+      assert.fail(`Conflict markers found in the following files:\n${failedFiles.join('\n')}`);
+    }
+  });
 });

--- a/serving/skills-cli/build-dist.test.ts
+++ b/serving/skills-cli/build-dist.test.ts
@@ -2,7 +2,7 @@ import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert';
 import fs from 'node:fs';
 import path from 'node:path';
-import { processSkills, buildDist } from './build-dist.ts';
+import { processSkills } from './build-dist.ts';
 import { replaceMacros } from '../lib/macros.ts';
 import { resetGuidesMap } from '../../lib/guide-validation.ts';
 
@@ -66,18 +66,9 @@ describe('processSkills', () => {
     assert.ok(result.includes('npx -y modern-web-guidance@latest retrieve "break-up-long-tasks"'), 'Macro output should match the pattern in SKILL.md');
   });
 
-  it('builds distribution successfully with buildDist', async () => {
-    const publishRoot = path.join(testOutputDir, 'full-dist');
+  it('verifies distribution was built successfully', async () => {
+    const publishRoot = path.join(rootDir, 'dist/skills-cli');
     
-    // Ensure clean state for this test
-    fs.rmSync(publishRoot, { recursive: true, force: true });
-
-    const result = await buildDist({ publishRoot, version: '1.0.0' });
-    
-    assert.ok(result, 'buildDist should return a result');
-    assert.ok(result.skillsCount > 0, 'Should have processed skills');
-    
-    // Verify that esbuild outputs exist
     assert.ok(fs.existsSync(path.join(publishRoot, 'skills/modern-web-guidance/modern-web.mjs')), 'modern-web.mjs should exist');
     assert.ok(fs.existsSync(path.join(publishRoot, 'skills/modern-web-guidance/search.mjs')), 'search.mjs should exist');
   });

--- a/serving/skills-cli/build-dist.ts
+++ b/serving/skills-cli/build-dist.ts
@@ -95,7 +95,9 @@ async function main(opts: { publishRoot: string, version?: string}): Promise<Bui
   });
 
   if (skipped && fs.existsSync(modernWebMjs)) {
-    return { featuresCount: 0, useCasesCount: 0, skillsCount: 0, skillNames: [] };
+    const { skillsCount, skillNames } = processSkills(publishRoot);
+    const { featuresCount, useCasesCount } = updateReadmeWithFeaturesAndUseCases(publishRoot);
+    return { featuresCount, useCasesCount, skillsCount, skillNames };
   }
 
   // Step 2: If we didn't short-circuit, we do a clean, purist build.

--- a/serving/skills-cli/publish-skills.test.ts
+++ b/serving/skills-cli/publish-skills.test.ts
@@ -9,10 +9,4 @@ test('getNextVersion derive from git tag', async () => {
   assert.strictEqual(version, '0.0.23');
 });
 
-test('getNextVersion fallback to package.json when no tags', async () => {
-  const mockGetTag = () => '';
-  
-  const version = await getNextVersion(mockGetTag);
-  assert.ok(version, 'Should return a version');
-  assert.match(version, /^\d+\.\d+\.\d+$/, 'Should be a valid semver');
-});
+

--- a/serving/skills-cli/publish-skills.test.ts
+++ b/serving/skills-cli/publish-skills.test.ts
@@ -8,3 +8,11 @@ test('getNextVersion derive from git tag', async () => {
   const version = await getNextVersion(mockGetTag);
   assert.strictEqual(version, '0.0.23');
 });
+
+test('getNextVersion fallback to package.json when no tags', async () => {
+  const mockGetTag = () => '';
+  
+  const version = await getNextVersion(mockGetTag);
+  assert.ok(version, 'Should return a version');
+  assert.match(version, /^\d+\.\d+\.\d+$/, 'Should be a valid semver');
+});

--- a/serving/skills-cli/publish-skills.ts
+++ b/serving/skills-cli/publish-skills.ts
@@ -29,11 +29,7 @@ function incrementVersion(version: string): string {
 }
 
 const getLatestGitTag = (target = 'HEAD') => {
-  try {
-    return execSync(`git describe --tags --match "v*.*.*" --abbrev=0 ${target}`, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim();
-  } catch {
-    return '';
-  }
+  return execSync(`git describe --tags --match "v*.*.*" --abbrev=0 ${target}`, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim();
 };
 
 export async function getNextVersion(getLatestTag = getLatestGitTag): Promise<string> {
@@ -42,24 +38,20 @@ export async function getNextVersion(getLatestTag = getLatestGitTag): Promise<st
   const target = isDryRun ? 'origin/main' : 'HEAD';
   console.log(`Checking latest tag against ${target}...`);
   
-  let latestTag = getLatestTag(target);
-  
-  // Fallback if origin/main failed or returned nothing (e.g. on PR branch not fully fetched)
-  if (!latestTag && isDryRun) {
-    console.log("Could not find tags on origin/main. Falling back to HEAD.");
-    latestTag = getLatestTag('HEAD');
+  let latestTag: string;
+  try {
+    latestTag = getLatestTag(target);
+  } catch (err) {
+    if (isDryRun) {
+      console.log(`Could not find tags on ${target}. Falling back to HEAD.`);
+      latestTag = getLatestTag('HEAD');
+    } else {
+      throw err;
+    }
   }
 
-  let currentVersion: string;
-
-  if (!latestTag) {
-    console.log("⚠️ No tags found anywhere. Falling back to package.json version. This may be inaccurate for PR dry-runs.");
-    const pkgJson = JSON.parse(await fs.readFile(path.join(ROOT_DIR, "package.json"), "utf-8"));
-    currentVersion = pkgJson.version;
-  } else {
-    currentVersion = latestTag.startsWith('v') ? latestTag.slice(1) : latestTag;
-    console.log(`Found latest tag: ${latestTag}`);
-  }
+  console.log(`Found latest tag: ${latestTag}`);
+  const currentVersion = latestTag.startsWith('v') ? latestTag.slice(1) : latestTag;
 
   const newVersion = incrementVersion(currentVersion);
   console.log(`Next version will be: ${newVersion}`);

--- a/serving/skills-cli/publish-skills.ts
+++ b/serving/skills-cli/publish-skills.ts
@@ -28,9 +28,9 @@ function incrementVersion(version: string): string {
   return `${parts[0]}.${parts[1]}.${patch}`;
 }
 
-const getLatestGitTag = () => {
+const getLatestGitTag = (target = 'HEAD') => {
   try {
-    return execSync('git tag -l "v*.*.*" --merged HEAD --sort=-v:refname | head -n 1', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim();
+    return execSync(`git describe --tags --match "v*.*.*" --abbrev=0 ${target}`, { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim();
   } catch {
     return '';
   }
@@ -39,12 +39,21 @@ const getLatestGitTag = () => {
 export async function getNextVersion(getLatestTag = getLatestGitTag): Promise<string> {
   console.log("Determining next version...");
 
-  // Get the latest tag that looks like v*.*.*
-  const latestTag = getLatestTag();
+  const target = isDryRun ? 'origin/main' : 'HEAD';
+  console.log(`Checking latest tag against ${target}...`);
+  
+  let latestTag = getLatestTag(target);
+  
+  // Fallback if origin/main failed or returned nothing (e.g. on PR branch not fully fetched)
+  if (!latestTag && isDryRun) {
+    console.log("Could not find tags on origin/main. Falling back to HEAD.");
+    latestTag = getLatestTag('HEAD');
+  }
+
   let currentVersion: string;
 
   if (!latestTag) {
-    console.log("No tags found merged into HEAD. Falling back to package.json version.");
+    console.log("⚠️ No tags found anywhere. Falling back to package.json version. This may be inaccurate for PR dry-runs.");
     const pkgJson = JSON.parse(await fs.readFile(path.join(ROOT_DIR, "package.json"), "utf-8"));
     currentVersion = pkgJson.version;
   } else {

--- a/serving/skills-cli/publish-skills.ts
+++ b/serving/skills-cli/publish-skills.ts
@@ -28,15 +28,29 @@ function incrementVersion(version: string): string {
   return `${parts[0]}.${parts[1]}.${patch}`;
 }
 
-const getLatestGitTag = () => execSync('git tag -l "v*.*.*" --merged HEAD --sort=-v:refname | head -n 1 | grep .', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim();
+const getLatestGitTag = () => {
+  try {
+    return execSync('git tag -l "v*.*.*" --merged HEAD --sort=-v:refname | head -n 1', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim();
+  } catch {
+    return '';
+  }
+};
 
 export async function getNextVersion(getLatestTag = getLatestGitTag): Promise<string> {
   console.log("Determining next version...");
 
   // Get the latest tag that looks like v*.*.*
   const latestTag = getLatestTag();
-  const currentVersion = latestTag.startsWith('v') ? latestTag.slice(1) : latestTag;
-  console.log(`Found latest tag: ${latestTag}`);
+  let currentVersion: string;
+
+  if (!latestTag) {
+    console.log("No tags found merged into HEAD. Falling back to package.json version.");
+    const pkgJson = JSON.parse(await fs.readFile(path.join(ROOT_DIR, "package.json"), "utf-8"));
+    currentVersion = pkgJson.version;
+  } else {
+    currentVersion = latestTag.startsWith('v') ? latestTag.slice(1) : latestTag;
+    console.log(`Found latest tag: ${latestTag}`);
+  }
 
   const newVersion = incrementVersion(currentVersion);
   console.log(`Next version will be: ${newVersion}`);


### PR DESCRIPTION
a few things.. not necessarily related:

1. we have a publish-skills dry-run .. if that exits non-zero i want to know
2. check for conflict markers even MORE. #773 was the second time we got conflict markers committed. now we'll catch those cases
3. build-dist.test.ts tests against the real build in `dist/skills-cli`  that's good and better than a separate copy. because A) faster because its already done and B) its the canonical.
4. minor fix to get correct counts in the publish-skills output