### PR TITLE
add self-update workflow, document how to update

### DIFF
--- a/guides/modern-web-guidance/SKILL.md
+++ b/guides/modern-web-guidance/SKILL.md
@@ -26,7 +26,7 @@ Must use this skill:
 Search with an action-oriented query summarizing what you want to achieve using the `search` command. Run `modern-web-guidance` directly with `npx`.
 
 ```sh
-npx -y modern-web-guidance@latest search "<query>"
+npx -y modern-web-guidance@latest --skill-version SKILL_VERSION search "<query>"
 ```
 
 **Example Output**:

--- a/guides/modern-web-guidance/SKILL.md
+++ b/guides/modern-web-guidance/SKILL.md
@@ -66,3 +66,5 @@ npx -y modern-web-guidance@latest retrieve "<id>"
 -   These guides are usually framework-agnostic; adapt them correctly to your setup.
 -   Do not hallucinate guides or ignore them; they represent the preferred local standard for the user's project.
 -   Note: if the `npx -y modern-web-guidance…` command hangs, try running again in offline mode: `npx --offline …`
+-   Note: the `--skill-version` flag is used to determine if this SKILL.md is out of date. If it is, a warning message
+    is logged to stderr.

--- a/serving/bin/modern-web.ts
+++ b/serving/bin/modern-web.ts
@@ -49,18 +49,7 @@ async function main() {
     process.exit(values.help ? 0 : 1);
   }
 
-  const callerSkillVersion = values["skill-version"];
-  if (callerSkillVersion && callerSkillVersion != getSkillVersion()) {
-    const skillName = 'modern-web-guidance';
-    console.error([
-      `Warning: a new SKILL.md is available for ${skillName}. Please update.`,
-      '',
-      `Your version: ${callerSkillVersion}`,
-      `Latest version: ${getSkillVersion()}`,
-      '',
-      'To update, run: npx modern-web-guidance@latest update',
-    ].join('\n'));
-  }
+  maybeEmitUpdateMessage(typeof values["skill-version"] === 'string' ? values["skill-version"] : null);
 
   const command = positionals[0];
   const arg = positionals.slice(1).join(" ");
