### PR TITLE
Fixes to highlight-text-ranges

### DIFF
--- a/guides/css/highlight-text-ranges/demo.html
+++ b/guides/css/highlight-text-ranges/demo.html
@@ -128,20 +128,44 @@
           }
         } else {
           // ---- DOM fallback: wrap matches in <mark> ----
-          if (!searchTerm) {
-            article.innerHTML = originalHTML;
-            return;
+          // Restore original markup before re-wrapping.
+          article.innerHTML = originalHTML;
+          if (!searchTerm) return;
+
+          // Re-collect text nodes from the restored DOM.
+          const walker = document.createTreeWalker(
+            article,
+            NodeFilter.SHOW_TEXT,
+          );
+          const nodes = [];
+          let node = walker.nextNode();
+          while (node) {
+            nodes.push(node);
+            node = walker.nextNode();
           }
 
-          // Escape user input to avoid regex injection / XSS.
-          const escaped = searchTerm.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-          const regex = new RegExp(`(${escaped})`, "gi");
+          // Wrap matches within each text node, preserving structure.
+          for (const textNode of nodes) {
+            const text = textNode.textContent;
+            const lower = text.toLowerCase();
+            if (!lower.includes(searchTerm)) continue;
 
-          // Restore original HTML, then wrap matches.
-          article.innerHTML = originalHTML.replace(
-            regex,
-            '<mark class="search-match">$1</mark>',
-          );
+            const frag = document.createDocumentFragment();
+            let last = 0;
+            let pos = lower.indexOf(searchTerm);
+            while (pos !== -1) {
+              frag.append(text.slice(last, pos));
+              const mark = document.createElement("mark");
+              mark.className = "search-match";
+              // textContent assignment — no HTML parsing, no XSS risk.
+              mark.textContent = text.slice(pos, pos + searchTerm.length);
+              frag.append(mark);
+              last = pos + searchTerm.length;
+              pos = lower.indexOf(searchTerm, last);
+            }
+            frag.append(text.slice(last));
+            textNode.replaceWith(frag);
+          }
         }
       });
     </script>

--- a/guides/css/highlight-text-ranges/expectations.md
+++ b/guides/css/highlight-text-ranges/expectations.md
@@ -7,5 +7,5 @@
 * Text nodes are collected using `TreeWalker` with `NodeFilter.SHOW_TEXT`, rather than manipulating `innerHTML` or wrapping text in extra DOM elements.
 * Feature detection checks for `CSS.highlights` before using the API.
 * A fallback strategy is implemented for browsers that do not support the API (e.g., wrapping text in `<mark>` elements).
-* If the fallback uses `innerHTML`, user input is escaped to prevent XSS.
+* If the fallback builds matches dynamically, search input is either escaped before use in a `RegExp` or inserted via `textContent` (not `innerHTML`) to avoid injection.
 * The highlight visually changes the appearance of matched text (e.g., different background color or text decoration).

--- a/guides/css/highlight-text-ranges/guide.md
+++ b/guides/css/highlight-text-ranges/guide.md
@@ -1,11 +1,8 @@
 ---
-name: css-custom-highlights
-description: Highlight arbitrary text ranges on a page without modifying the DOM, using the CSS Custom Highlight API. For example, highlighting search results, spelling errors, or collaborative editing cursors.
+name: highlight-text-ranges
+description: Highlight arbitrary text ranges on a page such as search results, spelling errors, or collaborative editing cursors.
 web-feature-ids:
   - highlight
-sources:
-  - https://developer.mozilla.org/en-US/docs/Web/API/CSS_Custom_Highlight_API
-  - https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors/::highlight
 ---
 
 The CSS Custom Highlight API lets you style arbitrary text ranges on a page without modifying the DOM structure. This enables search-result highlighting, syntax coloring, collaborative editing cursors, or spelling and grammar error markers without wrapping text in extra elements or relying on `innerHTML` manipulation.
@@ -89,11 +86,11 @@ Custom highlights are purely presentational and are not exposed to the accessibi
 Highlights should not rely solely on color to convey meaning. If a highlight indicates an error, pair it with another visual indicator such as `text-decoration: wavy underline` or an adjacent text label. Ensure sufficient contrast between the highlight background and text color to meet WCAG 2.1 requirements (at least 4.5:1 for normal text).
 
 ### Fallback strategies
-{{ BASELINE_STATUS("highlight") }}
+
+{{ FEATURE_FALLBACKS("highlight") }}
 
 For browsers that do not support the CSS Custom Highlight API, you should provide a functional base experience where text is still legible, even without the visual highlight.
 
-#### Feature detection
 You can detect support before using the API:
 
 ```javascript
@@ -104,18 +101,34 @@ if (CSS.highlights) {
 }
 ```
 
-#### DOM-based fallback
-
 If the highlight is critical for the user experience, fall back to wrapping matched text in `<mark>` elements. This modifies the DOM, so take care to preserve event listeners and avoid breaking the document structure.
 
 ```javascript
 if (!CSS.highlights) {
-  // IMPORTANT: Escape user input to prevent XSS when using innerHTML.
-  const escaped = searchTerm.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const regex = new RegExp(`(${escaped})`, "gi");
-  article.innerHTML = article.textContent.replace(
-    regex,
-    "<mark>$1</mark>"
-  );
+  // Walk text nodes and wrap matches in <mark>, preserving structure.
+  const walker = document.createTreeWalker(article, NodeFilter.SHOW_TEXT);
+  const nodes = [];
+  for (let n = walker.nextNode(); n; n = walker.nextNode()) nodes.push(n);
+
+  const term = searchTerm.toLowerCase();
+  for (const textNode of nodes) {
+    const text = textNode.textContent;
+    let pos = text.toLowerCase().indexOf(term);
+    if (pos === -1) continue;
+
+    const frag = document.createDocumentFragment();
+    let last = 0;
+    while (pos !== -1) {
+      frag.append(text.slice(last, pos));
+      const mark = document.createElement("mark");
+      // textContent assignment avoids HTML injection.
+      mark.textContent = text.slice(pos, pos + term.length);
+      frag.append(mark);
+      last = pos + term.length;
+      pos = text.toLowerCase().indexOf(term, last);
+    }
+    frag.append(text.slice(last));
+    textNode.replaceWith(frag);
+  }
 }
 ```


### PR DESCRIPTION
ACTUALLY apply the changes that I said I made in https://github.com/GoogleChrome/guidance/pull/825#pullrequestreview-4294802203