### PR TITLE
move --skill-version after search query in mwg SKILL.md

### DIFF
--- a/guides/modern-web-guidance/SKILL.md
+++ b/guides/modern-web-guidance/SKILL.md
@@ -35,7 +35,7 @@ Must use this skill:
 Search with an action-oriented query summarizing what you want to achieve using the `search` command. Run `modern-web-guidance` directly with `npx`.
 
 ```sh
-npx -y modern-web-guidance@latest --skill-version SKILL_VERSION search "<query>"
+npx -y modern-web-guidance@latest search "<query>" --skill-version SKILL_VERSION
 ```
 
 **Example Output**:

--- a/serving/skills-cli/test-dist.test.ts
+++ b/serving/skills-cli/test-dist.test.ts
@@ -117,6 +117,12 @@ test('modern-web CLI search and retrieve', async () => {
   const searchOut = execSync(`node "${binaryPath}" search "address form"`, { encoding: 'utf8' });
   assertSearchResults(searchOut);
 
+  // 1b. Validate search with --skill-version after search query
+  const skillVersionPath = path.join(STAGING_DIR, 'skills/modern-web-guidance/skill-version.txt');
+  const skillVersion = (await fs.readFile(skillVersionPath, 'utf8')).trim();
+  const searchOutWithVersion = execSync(`node "${binaryPath}" search "address form" --skill-version "${skillVersion}"`, { encoding: 'utf8' });
+  assertSearchResults(searchOutWithVersion);
+
   // 2. Validate retrieve
   const retrieveOut = execSync(`node "${binaryPath}" retrieve accessible-error-announcement`, { encoding: 'utf8' });
   assert.match(retrieveOut, /# Accessible Error/, 'Retrieve output should contain the guide title');


### PR DESCRIPTION
Moves the flag to the end of the command in the example, which works fine with args parsing. Added a test for it.


mostly aesthetics to keep the noisier thing less obvious