### PR TITLE
harness: auto-heal devtools-times if dependencies are missing

### DIFF
--- a/harness/tests/base-apps.test.ts
+++ b/harness/tests/base-apps.test.ts
@@ -7,9 +7,9 @@ import { execSync } from 'node:child_process';
 test('devtools-times base app builds successfully', () => {
   const appDir = path.resolve(import.meta.dirname, '../base_apps/devtools-times');
   
-  // If node_modules doesn't exist, run pnpm install first to ensure dependencies are present.
-  if (!fs.existsSync(path.join(appDir, 'node_modules'))) {
-    console.log(`node_modules missing in ${appDir}. Running pnpm install...`);
+  // If node_modules doesn't exist or astro is missing (e.g. dangling symlink), run pnpm install first.
+  if (!fs.existsSync(path.join(appDir, 'node_modules')) || !fs.existsSync(path.join(appDir, 'node_modules/astro'))) {
+    console.log(`node_modules or astro missing in ${appDir}. Running pnpm install...`);
     try {
       execSync('pnpm install --ignore-workspace', {
         cwd: appDir,


### PR DESCRIPTION
If devtools-times base app's node_modules is present but has broken/dangling symlinks (e.g. after root workspace store updates), the preflight build step fails. This checks for the presence of the astro binary before skipping install, running pnpm install to heal it automatically.