### PR TITLE
Add CLI and Skill version to dashboard in suite results

### DIFF
--- a/eval-view/dashboard.js
+++ b/eval-view/dashboard.js
@@ -389,6 +389,18 @@ function renderTestHeader(testId, jetskiVersion, timestamp, data) {
                     <span class="meta-value">${formatRuntime(data.totalRuntime)}</span>
                     <span class="meta-label">Total Runtime</span>
                 </div>` : ''}
+                ${data.cliVersion ? `
+                <div class="header-meta-item">
+                    <span class="meta-value">${escapeHtml(data.cliVersion)}</span>
+                    <span class="meta-label">CLI Version</span>
+                </div>
+                ` : ''}
+                ${data.skillVersion ? `
+                <div class="header-meta-item">
+                    <span class="meta-value" title="${escapeHtml(data.skillVersion)}">${escapeHtml(data.skillVersion)}</span>
+                    <span class="meta-label">Skill Version</span>
+                </div>
+                ` : ''}
                 ${jetskiVersion ? `
                 <div class="header-meta-item">
                     <span class="meta-value">${escapeHtml(jetskiVersion)}</span>

--- a/harness/evaluate.ts
+++ b/harness/evaluate.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import fs from 'fs';
+import { execSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import 'colors';
 import { collectResults, extractModelFromResults } from './lib/collection.ts';
@@ -8,6 +9,29 @@ import { generateMarkdownReport, generateJsonReport, saveReports } from './lib/r
 import { resultsDir } from '../lib/paths.ts';
 
 import { Serving, type SuiteConfig } from './config.ts';
+
+function getCliVersion(): string | undefined {
+  try {
+    const output = execSync('git tag --merged HEAD -l "v*.*.*" --sort=-v:refname', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim();
+    if (output) {
+      const firstTag = output.split('\n')[0].trim();
+      return firstTag.startsWith('v') ? firstTag.slice(1) : firstTag;
+    }
+  } catch {
+    // Ignore git error if tags are not reachable
+  }
+  return undefined;
+}
+
+function getSkillVersion(): string | undefined {
+  try {
+    const output = execSync('git log -1 --date=format:"%Y_%m_%d" --pretty=format:"%cd-%h" guides/modern-web-guidance/SKILL.md', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore'] }).trim();
+    return output || undefined;
+  } catch {
+    // Ignore git error if log is unavailable
+  }
+  return undefined;
+}
 
 function inferSuiteConfig(suiteResultsDir: string): SuiteConfig {
   let agent = 'gemini-cli';
@@ -78,9 +102,12 @@ export async function evaluateSuite(suiteResultsDir: string, suiteName: string, 
       }
     }
 
+    const skillVersion = getSkillVersion();
+    const cliVersion = getCliVersion();
+
     const model = extractModelFromResults(suiteResultsDir, suiteConfig.agent);
     const totalRuntime = suiteStartTime ? Date.now() - suiteStartTime : fallbackRuntime;
-    const jsonReport = generateJsonReport(metrics, allResults, timestamp, numRuns, suiteConfig.agent, suiteConfig.serving, model, totalRuntime);
+    const jsonReport = generateJsonReport(metrics, allResults, timestamp, numRuns, suiteConfig.agent, suiteConfig.serving, model, totalRuntime, skillVersion, cliVersion);
 
     if (totalRuntime) {
       console.log(`Total runtime: ${totalRuntime}ms`);

--- a/harness/lib/metrics.ts
+++ b/harness/lib/metrics.ts
@@ -77,6 +77,8 @@ export interface EvalsReport {
   serving: string;
   model: string;
   totalRuntime?: number;
+  skillVersion?: string;
+  cliVersion?: string;
 }
 
 export function calculateMetrics(allResults: Record<string, RunResult[]>, runsPerTest: number): Metrics {

--- a/harness/lib/reporting.ts
+++ b/harness/lib/reporting.ts
@@ -59,7 +59,7 @@ export function generateMarkdownReport(metrics: Metrics, allResults: Record<stri
   return md;
 }
 
-export function generateJsonReport(metrics: Metrics, allResults: Record<string, RunResult[]>, timestamp: string, runCount: number, agent: string, serving: string, model: string, totalRuntime?: number): EvalsReport {
+export function generateJsonReport(metrics: Metrics, allResults: Record<string, RunResult[]>, timestamp: string, runCount: number, agent: string, serving: string, model: string, totalRuntime?: number, skillVersion?: string, cliVersion?: string): EvalsReport {
   return {
     summary: metrics.summary,
     results: allResults,
@@ -69,7 +69,9 @@ export function generateJsonReport(metrics: Metrics, allResults: Record<string, 
     agent,
     serving,
     model,
-    totalRuntime
+    totalRuntime,
+    skillVersion,
+    cliVersion
   };
 }
 

--- a/harness/tests/reporting.test.ts
+++ b/harness/tests/reporting.test.ts
@@ -1,0 +1,56 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { generateJsonReport } from '../lib/reporting.ts';
+import type { Metrics } from '../lib/metrics.ts';
+
+const dummyMetrics: Metrics = {
+  summary: {
+    unguidedMedian: 0,
+    guidedMedian: 100,
+    unguidedPassRate: 0,
+    guidedPassRate: 100,
+    unguidedPassed: 0,
+    unguidedTotal: 10,
+    guidedPassed: 10,
+    guidedTotal: 10,
+    runsPerTest: 1,
+  },
+  testStats: {},
+  sortedKeys: [],
+};
+
+test('generateJsonReport includes skillVersion and cliVersion when provided', () => {
+  const report = generateJsonReport(
+    dummyMetrics,
+    {},
+    '2026-06-26T14:00:00Z',
+    1,
+    'gemini-cli',
+    'mcp',
+    'gemini-pro',
+    1234,
+    '2026_05_16-c5e78707',
+    '0.0.174'
+  );
+
+  assert.strictEqual(report.skillVersion, '2026_05_16-c5e78707');
+  assert.strictEqual(report.cliVersion, '0.0.174');
+  assert.strictEqual(report.agent, 'gemini-cli');
+  assert.strictEqual(report.serving, 'mcp');
+});
+
+test('generateJsonReport handles omitted optional version parameters gracefully', () => {
+  const report = generateJsonReport(
+    dummyMetrics,
+    {},
+    '2026-06-26T14:00:00Z',
+    1,
+    'codex',
+    'skills_cli',
+    'gpt-4o'
+  );
+
+  assert.strictEqual(report.skillVersion, undefined);
+  assert.strictEqual(report.cliVersion, undefined);
+  assert.strictEqual(report.agent, 'codex');
+});

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "dashboard": "pnpm --filter eval-view start",
     "build:mcp": "pnpm --filter serving build",
     "build:megaskill": "pnpm --filter serving build:megaskill",
-    "test:mcp": "pnpm --filter serving test",
     "setup:playwright": "pnpm --filter eval-view exec playwright install",
     "generate-negative": "node --env-file=.env --experimental-strip-types guides/negative-gen.ts",
     "generate-grader": "node --env-file=.env --experimental-strip-types guides/grader-gen.ts",

--- a/serving/scripts/collect-eval-results.ts
+++ b/serving/scripts/collect-eval-results.ts
@@ -24,6 +24,8 @@ interface EvalsSummary {
   assertionCount: number;
   unguidedPassRate: number;
   guidedPassRate: number;
+  skillVersion?: string;
+  cliVersion?: string;
 }
 
 function pullRecentGcsSuites(): string[] {
@@ -139,6 +141,8 @@ function collectResults() {
         assertionCount: summary.guidedTotal ?? 0,
         unguidedPassRate: summary.unguidedPassRate ?? 0,
         guidedPassRate: summary.guidedPassRate ?? 0,
+        skillVersion: data.skillVersion,
+        cliVersion: data.cliVersion,
       });
     } catch (e) {
       console.error(`Error reading/parsing ${folderName}/evals.json:`, e);


### PR DESCRIPTION
This data is now stored in the `evals.json` so it can be used in the guide history views as well @psiarkiewicz 

<img width="1086" height="86" alt="image" src="https://github.com/user-attachments/assets/df9c9d7c-50ba-4a0e-b0f8-d18c4ec8fdcc" />
