### PR TITLE
Add guidance for setting `contain-intrinsic-size`

### DIFF
--- a/guides/css/css/guide.md
+++ b/guides/css/css/guide.md
@@ -447,6 +447,7 @@ Rendering performance is critical for smooth user experiences, especially in hea
 - Prefer to animate `opacity` and `transform` (including individual transform properties, e.g. `translate` instead of `left/right/top/bottom`) to ensure animations stay on the compositor thread.
 - Use `transition-behavior: allow-discrete` + `@starting-style` to animate layout properties like `display` or `<dialog>` state natively.
 - Always pair `content-visibility` with `contain-intrinsic-size` to prevent scrollbar jumps (CLS).
+- When setting `contain-intrinsic-size` use the `auto` keyword and a value that’s derived from what is known about the contents (i.e. text size, spacing, size of graphics, character count). Preferably use units such as `rem`, `lh`, `cap`, or `ch` that match values used for the elements within the contents rather than `px`. If the content for items in a group is not consistently sized, then use an average size.
 - Use `contain: layout style paint` to isolate component rendering updates.
 
 #### Code Example: Render Optimization
@@ -454,7 +455,19 @@ Rendering performance is critical for smooth user experiences, especially in hea
 ```css
 .large-section {
   content-visibility: auto;
-  contain-intrinsic-size: auto 800px;
+  contain-intrinsic-block-size: auto 800px;
+}
+
+.row {
+  --row-gap: 8px;
+  --title-height: 1lh;
+  --description-height: 0.85lh;
+
+  display: grid;
+  row-gap: var(--row-gap);
+  content-visibility: auto;
+  /* The sum of the title height, row gap, and description height should be the size of the contents when skipped for rendering. */
+  contain-intrinsic-block-size: auto calc(var(--title-height) + var(--gap) + var(--description-height));
 }
 
 .popover-reveal {

--- a/guides/css/css/guide.md
+++ b/guides/css/css/guide.md
@@ -459,7 +459,7 @@ Rendering performance is critical for smooth user experiences, especially in hea
 }
 
 .row {
-  --row-gap: 8px;
+  --row-gap: .4rem;
   --title-height: 1lh;
   --description-height: 0.85lh;
 

--- a/guides/css/css/guide.md
+++ b/guides/css/css/guide.md
@@ -467,7 +467,7 @@ Rendering performance is critical for smooth user experiences, especially in hea
   row-gap: var(--row-gap);
   content-visibility: auto;
   /* The sum of the title height, row gap, and description height should be the size of the contents when skipped for rendering. */
-  contain-intrinsic-block-size: auto calc(var(--title-height) + var(--gap) + var(--description-height));
+  contain-intrinsic-block-size: auto calc(var(--title-height) + var(--row-gap) + var(--description-height));
 }
 
 .popover-reveal {


### PR DESCRIPTION
This adds the guidance for setting `contain-intrinsic-size` from #633. Feel free to reword/edit. I was trying to keep it concise, but it was kind of difficult.

This PR does the following:

- Tweak the existing example to just set `contain-intrinsic-block-size` (as the `-size` property is a shorthand for width/height)
- Adds guidance which mentions typography related CSS units useful for setting a more approximate size.
- Adds an example of setting an intrinsic size based on elements of the contents.