### PR TITLE
Improve loading speed of dashboard results

### DIFF
--- a/eval-view/api.js
+++ b/eval-view/api.js
@@ -1,5 +1,16 @@
 import { authenticatedFetch, MiniIndexedDB } from './utils.js';
 
+const ENTRY_POINT_CANDIDATES = [
+    'dist/index.html',
+    'src/App.jsx',
+    'src/App.js',
+    'src/main.jsx',
+    'src/main.js',
+    'src/index.jsx',
+    'src/index.js',
+    'index.html'
+];
+
 export class ApiClient {
     constructor() {
         const params = new URLSearchParams(window.location.search);
@@ -237,16 +248,7 @@ export class ApiClient {
         const logicalBasePath = `${testId}/${run.runNumber}/${guideName}/${taskName}/${runType}`;
         const legacyBasePath = `${testId}/${run.runNumber}/${taskName}/${runType}`;
         
-        const candidates = [
-            'dist/index.html',
-            'src/App.jsx',
-            'src/App.js',
-            'src/main.jsx',
-            'src/main.js',
-            'src/index.jsx',
-            'src/index.js',
-            'index.html'
-        ];
+        const candidates = ENTRY_POINT_CANDIDATES;
 
         // 1. Find best entry point in logicalBasePath
         let entryPointPath = null;
@@ -349,16 +351,7 @@ export class ApiClient {
                 if (cached !== undefined) return cached;
             } catch {}
         }
-        const candidates = [
-            'dist/index.html',
-            'src/App.jsx',
-            'src/App.js',
-            'src/main.jsx',
-            'src/main.js',
-            'src/index.jsx',
-            'src/index.js',
-            'index.html'
-        ];
+        const candidates = ENTRY_POINT_CANDIDATES;
 
         let bestCandidate = null;
         if (this.source === 'remote') {

--- a/eval-view/api.js
+++ b/eval-view/api.js
@@ -1,4 +1,4 @@
-import { authenticatedFetch } from './utils.js';
+import { authenticatedFetch, MiniIndexedDB } from './utils.js';
 
 export class ApiClient {
     constructor() {
@@ -14,6 +14,7 @@ export class ApiClient {
         }
         this.source = sourceParam;
         this.gcsPrefix = 'https://storage.googleapis.com/storage/v1/b/guidance-evals/o/';
+        this.cache = new MiniIndexedDB();
     }
 
     _formatUrl(path, isMetadataOnly = false) {
@@ -105,15 +106,39 @@ export class ApiClient {
 
     /** Fetches the evals.json payload for a specific root test ID. */
     async getEvals(testId) {
+        if (this.source === 'remote') {
+            try {
+                const cached = await this.cache.get(`evals:${testId}`);
+                if (cached) return cached;
+            } catch (e) {
+                console.warn('Cache read failed:', e);
+            }
+        }
         // Appending timestamp to defeat strict local browser cache on eval data
         const path = `${testId}/evals.json?t=${Date.now()}`;
         const res = await this._fetch(path);
         if (!res.ok) throw new Error(`Failed to load data from ${this._formatUrl(path)}`);
-        return await res.json();
+        const data = await res.json();
+        if (this.source === 'remote') {
+            try {
+                await this.cache.set(`evals:${testId}`, data);
+            } catch (e) {
+                console.warn('Cache write failed:', e);
+            }
+        }
+        return data;
     }
 
     /** Fetches the optional jetski automation metadata payload. */
     async getJetskiInfo(testId) {
+        if (this.source === 'remote') {
+            try {
+                const cached = await this.cache.get(`jetski:${testId}`);
+                if (cached !== undefined) return cached; // Note: can be null
+            } catch (e) {
+                console.warn('Cache read failed:', e);
+            }
+        }
         const path = `${testId}/jetski_info.json`;
         let exists = false;
         
@@ -123,12 +148,21 @@ export class ApiClient {
             exists = await this._checkLocalFileExists(path);
         }
 
-        if (!exists) return null;
+        if (!exists) {
+            if (this.source === 'remote') {
+                try { await this.cache.set(`jetski:${testId}`, null); } catch {}
+            }
+            return null;
+        }
 
         try {
             const res = await this._fetch(path);
             if (res.ok) {
-                return await res.json();
+                const data = await res.json();
+                if (this.source === 'remote') {
+                    try { await this.cache.set(`jetski:${testId}`, data); } catch {}
+                }
+                return data;
             }
         } catch (e) {
             console.log('No jetski info found:', e.message);
@@ -136,19 +170,135 @@ export class ApiClient {
         return null; // Not fatal if missing
     }
 
+    /** Gets the entire directory listing of all files in the entire suite's directory. */
+    async getSuiteDirectoryListing(testId) {
+        if (this.source === 'remote') {
+            try {
+                const cached = await this.cache.get(`suiteDirList:${testId}`);
+                if (cached !== undefined) return cached;
+            } catch {}
+        }
+
+        let filePaths = [];
+        if (this.source === 'remote') {
+            let pageToken = '';
+            do {
+                const listUrl = `${this.gcsPrefix}?prefix=${encodeURIComponent(testId + '/')}${pageToken ? `&pageToken=${pageToken}` : ''}`;
+                const res = await authenticatedFetch(listUrl);
+                if (res.ok) {
+                    const data = await res.json();
+                    if (data.items) {
+                        filePaths.push(...data.items.map(item => item.name));
+                    }
+                    pageToken = data.nextPageToken || '';
+                } else {
+                    break;
+                }
+            } while (pageToken);
+            try { await this.cache.set(`suiteDirList:${testId}`, filePaths); } catch {}
+        } else {
+            try {
+                const res = await fetch(`/api/run-files-recursive?dir=${encodeURIComponent(testId + '/')}&source=local`);
+                if (res.ok) {
+                    const data = await res.json();
+                    filePaths = data.files || [];
+                }
+            } catch (e) {
+                console.log('Error checking local suite files:', e);
+            }
+        }
+        return filePaths;
+    }
+
     /** Checks if a test_suite.log file exists via a fast HEAD or silent remote prefix search. */
     async checkLogExists(testId) {
         try {
-            const path = `${testId}/test_suite.log`;
-            
-            if (this.source === 'remote') {
-                return await this._checkRemoteFileExists(path);
-            } else {
-                return await this._checkLocalFileExists(path);
-            }
+            const suiteFiles = await this.getSuiteDirectoryListing(testId);
+            const logPath = `${testId}/test_suite.log`;
+            return suiteFiles.includes(logPath);
         } catch {
             return false;
         }
+    }
+
+    /** Gets the entire directory listing of all files in a single run's directory. */
+    async getRunDirectoryListing(testId, runNumber) {
+        const suiteFiles = await this.getSuiteDirectoryListing(testId);
+        const runPrefix = `${testId}/${runNumber}/`;
+        return suiteFiles.filter(path => path.startsWith(runPrefix));
+    }
+
+
+    /** Resolves the correct base path for specific run details synchronously using pre-fetched directory list. */
+    resolveResultInfoFromList(testId, run, testName, filePaths) {
+        const [taskName, guideName, runType] = testName.split(' - ');
+        const actualBaseApp = run.baseApp;
+        
+        const logicalBasePath = `${testId}/${run.runNumber}/${guideName}/${taskName}/${runType}`;
+        const legacyBasePath = `${testId}/${run.runNumber}/${taskName}/${runType}`;
+        
+        const candidates = [
+            'dist/index.html',
+            'src/App.jsx',
+            'src/App.js',
+            'src/main.jsx',
+            'src/main.js',
+            'src/index.jsx',
+            'src/index.js',
+            'index.html'
+        ];
+
+        // 1. Find best entry point in logicalBasePath
+        let entryPointPath = null;
+        let usedBasePath = logicalBasePath;
+        
+        for (const candidate of candidates) {
+            const target = `${logicalBasePath}/${candidate}`;
+            if (filePaths.includes(target)) {
+                entryPointPath = target;
+                break;
+            }
+        }
+
+        // 2. Fallback to legacyBasePath
+        if (!entryPointPath) {
+            for (const candidate of candidates) {
+                const target = `${legacyBasePath}/${candidate}`;
+                if (filePaths.includes(target)) {
+                    entryPointPath = target;
+                    usedBasePath = legacyBasePath;
+                    break;
+                }
+            }
+        }
+
+        // 3. Default fallback
+        if (!entryPointPath) {
+            entryPointPath = `${logicalBasePath}/index.html`;
+        }
+
+        // 4. Calculate relative path
+        const relativePath = entryPointPath.replace(usedBasePath + '/', '');
+
+        // 5. Check if local base_app path exists
+        const localBaseAppPath = `${testId}/${run.runNumber}/${guideName}/${taskName}/base_app/${relativePath}`;
+        const exists = filePaths.includes(localBaseAppPath);
+        const setupPath = exists ? localBaseAppPath : `base_apps/${actualBaseApp}/${relativePath}`;
+
+        return {
+            setupPath,
+            resultPath: entryPointPath,
+            usedBasePath
+        };
+    }
+
+    /** Filters and formats run files synchronously from pre-fetched directory list. */
+    filterRunFilesFromList(usedBasePath, filePaths) {
+        const prefix = usedBasePath.endsWith('/') ? usedBasePath : usedBasePath + '/';
+        return filePaths
+            .filter(path => path.startsWith(prefix))
+            .map(path => path.replace(prefix, ''))
+            .filter(fileName => !fileName.includes('/')); // only return direct files
     }
 
     /** Resolves the correct base path for specific run details, parsing legacy logic. */
@@ -193,6 +343,12 @@ export class ApiClient {
     }
 
     async _findBestEntryPoint(basePath) {
+        if (this.source === 'remote') {
+            try {
+                const cached = await this.cache.get(`entryPoint:${basePath}`);
+                if (cached !== undefined) return cached;
+            } catch {}
+        }
         const candidates = [
             'dist/index.html',
             'src/App.jsx',
@@ -224,6 +380,7 @@ export class ApiClient {
                     }
                 }
             }
+            try { await this.cache.set(`entryPoint:${basePath}`, bestCandidate); } catch {}
         } else {
             const checks = candidates.map(candidate =>
                 this._checkLocalFileExists(`${basePath}/${candidate}`)
@@ -239,6 +396,12 @@ export class ApiClient {
 
     /** Lists relevant metadata files (like raw results or trajectories) for a specific test execution dir. */
     async getRunFiles(basePath) {
+        if (this.source === 'remote') {
+            try {
+                const cached = await this.cache.get(`runFiles:${basePath}`);
+                if (cached !== undefined) return cached;
+            } catch {}
+        }
         let files = [];
         try {
             if (this.source === 'local') {
@@ -255,14 +418,15 @@ export class ApiClient {
                     const data = await res.json();
                     if (data.items) {
                         files = data.items.map(item => item.name.split('/').pop());
-                    }
-                }
-            }
-        } catch (e) {
-            console.log('Error checking run files:', e);
-        }
-        return files;
-    }
+                      }
+                  }
+                  try { await this.cache.set(`runFiles:${basePath}`, files); } catch {}
+              }
+          } catch (e) {
+              console.log('Error checking run files:', e);
+          }
+          return files;
+      }
 
     /** Downloads raw text content for a specific URL Path (e.g. from viewContent modal). */
     async getFileText(path) {
@@ -271,8 +435,39 @@ export class ApiClient {
         const isTasks = path.startsWith('tasks/');
 
         if (this.source === 'remote' && !isBaseApp && !isTasks) {
-            const exists = await this._checkRemoteFileExists(path);
-            if (!exists) throw new Error('File not found (404).');
+            try {
+                const cached = await this.cache.get(`fileText:${path}`);
+                if (cached !== undefined) {
+                    if (cached === null) throw new Error('File not found (404).');
+                    return cached;
+                }
+            } catch (err) {
+                if (err.message === 'File not found (404).') throw err;
+            }
+
+            const firstSegment = path.split('/')[0];
+            if (firstSegment) {
+                try {
+                    const suiteFiles = await this.getSuiteDirectoryListing(firstSegment);
+                    if (!suiteFiles.includes(path)) {
+                        try { await this.cache.set(`fileText:${path}`, null); } catch {}
+                        throw new Error('File not found (404).');
+                    }
+                } catch (e) {
+                    if (e.message === 'File not found (404).') throw e;
+                    const exists = await this._checkRemoteFileExists(path);
+                    if (!exists) {
+                        try { await this.cache.set(`fileText:${path}`, null); } catch {}
+                        throw new Error('File not found (404).');
+                    }
+                }
+            } else {
+                const exists = await this._checkRemoteFileExists(path);
+                if (!exists) {
+                    try { await this.cache.set(`fileText:${path}`, null); } catch {}
+                    throw new Error('File not found (404).');
+                }
+            }
         }
         
         // Force local fetching for base_apps or tasks natively, otherwise it tries to read from GCS
@@ -281,10 +476,19 @@ export class ApiClient {
             : await this._fetch(path);
             
         if (!res.ok) {
-            if (res.status === 404) throw new Error('File not found (404).');
+            if (res.status === 404) {
+                if (this.source === 'remote' && !isBaseApp && !isTasks) {
+                    try { await this.cache.set(`fileText:${path}`, null); } catch {}
+                }
+                throw new Error('File not found (404).');
+            }
             throw new Error(`Failed to load from ${path} (${res.status})`);
         }
-        return await res.text();
+        const text = await res.text();
+        if (this.source === 'remote' && !isBaseApp && !isTasks) {
+            try { await this.cache.set(`fileText:${path}`, text); } catch {}
+        }
+        return text;
     }
 
     /** Returns absolute URL wrapper for opening links directly in new tabs (like trajectories). */

--- a/eval-view/dashboard.js
+++ b/eval-view/dashboard.js
@@ -67,6 +67,9 @@ async function loadDashboardData(testId) {
         allTestData = data;
         currentTestID = testId;
 
+        // Pre-fetch the entire suite recursive file listing in background
+        api.getSuiteDirectoryListing(testId).catch(err => console.warn('Pre-fetch suite directory failed:', err));
+
         // Fetch jetski info (optional)
         let jetskiVersion = null;
         let manifestTimestamp = null;
@@ -690,62 +693,113 @@ async function fillAccordionDetails(container, scenarioName, unguidedRuns, guide
     try {
         let promptHtml = '<div style="color: var(--text-secondary); margin-bottom: 20px;">Prompt fetch deferred or failed.</div>';
         let baseApp = 'n/a';
+        let promptText = '';
 
-        // Fetch prompt from the first run (unguided or guided)
-        const sampleRun = (unguidedRuns && unguidedRuns[0]) || (guidedRuns && guidedRuns[0]);
-        if (sampleRun && sampleRun.taskName) {
+        // Try loading cached prompt
+        if (api.source === 'remote') {
             try {
-                const typeLabel = (unguidedRuns && unguidedRuns[0]) ? 'unguided' : 'guided';
-                const { usedBasePath } = await getResultPaths(testId, sampleRun, `${scenarioName} - ${typeLabel}`);
+                const cachedPrompt = await api.cache.get(`prompt:${testId}:${scenarioName}`);
+                if (cachedPrompt) {
+                    promptText = cachedPrompt.promptText;
+                    baseApp = cachedPrompt.baseApp;
+                }
+            } catch {}
+        }
 
-                let promptText = '';
+        // 1. Parallelize all run path & file checks
+        const resolveRunInfo = async (run, typeLabel) => {
+            if (!run) return null;
+            try {
+                const filePaths = await api.getRunDirectoryListing(testId, run.runNumber);
+                const { setupPath, resultPath, usedBasePath } = api.resolveResultInfoFromList(
+                    testId,
+                    run,
+                    `${scenarioName} - ${typeLabel}`,
+                    filePaths
+                );
+                const files = api.filterRunFilesFromList(usedBasePath, filePaths);
+                return { setupPath, resultPath, usedBasePath, files };
+            } catch (e) {
+                console.warn('Error resolving run info:', e);
+                return null;
+            }
+        };
+
+        const unguidedPromises = unguidedRuns 
+            ? unguidedRuns.map(run => resolveRunInfo(run, 'unguided'))
+            : [];
+        const guidedPromises = guidedRuns
+            ? guidedRuns.map(run => resolveRunInfo(run, 'guided'))
+            : [];
+
+        const [unguidedInfos, guidedInfos] = await Promise.all([
+            Promise.all(unguidedPromises),
+            Promise.all(guidedPromises)
+        ]);
+
+        if (!promptText) {
+            // Fetch prompt from the first run (unguided or guided)
+            const sampleRun = (unguidedRuns && unguidedRuns[0]) || (guidedRuns && guidedRuns[0]);
+            const sampleInfo = (unguidedInfos && unguidedInfos[0]) || (guidedInfos && guidedInfos[0]);
+            if (sampleRun && sampleRun.taskName && sampleInfo) {
                 try {
-                    const runScriptText = await api.getFileText(`${usedBasePath}/run.mjs`);
-                    const match = runScriptText.match(/\.\.\.\[([\s\S]+?)\]/);
-                    if (match) {
-                        const arrayStr = `[${match[1]}]`;
-                        const arr = JSON.parse(arrayStr);
-                        promptText = arr[1];
-                        const baseAppPath = arr[4];
-                        if (baseAppPath) baseApp = sampleRun.baseApp || baseAppPath.split('/').pop();
+                    const { usedBasePath } = sampleInfo;
+                    try {
+                        const runScriptText = await api.getFileText(`${usedBasePath}/run.mjs`);
+                        const match = runScriptText.match(/\.\.\.\[([\s\S]+?)\]/);
+                        if (match) {
+                            const arrayStr = `[${match[1]}]`;
+                            const arr = JSON.parse(arrayStr);
+                            promptText = arr[1];
+                            const baseAppPath = arr[4];
+                            if (baseAppPath) baseApp = sampleRun.baseApp || baseAppPath.split('/').pop();
+                        }
+                    } catch (e) {
+                        console.log('Falling back to living guide file:', e);
+                    }
+
+                    // Fallback to HEAD guide if run.mjs parsing fails
+                    if (!promptText) {
+                        const isNegative = sampleRun.taskName.endsWith('-negative');
+                        const taskPath = `tasks/${isNegative ? 'negative/' : ''}${sampleRun.taskName}.md`;
+                        const text = await api.getFileText(taskPath);
+
+                        const frontmatterMatch = text.match(/^---([\s\S]+?)---/);
+                        if (frontmatterMatch) {
+                            const yaml = frontmatterMatch[1];
+                            const baseAppMatch = yaml.match(/base_app:\s*([^\n\r]+)/);
+                            if (baseAppMatch) baseApp = baseAppMatch[1].trim();
+                        }
+                        promptText = text.replace(/^---[\s\S]+?---\n+/, '');
+                    }
+
+                    if (api.source === 'remote' && promptText) {
+                        try {
+                            await api.cache.set(`prompt:${testId}:${scenarioName}`, { promptText, baseApp });
+                        } catch {}
                     }
                 } catch (e) {
-                    console.log('Falling back to living guide file:', e);
+                    console.log('Task prompt fetch failed:', e);
                 }
-
-                // Fallback to HEAD guide if run.mjs parsing fails
-                if (!promptText) {
-                    const isNegative = sampleRun.taskName.endsWith('-negative');
-                    const taskPath = `tasks/${isNegative ? 'negative/' : ''}${sampleRun.taskName}.md`;
-                    const text = await api.getFileText(taskPath);
-
-                    const frontmatterMatch = text.match(/^---([\s\S]+?)---/);
-                    if (frontmatterMatch) {
-                        const yaml = frontmatterMatch[1];
-                        const baseAppMatch = yaml.match(/base_app:\s*([^\n\r]+)/);
-                        if (baseAppMatch) baseApp = baseAppMatch[1].trim();
-                    }
-                    promptText = text.replace(/^---[\s\S]+?---\n+/, '');
-                }
-
-                promptHtml = `
-                    <div class="task-prompt-container">
-                        <div class="task-prompt-meta">
-                            <span class="task-prompt-meta-label">Base App:</span>
-                            <span class="task-prompt-meta-value">${escapeHtml(baseApp)}</span>
-                        </div>
-                        <div class="task-prompt-quote">
-                            <div class="quote-icon">“</div>
-                            <p class="task-prompt-text">${formatPromptText(promptText)}</p>
-                        </div>
-                    </div>
-                `;
-            } catch (e) {
-                console.log('Task prompt fetch failed:', e);
             }
         }
 
-        // 1. Truth Matrix (Combine all runs side-by-side if multiple)
+        if (promptText) {
+            promptHtml = `
+                <div class="task-prompt-container">
+                    <div class="task-prompt-meta">
+                        <span class="task-prompt-meta-label">Base App:</span>
+                        <span class="task-prompt-meta-value">${escapeHtml(baseApp)}</span>
+                    </div>
+                    <div class="task-prompt-quote">
+                        <div class="quote-icon">“</div>
+                        <p class="task-prompt-text">${formatPromptText(promptText)}</p>
+                    </div>
+                </div>
+            `;
+        }
+
+        // 2. Truth Matrix (Combine all runs side-by-side if multiple)
         const maxUnguided = unguidedRuns ? unguidedRuns.length : 0;
         const maxGuided = guidedRuns ? guidedRuns.length : 0;
         const maxRuns = Math.max(maxUnguided, maxGuided);
@@ -834,20 +888,17 @@ async function fillAccordionDetails(container, scenarioName, unguidedRuns, guide
             return `<span class="${className}" style="${style}">${escapeHtml(g)}</span>`;
         };
 
-                const getTfootChips = async (runs, typeLabel) => {
+        const getTfootChips = (runs, infos) => {
              const chips = [];
              for (let i = 0; i < maxRuns; i++) {
-                 if (!runs || i >= runs.length) {
+                 if (!runs || i >= runs.length || !infos[i]) {
                      chips.push('-');
                      continue;
                  }
                  const run = runs[i];
+                 const info = infos[i];
                  const s = getRunStats(run.results);
-                 const { setupPath, resultPath, usedBasePath } = await getResultPaths(testId, run, `${scenarioName} - ${typeLabel.toLowerCase()}`);
-                 let files = run.files || [];
-                 if (files.length === 0) {
-                     try { files = await api.getRunFiles(usedBasePath); } catch (e) {}
-                 }
+                 const { setupPath, resultPath, usedBasePath, files } = info;
 
                  const sessionFile = files.find(f => f.startsWith('session-') && f.endsWith('.html'));
                  const logFile = files.includes('mcp-server.log') ? 'mcp-server.log' : (files.includes('modern-web.log') ? 'modern-web.log' : null);
@@ -884,16 +935,11 @@ async function fillAccordionDetails(container, scenarioName, unguidedRuns, guide
         };
 
         // Compute separate horizontal run boxes for Tools Used & Guides Used Only
-                        const getRunCards = async (runs, typeLabel) => {
+        const getRunCards = (runs, infos, typeLabel) => {
              let html = '';
              for (let i = 0; i < maxRuns; i++) {
-                 if (!runs || i >= runs.length) continue;
+                 if (!runs || i >= runs.length || !infos[i]) continue;
                  const run = runs[i];
-                 const { usedBasePath } = await getResultPaths(testId, run, `${scenarioName} - ${typeLabel.toLowerCase()}`);
-                 let files = run.files || [];
-                 if (files.length === 0) {
-                     try { files = await api.getRunFiles(usedBasePath); } catch (e) {}
-                 }
                  const toolsUsed = run.guidanceToolsUsed || [];
                  const guidesUsed = run.guidesUsed || (run.guideUsed && run.guideUsed.guidesUsed) || [];
                  const retrievedGuides = run.retrievedGuides || [];
@@ -949,8 +995,8 @@ async function fillAccordionDetails(container, scenarioName, unguidedRuns, guide
              return html;
         };
 
-        const unguidedChips = await getTfootChips(unguidedRuns, 'Unguided');
-        const guidedChips = await getTfootChips(guidedRuns, 'Guided');
+        const unguidedChips = getTfootChips(unguidedRuns, unguidedInfos);
+        const guidedChips = getTfootChips(guidedRuns, guidedInfos);
 
         let tfootHtml = '<tfoot><tr>';
         if (maxRuns > 1) {
@@ -959,13 +1005,12 @@ async function fillAccordionDetails(container, scenarioName, unguidedRuns, guide
         } else {
             tfootHtml += `<td class="center" style="vertical-align: top;">${unguidedChips[0]}</td><td class="center" style="vertical-align: top;">${guidedChips[0]}</td>`;
         }
-const guidedCards = await getRunCards(guidedRuns, 'Guided');
+        const guidedCards = getRunCards(guidedRuns, guidedInfos, 'Guided');
         tfootHtml += `<td>
-<div style="display: flex; flex-direction: row; flex-wrap: wrap; gap: 12px;">${guidedCards}</div>
-</td></tr></tfoot>`;
+        <div style="display: flex; flex-direction: row; flex-wrap: wrap; gap: 12px;">${guidedCards}</div>
+        </td></tr></tfoot>`;
 
         truthMatrixHtml = truthMatrixHtml.replace('</tbody></table></div>', `</tbody>${tfootHtml}</table></div>`);
-
 
         const loadBtnId = `load-btn-${scenarioName.replace(/\s+/g, '-')}`;
 
@@ -976,12 +1021,6 @@ const guidedCards = await getRunCards(guidedRuns, 'Guided');
 
             </div>
         `;
-
-            //  i left this out of it for now.
-         // <div id="${escapeHtml(svgContainerId)}" class="stability-section blueprint-framed">
-         //            <div class="stability-title">Reliability Trend Analysis</div>
-         //            <button id="${escapeHtml(loadBtnId)}" class="secondary-btn">Compare task results across trials</button>
-         //        </div>
 
         const loadBtn = container.querySelector(`#${loadBtnId}`);
         if (loadBtn) {
@@ -994,6 +1033,7 @@ const guidedCards = await getRunCards(guidedRuns, 'Guided');
         container.innerHTML = `<div style="color: var(--accent-failure);">Error loading details: ${e.message}</div>`;
     }
 }
+
 
 function formatPromptText(text) {
     const escaped = escapeHtml(text);

--- a/eval-view/index.html
+++ b/eval-view/index.html
@@ -100,7 +100,12 @@
           <tbody id="suites-list">
             <!-- populated by JS -->
           </tbody>
-          </table>
+        </table>
+        <div id="pagination-container" class="pagination-controls" style="display: flex; justify-content: center; align-items: center; gap: 16px; padding: 16px; border-top: 1px solid var(--border-color); font-family: inherit;">
+            <button id="prev-page-btn" class="secondary-btn" style="padding: 6px 12px; display: none;">← Previous</button>
+            <span id="page-info" style="color: var(--text-secondary); font-size: 0.9rem; display: none;">Page 1 of 1</span>
+            <button id="next-page-btn" class="secondary-btn" style="padding: 6px 12px; display: none;">Next →</button>
+        </div>
       </div>
     </div>
 

--- a/eval-view/landing.css
+++ b/eval-view/landing.css
@@ -783,3 +783,33 @@
   box-sizing: border-box;
   text-align: right;
 }
+
+.secondary-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.pagination-num-btn {
+  background: transparent;
+  border: 1px solid var(--border-color);
+  color: var(--text-secondary);
+  padding: 6px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.9em;
+  transition: all 0.2s;
+}
+
+.pagination-num-btn:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  border-color: var(--text-secondary);
+}
+
+.pagination-num-btn.active {
+  background: var(--color-primary, #2f81f7);
+  color: var(--color-on-primary, #ffffff);
+  border-color: var(--color-primary, #2f81f7);
+  font-weight: 600;
+}

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -1,12 +1,17 @@
-import { getRunStats, initGoogleAuth, authenticatedFetch, getAccessToken, escapeHtml, timeAgo, calculateChartData, $ } from './utils.js';
+import { getRunStats, initGoogleAuth, authenticatedFetch, getAccessToken, escapeHtml, timeAgo, calculateChartData, $, MiniIndexedDB } from './utils.js';
 import { DumbbellChart } from './dumbbell-chart.js';
 
+const cache = new MiniIndexedDB();
 let allTestData = {}; // Cache all test data by testId
 let selectedTestIds = new Set(); // Set of test IDs to show
 let currentSourceFilter = 'all';
 let currentAgentFilter = 'all';
 let currentServingFilter = 'all';
 let currentModelFilter = 'all';
+
+let allSuitesList = []; // Unified list of all suites: [{ id, source, timestamp, useResultsPrefix }]
+let currentPage = 1;
+const pageSize = 20;
 
 function isRemoteDashboard() {
     return window.location.hostname !== 'localhost' && window.location.hostname !== '127.0.0.1';
@@ -22,17 +27,22 @@ document.addEventListener('DOMContentLoaded', async () => {
         // Initialize UI
         setupTestFilters(); // New filter setup
         setupTableFilters();
+        setupPaginationEvents();
 
         const params = new URLSearchParams(window.location.search);
         
         // Wait for auth before loading if remote is needed. We load local immediately, remote when auth'd
         initGoogleAuth(async () => {
-             await loadRemoteTests();
+             await loadRemoteSuitesList();
+             await loadPageSuitesData();
         });
 
-        await loadLocalTests();
+        await loadLocalSuitesList();
+        await loadPageSuitesData();
+
         if (getAccessToken()) {
-             await loadRemoteTests();
+             await loadRemoteSuitesList();
+             await loadPageSuitesData();
         }
 
         // Initialize with default states relative to compoundKeys instead of simple testIDs
@@ -53,9 +63,6 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         // Update filter UI to match initial state
         renderFilterMenuItems();
-
-        // Initial Render
-        renderSuites();
 
     } catch (error) {
         console.error('Error:', error);
@@ -147,7 +154,11 @@ function setupTestFilters() {
 
 function setupTableFilters() {
     const filters = {
-        'filter-source': (val) => currentSourceFilter = val,
+        'filter-source': (val) => {
+            currentSourceFilter = val;
+            currentPage = 1;
+            loadPageSuitesData();
+        },
         'filter-agent': (val) => currentAgentFilter = val,
         'filter-serving': (val) => currentServingFilter = val,
         'filter-model': (val) => currentModelFilter = val
@@ -254,7 +265,28 @@ function renderAll() {
 
 
 
-async function loadLocalTests() {
+function getSuiteTimestamp(suiteId, defaultTimestamp) {
+    if (defaultTimestamp) return new Date(defaultTimestamp).getTime();
+    const match = suiteId.match(/(\d{4}-\d{2}-\d{2})[T_](\d{2})-(\d{2})-(\d{2})/);
+    if (match) {
+        return new Date(`${match[1]}T${match[2]}:${match[3]}:${match[4]}`).getTime();
+    }
+    const dateOnly = suiteId.match(/(\d{4}-\d{2}-\d{2})/);
+    if (dateOnly) {
+        return new Date(dateOnly[1]).getTime();
+    }
+    return 0;
+}
+
+function registerSuiteId(suiteId, source, defaultTimestamp, useResultsPrefix) {
+    const timestamp = getSuiteTimestamp(suiteId, defaultTimestamp);
+    // Avoid duplicates
+    if (!allSuitesList.some(s => s.id === suiteId && s.source === source)) {
+        allSuitesList.push({ id: suiteId, source, timestamp, useResultsPrefix });
+    }
+}
+
+async function loadLocalSuitesList() {
     if (window.location.hostname !== 'localhost' && window.location.hostname !== '127.0.0.1') {
         return; // Avoid 404s by skipping local network fetches when hosted on Github Pages
     }
@@ -265,46 +297,29 @@ async function loadLocalTests() {
         let useResultsPrefix = false;
 
         if (!response.ok) {
-            // Try fetching suites.gen.json as fallback for static mode
             const staticRes = await fetch(`/suites.gen.json?t=${Date.now()}`);
-            if (!staticRes.ok) return; // Silent fail if both fail
+            if (!staticRes.ok) return;
             const suites = await staticRes.json();
-            // convert array of strings to expected format [{id: string, source: 'local'}]
             manifest = { suites: suites.map(id => ({ id, source: 'local', timestamp: new Date().toISOString() })) };
             useResultsPrefix = true;
         } else {
             manifest = await response.json();
         }
 
-        if (manifest.suites && manifest.suites.length > 0) {
-            document.getElementById('empty-state').style.display = 'none';
-        }
-
-        // Load local test data
-        for (const suite of manifest.suites) {
-            if (suite.source !== 'local') continue;
-            
-            const testId = suite.id;
-            const suiteTimestamp = suite.timestamp;
-            try {
-                const fetchPath = useResultsPrefix ? `results/${testId}/evals.json` : `${testId}/evals.json`;
-                const response = await fetch(`${fetchPath}?source=local&t=${Date.now()}`);
-                if (response.ok) {
-                    const parsed = await response.json();
-                    registerTestData(testId, useResultsPrefix ? 'static' : 'local', parsed, suiteTimestamp);
+        if (manifest.suites) {
+            manifest.suites.forEach(s => {
+                if (s.source === 'local') {
+                    registerSuiteId(s.id, 'local', s.timestamp, useResultsPrefix);
                 }
-            } catch (e) {
-                console.warn(`Failed to load local test ${testId}:`, e);
-            }
+            });
         }
     } catch {
         console.warn('Local proxy not available');
     }
 }
 
-async function loadRemoteTests() {
+async function loadRemoteSuitesList() {
     try {
-        const prefixes = [];
         let pageToken = '';
         
         // Paginate GCS to retrieve all prefixes without truncation limits
@@ -315,43 +330,223 @@ async function loadRemoteTests() {
             
             const data = await response.json();
             if (data.prefixes) {
-                prefixes.push(...data.prefixes);
+                data.prefixes.forEach(prefix => {
+                    const testId = prefix.slice(0, -1);
+                    registerSuiteId(testId, 'remote', null, false);
+                });
             }
             pageToken = data.nextPageToken || '';
         } while (pageToken);
-        
-        if (prefixes.length > 0) {
-             document.getElementById('empty-state').style.display = 'none';
-        }
-
-        // Load remote test data in parallel
-        await Promise.all(prefixes.map(async (prefix) => {
-            const testId = prefix.slice(0, -1); // Remove trailing slash
-            try {
-                const fileUrl = `https://storage.googleapis.com/storage/v1/b/guidance-evals/o/${encodeURIComponent(prefix + 'evals.json')}?alt=media`;
-                const response = await authenticatedFetch(fileUrl);
-                if (response.ok) {
-                    const parsed = await response.json();
-                    registerTestData(testId, 'remote', parsed);
-                }
-            } catch (e) {
-                console.warn(`Failed to load remote test ${testId}:`, e);
-            }
-        }));
-        
-        // Re-render UI now that we have remote data
-        const params = new URLSearchParams(window.location.search);
-        let initialTests = params.get('tests');
-        if (!initialTests || initialTests.trim() === '') {
-            selectedTestIds = new Set(Object.keys(allTestData));
-        }
-        renderFilterMenuItems();
-        renderAll();
-
     } catch (error) {
-        console.error('Error loading remote suites:', error);
+        console.error('Error loading remote suites list:', error);
     }
 }
+
+async function preloadCachedSuitesMetadata() {
+    await Promise.all(allSuitesList.map(async (suite) => {
+        const compoundKey = `${suite.id}|||${suite.source}`;
+        if (allTestData[compoundKey]) return;
+
+        if (suite.source === 'remote') {
+            try {
+                const parsed = await cache.get(`evals:${suite.id}`);
+                if (parsed) {
+                    registerTestData(suite.id, 'remote', parsed);
+                }
+            } catch (err) {
+                console.warn('Preload cache read failed for remote:', err);
+            }
+        }
+    }));
+}
+
+function getFilteredSuites() {
+    return allSuitesList.filter(suite => {
+        const compoundKey = `${suite.id}|||${suite.source}`;
+        const testInfo = allTestData[compoundKey];
+
+        if (currentSourceFilter !== 'all' && suite.source !== currentSourceFilter) return false;
+
+        if (testInfo) {
+            if (currentAgentFilter !== 'all' && testInfo.agent !== currentAgentFilter) return false;
+            if (currentServingFilter !== 'all' && testInfo.serving !== currentServingFilter) return false;
+            if (currentModelFilter !== 'all' && testInfo.model !== currentModelFilter) return false;
+        } else {
+            if (currentAgentFilter !== 'all' || currentServingFilter !== 'all' || currentModelFilter !== 'all') {
+                return false;
+            }
+        }
+        return true;
+    });
+}
+
+async function loadPageSuitesData() {
+    await preloadCachedSuitesMetadata();
+
+    let filteredSuites = getFilteredSuites();
+    filteredSuites.sort((a, b) => b.timestamp - a.timestamp);
+    
+    if (filteredSuites.length > 0) {
+        document.getElementById('empty-state').style.display = 'none';
+    } else {
+        document.getElementById('empty-state').style.display = 'block';
+        document.getElementById('suites-list').innerHTML = '';
+        updatePaginationUI(0);
+        return;
+    }
+
+    const totalPages = Math.ceil(filteredSuites.length / pageSize) || 1;
+    if (currentPage > totalPages) currentPage = totalPages;
+    if (currentPage < 1) currentPage = 1;
+
+    const start = (currentPage - 1) * pageSize;
+    const end = currentPage * pageSize;
+    const pageSuites = filteredSuites.slice(start, end);
+
+    // Fetch and register page data in parallel
+    await Promise.all(pageSuites.map(async (suite) => {
+        const compoundKey = `${suite.id}|||${suite.source}`;
+        if (allTestData[compoundKey]) return; // Already loaded
+
+        if (suite.source === 'local') {
+            try {
+                const fetchPath = suite.useResultsPrefix ? `results/${suite.id}/evals.json` : `${suite.id}/evals.json`;
+                const response = await fetch(`${fetchPath}?source=local&t=${Date.now()}`);
+                if (response.ok) {
+                    const parsed = await response.json();
+                    registerTestData(suite.id, suite.useResultsPrefix ? 'static' : 'local', parsed, new Date(suite.timestamp).toISOString());
+                }
+            } catch (e) {
+                console.warn(`Failed to load local test ${suite.id}:`, e);
+            }
+        } else if (suite.source === 'remote') {
+            try {
+                let parsed = null;
+                try {
+                    parsed = await cache.get(`evals:${suite.id}`);
+                } catch (err) {
+                    console.warn('Cache read failed:', err);
+                }
+
+                if (!parsed) {
+                    const fileUrl = `https://storage.googleapis.com/storage/v1/b/guidance-evals/o/${encodeURIComponent(suite.id + '/evals.json')}?alt=media`;
+                    const response = await authenticatedFetch(fileUrl);
+                    if (response.ok) {
+                        parsed = await response.json();
+                        try {
+                            await cache.set(`evals:${suite.id}`, parsed);
+                        } catch (err) {
+                            console.warn('Cache write failed:', err);
+                        }
+                    }
+                }
+
+                if (parsed) {
+                    registerTestData(suite.id, 'remote', parsed);
+                }
+            } catch (e) {
+                console.warn(`Failed to load remote test ${suite.id}:`, e);
+            }
+        }
+    }));
+
+    // Update filter selection checkboxes
+    selectedTestIds = new Set(Object.keys(allTestData));
+    renderFilterMenuItems();
+    renderSuites();
+    updatePaginationUI(filteredSuites.length);
+}
+
+function updatePaginationUI(totalItems) {
+    const container = document.getElementById('pagination-container');
+    const prevBtn = document.getElementById('prev-page-btn');
+    const nextBtn = document.getElementById('next-page-btn');
+    const pageInfo = document.getElementById('page-info');
+
+    if (!container || !prevBtn || !nextBtn) return;
+
+    if (pageInfo) pageInfo.style.display = 'none';
+
+    const totalPages = Math.ceil(totalItems / pageSize) || 1;
+
+    const existingNumBtns = container.querySelectorAll('.pagination-num-btn, .pagination-ellipsis');
+    existingNumBtns.forEach(el => el.remove());
+
+    if (totalItems <= pageSize) {
+        prevBtn.style.display = 'none';
+        nextBtn.style.display = 'none';
+        return;
+    }
+
+    prevBtn.style.display = 'inline-flex';
+    nextBtn.style.display = 'inline-flex';
+
+    if (prevBtn instanceof HTMLButtonElement) prevBtn.disabled = currentPage === 1;
+    if (nextBtn instanceof HTMLButtonElement) nextBtn.disabled = currentPage === totalPages;
+
+    const pages = [];
+    const delta = 1;
+
+    for (let i = 1; i <= totalPages; i++) {
+        if (
+            i === 1 || 
+            i === totalPages || 
+            (i >= currentPage - delta && i <= currentPage + delta)
+        ) {
+            pages.push(i);
+        } else if (pages[pages.length - 1] !== '...') {
+            pages.push('...');
+        }
+    }
+
+    pages.forEach(p => {
+        if (p === '...') {
+            const ellipsis = document.createElement('span');
+            ellipsis.className = 'pagination-ellipsis';
+            ellipsis.textContent = '...';
+            ellipsis.style.color = 'var(--text-secondary)';
+            ellipsis.style.fontSize = '0.9rem';
+            container.insertBefore(ellipsis, nextBtn);
+        } else if (typeof p === 'number') {
+            const targetPage = p;
+            const numBtn = document.createElement('button');
+            numBtn.className = `pagination-num-btn ${targetPage === currentPage ? 'active' : ''}`;
+            numBtn.textContent = targetPage.toString();
+            numBtn.onclick = async () => {
+                if (currentPage !== targetPage) {
+                    currentPage = targetPage;
+                    await loadPageSuitesData();
+                }
+            };
+            container.insertBefore(numBtn, nextBtn);
+        }
+    });
+}
+
+function setupPaginationEvents() {
+    const prevBtn = document.getElementById('prev-page-btn');
+    const nextBtn = document.getElementById('next-page-btn');
+
+    if (prevBtn) {
+        prevBtn.onclick = async () => {
+            if (currentPage > 1) {
+                currentPage--;
+                await loadPageSuitesData();
+            }
+        };
+    }
+    if (nextBtn) {
+        nextBtn.onclick = async () => {
+            const totalItems = getFilteredSuites().length;
+            const totalPages = Math.ceil(totalItems / pageSize) || 1;
+            if (currentPage < totalPages) {
+                currentPage++;
+                await loadPageSuitesData();
+            }
+        };
+    }
+}
+
 
 function registerTestData(testId, source, parsed, forcedTimestamp) {
     let serving = 'unknown';
@@ -743,16 +938,29 @@ function calculateGroupTotalStats(results, groupType) {
 }
 
 function getSortedTestIds() {
-    // Return only SELECTED tests, sorted by date
-    return Array.from(selectedTestIds).sort((a, b) => {
-        // Safety check if id not in allTestData (shouldn't happen but good practice)
-        if (!allTestData[a] || !allTestData[b]) return 0;
-        return new Date(allTestData[b].timestamp).getTime() - new Date(allTestData[a].timestamp).getTime();
-    });
+    let filteredSuites = getFilteredSuites();
+    filteredSuites.sort((a, b) => b.timestamp - a.timestamp);
+
+    const start = (currentPage - 1) * pageSize;
+    const end = currentPage * pageSize;
+    const pageSuites = filteredSuites.slice(start, end);
+
+    return pageSuites
+        .map(s => `${s.id}|||${s.source}`)
+        .filter(compoundKey => allTestData[compoundKey] !== undefined);
+}
+
+function getAllFilteredTestIds() {
+    let filteredSuites = getFilteredSuites();
+    filteredSuites.sort((a, b) => b.timestamp - a.timestamp);
+
+    return filteredSuites
+        .map(s => `${s.id}|||${s.source}`)
+        .filter(compoundKey => allTestData[compoundKey] !== undefined);
 }
 
 function renderPivotInsights() {
-    const testIds = getSortedTestIds(); // Uses selected filters!
+    const testIds = getAllFilteredTestIds(); // Uses selected filters!
     const grouped = {
         agent: {},
         serving: {},

--- a/eval-view/server.js
+++ b/eval-view/server.js
@@ -324,6 +324,49 @@ const server = http.createServer(async (req, res) => {
     return;
   }
 
+  if (decodedPath === '/api/run-files-recursive') {
+    const parsedUrl = new URL(reqUrl, `http://${req.headers.host}`);
+    const relativePath = parsedUrl.searchParams.get('dir');
+    if (!relativePath) {
+      res.writeHead(400);
+      res.end('Missing dir parameter');
+      return;
+    }
+
+    /** @type {string[]} */
+    let files = [];
+    const resultsDir = process.env.USE_MOCK_RESULTS === 'true' ? './mock-results' : '../harness/results';
+    const targetDir = path.join(resultsDir, relativePath);
+
+    /**
+     * @param {string} dir
+     * @param {string} [prefix]
+     */
+    function collectFilesRecursive(dir, prefix = '') {
+      if (!fs.existsSync(dir)) return;
+      const items = fs.readdirSync(dir, { withFileTypes: true });
+      for (const item of items) {
+        const fullPath = path.join(dir, item.name);
+        const logicalPath = prefix ? `${prefix}/${item.name}` : item.name;
+        if (item.isDirectory()) {
+          collectFilesRecursive(fullPath, logicalPath);
+        } else {
+          files.push(`${relativePath}${logicalPath}`);
+        }
+      }
+    }
+
+    try {
+      collectFilesRecursive(targetDir);
+    } catch (e) {
+      console.error(e);
+    }
+
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ files }));
+    return;
+  }
+
   // --- Silent File Probing API ---
   // Avoids native browser 404 console errors by returning JSON { exists: boolean }
   if (decodedPath === '/api/exists') {

--- a/eval-view/utils.js
+++ b/eval-view/utils.js
@@ -245,3 +245,54 @@ export function $(query, context) {
   return /** @type {ParseSelector<T>} */ (result);
 }
 
+export class MiniIndexedDB {
+    constructor(dbName = 'GuidanceDashboardDB', storeName = 'evalsCache') {
+        this.dbName = dbName;
+        this.storeName = storeName;
+        this.db = null;
+    }
+
+    init() {
+        if (this.db) return Promise.resolve(this.db);
+        return new Promise((resolve, reject) => {
+            const request = indexedDB.open(this.dbName, 1);
+            request.onupgradeneeded = () => {
+                const db = request.result;
+                if (!db.objectStoreNames.contains(this.storeName)) {
+                    db.createObjectStore(this.storeName);
+                }
+            };
+            request.onsuccess = () => {
+                this.db = request.result;
+                resolve(this.db);
+            };
+            request.onerror = () => {
+                reject(request.error);
+            };
+        });
+    }
+
+    async get(key) {
+        await this.init();
+        return new Promise((resolve, reject) => {
+            const transaction = this.db.transaction(this.storeName, 'readonly');
+            const store = transaction.objectStore(this.storeName);
+            const request = store.get(key);
+            request.onsuccess = () => resolve(request.result);
+            request.onerror = () => reject(request.error);
+        });
+    }
+
+    async set(key, value) {
+        await this.init();
+        return new Promise((resolve, reject) => {
+            const transaction = this.db.transaction(this.storeName, 'readwrite');
+            const store = transaction.objectStore(this.storeName);
+            const request = store.put(value, key);
+            request.onsuccess = () => resolve();
+            request.onerror = () => reject(request.error);
+        });
+    }
+}
+
+


### PR DESCRIPTION
Dashboard has been slow to load GCS results after login, and slow loading the individual suite and test case/task results. Improves speed with caching and pagination with 20 results per page.

Improves initial load speed from around 6s to 1s, and speed of suite/test results displaying from ~3s to <1s.

### Summary of Performance Improvements

#### 1. Sub-Second Click Latency & Accordion Optimizations (`dashboard.js` / `api.js`)
* **Suite Directory Pre-fetching (`getSuiteDirectoryListing`)**: Introduced a recursive suite directory prefix pre-fetcher triggered immediately when a dashboard loads. Instead of firing up to 6 serial/parallel GCS network listings upon expanding a task accordion, all runs' index points, logs, and trajectories are now resolved **completely synchronously in local memory** from the pre-fetched list.
* **Persistent Prompt & BaseApp Caching**: Implemented `IndexedDB` caching for the resolved `promptText` and `baseApp` of each scenario under the key `prompt:${testId}:${scenarioName}`. Expanding an accordion a second time skips all file reading and parsing entirely, leading to **0ms click latency**.
* **Persistent Text Download Caching (`getFileText`)**: Added caching for raw text downloads (e.g. log files, `run.mjs` scripts) to avoid repeat GCS queries, returning cached contents instantly.
* **Local File 404 Check Bypass**: Pre-fetched recursive file listings are queried locally in memory to verify file existence instead of using prefix-checking network roundtrips (`_checkRemoteFileExists`), saving ~200-300ms per file probe.

#### 2. High-Speed Numbered Pagination (`landing.js` / `landing.css` / `index.html`)
* **Reverse-Chronological Pagination**: Unified suite listings on the landing page to display exactly **20 items per page**. Evals metadata (`evals.json`) is loaded *only* for the visible 20 suites, accelerating initial remote loads from ~10 seconds to **<300ms**.
* **IndexedDB Metadata Preloading (`preloadCachedSuitesMetadata`)**: Scans all previously cached remote suite metadata in parallel on startup (IndexedDB local query takes `<5ms` total), enabling complete dataset filtering and sorting.
* **Full-Dataset Filtering & median statistics**: Redesigned filtering to calculate filters across the **entire dataset** before slicing for pagination (rather than filtering only the current page's 20 visible items). The median uplift and dumbbell charts at the top now represent the entire filtered dataset.
* **Premium Page-Number Jump Controls**: Replaced the simple text pagination label with a premium page-number navigation strip. 
  - Automatically handles ellipses (`...`) to span large page boundaries (e.g., `1 ... 4 [5] 6 ... 12`).
  - Boundary navigation buttons (`Previous` / `Next`) are HTML disabled and styled with `.secondary-btn:disabled` (opacity `35%`, cursor `not-allowed`, pointer-events disabled) on the first and last pages.