### PR TITLE
role alert has an implicit aria-live value of assertive

### DIFF
--- a/guides/accessibility/accessibility/guide.md
+++ b/guides/accessibility/accessibility/guide.md
@@ -332,9 +332,9 @@ Live regions let assistive tech announce content updates that aren't tied to nav
 
 ```html
 <!-- Session Timeout Warning with controls -->
-<div role="alert" aria-live="assertive" class="timeout-warning">
+<div role="alert" class="timeout-warning">
   Your session will expire in 2 minutes. 
-  <button onclick="extendSession()">Extend Session</button>
+  <button type="button" onclick="extendSession()">Extend Session</button>
 </div>
 ```
 


### PR DESCRIPTION
Elements with the role alert have an implicit `aria-live` value of `assertive`, and an implicit `aria-atomic` value of `true`.

So extra aria-live="assertive" is redundant and I suggest we remove it.

Spec: https://www.w3.org/TR/wai-aria-1.2/#alert

Added also `<button type="button">` as `<button>` is a submit and can cause form submissions when it is a descendant of `<form>` elements.