### PR TITLE
use "shell: true" on windows

### DIFF
--- a/guides/test-fixture.ts
+++ b/guides/test-fixture.ts
@@ -53,7 +53,7 @@ export const test = base.extend<{}, ServerWorkerFixtures>({
       const buildResult = spawnSync('pnpm', ['run', 'build'], {
         cwd: targetDir,
         stdio: 'ignore',
-        shell: true
+        shell: process.platform === 'win32'
       });
       if (buildResult.status !== 0) {
         throw new Error(`pnpm build failed in ${targetDir}`);
@@ -70,7 +70,8 @@ export const test = base.extend<{}, ServerWorkerFixtures>({
       cwd: targetDir,
       env: { ...process.env, PORT: port.toString() },
       detached: true,
-      stdio: 'ignore'
+      stdio: 'ignore',
+      shell: process.platform === 'win32'
     });
 
     let isReady = false;

--- a/harness/lib/collection.ts
+++ b/harness/lib/collection.ts
@@ -168,10 +168,10 @@ export async function collectResults(resultsDir: string, suiteConfig: SuiteConfi
 
     try {
       console.log(`\n>>> Bootstrapping dependencies inside results workspace with pnpm install...`);
-      spawnSync('pnpm', ['install', '--no-frozen-lockfile'], { cwd: resultsDir, stdio: 'inherit' });
+      spawnSync('pnpm', ['install', '--no-frozen-lockfile'], { cwd: resultsDir, stdio: 'inherit', shell: process.platform === 'win32' });
 
       console.log(`\n>>> Discovered ${pnpmWorkspacePackages.length} un-graded tasks. Running parallel grading with pnpm -r run-grader...`);
-      spawnSync('pnpm', ['-r', 'run-grader'], { cwd: resultsDir, stdio: 'inherit' });
+      spawnSync('pnpm', ['-r', 'run-grader'], { cwd: resultsDir, stdio: 'inherit', shell: process.platform === 'win32' });
     } finally {
       if (fs.existsSync(pnpmWorkspacePath)) {
         fs.unlinkSync(pnpmWorkspacePath);

--- a/harness/npx-intercept.test.ts
+++ b/harness/npx-intercept.test.ts
@@ -38,7 +38,8 @@ fs.writeFileSync(path.join(__dirname, 'called.txt'), 'yes');
       cwd: tempDir,
       stdio: 'inherit',
       env,
-      timeout: 10000
+      timeout: 10000,
+      shell: process.platform === 'win32'
     });
 
     assert.strictEqual(result.status, 0, 'Intercepted command should succeed');
@@ -56,7 +57,8 @@ fs.writeFileSync(path.join(__dirname, 'called.txt'), 'yes');
       cwd: tempDir,
       stdio: 'inherit',
       env,
-      timeout: 10000
+      timeout: 10000,
+      shell: process.platform === 'win32'
     });
 
     assert.strictEqual(resultFallback.status, 0, 'Fallback command should succeed');

--- a/harness/run_suite.ts
+++ b/harness/run_suite.ts
@@ -282,7 +282,7 @@ async function runCommand(command: string, args: string[] = [], envOverrides?: R
   return new Promise((resolve, reject) => {
     const childProcess = spawn(command, args, {
       stdio: 'inherit',
-      shell: true,
+      shell: process.platform === 'win32',
       cwd,
       env: envOverrides ? { ...process.env, ...envOverrides } : process.env
     });

--- a/serving/bin/modern-web.ts
+++ b/serving/bin/modern-web.ts
@@ -108,7 +108,7 @@ async function main() {
       .split(" ")
       .filter(Boolean);
 
-    const result = spawnSync("npx", installArgs, { stdio: "inherit" });
+    const result = spawnSync("npx", installArgs, { stdio: "inherit", shell: process.platform === "win32" });
 
     if (result.error) {
       console.error("Install failed:", result.error);
@@ -119,6 +119,7 @@ async function main() {
     const skills = getOurCLIAdjacentSkillIDs();
     const result = spawnSync("npx", ["skills", "update", ...skills], {
       stdio: "inherit",
+      shell: process.platform === "win32",
     });
     if (result.error) {
       console.error("Update failed:", result.error);


### PR DESCRIPTION
on windows: `npx modern-web-guidance install` fails w/ spawnSync npx ENOENT error.

fix: use shell: true
