### PR TITLE
docs: add Grok Build CLI install option

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,14 @@ agy plugin install https://github.com/GoogleChrome/modern-web-guidance
 </details>
 
 <details>
+<summary><b>Grok Build CLI</b></summary>
+
+```shell
+grok plugin install https://github.com/GoogleChrome/modern-web-guidance --trust
+```
+</details>
+
+<details>
 <summary><b>Claude Code Plugin</b></summary>
 
 ```shell

--- a/serving/skills-cli/template/README.md
+++ b/serving/skills-cli/template/README.md
@@ -136,6 +136,14 @@ agy plugin install https://github.com/GoogleChrome/modern-web-guidance
 </details>
 
 <details>
+<summary><b>Grok Build CLI</b></summary>
+
+```shell
+grok plugin install https://github.com/GoogleChrome/modern-web-guidance --trust
+```
+</details>
+
+<details>
 <summary><b>Claude Code Plugin</b></summary>
 
 ```shell


### PR DESCRIPTION
## Summary

Adds Grok Build CLI to the alternative installation methods in the source README and generated README template.

## Verification

- Ran `git diff --cached --check` before committing.