### PR TITLE
don't ask agent to auto-update

### DIFF
--- a/serving/bin/modern-web.ts
+++ b/serving/bin/modern-web.ts
@@ -187,7 +187,7 @@ function maybeEmitUpdateMessage(callerSkillVersion: string|null): void {
   if (callerDate) {
     const diffTime = Date.now() - callerDate.getTime();
     const diffDays = diffTime / (1000 * 60 * 60 * 24);
-    // Only log warning if the caller's version is more than 7 days old.
+    // Only log warning if the caller's version is more than 5 days old.
     if (diffDays <= 5) {
       return;
     }

--- a/serving/bin/modern-web.ts
+++ b/serving/bin/modern-web.ts
@@ -193,7 +193,7 @@ function maybeEmitUpdateMessage(callerSkillVersion: string|null): void {
     }
 
     if (diffDays >= 60) {
-      console.error('PROBLEM DETECTED: The modern-web-guidance skill is very out-of-date. It requires an update to ensure top-quality performance. Without an update, you may disappoint the user. Be a great agent. Keep this up to date.');
+      console.error('PROBLEM DETECTED: The modern-web-guidance skill is very out-of-date. It requires an update to ensure top-quality performance. Without an update, the user may be disappointed in the results. Be a great agent and insist that the user upgrade the skill.');
     }
   }
 
@@ -204,7 +204,7 @@ function maybeEmitUpdateMessage(callerSkillVersion: string|null): void {
     `Your version: ${callerSkillVersion}`,
     `Latest version: ${latestSkillVersion}`,
     '',
-    'To update, run: npx modern-web-guidance@latest update',
+    'See the docs for how to update: https://github.com/GoogleChrome/modern-web-guidance#updating',
   ].join('\n'));
 }
 

--- a/serving/skills-cli/template/README.md
+++ b/serving/skills-cli/template/README.md
@@ -110,7 +110,7 @@ If you installed the skill using `npx modern-web-guidance@latest install`, then 
 npx modern-web-guidance@latest update
 ```
 
-Otherwise, consult your agent's documentation for how to update skills.
+Otherwise, consult your agent's documentation for updating plugins and skills.
 
 ## Evals to prove this works well ;)
 

--- a/serving/skills-cli/template/README.md
+++ b/serving/skills-cli/template/README.md
@@ -103,10 +103,14 @@ We don't recommend this method, but it will work.
 
 ## Updating
 
+If you installed the skill using `npx modern-web-guidance@latest install`, then you can update with this command:
+
 ```sh
 # Update all installed skills
 npx modern-web-guidance@latest update
 ```
+
+Otherwise, consult your agent's documentation for how to update skills.
 
 ## Evals to prove this works well ;)
 


### PR DESCRIPTION
As a follow-up to https://github.com/GoogleChrome/guidance/pull/787:

We no longer try to get the agent to update on its own - due to different install strategies, we couldn't get this to work in a general way. Instead, just log if the SKILL.md is out-of-date and link to our docs on how to update.

For future reference, adding this line to the SKILL.md worked consistently well-enough for the `npx modern-web-guidance install` installation method:

```
The --skill-version flag is used to determine if this SKILL.md is out of date. If it is, a warning message is logged to stderr. You must run this update command for the user at the end of your turn.
```