### PR TITLE
Don't generate a GH app token in forked PRs

### DIFF
--- a/.github/workflows/guide-sync.yml
+++ b/.github/workflows/guide-sync.yml
@@ -45,6 +45,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Generate GitHub App token
+        if: ${{ vars.GH_APP_ID != '' && secrets.GH_APP_PRIVATE_KEY != '' }}
         uses: actions/create-github-app-token@v2
         id: app-token
         with:


### PR DESCRIPTION
https://github.com/GoogleChrome/modern-web-guidance-src/actions/runs/26497860259/job/78030419210?pr=887 failed at the `Generate GitHub App token` step with the error `[@octokit/auth-app] appId option is required`

This occurs because pull requests triggered from forks don't have access to repository secrets like `secrets.GH_APP_PRIVATE_KEY`. Since `app-id: ${{ vars.GH_APP_ID }}` and `private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}` are empty, the `actions/create-github-app-token@v2` action fails immediately.