### PR TITLE
Nightly fix: fail agent runs safely

### DIFF
--- a/guides/negative-gen.ts
+++ b/guides/negative-gen.ts
@@ -150,7 +150,7 @@ The output should be a single file named negative-demo.html. Do not modify any o
 
   } catch (err) {
     console.error("Error during Gemini CLI execution:", err);
-    process.exit(1);
+    process.exitCode = 1;
   } finally {
     cleanupIsolatedHome(path.dirname(workDir));
   }

--- a/harness/agents/claude-code-agent.ts
+++ b/harness/agents/claude-code-agent.ts
@@ -144,7 +144,7 @@ async function run() {
 
   } catch (err) {
     console.error("Error during Claude Code execution:", err);
-    process.exit(1);
+    process.exitCode = 1;
   } finally {
     cleanupIsolatedHome(path.dirname(workDir));
   }

--- a/harness/agents/codex-cli-agent.ts
+++ b/harness/agents/codex-cli-agent.ts
@@ -107,7 +107,8 @@ async function run() {
     const commandArgs = [
       'exec', 
       userPrompt,
-      '--yolo'
+      '--yolo',
+      '--model', process.env.CODEX_MODEL || 'gpt-5.5'
     ];
 
     console.log(`Executing: ${command} ${commandArgs.join(' ')}`);

--- a/harness/agents/codex-cli-agent.ts
+++ b/harness/agents/codex-cli-agent.ts
@@ -134,7 +134,7 @@ async function run() {
     console.log("Codex agent finished successfully.");
   } catch (err) {
     console.error("Error during Codex execution:", err);
-    process.exit(1);
+    process.exitCode = 1;
   } finally {
     cleanupIsolatedHome(path.dirname(workDir));
   }

--- a/harness/agents/gemini-cli-agent.ts
+++ b/harness/agents/gemini-cli-agent.ts
@@ -120,7 +120,7 @@ async function run() {
 
   } catch (err) {
     console.error("Error during Gemini CLI execution:", err);
-    process.exit(1);
+    process.exitCode = 1;
   } finally {
     cleanupIsolatedHome(path.dirname(workDir));
   }

--- a/harness/agents/jetski-agent.ts
+++ b/harness/agents/jetski-agent.ts
@@ -464,7 +464,7 @@ async function run(): Promise<void> {
 
   } catch (err) {
     console.error("Error during execution:", err);
-    process.exit(1);
+    process.exitCode = 1;
   } finally {
     stopWatchingMcpLog();
     killProcessOnPort(config.environment.jetskiDebugPort);

--- a/harness/agents/jetski-cli-agent.ts
+++ b/harness/agents/jetski-cli-agent.ts
@@ -105,7 +105,7 @@ async function run() {
 
   } catch (err) {
     console.error("Error during Jetski CLI execution:", err);
-    process.exit(1);
+    process.exitCode = 1;
   } finally {
     cleanupIsolatedHome(path.dirname(workDir));
   }

--- a/nightly/run_agent.sh
+++ b/nightly/run_agent.sh
@@ -22,7 +22,7 @@ EOF
 
 # Parse flags
 AGENT=""
-WORKERS=""
+WORKERS="20"
 PREFIX="nightly"
 RUN_LOCAL="false"
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
### Summary
This PR fixes issues causing nightly evaluation runs to fail (including inode exhaustion under `/tmp` and unsupported model errors), and optimizes manual run concurrency.

### Changes

#### 1. Fix `/tmp` Isolation Directory Leaks
* **Files Modified**: `harness/agents/codex-cli-agent.ts`, `harness/agents/claude-code-agent.ts`, `harness/agents/gemini-cli-agent.ts`, `harness/agents/jetski-cli-agent.ts`, `harness/agents/jetski-agent.ts`, `guides/negative-gen.ts`
* **Details**: Replaced direct calls to `process.exit(1)` in the `catch` blocks of each agent script with `process.exitCode = 1`. This allows Node.js to exit gracefully and guarantees that the `finally` block containing the isolation cleanup logic (`cleanupIsolatedHome()`) is executed. This prevents orphaned `/tmp/ghh-*` workspace folders from leaking on disk and causing inode/disk space exhaustion.

#### 2. Default to Supported Codex Model (`gpt-5.5`)
* **Files Modified**: `harness/agents/codex-cli-agent.ts`
* **Details**: Updated the model argument for `codex_cli` to use `gpt-5.5` (or custom overrides via `process.env.CODEX_MODEL`). Previously, it defaulted to `gpt-5.3-codex`, which is no longer supported and caused Codex CLI executions to crash with a `400 Bad Request` error.

#### 3. Optimize Default Concurrency for `run_agent.sh`
* **Files Modified**: `nightly/run_agent.sh`
* **Details**: Changed the default number of workers from `""` (empty) to `20`. This ensures that running `run_agent.sh` directly runs the evaluation suite in parallel utilizing 20 concurrent workers, instead of defaulting to `pnpm`'s default recursive concurrency of 4.
