### PR TITLE
chore: ignore .antigravitycli directory in local git configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ project-gleam/
 # Local agent stuff
 .gemini/
 .claude/
+.antigravitycli/
 GEMINI.md
 
 # Research drafts


### PR DESCRIPTION
Add .antigravitycli/ to .gitignore to exclude local agy confgs.