### PR TITLE
pass -y to our wrapped calls to npx in CLI

### DIFF
--- a/serving/bin/modern-web.ts
+++ b/serving/bin/modern-web.ts
@@ -104,7 +104,7 @@ async function main() {
       }
     }
   } else if (command === "install") {
-    const installArgs = `skills add GoogleChrome/modern-web-guidance ${values.choose ? "" : "--skill modern-web-guidance"}`
+    const installArgs = `-y skills add GoogleChrome/modern-web-guidance ${values.choose ? "" : "--skill modern-web-guidance"}`
       .split(" ")
       .filter(Boolean);
 
@@ -117,7 +117,7 @@ async function main() {
     process.exit(result.status ?? 0);
   } else if (command === "update") {
     const skills = getOurCLIAdjacentSkillIDs();
-    const result = spawnSync("npx", ["skills", "update", ...skills], {
+    const result = spawnSync("npx", ["-y", "skills", "update", ...skills], {
       stdio: "inherit",
     });
     if (result.error) {


### PR DESCRIPTION
this avoid an extra prompt from npx for "are you sure you want to download version x.y.z of the skills package?" when we call it.