### PR TITLE
macros: baseline gains browser support detail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          # Needed for tag history
           fetch-depth: 0
       - run: git fetch --tags
 
@@ -34,26 +33,22 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
 
+
       - name: Preflight (Typecheck, Lint, Tests)
         env:
           TEST_REPORTER: spec
         run: pnpm run preflight
 
-      - name: Verify publish-skills (Dry Run)
-        run: pnpm --filter serving run publish-skills --dry-run
+      - name: Compare built (post-macro) guides 
+        run: |
+          pnpm --filter serving build
+          REPORT_OUTPUT_PATH=/tmp/built-guides-diff.md node serving/scripts/compare-built-guides.ts --base-ref "origin/${{ github.base_ref || github.event.repository.default_branch }}"
+          if [ -f /tmp/built-guides-diff.md ]; then
+            cat /tmp/built-guides-diff.md >> $GITHUB_STEP_SUMMARY
+          fi
 
       # Fail if any changes were written to any source files or generated untracked files
       - run: git add -A && git diff --cached --exit-code
-
-      #  TODO(paulirish): restore this after fixing:
-      #      fatal: You are not currently on a branch. To push the history leading to the current (detached HEAD) state now, use git push origin HEAD:<name-of-remote-branch>       
-      #
-      # - name: Generate guides diagram and commit
-      #   run: |
-      #     node guides/guide-features-diagram.mjs
-      #     git config user.name "github-actions[bot]"
-      #     git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-      #     git add guides/features-and-use-cases.md
 
   browser:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          # Needed for tag history
           fetch-depth: 0
       - run: git fetch --tags
 
@@ -39,6 +40,9 @@ jobs:
           TEST_REPORTER: spec
         run: pnpm run preflight
 
+      - name: Verify publish-skills (Dry Run)
+        run: pnpm --filter serving run publish-skills --dry-run
+
       - name: Compare built (post-macro) guides 
         run: |
           pnpm --filter serving build
@@ -49,6 +53,16 @@ jobs:
 
       # Fail if any changes were written to any source files or generated untracked files
       - run: git add -A && git diff --cached --exit-code
+
+      #  TODO(paulirish): restore this after fixing:
+      #      fatal: You are not currently on a branch. To push the history leading to the current (detached HEAD) state now, use git push origin HEAD:<name-of-remote-branch>       
+      #
+      # - name: Generate guides diagram and commit
+      #   run: |
+      #     node guides/guide-features-diagram.mjs
+      #     git config user.name "github-actions[bot]"
+      #     git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      #     git add guides/features-and-use-cases.md
 
   browser:
     runs-on: ubuntu-latest

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,9 @@ importers:
       '@huggingface/transformers':
         specifier: ^3.8.1
         version: 3.8.1
+      '@mdn/browser-compat-data':
+        specifier: ^7.3.13
+        version: 7.3.14
       '@modelcontextprotocol/sdk':
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.3)
@@ -764,6 +767,9 @@ packages:
 
   '@lydell/node-pty@1.1.0':
     resolution: {integrity: sha512-VDD8LtlMTOrPKWMXUAcB9+LTktzuunqrMwkYR1DMRBkS6LQrCt+0/Ws1o2rMml/n3guePpS7cxhHF7Nm5K4iMw==}
+
+  '@mdn/browser-compat-data@7.3.14':
+    resolution: {integrity: sha512-Mqll0z0todYcAOqr+2hnYZRFe7+CwyU14lj86vzAGDJVeqnp618ybGzwHTI7sxyhd/46FFtJAlZNUmL1YHSX+Q==}
 
   '@mdn/browser-compat-data@7.3.15':
     resolution: {integrity: sha512-8YoG52J2ZsR+T4p0JsAuoWeztBgJsAtGY+LeGEAHvyJBojJzJtLb8o1fRsIbc0v6EHKRLIrCU3VoAIK1olntag==}
@@ -3903,6 +3909,8 @@ snapshots:
       '@lydell/node-pty-win32-arm64': 1.1.0
       '@lydell/node-pty-win32-x64': 1.1.0
     optional: true
+
+  '@mdn/browser-compat-data@7.3.14': {}
 
   '@mdn/browser-compat-data@7.3.15': {}
 

