### PR TITLE
fix: correct typos and improve clarity in user experience guides

### DIFF
--- a/guides/css/design-token-reactivity/guide.md
+++ b/guides/css/design-token-reactivity/guide.md
@@ -95,7 +95,7 @@ For core features, an alternate approach using selectors should be used. This ex
 }
 ```
 
-A major limitation of this fallback approach is that it does not support nesting elements with the `data-density` attribute set, since the selector specificity is the same, order of appearance will be used to determine the styles (i.e. `[data-density="spacious"]` will always take precendence over `[data-density="compact"]`).
+A major limitation of this fallback approach is that it does not support nesting elements with the `data-density` attribute set, since the selector specificity is the same, order of appearance will be used to determine the styles (i.e. `[data-density="spacious"]` will always take precedence over `[data-density="compact"]`).
 
 ### Using style queries as a progressive enhancement
 

--- a/guides/ui-atoms/scroll-progress-indicator/guide.md
+++ b/guides/ui-atoms/scroll-progress-indicator/guide.md
@@ -48,7 +48,7 @@ This code grows the `#progress` element on scroll using an anonymous scroll-time
 }
 ```
 
-Because of its location in the DOM, the `scroll()` function will track its neareast ancestor scroller in the `block` direction, which here is the root scroller.
+Because of its location in the DOM, the `scroll()` function will track its nearest ancestor scroller in the `block` direction, which here is the root scroller.
 
 ```html
 <body>

--- a/guides/ui-atoms/shrinking-header-on-scroll/guide.md
+++ b/guides/ui-atoms/shrinking-header-on-scroll/guide.md
@@ -5,7 +5,7 @@ web-feature-ids:
   - scroll-driven-animations
 ---
 
-# Shrinking headder on scroll
+# Shrinking header on scroll
 
 A shrinking header on scroll is a common UI pattern where a fixed header element at the top of the page smoothly transitions to a smaller size as the user scrolls down. This effect is often used to maximize screen real estate for the main content while keeping essential navigation or branding elements accessible. With CSS scroll-driven animations, this effect can be achieved in a declarative and performant way, by linking an animation to the scroll position of the document.
 

--- a/guides/ui-behaviors/scroll-snap-state-sync/guide.md
+++ b/guides/ui-behaviors/scroll-snap-state-sync/guide.md
@@ -80,7 +80,7 @@ if (!('onscrollsnapchange' in HTMLElement.prototype)) {
       const topEntry = [...headers].reduce((currentTop, header) => {
         // Use the bottom to handle scrolling up, when the top is still offscreen
         const {bottom} = header.getBoundingClientRect();
-        // Don't match if the header's bottom is aboce the scrollport
+        // Don't match if the header's bottom is above the scrollport
         if (bottom < 0) return;
         if (!currentTop) return header;
         return bottom <

--- a/guides/ui-behaviors/search-hidden-content/guide.md
+++ b/guides/ui-behaviors/search-hidden-content/guide.md
@@ -126,7 +126,7 @@ accordion.addEventListener('beforematch', (e) => {
 
 The `<details>` element is Baseline Widely available, so a fallback strategy is not required.
 
-The `hidden="until-found"` attribute is not yet Baseline Widely available, but it can be safely used with a fallback in unsupporting browsers. **DO NOT** avoid `hidden="until-found"` because of missing browser support, as its accessiblity benefits far outweigh the cost of implementing a fallback.
+The `hidden="until-found"` attribute is not yet Baseline Widely available, but it can be safely used with a fallback in unsupporting browsers. **DO NOT** avoid `hidden="until-found"` because of missing browser support, as its accessibility benefits far outweigh the cost of implementing a fallback.
 
 #### `hidden="until-found"` fallback
 

--- a/guides/ui-components/navigation-drawer/guide.md
+++ b/guides/ui-components/navigation-drawer/guide.md
@@ -89,7 +89,7 @@ The popover must cover the whole viewport so its `::backdrop` dims the entire pa
   overflow: visible;
 }
 
-/* Style the popover's ::backdrop to achive the overlay effect and
+/* Style the popover's ::backdrop to achieve the overlay effect and
    provide visual affordances indicating that the rest of the page is inert */
 .Drawer::backdrop {
   background: #000;
@@ -349,7 +349,7 @@ async function openDrawer() {
 
 {{ BASELINE_STATUS("registered-custom-properties") }}
 
-`@property` is only needed because the scroll-driven animation interpolates `--drawer-backdrop` between keyframes — without registration, the property would be treated as a string and would jump between 0 and 1 with no fade. If the scroll-driven animation fallback above is in place, that JavaScript writes a fresh numeric string to `--drawer-backdrop` on every scroll frame and never interpolates, so no seprarate `@property` fallback is needed since all browsers that support scroll-driven animations also support `@property`.
+`@property` is only needed because the scroll-driven animation interpolates `--drawer-backdrop` between keyframes — without registration, the property would be treated as a string and would jump between 0 and 1 with no fade. If the scroll-driven animation fallback above is in place, that JavaScript writes a fresh numeric string to `--drawer-backdrop` on every scroll frame and never interpolates, so no separate `@property` fallback is needed since all browsers that support scroll-driven animations also support `@property`.
 
 
 #### Popover API fallback (no `popover` attribute support):

--- a/guides/visual-design/improve-text-layout-and-legibility/guide.md
+++ b/guides/visual-design/improve-text-layout-and-legibility/guide.md
@@ -8,7 +8,7 @@ web-feature-ids:
 
 # Improve Text Layout and Legibility
 
-The layout of text, particularly at the ends of lines and and ends of paragraphs, can impact the legibility and aesthetic appeal of a page. CSS provides several text wrapping options that can improve specific use cases.
+The layout of text, particularly at the ends of lines and ends of paragraphs, can impact the legibility and aesthetic appeal of a page. CSS provides several text wrapping options that can improve specific use cases.
 
 For short text blocks like headings, use `text-wrap: balance`. This property instructs the browser to distribute text as evenly as possible across lines, creating a more symmetrical appearance.
 


### PR DESCRIPTION
## Summary

Fix several typos across `guides/user-experience/` to improve clarity and readability. No behavioral or guidance changes.

Affected guides:
- `design-token-reactivity` — `precendence` → `precedence`
- `improve-text-layout-and-legibility` — duplicate `and and` → `and`
- `navigation-drawer` — `achive` → `achieve`, `seprarate` → `separate`
- `scroll-progress-indicator` — `neareast` → `nearest`
- `scroll-snap-state-sync` — `aboce` → `above`
- `search-hidden-content` — `accessiblity` → `accessibility`
- `shrinking-header-on-scroll` — `headder` → `header` (heading)

## Test plan

- [x] `pnpm preflight` (w/ node v24)
- [x] Visual diff review of all 7 guides