### PR TITLE
The Translator API is also supported in Edge

### DIFF
--- a/guides/built-in-ai/translator/guide.md
+++ b/guides/built-in-ai/translator/guide.md
@@ -6,7 +6,7 @@ web-feature-ids:
   - translator
 ---
 
-The **Translator API** allows developers to perform client-side text translation using built-in AI models in Chrome. This approach eliminates the need for cloud-based translation services for ephemeral content, reducing costs and improving privacy by keeping data on the user's device.
+The **Translator API** allows developers to perform client-side text translation using built-in AI models in Chrome and Edge. This approach eliminates the need for cloud-based translation services for ephemeral content, reducing costs and improving privacy by keeping data on the user's device.
 
 
 ## Prerequisites & Requirements
@@ -14,7 +14,8 @@ The **Translator API** allows developers to perform client-side text translation
 ### Browser Support
 
 - **Chrome:** Version 138+ (Desktop only).
-- **Not Supported:** Mobile (Android/iOS), Edge, Firefox, Safari.
+- **Edge:** Version 148+ (Desktop only).
+- **Not Supported:** Mobile (Android/iOS), Firefox, Safari.
 
 ### Hardware Requirements
 
@@ -22,7 +23,7 @@ To run Gemini Nano and associated models, the system needs:
 
 - **Operating System:** Windows 10/11, macOS 13+, Linux, or ChromeOS (Chromebook
   Plus).
-- **Storage:** At least **22 GB** free on the Chrome profile volume.
+- **Storage:** At least **22 GB** free on the profile volume.
 - **Memory/CPU:** 16 GB+ RAM and 4+ CPU cores.
 - **GPU:** 4 GB+ VRAM (Mandatory for Prompt API with audio).
 - **Network:** Required only for the initial download of language packs/models.


### PR DESCRIPTION
Adding Edge 148 to the Translator API guide.

However, going forward, can we avoid hardcoding browser versions in guides and rely on the web-features data instead?
The web-features data isn't yet up to date for this particular one (see the [translator feature](https://web-platform-dx.github.io/web-features-explorer/features/translator/)), however, the BCD data [has been updated](https://github.com/mdn/browser-compat-data/pull/29775) and that change will get into web-features very soon.