### PR TITLE
guides: enforce HTML tag escaping and fix unescaped guide tags

### DIFF
--- a/guides/forms/autofill-address-form/guide.md
+++ b/guides/forms/autofill-address-form/guide.md
@@ -22,7 +22,7 @@ Make the most of the elements and attributes built for creating forms:
 
 These enable built-in browser functionality, improve accessibility, and add meaning to markup.
 
-### Use the <label> element to label form fields for data entry
+### Use the `<label>` element to label form fields for data entry
 
 To label an `<input>`, `<select>`, or `<textarea>`, use a `<label>`. Associate a label with an input by giving the label's `for` attribute the same value as the input's `id`.
 

--- a/guides/forms/autofill-payment-form/guide.md
+++ b/guides/forms/autofill-payment-form/guide.md
@@ -26,7 +26,7 @@ Make the most of the elements and attributes built for creating forms:
 
 These enable built-in browser functionality, improve accessibility, and add meaning to markup.
 
-### Use the <label> element to label form fields for data entry
+### Use the `<label>` element to label form fields for data entry
 
 To label an `<input>`, `<select>`, or `<textarea>`, use a `<label>`. Associate a label with an input by giving the label's `for` attribute the same value as the input's `id`.
 

--- a/guides/forms/autofill-sign-in-form/guide.md
+++ b/guides/forms/autofill-sign-in-form/guide.md
@@ -65,7 +65,7 @@ This enables browsers to help users by securely storing sign-in details and corr
 
 Validate data entry both in realtime and before form submission. Use `type="email"` for email inputs — the browser will validate the format automatically. Add the `required` attribute to mandatory fields to prevent empty submissions.
 
-### Put sign-in in its own <form> element
+### Put sign-in in its own `<form>` element
 
 Always use the `<form>` element when you're getting users to enter data
 

--- a/guides/forms/autofill-sign-in-form/guide.md
+++ b/guides/forms/autofill-sign-in-form/guide.md
@@ -25,7 +25,7 @@ Make the most of the elements and attributes built for creating forms:
 
 These enable built-in browser functionality, improve accessibility, and add meaning to markup.
 
-### Use the <label> element to label form fields for data entry
+### Use the `<label>` element to label form fields for data entry
 
 To label an `<input>`, `<select>`, or `<textarea>`, use a `<label>`. Associate a label with an input by giving the label's `for` attribute the same value as the input's `id`.
 

--- a/guides/forms/autofill-sign-up-form/guide.md
+++ b/guides/forms/autofill-sign-up-form/guide.md
@@ -25,7 +25,7 @@ Make the most of the elements and attributes built for creating forms:
 
 These enable built-in browser functionality, improve accessibility, and add meaning to markup.
 
-### Use the <label> element to label form fields for data entry
+### Use the `<label>` element to label form fields for data entry
 
 To label an `<input>`, `<select>`, or `<textarea>`, use a `<label>`. Associate a label with an input by giving the label's `for` attribute the same value as the input's `id`.
 

--- a/guides/forms/autofill-sign-up-form/guide.md
+++ b/guides/forms/autofill-sign-up-form/guide.md
@@ -65,7 +65,7 @@ This enables browsers to help users by securely storing sign-up details and corr
 
 Validate data entry both in realtime and before form submission. Use `type="email"` for email inputs — the browser will validate the format automatically. For passwords, use a `pattern` attribute to enforce strength requirements and provide clear error messages when validation fails. Add the `required` attribute to mandatory fields to prevent empty submissions.
 
-### Put sign-up in its own <form> element
+### Put sign-up in its own `<form>` element
 
 Always use the `<form>` element when you're getting users to enter data
 

--- a/guides/user-experience/deliver-optimized-decorative-images/guide.md
+++ b/guides/user-experience/deliver-optimized-decorative-images/guide.md
@@ -7,7 +7,7 @@ web-feature-ids:
 
 Delivering optimized decorative images via CSS improves perceived performance without sacrificing visual quality. By using the `image-set()` CSS function, you can provide the browser with multiple options for a single background or mask image. You can specify modern formats (like AVIF or WebP) alongside different resolutions (like `1x` and `2x`). The browser will dynamically select the smallest compatible image that provides the appropriate pixel density for the user's device.
 
-**CAUTION**: If the image is likely to be the Largest Contentful Paint (LCP) element (e.g., a large hero banner), be aware that images referenced in CSS via image-set() are not discoverable by the browser's preload scanner. This can significantly delay image loading and harm LCP. For LCP candidates, consider using a standard HTML <img> or <picture> tag instead or alternatively, preloading the image as well using `<link rel=preload>` option with a `media` attribute.
+**CAUTION**: If the image is likely to be the Largest Contentful Paint (LCP) element (e.g., a large hero banner), be aware that images referenced in CSS via image-set() are not discoverable by the browser's preload scanner. This can significantly delay image loading and harm LCP. For LCP candidates, consider using a standard HTML `<img>` or `<picture>` tag instead or alternatively, preloading the image as well using `<link rel=preload>` option with a `media` attribute.
 
 ### Implementation
 

