### PR TITLE
Set ARIA boolean attribute correctly for features/user-pseudos

### DIFF
--- a/features/user-pseudos.md
+++ b/features/user-pseudos.md
@@ -7,7 +7,7 @@ Native `:user-invalid` does not automatically sync with ARIA attributes. Add the
 ```javascript
 // Sync aria-invalid with the CSS :user-invalid state
 const syncAria = (el) => {
-  el.toggleAttribute?.('aria-invalid', el.matches(':user-invalid'));
+  el.setAttribute?.('aria-invalid', el.matches(':user-invalid') ? 'true' : 'false');
 };
 
 // Update on blur (to show error) and input (to clear it)


### PR DESCRIPTION
I noticed this while reviewing the results of the automated accessibility audit #797.

ARIA typically uses `"true"` and `"false"` rather than presence for states unlike HTML, so `toggleAttribute()` does not work.