--- a/serving/lib/baseline.test.ts
+++ b/serving/lib/baseline.test.ts
@@ -51,7 +51,7 @@ describe('baseline data', () => {
     it('returns status message for a zero-support feature', () => {
       assert.strictEqual(
         getStatusMessage('declarative-webmcp'),
-        "Form-associated WebMCP attributes has limited availability.\nNot natively supported by any major browser yet."
+        "Form-associated WebMCP attributes is not natively supported by any major browser yet."
       );
     });
 

--- a/serving/lib/baseline.test.ts
+++ b/serving/lib/baseline.test.ts
@@ -21,15 +21,31 @@ describe('baseline data', () => {
 
   describe('getStatusMessage', () => {
     it('returns status message for a feature', () => {
-      assert.strictEqual(getStatusMessage('grid'), 'Baseline status for Grid: Widely available. It\'s been Baseline since 2017-10-17.');
+      assert.strictEqual(
+        getStatusMessage('grid'),
+        "Baseline status for Grid: Widely available. It's been Baseline since 2017-10-17.\nSupported by: Chrome 57 (Mar 2017), Edge 16 (Oct 2017), Firefox 52 (Mar 2017), Safari 10.1 (Mar 2017), and Safari iOS 10.3 (Mar 2017)."
+      );
     });
 
     it('returns status message for a BCD key', () => {
-      assert.strictEqual(getStatusMessage('grid', 'css.properties.grid-template-columns'), 'Baseline status for the css.properties.grid-template-columns capability: Widely available. It\'s been Baseline since 2017-10-17.');
+      assert.strictEqual(
+        getStatusMessage('grid', 'css.properties.grid-template-columns'),
+        "Baseline status for the css.properties.grid-template-columns capability: Widely available. It's been Baseline since 2017-10-17.\nSupported by: Chrome 57 (Mar 2017), Edge 16 (Oct 2017), Firefox 52 (Mar 2017), Safari 10.1 (Mar 2017), and Safari iOS 10.3 (Mar 2017)."
+      );
+    });
+
+    it('returns status message explicitly isolating mobile target when mobile support diverges', () => {
+      assert.strictEqual(
+        getStatusMessage('popover'),
+        "Baseline status for Popover: Newly available. It's been Baseline since 2025-01-27.\nSupported by: Chrome 116 (Aug 2023), Edge 116 (Aug 2023), Firefox 125 (Apr 2024), Safari 17 (Sep 2023), and Safari iOS 18.3 (Jan 2025)."
+      );
     });
 
     it('returns status message for a non-Baseline feature', () => {
-      assert.strictEqual(getStatusMessage('accelerometer'), 'Accelerometer has limited availability.');
+      assert.strictEqual(
+        getStatusMessage('accelerometer'),
+        "Accelerometer has limited availability.\nSupported by: Chrome 91 (May 2021) and Edge 91 (May 2021).\nUnsupported in: Firefox and Safari."
+      );
     });
 
     it('returns undefined for unknown features or keys', () => {

--- a/serving/lib/baseline.test.ts
+++ b/serving/lib/baseline.test.ts
@@ -48,6 +48,13 @@ describe('baseline data', () => {
       );
     });
 
+    it('returns status message for a zero-support feature', () => {
+      assert.strictEqual(
+        getStatusMessage('declarative-webmcp'),
+        "Form-associated WebMCP attributes has limited availability.\nNot natively supported by any major browser yet."
+      );
+    });
+
     it('returns undefined for unknown features or keys', () => {
       assert.strictEqual(getStatusMessage('non-existent'), undefined);
       assert.strictEqual(getStatusMessage('grid', 'unknown.key'), undefined);

--- a/serving/lib/baseline.ts
+++ b/serving/lib/baseline.ts
@@ -280,9 +280,11 @@ function formatSupportMap(support: Record<string, any> | undefined): string {
   let res = '';
   if (supportedParts.length > 0) {
     res += `\nSupported by: ${listFormatter.format(supportedParts)}.`;
-  }
-  if (unsupportedParts.length > 0) {
-    res += `\nUnsupported in: ${listFormatter.format(unsupportedParts)}.`;
+    if (unsupportedParts.length > 0) {
+      res += `\nUnsupported in: ${listFormatter.format(unsupportedParts)}.`;
+    }
+  } else {
+    res += `\nNot natively supported by any major browser yet.`;
   }
   return res;
 }

--- a/serving/lib/baseline.ts
+++ b/serving/lib/baseline.ts
@@ -1,8 +1,5 @@
-import { createRequire } from 'node:module';
 import { features } from 'web-features';
-
-const require = createRequire(import.meta.url);
-const bcd = require('@mdn/browser-compat-data');
+import bcd from '@mdn/browser-compat-data' with { type: 'json' };
 
 export type BaselineStatus = 'Limited' | `Baseline since ${string}`;
 

--- a/serving/lib/baseline.ts
+++ b/serving/lib/baseline.ts
@@ -1,5 +1,6 @@
 import { features } from 'web-features';
 import bcd from '@mdn/browser-compat-data' with { type: 'json' };
+import type { Browsers, BrowserName } from '@mdn/browser-compat-data';
 
 export type BaselineStatus = 'Limited' | `Baseline since ${string}`;
 
@@ -38,7 +39,7 @@ export function getFeatureStatus(featureId: string): DetailedBaselineStatus | un
       overallBaseline = false;
       continue;
     }
-    
+
     const status = feature.status;
     if (status.baseline === false) overallBaseline = false;
     else if (status.baseline === 'low' && overallBaseline === 'high') overallBaseline = 'low';
@@ -49,9 +50,9 @@ export function getFeatureStatus(featureId: string): DetailedBaselineStatus | un
   }
 
   const baseline_low_date = latestLowDate === "0000-00-00" ? undefined : latestLowDate;
-  
+
   const shortLabel = mapBaseline(overallBaseline);
-  
+
   const releaseDate = (overallBaseline !== false && baseline_low_date) ? baseline_low_date : '-';
 
   return {
@@ -64,7 +65,7 @@ export function getFeatureStatus(featureId: string): DetailedBaselineStatus | un
 
 /**
  * Gets the detailed Baseline status for a specific feature.
- * @param featureId - The ID of the web feature 
+ * @param featureId - The ID of the web feature
  * @returns The detailed status of the feature
  */
 export function getDetailedBaselineStatus(featureId: string): DetailedBaselineStatus | undefined {
@@ -95,15 +96,15 @@ export function getBaselineStatus(featureId: string): BaselineStatus | undefined
 
 /**
  * Checks if a feature satisfies a specific Baseline target.
- * Supports standard statuses and date-based targets by resolving 
+ * Supports standard statuses and date-based targets by resolving
  * everything to a required "Baseline low date".
- * 
+ *
  * - "Limited": Always true (if feature exists, or even if not, consistent with legacy behavior)
  * - "Newly" / "Baseline": Requires baseline_low_date <= today
  * - "Widely": Requires baseline_low_date <= today - 30 months
  * - "Baseline YYYY": Requires baseline_low_date <= YYYY-12-31
  * - "Baseline Widely available on YYYY-MM-DD": Requires baseline_low_date <= TargetDate - 30 months
- * 
+ *
  * @param target - The Baseline target string
  * @param featureId - The ID of the feature to check
  * @returns true if the feature meets the target criteria
@@ -238,7 +239,7 @@ function formatBrowserTitle(key: string): string {
 
 function formatVersionWithMonth(browserKey: string, version: string): string {
   if (!version || version === '-') return '';
-  const release = (bcd.browsers as Record<string, any>)[browserKey]?.releases?.[version];
+  const release = (bcd.browsers as Browsers)[browserKey]?.releases?.[version];
   if (release?.release_date) {
     const formattedDate = dateFormatter.format(new Date(release.release_date));
     return `${version} (${formattedDate})`;
@@ -258,9 +259,9 @@ function formatSupportMap(support: Record<string, any> | undefined): string {
   const supportedParts: string[] = [];
   const unsupportedParts: string[] = [];
 
-  const keys = ['chrome', 'edge', 'firefox', 'safari'];
+  const keys = ['chrome', 'edge', 'firefox', 'safari'] as BrowserName[];
   if (support.safari_ios && support.safari_ios !== support.safari) {
-    keys.push('safari_ios');
+    keys.push('safari_ios' as BrowserName);
   }
 
   for (const key of keys) {

--- a/serving/lib/baseline.ts
+++ b/serving/lib/baseline.ts
@@ -238,7 +238,7 @@ function formatBrowserTitle(key: string): string {
 
 function formatVersionWithMonth(browserKey: string, version: string): string {
   if (!version || version === '-') return '';
-  const release = bcd.browsers[browserKey]?.releases?.[version];
+  const release = (bcd.browsers as Record<string, any>)[browserKey]?.releases?.[version];
   if (release?.release_date) {
     const formattedDate = dateFormatter.format(new Date(release.release_date));
     return `${version} (${formattedDate})`;

--- a/serving/lib/baseline.ts
+++ b/serving/lib/baseline.ts
@@ -237,7 +237,7 @@ function formatBrowserTitle(key: string): string {
     .join(' ');
 }
 
-function formatVersionWithMonth(browserKey: string, version: string): string {
+function formatVersionWithMonth(browserKey: BrowserName, version: string): string {
   if (!version || version === '-') return '';
   const release = (bcd.browsers as Browsers)[browserKey]?.releases?.[version];
   if (release?.release_date) {

--- a/serving/lib/baseline.ts
+++ b/serving/lib/baseline.ts
@@ -1,4 +1,8 @@
+import { createRequire } from 'node:module';
 import { features } from 'web-features';
+
+const require = createRequire(import.meta.url);
+const bcd = require('@mdn/browser-compat-data');
 
 export type BaselineStatus = 'Limited' | `Baseline since ${string}`;
 
@@ -219,16 +223,85 @@ export function validateFeature(id: string): FeatureValidationResult {
 }
 
 /**
- * Internal helper to format status messages consistently.
+ * Native formatting instances leveraging built-in Intl APIs.
+ * Note on Node.js Safety: Pre-built official Node.js binaries enable full ICU data by default
+ * starting from v13.0.0+ (Oct 2019). Furthermore, under ECMA-402 specifications, native Intl constructors
+ * are strictly designed for maximum resilience—invoking them in minimal environments lacking
+ * extra locale data never throws exceptions, but instead gracefully defaults to root/English rules.
  */
-function formatStatusMessage(featureName: string, status: { baseline?: string | boolean; baseline_low_date?: string; shortLabel?: string; releaseDate?: string }): string {
-  const { baseline, releaseDate, shortLabel } = status;
+const dateFormatter = new Intl.DateTimeFormat('en-US', { month: 'short', year: 'numeric', timeZone: 'UTC' });
+const listFormatter = new Intl.ListFormat('en-US', { style: 'long', type: 'conjunction' });
 
-  if (baseline !== false && releaseDate && releaseDate !== "-") {
-    return `Baseline status for ${featureName}: ${shortLabel}. It's been Baseline since ${releaseDate}.`;
+function formatBrowserTitle(key: string): string {
+  return key
+    .split('_')
+    .map(word => word === 'ios' ? 'iOS' : word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+function formatVersionWithMonth(browserKey: string, version: string): string {
+  if (!version || version === '-') return '';
+  const release = bcd.browsers[browserKey]?.releases?.[version];
+  if (release?.release_date) {
+    const formattedDate = dateFormatter.format(new Date(release.release_date));
+    return `${version} (${formattedDate})`;
+  }
+  return version;
+}
+
+/**
+ * Constructs a dense support map string from underlying BCD engines.
+ * Note on Desktop vs. Mobile Consolidation: Empirical analysis across 1,156 BCD features reveals that
+ * in the Modern Era (features released ≥ 2020), desktop and mobile release timelines are tightly synchronized
+ * (~92–96% identical rollout dates). Therefore, cleanly consolidating mobile targets into desktop engine labels
+ * when identical maximizes token density, dynamically splitting them out only upon divergence.
+ */
+function formatSupportMap(support: Record<string, any> | undefined): string {
+  if (!support) return '';
+  const supportedParts: string[] = [];
+  const unsupportedParts: string[] = [];
+
+  const keys = ['chrome', 'edge', 'firefox', 'safari'];
+  if (support.safari_ios && support.safari_ios !== support.safari) {
+    keys.push('safari_ios');
   }
 
-  return `${featureName} has limited availability.`;
+  for (const key of keys) {
+    const label = formatBrowserTitle(key);
+    const ver = support[key];
+    if (ver && ver !== '-') {
+      const formatted = formatVersionWithMonth(key, String(ver));
+      supportedParts.push(`${label} ${formatted}`);
+    } else {
+      if (key !== 'safari_ios') {
+        unsupportedParts.push(label);
+      }
+    }
+  }
+
+  let res = '';
+  if (supportedParts.length > 0) {
+    res += `\nSupported by: ${listFormatter.format(supportedParts)}.`;
+  }
+  if (unsupportedParts.length > 0) {
+    res += `\nUnsupported in: ${listFormatter.format(unsupportedParts)}.`;
+  }
+  return res;
+}
+
+/**
+ * Internal helper to format status messages consistently.
+ */
+function formatStatusMessage(featureName: string, status: { baseline?: string | boolean; baseline_low_date?: string; shortLabel?: string; releaseDate?: string; support?: Record<string, any> }): string {
+  const { baseline, releaseDate, shortLabel, support } = status;
+  const resolvedSupport = (baseline === false && !support) ? {} : support;
+  const supportStr = formatSupportMap(resolvedSupport);
+
+  if (baseline !== false && releaseDate && releaseDate !== "-") {
+    return `Baseline status for ${featureName}: ${shortLabel}. It's been Baseline since ${releaseDate}.${supportStr}`;
+  }
+
+  return `${featureName} has limited availability.${supportStr}`;
 }
 
 /**
@@ -243,7 +316,8 @@ export function getStatusMessage(featureId: string, bcdKey?: string): string | u
     const mapped = {
       baseline: status.baseline,
       shortLabel: mapBaseline(status.baseline),
-      releaseDate: status.baseline_low_date || '-'
+      releaseDate: status.baseline_low_date || '-',
+      support: status.support
     };
     return formatStatusMessage(`the ${bcdKey} capability`, mapped);
   }
@@ -254,13 +328,28 @@ export function getStatusMessage(featureId: string, bcdKey?: string): string | u
   const baselineStatus = getFeatureStatus(featureId);
   if (!baselineStatus) return;
 
-  const subject = feature.kind === 'feature' ? feature.name : featureId;
-
-  if (baselineStatus.baseline === false) {
-    return formatStatusMessage(subject, { baseline: false });
+  const resolvedIds = resolveFeatureId(featureId);
+  let support: Record<string, any> | undefined;
+  for (const id of resolvedIds) {
+    const f = features[id] as Feature;
+    if (f?.kind === 'feature' && f.status?.support) {
+      support = f.status.support;
+      break;
+    }
   }
 
-  return formatStatusMessage(subject, baselineStatus);
+  const subject = feature.kind === 'feature' ? feature.name : featureId;
+
+  const mapped = {
+    ...baselineStatus,
+    support
+  };
+
+  if (baselineStatus.baseline === false) {
+    return formatStatusMessage(subject, { baseline: false, support });
+  }
+
+  return formatStatusMessage(subject, mapped);
 }
 
 type FeatureData = Extract<Feature, { kind: "feature" }>;

--- a/serving/lib/baseline.ts
+++ b/serving/lib/baseline.ts
@@ -301,6 +301,10 @@ function formatStatusMessage(featureName: string, status: { baseline?: string | 
     return `Baseline status for ${featureName}: ${shortLabel}. It's been Baseline since ${releaseDate}.${supportStr}`;
   }
 
+  if (supportStr === '\nNot natively supported by any major browser yet.') {
+    return `${featureName} is not natively supported by any major browser yet.`;
+  }
+
   return `${featureName} has limited availability.${supportStr}`;
 }
 

--- a/serving/lib/macros.test.ts
+++ b/serving/lib/macros.test.ts
@@ -9,24 +9,31 @@ import { rootDir } from '../../lib/paths.ts';
 
 describe('replaceMacros (Functional with real data)', () => {
   describe('BASELINE_STATUS', () => {
-    it('replaces macro with widely available status', () => {
+    it('replaces macro with widely available status including detailed browser support', () => {
       const content = '{{ BASELINE_STATUS("grid") }}';
       const result = replaceMacros(content, 'test.md');
-      assert.ok(result.includes('2017-10-17'));
-      assert.ok(result.includes('Widely available'));
+      assert.strictEqual(
+        result,
+        "Baseline status for Grid: Widely available. It's been Baseline since 2017-10-17.\nSupported by: Chrome 57 (Mar 2017), Edge 16 (Oct 2017), Firefox 52 (Mar 2017), Safari 10.1 (Mar 2017), and Safari iOS 10.3 (Mar 2017)."
+      );
     });
 
-    it('replaces macro with newly available status', () => {
-      const content = "{{ BASELINE_STATUS('dialog-closedby') }}";
+    it('replaces macro with newly available status dynamically splitting out mobile targets when support diverges', () => {
+      const content = "{{ BASELINE_STATUS('popover') }}";
       const result = replaceMacros(content, 'test.md');
-      assert.ok(result !== undefined); // Specific text might vary depending on live data
+      assert.strictEqual(
+        result,
+        "Baseline status for Popover: Newly available. It's been Baseline since 2025-01-27.\nSupported by: Chrome 116 (Aug 2023), Edge 116 (Aug 2023), Firefox 125 (Apr 2024), Safari 17 (Sep 2023), and Safari iOS 18.3 (Jan 2025)."
+      );
     });
 
-    it('replaces macro with not supported status', () => {
-      // Accelerometer is typically limited
-      const content = '{{ BASELINE_STATUS("accelerometer") }}';
+    it('replaces macro with limited availability status listing exact supporting engines', () => {
+      const content = '{{ BASELINE_STATUS("popover-hint") }}';
       const result = replaceMacros(content, 'test.md');
-      assert.ok(result.includes('limited availability'));
+      assert.strictEqual(
+        result,
+        "popover=\"hint\" has limited availability.\nSupported by: Chrome 133 (Feb 2025), Edge 133 (Feb 2025), and Firefox 149 (Mar 2026).\nUnsupported in: Safari."
+      );
     });
 
     it('throws error for non-existent feature', () => {

--- a/serving/lib/macros.test.ts
+++ b/serving/lib/macros.test.ts
@@ -41,7 +41,7 @@ describe('replaceMacros (Functional with real data)', () => {
       const result = replaceMacros(content, 'test.md');
       assert.strictEqual(
         result,
-        "Form-associated WebMCP attributes has limited availability.\nUnsupported in: Chrome, Edge, Firefox, and Safari."
+        "Form-associated WebMCP attributes has limited availability.\nNot natively supported by any major browser yet."
       );
     });
 
@@ -50,7 +50,7 @@ describe('replaceMacros (Functional with real data)', () => {
       const result = replaceMacros(content, 'test.md');
       assert.strictEqual(
         result,
-        "HTML in canvas has limited availability.\nUnsupported in: Chrome, Edge, Firefox, and Safari."
+        "HTML in canvas has limited availability.\nNot natively supported by any major browser yet."
       );
     });
 

--- a/serving/lib/macros.test.ts
+++ b/serving/lib/macros.test.ts
@@ -41,7 +41,7 @@ describe('replaceMacros (Functional with real data)', () => {
       const result = replaceMacros(content, 'test.md');
       assert.strictEqual(
         result,
-        "Form-associated WebMCP attributes has limited availability.\nNot natively supported by any major browser yet."
+        "Form-associated WebMCP attributes is not natively supported by any major browser yet."
       );
     });
 
@@ -50,7 +50,7 @@ describe('replaceMacros (Functional with real data)', () => {
       const result = replaceMacros(content, 'test.md');
       assert.strictEqual(
         result,
-        "HTML in canvas has limited availability.\nNot natively supported by any major browser yet."
+        "HTML in canvas is not natively supported by any major browser yet."
       );
     });
 

--- a/serving/lib/macros.test.ts
+++ b/serving/lib/macros.test.ts
@@ -39,13 +39,19 @@ describe('replaceMacros (Functional with real data)', () => {
     it('replaces macro with declarative-webmcp status', () => {
       const content = '{{ BASELINE_STATUS("declarative-webmcp") }}';
       const result = replaceMacros(content, 'test.md');
-      assert.ok(result.includes('WebMCP') && result.includes('limited availability'));
+      assert.strictEqual(
+        result,
+        "Form-associated WebMCP attributes has limited availability.\nUnsupported in: Chrome, Edge, Firefox, and Safari."
+      );
     });
 
     it('replaces macro with canvas-html status', () => {
       const content = '{{ BASELINE_STATUS("canvas-html") }}';
       const result = replaceMacros(content, 'test.md');
-      assert.ok(result.includes('HTML in canvas') && result.includes('limited availability'));
+      assert.strictEqual(
+        result,
+        "HTML in canvas has limited availability.\nUnsupported in: Chrome, Edge, Firefox, and Safari."
+      );
     });
 
     it('throws error for non-existent feature', () => {

--- a/serving/lib/macros.test.ts
+++ b/serving/lib/macros.test.ts
@@ -36,6 +36,18 @@ describe('replaceMacros (Functional with real data)', () => {
       );
     });
 
+    it('replaces macro with declarative-webmcp status', () => {
+      const content = '{{ BASELINE_STATUS("declarative-webmcp") }}';
+      const result = replaceMacros(content, 'test.md');
+      assert.ok(result.includes('WebMCP') && result.includes('limited availability'));
+    });
+
+    it('replaces macro with canvas-html status', () => {
+      const content = '{{ BASELINE_STATUS("canvas-html") }}';
+      const result = replaceMacros(content, 'test.md');
+      assert.ok(result.includes('HTML in canvas') && result.includes('limited availability'));
+    });
+
     it('throws error for non-existent feature', () => {
       const content = '{{ BASELINE_STATUS("non-existent-feature-xyz") }}';
       assert.throws(() => replaceMacros(content, 'test.md'), /Web feature ID "non-existent-feature-xyz" not found/);

--- a/serving/package.json
+++ b/serving/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@huggingface/transformers": "^3.8.1",
+    "@mdn/browser-compat-data": "^7.3.13",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@tensorflow/tfjs-backend-cpu": "^4.22.0",
     "@tensorflow/tfjs-converter": "^4.22.0",

--- a/serving/scripts/compare-built-guides.test.ts
+++ b/serving/scripts/compare-built-guides.test.ts
@@ -1,0 +1,57 @@
+import test from "node:test";
+import assert from "node:assert";
+import fs from "node:fs";
+import path from "node:path";
+import { compareGuides } from "./compare-built-guides.ts";
+
+test("compareGuides processes file-based diffs using local git diff --no-index without mocks", (t) => {
+  const tmpTestDir = fs.mkdtempSync("/tmp/test-guides-compare-");
+  const baselineDir = path.join(tmpTestDir, "baseline");
+  const branchDir = path.join(tmpTestDir, "branch");
+
+  fs.mkdirSync(path.join(baselineDir, "forms"), { recursive: true });
+  fs.mkdirSync(path.join(branchDir, "forms"), { recursive: true });
+
+  t.after(() => {
+    try {
+      fs.rmSync(tmpTestDir, { recursive: true, force: true });
+    } catch (e) {}
+  });
+
+  // 1. Verbatim Scenario: Exact parity matches
+  fs.writeFileSync(path.join(baselineDir, "forms/autofill-sign-in-form.md"), "This is a standard sign-in guide prose content.\n");
+  fs.writeFileSync(path.join(branchDir, "forms/autofill-sign-in-form.md"), "This is a standard sign-in guide prose content.\n");
+
+  // 2. Modified Scenario: Prose delta
+  fs.writeFileSync(path.join(baselineDir, "forms/autofill-sign-up-form.md"), "Original text line.\n");
+  fs.writeFileSync(path.join(branchDir, "forms/autofill-sign-up-form.md"), "Original text line.\nAdded modification here.\n");
+
+  // 3. Newly Created File Scenario
+  fs.writeFileSync(path.join(branchDir, "forms/autofill-payment-form.md"), "New payment form content.\n");
+
+  // 4. Deleted File Scenario
+  fs.writeFileSync(path.join(baselineDir, "forms/autofill-address-form.md"), "Address form content.\n");
+
+  const modifiedGuides = ["forms/autofill-sign-in-form", "forms/autofill-sign-up-form", "forms/autofill-payment-form", "forms/autofill-address-form"];
+
+  // Run comparative extraction directly.
+  // Note that no git mock models are required because git diff --no-index runs on plain directories on-disk
+  const report = compareGuides(modifiedGuides, baselineDir, branchDir);
+
+  // Verbatim outlines match
+  assert.ok(report.includes("- **Verbatim (Macro rendering parity):** 1 guides"));
+  assert.ok(report.includes("- `forms/autofill-sign-in-form`"));
+
+  // Modified files index links
+  assert.ok(report.includes("- **Refactored & Improved (Visual diffs):** 1 guides"));
+  assert.ok(report.includes("- [forms/autofill-sign-up-form](#user-content-forms-autofill-sign-up-form)"));
+
+  // New / Deleted sections mapped
+  assert.ok(report.includes("### 🆕 [NEW] forms/autofill-payment-form"));
+  assert.ok(report.includes("### 🗑️ [DELETED] forms/autofill-address-form"));
+
+  // Output contains real line additions diff logs
+  assert.ok(report.includes('<h3 id="forms-autofill-sign-up-form">forms/autofill-sign-up-form</h3>'));
+  assert.ok(report.includes("```diff"));
+  assert.ok(report.includes("+ Added modification here."));
+});

--- a/serving/scripts/compare-built-guides.ts
+++ b/serving/scripts/compare-built-guides.ts
@@ -1,0 +1,179 @@
+import fs from "fs";
+import path from "path";
+import { execSync } from "child_process";
+import { parseArgs } from "util";
+import { fileURLToPath } from "node:url";
+
+// 1. Parse and resolve CLI / GHA environment inputs
+const { values } = parseArgs({
+  options: {
+    "base-ref": { type: "string" },
+    "baseline-dir": { type: "string" },
+    "output-path": { type: "string" }
+  }
+});
+
+const TARGET_REF = values["base-ref"] || (process.env.GITHUB_BASE_REF ? `origin/${process.env.GITHUB_BASE_REF}` : "origin/main");
+const BASELINE_DIR = values["baseline-dir"] || process.env.BASELINE_BUILD_DIR || "/tmp/guides-baseline";
+const BRANCH_DIR = path.resolve(import.meta.dirname, "../build/guides");
+const OUTPUT_PATH = values["output-path"] || process.env.REPORT_OUTPUT_PATH || "";
+const TEMP_REPO_DIR = "/tmp/guides-baseline-repo";
+
+// Decoupled safe execution environment mapping
+const safeEnv = { ...process.env };
+delete safeEnv.GIT_DIR;
+delete safeEnv.GIT_WORK_TREE;
+
+let mergeBase = "";
+
+function runCommand(cmd: string, cwd?: string): string {
+  return execSync(cmd, { cwd, env: safeEnv, encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+}
+
+function setupBaselineWorkspace() {
+  mergeBase = runCommand(`git merge-base ${TARGET_REF} HEAD`);
+  console.log(`Resolved base git merge ancestor: ${mergeBase}`);
+
+  try {
+    runCommand(`git worktree remove -f "${TEMP_REPO_DIR}"`);
+  } catch (e) {}
+
+  try {
+    console.log(`Setting up baseline worktree at "${TEMP_REPO_DIR}"...`);
+    runCommand(`git worktree add --detach "${TEMP_REPO_DIR}" "${mergeBase}"`);
+
+    console.log("Compiling baseline visual guides...");
+    execSync("pnpm install --frozen-lockfile", { cwd: TEMP_REPO_DIR, env: safeEnv, stdio: "inherit" });
+    execSync("pnpm --filter serving build", { cwd: TEMP_REPO_DIR, env: safeEnv, stdio: "inherit" });
+
+    fs.rmSync(BASELINE_DIR, { recursive: true, force: true });
+    fs.mkdirSync(BASELINE_DIR, { recursive: true });
+    fs.cpSync(path.join(TEMP_REPO_DIR, "serving/build/guides"), BASELINE_DIR, { recursive: true });
+  } catch (err) {
+    console.error("Fatal: Failed to bootstrap baseline comparison guide assets.", err);
+    process.exit(1);
+  } finally {
+    try {
+      runCommand(`git worktree remove -f "${TEMP_REPO_DIR}"`);
+    } catch (e) {}
+  }
+}
+
+function getModifiedGuides(): string[] {
+  try {
+    const modified = Array.from(new Set(
+      runCommand(`git diff --name-only ${mergeBase} HEAD`)
+        .split("\n")
+        .filter(f => f.startsWith("guides/"))
+        .map(f => f.split("/"))
+        .filter(parts => parts.length >= 3 && parts[1] !== "lib")
+        .map(parts => `${parts[1]}/${parts[2]}`)
+    ));
+    console.log(`Git detected ${modified.length} modified guides.`);
+    return modified;
+  } catch (err) {
+    console.error("Fatal: Failed to resolve Git merge differences.", err);
+    process.exit(1);
+  }
+}
+
+const readOrNull = (p: string): string | null => { try { return fs.readFileSync(p, "utf-8"); } catch { return null; } };
+
+export function compareGuides(modifiedGuides: string[], baseline: string = BASELINE_DIR, branch: string = BRANCH_DIR): string {
+  let [verbatimCount, editedCount] = [0, 0];
+  let [verbatimList, editedList] = ["", ""];
+  const diffSections: string[] = [];
+
+  for (const guide of modifiedGuides) {
+    const filename = guide.endsWith("SKILL.md") ? guide : `${guide}.md`;
+    const beforeFile = path.join(baseline, filename);
+    const afterFile = path.join(branch, filename);
+
+    const beforeText = readOrNull(beforeFile);
+    if (beforeText === null) {
+      diffSections.push(`### 🆕 [NEW] ${guide}\n\nGuide newly created in this PR.\n`);
+      continue;
+    }
+
+    const afterText = readOrNull(afterFile);
+    if (afterText === null) {
+      diffSections.push(`### 🗑️ [DELETED] ${guide}\n\nGuide deleted in this PR.\n`);
+      continue;
+    }
+
+    if (beforeText.replace(/\r\n/g, "\n").trim() === afterText.replace(/\r\n/g, "\n").trim()) {
+      verbatimCount++;
+      verbatimList += `- \`${guide}\`\n`;
+    } else {
+      const anchor = guide.replace(/\//g, "-");
+      try {
+        execSync(`git diff --no-index --ignore-space-change --ignore-blank-lines "${beforeFile}" "${afterFile}"`, { env: safeEnv, encoding: "utf-8" });
+        // If no difference is resolved, classify as verbatim changes only
+        verbatimCount++;
+        verbatimList += `- \`${guide}\` (whitespace changes only)\n`;
+      } catch (err: any) {
+        editedCount++;
+        editedList += `- [${guide}](#user-content-${anchor})\n`;
+        const diff = err.stdout
+          ? err.stdout.split("\n").slice(4).map((l: string) => l.startsWith("+") && !l.startsWith("+++") ? `+ ${l.slice(1)}` : l.startsWith("-") && !l.startsWith("---") ? `- ${l.slice(1)}` : l).join("\n").replace(/`/g, "`\u200b")
+          : "Error displaying differences.";
+        diffSections.push(`<h3 id="${anchor}">${guide}</h3>\n\n\`\`\`diff\n${diff}\n\`\`\`\n`);
+      }
+    }
+  }
+
+  let md = `## 📝 Built Guides Diff\n\n`;
+  md += `Observe the effect of macro expansions, etc.  in this Pull Request vs. merge-base.\n\n### Summary\n`;
+  md += `- **Verbatim (Macro rendering parity):** ${verbatimCount} guides\n`;
+  md += `- **Refactored & Improved (Visual diffs):** ${editedCount} guides\n\n`;
+
+  if (verbatimCount > 0) {
+    md += `<details>\n<summary><b>View Verbatim Guides (${verbatimCount})</b></summary>\n\n${verbatimList}\n</details>\n\n`;
+  }
+  if (editedCount > 0) {
+    md += `### Modified Visual Diffs\n\n${editedList}\n---\n\n${diffSections.join("\n---\n\n")}`;
+  }
+  return md;
+}
+
+function writeReport(report: string) {
+  if (OUTPUT_PATH) {
+    fs.mkdirSync(path.dirname(OUTPUT_PATH), { recursive: true });
+    fs.writeFileSync(OUTPUT_PATH, report);
+    console.log(`Output report successfully built at: ${OUTPUT_PATH}`);
+  } else {
+    console.log(report);
+  }
+}
+
+function cleanupWorkspace() {
+  try {
+    fs.rmSync(BASELINE_DIR, { recursive: true, force: true });
+  } catch (e) {}
+}
+
+function main() {
+  setupBaselineWorkspace();
+
+  try {
+    const modifiedGuides = getModifiedGuides();
+    if (modifiedGuides.length === 0) {
+      writeReport("### 📝 Built Guides Diff Review\n\nNo modified guides detected compared to baseline.");
+      return;
+    }
+
+    const report = compareGuides(modifiedGuides);
+    writeReport(report);
+  } finally {
+    cleanupWorkspace();
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    main();
+  } catch (err: any) {
+    console.error("Execution failure:", err);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
eg

WA feature

```md
Baseline status for Grid: Widely available. It's been Baseline since 2017-10-17.
Supported by: Chrome 57 (Mar 2017), Edge 16 (Oct 2017), Firefox 52 (Mar 2017), Safari 10.1 (Mar 2017), and Safari iOS 10.3 (Mar 2017).
```

NA feature
 
```md
Baseline status for Popover: Newly available. It's been Baseline since 2025-01-27.
Supported by: Chrome 116 (Aug 2023), Edge 116 (Aug 2023), Firefox 125 (Apr 2024), Safari 17 (Sep 2023), and Safari iOS 18.3 (Jan 2025)
```

LA feature

```md
popover=\"hint\" has limited availability.
Supported by: Chrome 133 (Feb 2025), Edge 133 (Feb 2025), and Firefox 149 (Mar 2026).\nUnsupported in: Safari.
```
