### PR TITLE
Dedupe popover fallback guidance

### DIFF
--- a/features/popover.md
+++ b/features/popover.md
@@ -1,0 +1,36 @@
+# Popover API
+
+## Fallbacks
+
+The Popover API is mostly **progressive enhancement**, but its defining behaviors — top-layer promotion, light-dismiss, and `popovertarget` invocation — have no CSS-only equivalent. Older browsers need a polyfill, or a manual fallback if you would rather not ship one.
+
+**Polyfill:** To support the `popover` attribute in older browsers, conditionally load [`@oddbird/popover-polyfill`](https://github.com/oddbird/popover-polyfill). **MANDATORY:** Feature detect by checking for the `popover` property on `HTMLElement.prototype`, and load the polyfill **only** when native support is missing — do NOT load it unconditionally.
+
+With a bundler or import map:
+
+```js
+// MANDATORY: Feature detect 'popover' on HTMLElement.prototype.
+if (!("popover" in HTMLElement.prototype)) {
+  import("@oddbird/popover-polyfill/fn").then(({ apply }) => apply());
+}
+```
+
+Without a bundler, import from a CDN inside a `<script type="module">`:
+
+```html
+<script type="module">
+  if (!("popover" in HTMLElement.prototype)) {
+    import("https://unpkg.com/@oddbird/popover-polyfill@latest/dist/popover-fn.js").then(({ apply }) => apply());
+  }
+</script>
+```
+
+**Styling caveat:** The polyfill cannot define the real `:popover-open` pseudo-class, so it applies a `.\:popover-open` class instead. **MANDATORY:** Combine the two with `:is()` or `:where()`, otherwise browsers that lack `:popover-open` discard the entire rule:
+
+```css
+[popover]:is(:popover-open, .\:popover-open) {
+  display: block;
+}
+```
+
+Alternatively, for a legacy fallback without a polyfill, use `position: fixed` and manually calculate coordinates via `getBoundingClientRect()` or rely on default positioning with `inset: auto` if that's acceptable for the use case.

--- a/features/popover.md
+++ b/features/popover.md
@@ -20,7 +20,7 @@ Without a bundler, import from a CDN inside a `<script type="module">`:
 ```html
 <script type="module">
   if (!("popover" in HTMLElement.prototype)) {
-    import("https://unpkg.com/@oddbird/popover-polyfill@latest/dist/popover-fn.js").then(({ apply }) => apply());
+    import("https://unpkg.com/@oddbird/popover-polyfill@latest/dist/popover.min.js");
   }
 </script>
 ```

--- a/features/popover.md
+++ b/features/popover.md
@@ -11,7 +11,7 @@ With a bundler or import map:
 ```js
 // MANDATORY: Feature detect 'popover' on HTMLElement.prototype.
 if (!("popover" in HTMLElement.prototype)) {
-  import("@oddbird/popover-polyfill/fn").then(({ apply }) => apply());
+  import("@oddbird/popover-polyfill");
 }
 ```
 

--- a/guides/overlays/animate-to-from-top-layer/guide.md
+++ b/guides/overlays/animate-to-from-top-layer/guide.md
@@ -108,7 +108,7 @@ dialog[open]::backdrop,
 
 ## Fallback strategies
 
-#### Top-layer animation features
+### Top-layer animation features
 
 {{ BASELINE_STATUS("starting-style") }}
 {{ BASELINE_STATUS("transition-behavior") }}
@@ -130,18 +130,4 @@ if (!supportsTopLayerAnimation) {
 }
 ```
 
-#### popover
-
-{{ BASELINE_STATUS("popover") }}
-
-If the browser does not support Popover, use the `@oddbird/popover-polyfill`:
-
-```html
-<script type="module">
-  if (!HTMLElement.prototype.hasOwnProperty('popover')) {
-    await import('https://unpkg.com/@oddbird/popover-polyfill');
-  }
-</script>
-```
-
-Alternatively, for legacy support without a polyfill, use `position: fixed` and manually calculate coordinates via JavaScript `getBoundingClientRect()`.
+{{ FEATURE_FALLBACKS("popover") }}

--- a/guides/overlays/declarative-dialog-popover-control/guide.md
+++ b/guides/overlays/declarative-dialog-popover-control/guide.md
@@ -72,7 +72,6 @@ Unlike popovers, modal dialogs typically use separate buttons for opening and cl
 ## Fallback strategies
 
 {{ BASELINE_STATUS("invoker-commands") }}
-{{ BASELINE_STATUS("popover") }}
 
 Because Invoker Commands and Popovers are not yet universally supported, you MUST use polyfills as fallbacks for older browsers.
 
@@ -110,44 +109,4 @@ MANDATORY: This polyfill does not handle the ARIA states (e.g., `aria-expanded`)
 
 {{ INCLUDE("../../html/custom-button-actions/guide.md#fallback-strategies") }}
 
-### Polyfilling the Popover Attribute
-
-To support the `popover` attribute in older browsers, use the `@oddbird/popover-polyfill`.
-
-MANDATORY: Feature detect popover support by checking for the `popover` property on the `HTMLElement` prototype. Conditionally initialize the polyfill only if native support is missing.
-
-**Option 1: Using a bundler**
-Install the package via npm (`npm install @oddbird/popover-polyfill`). This method requires a bundler or import maps to resolve the module path.
-
-```javascript
-// MANDATORY: Feature detect 'popover' on HTMLElement.prototype.
-if (!('popover' in HTMLElement.prototype)) {
-  import('@oddbird/popover-polyfill/fn').then(({ apply }) => {
-    apply();
-  });
-}
-```
-
-**Option 2: Using a CDN**
-For projects without a bundler, dynamically import the polyfill directly from a CDN inside a `<script type="module">`.
-
-```html
-<script type="module">
-  // MANDATORY: Feature detect 'popover' on HTMLElement.prototype.
-  // Conditionally load the popover-polyfill from a CDN only in browsers lacking native support.
-  if (!('popover' in HTMLElement.prototype)) {
-    import('https://unpkg.com/@oddbird/popover-polyfill@latest/dist/popover-fn.js').then(({ apply }) => {
-      apply();
-    });
-  }
-</script>
-```
-
-**Popover Polyfill Limitations & Styling Caveats**
-MANDATORY: Use `:is()` or `:where()` to combine `:popover-open` with the corresponding polyfill class, otherwise browsers that do not support `:popover-open` will throw away the entire rule.
-
-```css
-[popover]:is(:popover-open, .\:popover-open) {
-  display: block;
-}
-```
+{{ FEATURE_FALLBACKS("popover") }}

--- a/guides/overlays/interest-triggered-tooltips/guide.md
+++ b/guides/overlays/interest-triggered-tooltips/guide.md
@@ -96,18 +96,11 @@ Interest invokers must be conditionally polyfilled using the `interestfor` polyf
 </script>
 ```
 
-{{ BASELINE_STATUS("popover") }}
+{{ FEATURE_FALLBACKS("popover") }}
+
 {{ BASELINE_STATUS("popover-hint") }}
 
-Popover and popover hint must conditionally be polyfilled with the `@oddbird/popover-polyfill` polyfill. The hint behavior will not be polyfilled in browsers that support `popover` but not `popover="hint"`. For those browsers, a tooltip opened via focus may stay open when a second tooltip opened via hover.
-
-```html
-<script type="module">
-  if(!HTMLElement.prototype.hasOwnProperty("popover")){
-    await import("https://unpkg.com/@oddbird/popover-polyfill@latest");
-  }
-</script>
-```
+The `popover-polyfill` does not polyfill the hint behavior in browsers that support `popover` but not `popover="hint"`. For those browsers, a tooltip opened via focus may stay open when a second tooltip opened via hover.
 
 {{ BASELINE_STATUS("anchor-positioning") }}
 

--- a/guides/overlays/navigation-drawer/guide.md
+++ b/guides/overlays/navigation-drawer/guide.md
@@ -300,8 +300,6 @@ document.addEventListener('keydown', (event) => {
 
 ### Fallback strategies
 
-{{ FEATURE_FALLBACKS("popover") }}
-
 The drawer's core mechanics — scroll snap, `IntersectionObserver`, and `inert` — are all Baseline Widely available and required for the component to function. The popover API, the scroll-driven animation that fades the backdrop, and `scroll-initial-target` are progressive enhancements with simple fallbacks that can be easily implemented if wide browser support is required.
 
 #### Backdrop fade fallback (no `animation-timeline` support):

--- a/guides/overlays/persistent-app-tours/guide.md
+++ b/guides/overlays/persistent-app-tours/guide.md
@@ -64,18 +64,6 @@ tourStep.querySelector('button').focus();
 
 {{ FEATURE_FALLBACKS("popover") }}
 
-If the browser does not support Popover, use the `@oddbird/popover-polyfill`:
-
-```html
-<script type="module">
-  if (!HTMLElement.prototype.hasOwnProperty('popover')) {
-    await import('https://unpkg.com/@oddbird/popover-polyfill');
-  }
-</script>
-```
-
-Alternatively, for legacy support without a polyfill, use `position: fixed` and manually calculate coordinates via JavaScript `getBoundingClientRect()`.
-
 #### anchor-positioning
 
 {{ BASELINE_STATUS("anchor-positioning") }}

--- a/guides/overlays/persistent-toast-notifications/guide.md
+++ b/guides/overlays/persistent-toast-notifications/guide.md
@@ -23,9 +23,7 @@ Toast notifications are transient status messages. Unlike menus, they should not
 
 ### Fallback Strategies
 
-#### popover
-
-* **Guidance:** Use the [Popover Polyfill](https://github.com/oddbird/popover-polyfill). For legacy browsers, fall back to a fixed-position div with a high z-index.
+{{ FEATURE_FALLBACKS("popover") }}
 
 #### sibling-index()
 

--- a/guides/overlays/position-aware-tooltips/guide.md
+++ b/guides/overlays/position-aware-tooltips/guide.md
@@ -121,39 +121,6 @@ Positioning the arrow based on the applied fallback is a progressive enhancement
 }
 ```
 
-### Polyfilling the Popover Attribute
-
-{{ BASELINE_STATUS("popover") }}
-
-To support the `popover` attribute in older browsers, use the `@oddbird/popover-polyfill`.
-
-MANDATORY: Feature detect popover support by checking for the `popover` property on the `HTMLElement` prototype. Conditionally initialize the polyfill only if native support is missing.
-
-**Option 1: Using a package manager**
-Install the package (`npm install @oddbird/popover-polyfill`).
-
-```javascript
-// MANDATORY: Feature detect 'popover' on HTMLElement.prototype.
-if (!('popover' in HTMLElement.prototype)) {
-  import('@oddbird/popover-polyfill/fn').then(({ apply }) => {
-    apply();
-  });
-}
-```
-
-**Option 2: Manual installation without npm**
-If you are not using a package manager, dynamically import the polyfill directly from a CDN (such as unpkg) inside a `<script type="module">`.
-
-```html
-<script type="module">
-  // MANDATORY: Feature detect 'popover' on HTMLElement.prototype.
-  // Conditionally load the popover-polyfill from a CDN only in browsers lacking native support.
-  if (!('popover' in HTMLElement.prototype)) {
-    import('https://unpkg.com/@oddbird/popover-polyfill@latest/dist/popover-fn.js').then(({ apply }) => {
-      apply();
-    });
-  }
-</script>
-```
+{{ FEATURE_FALLBACKS("popover") }}
 
 Browsers without support for the Popover API also do not support anchor positioning, so the tooltip will appear in the center of the screen.

--- a/guides/overlays/resilient-context-menus-and-nested-dropdowns/guide.md
+++ b/guides/overlays/resilient-context-menus-and-nested-dropdowns/guide.md
@@ -70,16 +70,6 @@ To prevent the panel from being cut off at the edge of the screen, define "try t
 
 {{ FEATURE_FALLBACKS("popover") }}
 
-Popover must conditionally be polyfilled with the `@oddbird/popover-polyfill` polyfill.
-
-```html
-<script type="module">
-  if(!HTMLElement.prototype.hasOwnProperty("popover")){
-    await import("https://unpkg.com/@oddbird/popover-polyfill@latest");
-  }
-</script>
-```
-
 {{ BASELINE_STATUS("anchor-positioning") }}
 
 To support browsers without anchor positioning, you must set a reasonable position. By default popovers are centered in the middle of the screen, which may work for your use case.


### PR DESCRIPTION
Multiple guides independently repeated the same Popover-API fallback advice (the @oddbird/popover-polyfill recommendation with feature detection, the :popover-open styling caveat, the position: fixed no-polyfill fallback, etc).

Consolidate it once in `features/popover.md`'s Fallbacks section and replace the duplicated prose in each guide with the FEATURE_FALLBACKS, which also prepends the live Baseline status.

navigation-drawer is not converted: it has bespoke component-specific popover guidance (popover="manual", drop popover entirely rather than polyfill), so its redundant top-level macro call is removed instead.