--- a/guides/user-experience/move-dom-element-without-losing-state/guide.md
+++ b/guides/user-experience/move-dom-element-without-losing-state/guide.md
@@ -1,6 +1,6 @@
 ---
 name: move-dom-element-without-losing-state
-description: Move or reparent a DOM element without losing important element state, such as interactivity states (:focus/:active), <iframe> loading state, animation/transition state, etc
+description: Move or reparent a DOM element without losing important element state, such as interactivity states (:focus/:active), `<iframe>` loading state, animation/transition state, etc
 web-feature-ids:
 - move-before
 ---

--- a/lib/guide-validation.test.ts
+++ b/lib/guide-validation.test.ts
@@ -64,6 +64,7 @@ describe('parseExpectations', () => {
 });
 
 describe('validateHtmlTags', () => {
+  // Tests that safe inline typographic elements are permitted
   test('allows comments, kbd, br, wbr tags', () => {
     const body = `This is a comment: <!-- comment -->
 Some keyboard shortcut: <kbd>Ctrl</kbd> + <kbd>C</kbd>

--- a/lib/guide-validation.test.ts
+++ b/lib/guide-validation.test.ts
@@ -1,6 +1,6 @@
 import { test, describe } from 'node:test';
 import assert from 'node:assert';
-import { parseExpectations } from './guide-validation.ts';
+import { parseExpectations, validateHtmlTags } from './guide-validation.ts';
 
 describe('parseExpectations', () => {
   test('legacy flat format: all bullets treated as mustPass', () => {
@@ -62,3 +62,47 @@ describe('parseExpectations', () => {
     assert.deepStrictEqual(result.appAgnostic, []);
   });
 });
+
+describe('validateHtmlTags', () => {
+  test('allows comments, kbd, br, wbr tags', () => {
+    const body = `This is a comment: <!-- comment -->
+Some keyboard shortcut: <kbd>Ctrl</kbd> + <kbd>C</kbd>
+Line break: <br> and <br />
+Word break: <wbr>
+`;
+    const errors = validateHtmlTags(body, 'test.md');
+    assert.deepStrictEqual(errors, []);
+  });
+
+  test('detects unescaped invalid tags', () => {
+    const body = `Please use <select> or <button> here.
+And an iframe: <iframe src="foo"></iframe>.
+Also unescaped <label>.
+`;
+    const errors = validateHtmlTags(body, 'test.md');
+    assert.strictEqual(errors.length, 4);
+    assert.ok(errors[0].includes('Unescaped HTML tag <select> found on line 1'));
+    assert.ok(errors[1].includes('Unescaped HTML tag <button> found on line 1'));
+    assert.ok(errors[2].includes('Unescaped HTML tag <iframe> found on line 2'));
+    assert.ok(errors[3].includes('Unescaped HTML tag <label> found on line 3'));
+  });
+
+  test('ignores code blocks', () => {
+    const body = `\`\`\`html
+<select>
+  <option>foo</option>
+</select>
+\`\`\`
+`;
+    const errors = validateHtmlTags(body, 'test.md');
+    assert.deepStrictEqual(errors, []);
+  });
+
+  test('ignores code spans', () => {
+    const body = `Using \`<select>\` is recommended.
+`;
+    const errors = validateHtmlTags(body, 'test.md');
+    assert.deepStrictEqual(errors, []);
+  });
+});
+

--- a/lib/guide-validation.ts
+++ b/lib/guide-validation.ts
@@ -501,6 +501,7 @@ export function resetGuidesMap() {
   cachedGuidesMap = null;
 }
 
+// Safe typographic inline tags that don't represent interactive elements or cause layout breakage.
 const ALLOWED_HTML_TAGS = new Set(['kbd', 'br', 'wbr']);
 
 export function validateHtmlTags(body: string, relativePath: string): string[] {

--- a/lib/guide-validation.ts
+++ b/lib/guide-validation.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import matter from 'gray-matter';
+import { marked } from 'marked';
 
 // Import shared utilities (using relative paths from guides/)
 import { validateMacros } from '../serving/lib/macros.ts';
@@ -115,6 +116,7 @@ export function validateGuide(filePath: string): ValidationResult {
   }
 
   errors.push(...validateMacros(body, relativePath));
+  errors.push(...validateHtmlTags(body, relativePath));
 
   return { errors, data, body, filePath };
 }
