### PR TITLE
add instructions for npx.cmd on windows

### DIFF
--- a/guides/modern-web-guidance/SKILL.md
+++ b/guides/modern-web-guidance/SKILL.md
@@ -38,8 +38,6 @@ Search with an action-oriented query summarizing what you want to achieve using 
 npx -y modern-web-guidance@latest --skill-version SKILL_VERSION search "<query>"
 ```
 
-IMPORTANT: on Windows, using `npx` may fail. Use `npx.cmd ...` instead.
-
 **Example Output**:
 ```json
 [
@@ -67,17 +65,21 @@ Once you have a relevant `id` from the search results, call this script using th
 npx -y modern-web-guidance@latest retrieve "<id>"
 ```
 
-IMPORTANT: on Windows, using `npx` may fail. Use `npx.cmd ...` instead.
-
 
 **Example Output**:
 `The markdown content of the guide describing implementation steps...`
+
+## Using npx
+
+-   IMPORTANT: on Windows, using `npx` may fail. Use `npx.cmd ...` instead.
+-   Network access is required for fetching npm packages needed by the task.
+-   If the `npx -y modern-web-guidance…` command hangs, you may be offline. Try running again in offline
+    mode: `npx --offline …`.
+-   The `--skill-version` flag is used to determine if this SKILL.md is out of date. If it is, a warning
+    message is logged to stderr.
 
 ## Guidelines
 
 -   Always search **first** to find the most specific design/performance patterns.
 -   These guides are usually framework-agnostic; adapt them correctly to your setup.
 -   Do not hallucinate guides or ignore them; they represent the preferred local standard for the user's project.
--   Note: if the `npx -y modern-web-guidance…` command hangs, try running again in offline mode: `npx --offline …`
--   Note: the `--skill-version` flag is used to determine if this SKILL.md is out of date. If it is, a warning message
-    is logged to stderr.

--- a/guides/modern-web-guidance/SKILL.md
+++ b/guides/modern-web-guidance/SKILL.md
@@ -38,6 +38,8 @@ Search with an action-oriented query summarizing what you want to achieve using 
 npx -y modern-web-guidance@latest --skill-version SKILL_VERSION search "<query>"
 ```
 
+IMPORTANT: on Windows, using `npx` may fail. Use `npx.cmd ...` instead.
+
 **Example Output**:
 ```json
 [
@@ -64,6 +66,8 @@ Once you have a relevant `id` from the search results, call this script using th
 ```sh
 npx -y modern-web-guidance@latest retrieve "<id>"
 ```
+
+IMPORTANT: on Windows, using `npx` may fail. Use `npx.cmd ...` instead.
 
 
 **Example Output**:


### PR DESCRIPTION
windows, after installing skill:

when agent invokes npx, i get this error:

```
│ ✓  Shell npx -y modern-web-guidance@latest --skill-version 2026_05_14-6d34b725 search ""system theme light dark mode background color""         │
│                                                                                                                                               │
│ npx : File C:\Program Files\nodejs\npx.ps1 cannot be loaded. The file C:\Program Files\nodejs\npx.ps1 is not digitally signed. You cannot     │
│ run this script on the current system. For more information about running scripts and setting execution policy, see                           │
│ about_Execution_Policies at https:/go.microsoft.com/fwlink/?LinkID=135170.                                                                    │
│ At line:1 char:1                                                                                                                              │
│ + npx -y modern-web-guidance@latest --skill-version 2026_05_14-6d34b725 ...                                                                   │
│ + ~~~                                                                                                                                         │
│     + CategoryInfo          : SecurityError: (:) [], PSSecurityException                                                                      │
│     + FullyQualifiedErrorId : UnauthorizedAccess    
```

using npx.cmd instead works.