### PR TITLE
update discipline tasks to remove SKILL mention to reflect monoskill approach

### DIFF
--- a/guides/forms/forms/tasks/task.md
+++ b/guides/forms/forms/tasks/task.md
@@ -1,4 +1,4 @@
 ---
 base_app: daily-grind
 ---
-- Build a comprehensive, accessible, and secure multi-step registration form for our rewards program at the bottom of the page, AND audit and fix any existing accessibility or security issues in the page's current forms or structure. If the `forms` skill guide is available, apply all its rules and patterns fully.
+- Build a comprehensive, accessible, and secure multi-step registration form for our rewards program at the bottom of the page, AND audit and fix any existing accessibility or security issues in the page's current forms or structure.

--- a/guides/performance/performance/tasks/task.md
+++ b/guides/performance/performance/tasks/task.md
@@ -1,4 +1,4 @@
 ---
 base_app: daily-grind
 ---
-- Perform a comprehensive audit and optimization of the site. If the `performance` SKILL guide is available, apply all its rules and patterns fully to the project, except for Service Worker guidelines which are out of scope for this task.
+- Perform a comprehensive audit and optimization of the site.


### PR DESCRIPTION
noticed this as an issue while testing the evals with an updated MWG skill [description](https://github.com/GoogleChrome/guidance/pull/456#discussion_r3230866502)