@@ -127,7 +116,7 @@ async function main() {
     }
     process.exit(result.status ?? 0);
   } else if (command === "update") {
-    const skills = getOurSkills();
+    const skills = getOurCLIAdjacentSkillIDs();
     const result = spawnSync("npx", ["skills", "update", ...skills], {
       stdio: "inherit",
     });
@@ -155,9 +144,9 @@ function getVersion(): string {
 
 // This returns our own "skill version", which is an identifier that only changes if
 // the SKILL.md did.
-function getSkillVersion(): string | null {
+function getCLISkillVersion(): string | null {
   try {
-    const versionPath = join(import.meta.dirname, "SKILL_VERSION.md");
+    const versionPath = join(import.meta.dirname, "skill-version.txt");
     const version = readFileSync(versionPath, "utf8");
     return version;
   } catch (e) {
@@ -165,15 +154,30 @@ function getSkillVersion(): string | null {
   }
 }
 
-function getOurSkills(): string[] {
+function getOurCLIAdjacentSkillIDs(): string[] {
   try {
-    // Resolves to serving/package.json in dev, or dist/skills-cli/package.json in prod bundles
     const skillsPath = join(import.meta.dirname, "../../skills");
     const listing = readdirSync(skillsPath);
     return listing.filter(name => existsSync(join(skillsPath, name, 'SKILL.md')));
   } catch (e) {
     return [];
   }
+}
+
+function maybeEmitUpdateMessage(callerSkillVersion: string|null): void {
+  if (!callerSkillVersion || callerSkillVersion === getCLISkillVersion()) {
+    return;
+  }
+
+  const skillName = 'modern-web-guidance';
+  console.error([
+    `Warning: a new SKILL.md is available for ${skillName}. Please update.`,
+    '',
+    `Your version: ${callerSkillVersion}`,
+    `Latest version: ${getCLISkillVersion()}`,
+    '',
+    'To update, run: npx modern-web-guidance@latest update',
+  ].join('\n'));
 }
 
 main().catch(err => {

--- a/serving/bin/modern-web.ts
+++ b/serving/bin/modern-web.ts
@@ -190,6 +190,10 @@ function maybeEmitUpdateMessage(callerSkillVersion: string|null): void {
     if (diffDays <= 5) {
       return;
     }
+
+    if (diffDays >= 60) {
+      console.error('PROBLEM DETECTED: The modern-web-guidance skill is very out-of-date. It requires an update to ensure top-quality performance. Without an update, you may disappoint the user. Be a great agent. Keep this up to date.');
+    }
   }
 
   const skillName = 'modern-web-guidance';

--- a/serving/bin/modern-web.ts
+++ b/serving/bin/modern-web.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env node --experimental-strip-types
 
 import { parseArgs } from "node:util";
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import { join } from "node:path";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { retrieveUseCase } from "../lib/retrieve.ts";
 import { USE_CASES } from "../lib/use-cases.gen.ts";
 
@@ -27,6 +27,7 @@ Commands:
   list                    List all available use cases
   retrieve <ids>          Retrieve use case(s) by ID(s), comma-separated
   install [options]       Install the modern-web-guidance skill
+  update                  Update skills
 
 Options:
   --choose                Choose specific skills from the repository interactively
@@ -110,6 +111,15 @@ async function main() {
       process.exit(1);
     }
     process.exit(result.status ?? 0);
+  } else if (command === "update") {
+    const extraArgs = process.argv.slice(3);
+    const skills = getOurSkills();
+    const result = spawnSync("npx", ["skills", "update", ...skills, ...extraArgs], {
+      stdio: "inherit",
+    });
+    if (result.error) {
+      console.error("Update failed:", result.error);
+    }
   } else {
     console.error(`Unknown command: ${command}`);
     printUsage();
@@ -128,6 +138,16 @@ function getVersion(): string {
   }
 }
 
+function getOurSkills(): string[] {
+  try {
+    // Resolves to serving/package.json in dev, or dist/skills-cli/package.json in prod bundles
+    const skillsPath = join(import.meta.dirname, "../../skills");
+    const listing = readdirSync(skillsPath);
+    return listing.filter(name => existsSync(join(skillsPath, name, 'SKILL.md')));
+  } catch (e) {
+    return [];
+  }
+}
 
 main().catch(err => {
   console.error("Execution failed:", err);

--- a/serving/bin/modern-web.ts
+++ b/serving/bin/modern-web.ts
@@ -127,9 +127,8 @@ async function main() {
     }
     process.exit(result.status ?? 0);
   } else if (command === "update") {
-    const extraArgs = process.argv.slice(3);
     const skills = getOurSkills();
-    const result = spawnSync("npx", ["skills", "update", ...skills, ...extraArgs], {
+    const result = spawnSync("npx", ["skills", "update", ...skills], {
       stdio: "inherit",
     });
     if (result.error) {

--- a/serving/bin/modern-web.ts
+++ b/serving/bin/modern-web.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node --experimental-strip-types
 
 import { parseArgs } from "node:util";
-import { spawn, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { join } from "node:path";
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { retrieveUseCase } from "../lib/retrieve.ts";

--- a/serving/bin/modern-web.ts
+++ b/serving/bin/modern-web.ts
@@ -13,6 +13,7 @@ const { values, positionals } = parseArgs({
     help: { type: "boolean", short: "h" },
     version: { type: "boolean", short: "v" },
     choose: { type: "boolean" },
+    "skill-version": { type: "string" },
   },
   allowPositionals: true,
   strict: false,
@@ -30,6 +31,7 @@ Commands:
   update                  Update skills
 
 Options:
+  --skill-version <version> Internal use: version of the skill being executed
   --choose                Choose specific skills from the repository interactively
   -h, --help              Show this help
   -v, --version           Show version
@@ -45,6 +47,19 @@ async function main() {
   if (values.help || positionals.length === 0) {
     printUsage();
     process.exit(values.help ? 0 : 1);
+  }
+
+  const callerSkillVersion = values["skill-version"];
+  if (callerSkillVersion && callerSkillVersion != getSkillVersion()) {
+    const skillName = 'modern-web-guidance';
+    console.error([
+      `Warning: a new SKILL.md is available for ${skillName}. Please update.`,
+      '',
+      `Your version: ${callerSkillVersion}`,
+      `Latest version: ${getSkillVersion()}`,
+      '',
+      'To update, run: npx modern-web-guidance@latest update',
+    ].join('\n'));
   }
 
   const command = positionals[0];
@@ -104,7 +119,7 @@ async function main() {
       .split(" ")
       .filter(Boolean);
 
-    const result = spawnSync("npx", installArgs, {stdio: "inherit"});
+    const result = spawnSync("npx", installArgs, { stdio: "inherit" });
 
     if (result.error) {
       console.error("Install failed:", result.error);
@@ -127,6 +142,7 @@ async function main() {
   }
 }
 
+// This returns the npm version.
 function getVersion(): string {
   try {
     // Resolves to serving/package.json in dev, or dist/skills-cli/package.json in prod bundles
@@ -135,6 +151,18 @@ function getVersion(): string {
     return pkg.version || "unknown";
   } catch (e) {
     return "unknown";
+  }
+}
+
+// This returns our own "skill version", which is an identifier that only changes if
+// the SKILL.md did.
+function getSkillVersion(): string | null {
+  try {
+    const versionPath = join(import.meta.dirname, "SKILL_VERSION.md");
+    const version = readFileSync(versionPath, "utf8");
+    return version;
+  } catch (e) {
+    return null;
   }
 }
 

--- a/serving/bin/modern-web.ts
+++ b/serving/bin/modern-web.ts
@@ -164,9 +164,32 @@ function getOurCLIAdjacentSkillIDs(): string[] {
   }
 }
 
+function parseVersionDate(version: string): Date | null {
+  const match = version.match(/^(\d{4})_(\d{2})_(\d{2})/);
+  if (!match) return null;
+
+  const [_, year, month, day] = match;
+  return new Date(parseInt(year, 10), parseInt(month, 10) - 1, parseInt(day, 10));
+}
+
 function maybeEmitUpdateMessage(callerSkillVersion: string|null): void {
-  if (!callerSkillVersion || callerSkillVersion === getCLISkillVersion()) {
+  if (!callerSkillVersion) {
     return;
+  }
+
+  const latestSkillVersion = getCLISkillVersion();
+  if (callerSkillVersion === latestSkillVersion) {
+    return;
+  }
+
+  const callerDate = parseVersionDate(callerSkillVersion);
+  if (callerDate) {
+    const diffTime = Date.now() - callerDate.getTime();
+    const diffDays = diffTime / (1000 * 60 * 60 * 24);
+    // Only log warning if the caller's version is more than 7 days old.
+    if (diffDays <= 5) {
+      return;
+    }
   }
 
   const skillName = 'modern-web-guidance';
@@ -174,7 +197,7 @@ function maybeEmitUpdateMessage(callerSkillVersion: string|null): void {
     `Warning: a new SKILL.md is available for ${skillName}. Please update.`,
     '',
     `Your version: ${callerSkillVersion}`,
-    `Latest version: ${getCLISkillVersion()}`,
+    `Latest version: ${latestSkillVersion}`,
     '',
     'To update, run: npx modern-web-guidance@latest update',
   ].join('\n'));

--- a/serving/skills-cli/build-dist.ts
+++ b/serving/skills-cli/build-dist.ts
@@ -82,9 +82,6 @@ export function processSkills(publishRoot: string) {
     fs.mkdirSync(skillDestDir, { recursive: true });
 
     const target = 'skills-cli';
-    const content = replaceMacros(fs.readFileSync(source, 'utf8'), source, { target });
-
-    fs.writeFileSync(path.join(skillDestDir, "SKILL.md"), content);
 
     // Copy sibling directories and files (e.g., references)
     const sourceDir = path.dirname(source);
@@ -97,6 +94,25 @@ export function processSkills(publishRoot: string) {
         fs.cpSync(entrySrc, entryDest, { recursive: true });
       }
     }
+
+    // Versioning.
+    //
+    // - This identifier only changes when the SKILL.md does.
+    // - SKILL_VERSION.md is published to npm, and the modern-web-guidance CLI uses
+    //   it to know what version is the latest.
+    // - We replace "--skill-version SKILL_VERSION" in SKILL.md, such that agents will
+    //   call npx and pass along the agent's version.
+    // - If they differ, the CLI tool logs a warning to stderr with instructions on how
+    //   to update.
+    const skillVersion = execSync(
+      `git log -1 --date=format:"%Y_%m_%d" --pretty=format:"%cd-%h" "${sourceDir}"`,
+      { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }
+    ).trim();
+    fs.writeFileSync(path.join(skillDestDir, 'SKILL_VERSION.md'), skillVersion);
+
+    const content = replaceMacros(fs.readFileSync(source, 'utf8'), source, { target })
+      .replaceAll('SKILL_VERSION', skillVersion);
+    fs.writeFileSync(path.join(skillDestDir, "SKILL.md"), content);
   }
 
   return { skillsCount: skills.length, skillNames: skills.map(s => s.name) };

--- a/serving/skills-cli/build-dist.ts
+++ b/serving/skills-cli/build-dist.ts
@@ -98,17 +98,17 @@ export function processSkills(publishRoot: string) {
     // Versioning.
     //
     // - This identifier only changes when the SKILL.md does.
-    // - SKILL_VERSION.md is published to npm, and the modern-web-guidance CLI uses
+    // - skill-version.txt is published to npm, and the modern-web-guidance CLI uses
     //   it to know what version is the latest.
     // - We replace "--skill-version SKILL_VERSION" in SKILL.md, such that agents will
     //   call npx and pass along the agent's version.
     // - If they differ, the CLI tool logs a warning to stderr with instructions on how
     //   to update.
     const skillVersion = execSync(
-      `git log -1 --date=format:"%Y_%m_%d" --pretty=format:"%cd-%h" "${sourceDir}"`,
-      { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }
+      'git log -1 --date=format:"%Y_%m_%d" --pretty=format:"%cd-%h" SKILL.md',
+      { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'], cwd: sourceDir }
     ).trim();
-    fs.writeFileSync(path.join(skillDestDir, 'SKILL_VERSION.md'), skillVersion);
+    fs.writeFileSync(path.join(skillDestDir, 'skill-version.txt'), skillVersion);
 
     const content = replaceMacros(fs.readFileSync(source, 'utf8'), source, { target })
       .replaceAll('SKILL_VERSION', skillVersion);

--- a/serving/skills-cli/build-dist.ts
+++ b/serving/skills-cli/build-dist.ts
@@ -106,20 +106,21 @@ async function main(opts: { publishRoot: string, version?: string}): Promise<Bui
   const { publishRoot, version} = opts;
 
   const DIST_DIR = path.join(publishRoot, "skills/modern-web-guidance");
-  const modernWebMjs = path.join(DIST_DIR, "modern-web.mjs");
+  // const modernWebMjs = path.join(DIST_DIR, "modern-web.mjs");
 
   // Step 1: Check if we can short-circuit without wiping anything.
   // processGuides internally uses dist/.cache/ and evaluates the source hashes.
-  const skipped = await processGuides({
+  const _skipped = await processGuides({
     outputDir: DIST_DIR,
     target: 'skills-cli',
   });
 
-  if (skipped && fs.existsSync(modernWebMjs)) {
-    const { skillsCount, skillNames } = processSkills(publishRoot);
-    const { featuresCount, useCasesCount } = updateReadmeWithFeaturesAndUseCases(publishRoot);
-    return { featuresCount, useCasesCount, skillsCount, skillNames };
-  }
+  // TODO: this code prevented modern-web.mjs from rebuilding on changes.
+  // if (skipped && fs.existsSync(modernWebMjs)) {
+  //   const { skillsCount, skillNames } = processSkills(publishRoot);
+  //   const { featuresCount, useCasesCount } = updateReadmeWithFeaturesAndUseCases(publishRoot);
+  //   return { featuresCount, useCasesCount, skillsCount, skillNames };
+  // }
 
   // Step 2: If we didn't short-circuit, we do a clean, purist build.
   // Now we can safely wipe publishRoot completely!

--- a/serving/skills-cli/template/README.md
+++ b/serving/skills-cli/template/README.md
@@ -101,21 +101,6 @@ We don't recommend this method, but it will work.
 npx modern-web-guidance@latest update
 ```
 
-**(Claude Code): auto-check on session start.** Add a `SessionStart` hook to your Claude Code `settings.json` to keep these skills up-to-date:
-
-```json
-{
-  "hooks": {
-    "SessionStart": [
-      {
-        "type": "command",
-        "command": "npx modern-web-guidance@latest update -g -y 2>/dev/null"
-      }
-    ]
-  }
-}
-```
-
 ## This isn't slop. We've got the evals to prove it. ;)
 
 Every piece of guidance in this pack isn't just a tutorial—it is **empirically proven and continuously calibrated** to guarantee AI agents write better code. We test every guide using an automated quality-assurance harness to ensure correct agent behavior.

--- a/serving/skills-cli/template/README.md
+++ b/serving/skills-cli/template/README.md
@@ -61,7 +61,7 @@ Token-efficient, targeted, and private guidance injected right into the context 
 ## Get started
 
 ```shell
-npx modern-web-guidance install
+npx modern-web-guidance@latest install
 ```
 
 This will run a quick interactive wizard to install the modern-web-guidance-skill to your preferences, and for your configured agents.
@@ -92,6 +92,28 @@ We don't recommend this method, but it will work.
 /plugin install modern-web-guidance@googlechrome
 /plugin  # Select GoogleChrome marketplace, hit enter, enable AutoUpdate
 /reload-plugins
+```
+
+## Updating
+
+```sh
+# Update all installed skills
+npx modern-web-guidance@latest update
+```
+
+**(Claude Code): auto-check on session start.** Add a `SessionStart` hook to your Claude Code `settings.json` to keep these skills up-to-date:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "type": "command",
+        "command": "npx modern-web-guidance@latest update -g -y 2>/dev/null"
+      }
+    ]
+  }
+}
 ```
 
 ## This isn't slop. We've got the evals to prove it. ;)
@@ -145,4 +167,4 @@ We grade both outputs and only release guides that demonstrate a massive, quanti
 * **`chrome-extensions`**: (181 tokens) Manifest V3 development, background service workers, content scripts, and extension APIs. Manage Chrome Web Store metadata, permissions justifications, privacy policies, and publishing readiness.
 
 \# Choose which skills you want  
-`npx modern-web-guidance install --choose`
+`npx modern-web-guidance@latest install --choose`


### PR DESCRIPTION
Adds a self-updating procedure for the modern-web-guidance skill. Roughly:

- The SKILL.md we publish is instructed to call `npx modern-web-guidance` with a version identifier: `--skill-version 2026_05_13-bc852b5c`
- That version identifier only updates if the SKILL.md we publish updates (not if we just publish new guides to NPM)
- The modern-web-guidance CLI compares the agent caller's version with the latest version. If it differs, it logs a warning to stderr with
  instructions on how to update.


Also:

* add `npx modern-web-guidance@latest update` command, which defers to `npx skills update` but for just our skills
* ~~documented how users can update our skills, including how to automate it with Claude Code (learned this here https://joost.blog/self-updating-agent-skills/)~~
* add `@latest` to documented commands - without this, if a user happens to be in a project repo that has our npm package installed by any dependency, it would result in using whatever version that happened to be pinned at (stale)
* commented out skip logic from recent build changes - it was preventing me from iterating on modern-web.mjs
