### PR TITLE
feat: create symlink for prompt-api.md pointing to language-model.md …

### DIFF
--- a/serving/scripts/build-megaskill.ts
+++ b/serving/scripts/build-megaskill.ts
@@ -127,6 +127,17 @@ function buildMegaskill(): void {
   fs.writeFileSync(path.join(distDir, 'SKILL.md'), finalContent);
   console.log(`Generated megaskill successfully in ${distDir}`);
 
+  // Create a symbolic link for prompt-api pointing to language-model.md
+  const promptApiLink = path.join(distRefsDir, "built-in-ai/prompt-api.md");
+  const categoryDir = path.dirname(promptApiLink);
+  if (fs.existsSync(categoryDir)) {
+    if (fs.existsSync(promptApiLink)) {
+      fs.unlinkSync(promptApiLink);
+    }
+    fs.symlinkSync("language-model.md", promptApiLink);
+    console.log("Created prompt-api.md symlink pointing to language-model.md in megaskill references");
+  }
+
   createLocalSymlink(repoRoot, distDir);
 }
 

--- a/serving/skills-cli/build-dist.ts
+++ b/serving/skills-cli/build-dist.ts
@@ -138,6 +138,17 @@ async function main(opts: { publishRoot: string, version?: string}): Promise<Bui
     target: 'skills-cli',
   });
 
+  // Create a symbolic link for prompt-api pointing to language-model.md
+  const promptApiLink = path.join(DIST_DIR, "guides/built-in-ai/prompt-api.md");
+  const categoryDir = path.dirname(promptApiLink);
+  if (fs.existsSync(categoryDir)) {
+    if (fs.existsSync(promptApiLink)) {
+      fs.unlinkSync(promptApiLink);
+    }
+    fs.symlinkSync("language-model.md", promptApiLink);
+    console.log("Created prompt-api.md symlink pointing to language-model.md in distribution guides");
+  }
+
   fs.mkdirSync(ROOT_DIST_DIR, { recursive: true });
   const lockFilePath = path.join(ROOT_DIST_DIR, "build-dist.lock");
 


### PR DESCRIPTION
## Summary
This PR introduces a symbolic link alias (`prompt-api.md`) for the `language-model.md` guide within the build pipelines. This allows users and developers looking for "Prompt API" guides to easily locate and reference the appropriate language model documentation under its common user-facing name.

## Rationale
The browser's on-device AI API is officially called the **Prompt API**, but the underlying feature ID and our source guide directory name are structured as `language-model`. Users and coding agents frequently search for `prompt-api` when referencing or importing these skills. Creating a symbolic link at build/dist time bridges this gap without renaming the source directories or duplicating file contents.

## Changes
* **`serving/scripts/build-megaskill.ts`**:
  - Automatically creates a relative symlink `prompt-api.md` pointing to `language-model.md` inside `skills/modern-web/references/built-in-ai/` during local megaskill builds.
* **`serving/skills-cli/build-dist.ts`**:
  - Automatically creates a relative symlink `prompt-api.md` pointing to `language-model.md` inside the output distribution directory `dist/skills-cli/skills/modern-web-guidance/guides/built-in-ai/` during the release/publish compilation pipeline.

## Verification & Testing
Tested locally by running both build steps:
1. Run the local megaskill build: `npx tsx serving/scripts/build-megaskill.ts`
   - Verified that `skills/modern-web/references/built-in-ai/prompt-api.md -> language-model.md` is created and resolves correctly.
2. Run the distribution build: `npx tsx serving/skills-cli/build-dist.ts`
   - Verified that `dist/skills-cli/skills/modern-web-guidance/guides/built-in-ai/prompt-api.md -> language-model.md` is created and resolves correctly.