### PR TITLE
typo: Update link reference in README.md description

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for how we work on the project and orie
 npx modern-web-guidance@latest install
 ```
 
-This command runs an interactive wizard to place the SKILL.md appropriately. See [Alternative Installation Methods](#alternative-installation-methods) below.
+This command runs an interactive wizard to place the SKILL.md appropriately. See [Alternative Installation Methods](#-alternative-installation-methods) below.
 
 #### Try it out (without installing)
 


### PR DESCRIPTION
Updates the README installation link so it points to the correct Alternative Installation Methods section.