### PR TITLE
guides: fix contradictory claims about Safari's accent-color support

### DIFF
--- a/features/accent-color.md
+++ b/features/accent-color.md
@@ -2,7 +2,7 @@
 
 ## Issues
 
-- When placing visual elements over the accent color (e.g. a checkbox checkmark), Chrome and Safari will automatically select a contrasting color, whereas Safari will modify the accent color, and may not maintain adequate contrast.
+- When placing visual elements over the accent color (e.g. a checkbox checkmark), Chrome and Firefox will automatically select a contrasting color, whereas Safari will modify the accent color, and may not maintain adequate contrast.
 
 ## Fallbacks
 


### PR DESCRIPTION
In features/accent-color.md, Safari was mentioned twice with opposing claims about how it handles contrast. Replaced the first mention of Safari with Firefox to correctly reflect browser behaviors.

Closes #882