@@ -498,3 +500,62 @@ export function getGuidesMap(): Map<string, GuideInventory> {
 export function resetGuidesMap() {
   cachedGuidesMap = null;
 }
+
+const ALLOWED_HTML_TAGS = new Set(['kbd', 'br', 'wbr']);
+
+export function validateHtmlTags(body: string, relativePath: string): string[] {
+  const errors: string[] = [];
+
+  try {
+    const tokens = marked.lexer(body);
+    findInvalidHtmlTokens(tokens, errors, relativePath, body);
+  } catch (e) {
+    errors.push(`Failed to parse markdown with marked lexer for HTML validation in ${relativePath}: ${e}`);
+  }
+
+  return errors;
+}
+
+function findInvalidHtmlTokens(tokens: any[], errors: string[], relativePath: string, content: string) {
+  for (const token of tokens) {
+    if (token.type === 'html') {
+      const raw = token.raw.trim();
+
+      // Allow HTML comments
+      if (raw.startsWith('<!--') && raw.endsWith('-->')) {
+        continue;
+      }
+
+      // Parse tag name
+      const match = raw.match(/^<\/?([a-zA-Z0-9:-]+)(?:\s+[^>]*)?\/?>$/);
+      if (match) {
+        const tagName = match[1].toLowerCase();
+        if (!ALLOWED_HTML_TAGS.has(tagName)) {
+          // Find line number in content
+          const offset = content.indexOf(token.raw);
+          const line = offset !== -1 ? content.slice(0, offset).split('\n').length : -1;
+          const lineSuffix = line !== -1 ? ` on line ${line}` : '';
+          errors.push(`Unescaped HTML tag <${tagName}> found${lineSuffix} in ${relativePath}. Use backticks or escape angle brackets if it is a tag name reference.`);
+        }
+      } else {
+        // If it does not match a standard tag, but is still parsed as HTML token, warn/fail
+        const offset = content.indexOf(token.raw);
+        const line = offset !== -1 ? content.slice(0, offset).split('\n').length : -1;
+        const lineSuffix = line !== -1 ? ` on line ${line}` : '';
+        errors.push(`Potentially invalid or unescaped HTML block/tag "${raw}" found${lineSuffix} in ${relativePath}.`);
+      }
+    }
+
+    if (token.tokens) {
+      findInvalidHtmlTokens(token.tokens, errors, relativePath, content);
+    }
+    if (token.items) {
+      for (const item of token.items) {
+        if (item.tokens) {
+          findInvalidHtmlTokens(item.tokens, errors, relativePath, content);
+        }
+      }
+    }
+  }
+}
+

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@types/omelette": "^0.4.5",
     "gh-pages": "^6.3.0",
     "gray-matter": "^4.0.3",
+    "marked": "^18.0.3",
     "oxlint": "^1.55.0",
     "typescript": "^5.9.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
+      marked:
+        specifier: ^18.0.3
+        version: 18.0.3
       oxlint:
         specifier: ^1.55.0
         version: 1.55.0

--- a/serving/skills-cli/build-readme.test.ts
+++ b/serving/skills-cli/build-readme.test.ts
@@ -42,6 +42,6 @@ describe('updateReadmeWithFeaturesAndUseCases', () => {
     assert.match(content, /https:\/\/web-platform-dx\.github\.io\/web-features-explorer\/features\//, 'Should contain explorer feature links');
     assert.match(content, /https:\/\/github\.com\/GoogleChrome\/modern-web-guidance\/blob\/main\/skills\/modern-web-guidance\/guides\//, 'Should link use cases to GitHub blob files');
 
-    assert.ok(content.includes('&lt;iframe&gt; loading state'), 'Should escape angle brackets in descriptions');
+    assert.ok(content.includes('`&lt;iframe&gt;` loading state'), 'Should escape angle brackets in descriptions');
   });
 });


### PR DESCRIPTION

* **HTML Tag Validation**: Implemented HTML tag validation in `lib/guide-validation.ts` using the `marked` lexer to automatically flag unescaped HTML elements (such as `<iframe>`, `<select>`, `<button>`, etc.) which break rendering when shown in a markdown renderer (usually)

* **Permitted Tags**: Specifically allowed safe typographic inline elements (`<kbd>`, `<br>`, `<wbr>`) -- though we only use kdb.

* **Guide Fixes**: Fixed unescaped HTML tag references on:
  * `move-dom-element-without-losing-state/guide.md` (`<iframe>`)
  * `autofill-sign-in-form/guide.md` (`<form>`)
  * `autofill-sign-up-form/guide.md` (`<form>`)
