### PR TITLE
Revert "capture stdout from install command"

### DIFF
--- a/serving/bin/modern-web.ts
+++ b/serving/bin/modern-web.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node --experimental-strip-types
 
 import { parseArgs } from "node:util";
-import { spawn } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { join } from "node:path";
 import { readFileSync } from "node:fs";
 import { retrieveUseCase } from "../lib/retrieve.ts";
@@ -89,29 +89,14 @@ async function main() {
     }
   } else if (command === "install") {
     const extraArgs = process.argv.slice(3);
-    const child = spawn("npx", ["skills", "add", "GoogleChrome/modern-web-guidance", ...extraArgs], {
-      stdio: ["inherit", "pipe", "inherit"],
-      env: { ...process.env, FORCE_COLOR: "1" }
+    const result = spawnSync("npx", ["skills", "add", "GoogleChrome/modern-web-guidance", ...extraArgs], {
+      stdio: "inherit",
     });
-
-    let capturedStdout = "";
-    child.stdout?.on("data", (data) => {
-      capturedStdout += data.toString();
-      process.stdout.write(data);
-    });
-
-    const status = await new Promise<number>((resolve) => {
-      child.on("close", (code) => resolve(code ?? 0));
-      child.on("error", (err) => {
-        console.error("Install failed:", err);
-        resolve(1);
-      });
-    });
-
-    // You can now post-process capturedStdout here.
-    // e.g. if (capturedStdout.includes("...")) { ... }
-
-    process.exit(status);
+    if (result.error) {
+      console.error("Install failed:", result.error);
+      process.exit(1);
+    }
+    process.exit(result.status ?? 0);
   } else {
     console.error(`Unknown command: ${command}`);
     printUsage();


### PR DESCRIPTION
Reverts GoogleChrome/guidance#786

it broke the interactivity of `node serving/bin/modern-web.ts install`