### PR TITLE
cli: set env -S to pass --experimental-strip-types in shebang

### DIFF
--- a/serving/bin/modern-web.ts
+++ b/serving/bin/modern-web.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --experimental-strip-types
+#!/usr/bin/env -S node --experimental-strip-types
 
 import { parseArgs } from "node:util";
 import { spawnSync } from "node:child_process";


### PR DESCRIPTION
before the change

```sh
$ npx modern-web-guidance
/usr/bin/env: ‘node --experimental-strip-types’: No such file or directory
/usr/bin/env: use -[v]S to pass options in shebang lines
```

confirmed it works on stock ubuntu after this change, and continues to work on macos