### PR TITLE
Add toggle for trace on evals

### DIFF
--- a/eval-view/api.js
+++ b/eval-view/api.js
@@ -256,7 +256,7 @@ export class ApiClient {
                 if (res.ok) {
                     const data = await res.json();
                     if (data.items) {
-                        files = data.items.map(item => item.name.split('/').pop());
+                        files = data.items.map(item => item.name.startsWith(gcsPrefix) ? item.name.substring(gcsPrefix.length) : item.name.split('/').pop());
                     }
                 }
             }
@@ -293,6 +293,10 @@ export class ApiClient {
     getAbsoluteUrl(path) {
         if (this.source === 'remote') {
             let fixedPath = path.split('?')[0];
+            const isLocalServer = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
+            if (isLocalServer) {
+                return `/gcs-proxy/${fixedPath}`;
+            }
             return `${this.gcsPrefix}${encodeURIComponent(fixedPath)}?alt=media`;
         }
         return this._formatUrl(path);

--- a/eval-view/dashboard.js
+++ b/eval-view/dashboard.js
@@ -884,10 +884,9 @@ async function fillAccordionDetails(container, scenarioName, unguidedRuns, guide
                  const run = runs[i];
                  const s = getRunStats(run.results);
                  const { setupPath, resultPath, usedBasePath } = await getResultPaths(testId, run, `${scenarioName} - ${typeLabel.toLowerCase()}`);
-                 let files = run.files || [];
-                 if (files.length === 0) {
-                     try { files = await api.getRunFiles(usedBasePath); } catch (e) {}
-                 }
+                 let files = [];
+                 try { files = await api.getRunFiles(usedBasePath); } catch (e) {}
+                 if (files.length === 0) files = run.files || [];
 
                  const sessionFile = files.find(f => f.startsWith('session-') && f.endsWith('.html'));
                  const logFile = files.includes('mcp-server.log') ? 'mcp-server.log' : (files.includes('modern-web.log') ? 'modern-web.log' : null);
@@ -895,11 +894,12 @@ async function fillAccordionDetails(container, scenarioName, unguidedRuns, guide
                  const runtimeFile = files.includes('runtime.json') ? 'runtime.json' : null;
                  const isEarlyFailure = run.results && run.results.some(c => c.isEarlyFailure);
                  const failureFile = isEarlyFailure ? (files.includes('generation_failed.json') ? 'generation_failed.json' : (files.includes('agent_stderr.log') ? 'agent_stderr.log' : null)) : null;
-                 const appUrl = api.source === 'remote'
+                 const isLocalServer = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
+                 const appUrl = (api.source === 'remote' && !isLocalServer)
                      ? `https://storage.mtls.cloud.google.com/guidance-evals/${resultPath.split('?')[0]}`
                       : api.getAbsoluteUrl ? api.getAbsoluteUrl(resultPath) : `${usedBasePath}/index.html`;
 
-                 const playWUrl = api.source === 'remote'
+                 const playWUrl = (api.source === 'remote' && !isLocalServer)
                      ? `https://storage.mtls.cloud.google.com/guidance-evals/${usedBasePath}/grade-report/index.html`
                      : api.getAbsoluteUrl(`${usedBasePath}/grade-report/index.html`);
 

--- a/eval-view/eval-ui.css
+++ b/eval-view/eval-ui.css
@@ -512,3 +512,59 @@ tr:hover td {
   font-size: 0.8125rem;
   font-weight: 800;
 }
+
+/* Switch toggle */
+.switch-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  cursor: pointer;
+  user-select: none;
+}
+
+.switch-toggle input[type="checkbox"] {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.switch-toggle .slider {
+  position: relative;
+  width: 44px;
+  height: 24px;
+  background-color: #11141c;
+  border: 1px solid var(--border-color);
+  border-radius: 24px;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  display: inline-block;
+}
+
+.switch-toggle .slider::before {
+  content: '';
+  position: absolute;
+  height: 18px;
+  width: 18px;
+  left: 2px;
+  bottom: 2px;
+  background-color: var(--text-secondary);
+  border-radius: 50%;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.switch-toggle input:checked + .slider {
+  background-color: rgba(59, 130, 246, 0.2);
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.4);
+}
+
+.switch-toggle input:checked + .slider::before {
+  transform: translateX(20px);
+  background-color: var(--primary-color);
+}
+
+.switch-toggle .toggle-label {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--text-primary);
+}

--- a/eval-view/eval-ui.html
+++ b/eval-view/eval-ui.html
@@ -64,11 +64,20 @@
                         </div>
                     </div>
                     
-                    <div class="input-group" style="margin-top: 15px;">
-                        <label>Skills to Enable</label>
-
-                        <div class="skills-container" id="skills-container" style="display: flex; flex-wrap: wrap; gap: 8px;">
-                            <!-- Skill buttons will be injected here -->
+                    <div class="row" style="margin-top: 1.5rem; align-items: flex-start;">
+                        <div class="input-group" style="flex: 0 0 auto; min-width: 200px;">
+                            <label>Trace</label>
+                            <label class="switch-toggle" style="margin-top: 0.75rem;">
+                                <input type="checkbox" id="includeTrace">
+                                <span class="slider"></span>
+                                <span class="toggle-label">Include on Failure</span>
+                            </label>
+                        </div>
+                        <div class="input-group" style="flex: 1;">
+                            <label>Skills to Enable</label>
+                            <div class="skills-container" id="skills-container" style="display: flex; flex-wrap: wrap; gap: 8px; margin-top: 0.5rem;">
+                                <!-- Skill buttons will be injected here -->
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -79,39 +88,6 @@
             </div>
 
             <section class="tasks-section" style="margin-top: 0;">
-                <div class="glass-panel" style="margin-bottom: 30px;">
-                    <div class="panel-header">
-                        <h3 id="discipline-header">Discipline Tasks</h3>
-                        <div class="quick-actions">
-                            <button type="button" class="btn-secondary" id="action-clear-disciplines">Clear All</button>
-                        </div>
-                    </div>
-                    <div class="table-container">
-                        <table id="disciplines-table">
-                            <thead>
-                                <tr id="disciplines-table-headers">
-                                    <th>Discipline</th>
-                                    <th class="checkbox-header">
-                                        <label class="custom-checkbox">
-                                            <input type="checkbox" class="header-check" data-task="task" checked>
-                                            <span class="checkmark"></span>
-                                        </label>
-                                    </th>
-                                    <th class="checkbox-header">
-                                        <label class="custom-checkbox">
-                                            <input type="checkbox" class="header-check" data-task="negative">
-                                            <span class="checkmark"></span>
-                                        </label>
-                                    </th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <!-- Disciplines go here -->
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-
                 <div class="glass-panel">
                     <div class="panel-header">
                         <h3 id="guide-header">Guide Tasks</h3>

--- a/eval-view/eval-ui.js
+++ b/eval-view/eval-ui.js
@@ -38,7 +38,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     const data = await response.json();
     allGuides = data.guides || {};
     renderGuides(allGuides);
-    renderDisciplines(data.disciplines || {});
     
     const skillsResponse = await fetch('/api/available-skills');
     const skillsData = await skillsResponse.json();
@@ -88,7 +87,6 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   function updateTaskCount() {
     const count = document.querySelectorAll('.task-check:checked').length;
-    const discCount = document.querySelectorAll('#disciplines-table .task-check:checked').length;
     const guideCount = document.querySelectorAll('#tasks-table .task-check:checked').length;
 
     const spans = [
@@ -101,12 +99,8 @@ document.addEventListener('DOMContentLoaded', async () => {
       }
     });
 
-    const discHeader = document.getElementById('discipline-header');
     const guideHeader = document.getElementById('guide-header');
 
-    if (discHeader) {
-      discHeader.textContent = discCount > 0 ? `Discipline Tasks (${discCount} selected)` : 'Discipline Tasks';
-    }
     if (guideHeader) {
       guideHeader.textContent = guideCount > 0 ? `Guide Tasks (${guideCount} selected)` : 'Guide Tasks';
     }
@@ -228,76 +222,6 @@ document.addEventListener('DOMContentLoaded', async () => {
         tableBody.appendChild(row);
       }
     }
-    }
-
-  function renderDisciplines(disciplines) {
-    const tableBody = document.querySelector('#disciplines-table tbody');
-    if (!tableBody) return;
-    tableBody.innerHTML = '';
-
-    const taskTypes = new Set();
-    for (const tasks of Object.values(disciplines)) {
-      tasks.forEach(t => taskTypes.add(t));
-    }
-    const headers = Array.from(taskTypes).sort((a, b) => {
-      const order = ['task', 'negative'];
-      const indexA = order.indexOf(a);
-      const indexB = order.indexOf(b);
-      if (indexA !== -1 && indexB !== -1) return indexA - indexB;
-      if (indexA !== -1) return -1;
-      if (indexB !== -1) return 1;
-      return a.localeCompare(b);
-    });
-
-    const headersRow = document.getElementById('disciplines-table-headers');
-    if (headersRow) {
-      let headerHtml = `<th>Discipline</th>`;
-      headers.forEach(h => {
-        const isSelected = h === 'task';
-        headerHtml += `<th class="checkbox-header">
-          <label class="custom-checkbox">
-            <input type="checkbox" class="header-check" data-task="${h}" ${isSelected ? 'checked' : ''}>
-            <span class="checkmark"></span>
-          </label>
-        </th>`;
-      });
-      headersRow.innerHTML = headerHtml;
-    }
-
-    for (const [disciplineName, tasks] of Object.entries(disciplines)) {
-      const row = document.createElement('tr');
-      row.classList.add('guide-row');
-      
-      let rowHtml = `
-        <td class="guide-name">
-          <div class="guide-cell-content">
-            <label class="custom-checkbox">
-              <input type="checkbox" class="guide-check-all" data-guide="${disciplineName}">
-              <span class="checkmark"></span>
-            </label>
-            ${disciplineName}
-          </div>
-        </td>
-      `;
-
-      headers.forEach(h => {
-        if (tasks.includes(h)) {
-          rowHtml += `
-            <td class="checkbox-cell">
-              <label class="pill-checkbox">
-                <input type="checkbox" name="tasks" value="${disciplineName}" class="task-check" data-guide="${disciplineName}" data-task="${h}" ${h === 'task' ? 'checked' : ''}>
-                <span class="pill-label">${h}</span>
-              </label>
-            </td>
-          `;
-        } else {
-          rowHtml += `<td class="checkbox-cell"></td>`;
-        }
-      });
-
-      row.innerHTML = rowHtml;
-      tableBody.appendChild(row);
-    }
   }
 
     // Attach row events (works exactly as before using fullKey as data-guide)
@@ -407,12 +331,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     } else if (target.id === 'action-clear-guides') {
       const table = document.getElementById('tasks-table');
       if (table) table.querySelectorAll('input[type="checkbox"]').forEach(c => { if (c instanceof HTMLInputElement) c.checked = false; });
-    } else if (target.id === 'action-clear-disciplines') {
-      const table = document.getElementById('disciplines-table');
-      if (table) table.querySelectorAll('input[type="checkbox"]').forEach(c => { if (c instanceof HTMLInputElement) c.checked = false; });
     }
     
-    if (['action-all-default', 'action-all-negative', 'action-clear', 'action-clear-guides', 'action-clear-disciplines'].includes(target.id)) {
+    if (['action-all-default', 'action-all-negative', 'action-clear', 'action-clear-guides'].includes(target.id)) {
       updateTaskCount();
     }
   });
@@ -438,11 +359,13 @@ document.addEventListener('DOMContentLoaded', async () => {
     const workerCountEl = document.getElementById('workerCount');
     const agentEl = document.getElementById('agent');
     const servingEl = document.getElementById('serving');
+    const traceEl = document.getElementById('includeTrace');
 
     const payload = {
       name: (nameEl instanceof HTMLInputElement) ? nameEl.value || null : null,
       numRuns: (numRunsEl instanceof HTMLInputElement) ? parseInt(numRunsEl.value) : 0,
       workerCount: (workerCountEl instanceof HTMLInputElement && workerCountEl.value) ? parseInt(workerCountEl.value) : null,
+      includeTrace: (traceEl instanceof HTMLInputElement) ? traceEl.checked : false,
       agent: (agentEl instanceof HTMLInputElement) ? agentEl.value : '',
       serving: (servingEl instanceof HTMLInputElement) ? servingEl.value : '',
       tasks: selectedTasks,

--- a/eval-view/server.js
+++ b/eval-view/server.js
@@ -1,6 +1,7 @@
 
 
 import * as http from "http";
+import * as https from "https";
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
@@ -91,6 +92,35 @@ const MIME_TYPES = {
  * @property {string | null} timestamp
  */
 
+/** @type {string | null} */
+let cachedGcsToken = null;
+let tokenExpiry = 0;
+
+async function getGcsAccessToken() {
+  if (cachedGcsToken && Date.now() < tokenExpiry) {
+    return cachedGcsToken;
+  }
+  return new Promise((resolve) => {
+    exec('gcloud auth application-default print-access-token || gcloud auth print-access-token', (err, stdout) => {
+      if (err || !stdout.trim()) {
+        exec('gcloud auth print-access-token', (err2, stdout2) => {
+          if (err2 || !stdout2.trim()) {
+            resolve(null);
+          } else {
+            cachedGcsToken = stdout2.trim();
+            tokenExpiry = Date.now() + 50 * 60 * 1000;
+            resolve(cachedGcsToken);
+          }
+        });
+      } else {
+        cachedGcsToken = stdout.trim();
+        tokenExpiry = Date.now() + 50 * 60 * 1000;
+        resolve(cachedGcsToken);
+      }
+    });
+  });
+}
+
 const server = http.createServer(async (req, res) => {
   const reqUrl = req.url || '';
   
@@ -105,6 +135,70 @@ const server = http.createServer(async (req, res) => {
     return;
   }
 
+  const urlPath = reqUrl.split('?')[0];
+  const decodedPath = decodeURIComponent(urlPath);
+
+  // --- Remote GCS Reverse Proxy Route for Local Dashboard Server ---
+  if (decodedPath.startsWith('/gcs-proxy/') || (req.headers.referer && req.headers.referer.includes('/gcs-proxy/'))) {
+    let gcsObjectPath = '';
+    if (decodedPath.startsWith('/gcs-proxy/')) {
+      gcsObjectPath = decodedPath.substring(11);
+    } else if (req.headers.referer) {
+      try {
+        const refUrl = new URL(req.headers.referer);
+        if (refUrl.pathname.startsWith('/gcs-proxy/')) {
+          const refGcsPath = refUrl.pathname.substring(11);
+          const parts = refGcsPath.split('/');
+          const relative = decodedPath.startsWith('/') ? decodedPath.substring(1) : decodedPath;
+          if (parts.length >= 2 && !relative.startsWith(parts[0] + '/')) {
+            const basePath = parts.slice(0, parts.length - 1).join('/');
+            gcsObjectPath = path.join(basePath, relative);
+          } else {
+            gcsObjectPath = relative;
+          }
+        }
+      } catch (e) {}
+    }
+
+    if (gcsObjectPath.startsWith('guidance-evals/')) {
+      gcsObjectPath = gcsObjectPath.substring(15);
+    }
+
+    if (gcsObjectPath) {
+      const token = await getGcsAccessToken();
+      const gcsUrl = `https://storage.googleapis.com/storage/v1/b/guidance-evals/o/${encodeURIComponent(gcsObjectPath)}?alt=media`;
+      
+      const options = {
+        headers: token ? { 'Authorization': `Bearer ${token}` } : {}
+      };
+
+      const gcsReq = https.request(gcsUrl, options, (gcsRes) => {
+        const headers = { ...gcsRes.headers };
+        delete headers['content-disposition'];
+        delete headers['content-disposition-filename'];
+        headers['Access-Control-Allow-Origin'] = '*';
+        headers['Access-Control-Allow-Methods'] = 'GET, POST, OPTIONS';
+        
+        const extname = path.extname(gcsObjectPath);
+        if (MIME_TYPES[extname]) {
+          headers['content-type'] = MIME_TYPES[extname];
+        }
+        
+        res.writeHead(gcsRes.statusCode || 200, headers);
+        gcsRes.pipe(res);
+      });
+
+      gcsReq.on('error', (e) => {
+        console.error('GCS Proxy error:', e);
+        res.writeHead(500);
+        res.end('GCS Proxy error');
+      });
+
+      gcsReq.end();
+      return;
+    }
+  }
+
   // Ultra-strict raw URL check
   if (reqUrl.includes('..') || reqUrl.toLowerCase().includes('%2e')) {
     console.log(`403 Forbidden: Traversal/Encoded attempt - ${req.method} ${reqUrl}`);
@@ -112,12 +206,6 @@ const server = http.createServer(async (req, res) => {
     res.end('403 Forbidden: Directory traversal is not allowed');
     return;
   }
-
-  // Normalize the URL and decode components for security checks
-  const urlPath = reqUrl.split('?')[0];
-  const decodedPath = decodeURIComponent(urlPath);
-  // Debug logging. Do not keep enabled.
-  // console.log(`Incoming request: ${req.method} ${reqUrl} (path: ${urlPath}, decoded: ${decodedPath})`);
 
   // Block directory traversal attempts
   if (decodedPath.includes('..')) {
@@ -310,6 +398,12 @@ const server = http.createServer(async (req, res) => {
           files = fs.readdirSync(targetDir, { withFileTypes: true })
             .filter(d => !d.isDirectory())
             .map(d => d.name);
+          const gradeReportDataDir = path.join(targetDir, 'grade-report', 'data');
+          if (fs.existsSync(gradeReportDataDir)) {
+            const dataFiles = fs.readdirSync(gradeReportDataDir)
+              .map(f => `grade-report/data/${f}`);
+            files.push(...dataFiles);
+          }
         }
       } catch (e) {
         const message = e instanceof Error ? e.message : String(e);

--- a/guides/playwright.config.ts
+++ b/guides/playwright.config.ts
@@ -1,5 +1,22 @@
 import { defineConfig, devices } from '@playwright/test';
 import * as path from 'path';
+import * as fs from 'fs';
+
+function shouldIncludeTrace(): boolean {
+  const configEnv = process.env.GD_SUITE_CONFIG;
+  if (!configEnv) return false;
+  try {
+    let content = configEnv;
+    if (!configEnv.trim().startsWith('{') && fs.existsSync(configEnv)) {
+      content = fs.readFileSync(configEnv, 'utf8');
+    }
+    return !!JSON.parse(content).includeTrace;
+  } catch {
+    return false;
+  }
+}
+
+const includeTrace = shouldIncludeTrace();
 
 export default defineConfig({
   timeout: 5000,
@@ -15,8 +32,7 @@ export default defineConfig({
   reporter: 'list',
   outputDir: process.env.PLAYWRIGHT_OUTPUT_DIR || path.join(import.meta.dirname, 'test-results'),
   use: {
-    trace: 'retain-on-failure',
-    screenshot: 'only-on-failure',
+    trace: includeTrace ? 'retain-on-failure' : 'off',
   },
   projects: [
     {

--- a/guides/run-grader.ts
+++ b/guides/run-grader.ts
@@ -104,6 +104,9 @@ export async function runPlaywright(
 
   await once(child, 'close');
 
+  const testResultsDir = path.join(path.dirname(targetFileAbs), 'test-results');
+  await fs.promises.rm(testResultsDir, { recursive: true, force: true }).catch(() => {});
+
   const content = await fs.promises.readFile(tmpJson, 'utf-8').catch(() => null);
   if (!content) {
     throw new Error(`Playwright did not produce a JSON report at ${tmpJson}`);

--- a/harness/config.ts
+++ b/harness/config.ts
@@ -67,6 +67,7 @@ export const defaultSuiteConfig: SuiteConfig = {
   serving: Serving.SKILLS_CLI,
   agent: Agents.GEMINI_CLI,
   workerCount: undefined,
+  includeTrace: false,
 };
 
 export function mergeSuiteConfig(overrides: Partial<SuiteConfig>): SuiteConfig {
@@ -121,6 +122,7 @@ export interface SuiteConfig {
   serving: Serving;
   agent: string;
   workerCount?: number;
+  includeTrace?: boolean;
 }
 
 export const config = {


### PR DESCRIPTION
To reduce the size of the evals being stored on every nightly run.

Context: [b/503049366](https://b.corp.google.com/issues/503049366#comment3)

Also removes screenshots since they are already included in the trace, and removes the `test-results` folder because it contains redundant data as the `grade-report`. Additionally, this PR enables functionality to view the trace/screenshots for *remote test suites* when viewing them on a *local version of the dashboard*.

This will reduce the size of a nightly evaluation suite from **2.3 GB to 0.92 GB (58.45%)**.

---

## Summary

This PR simplifies the evaluation trace configuration across the benchmark suite and introduces a local reverse proxy on the evaluation dashboard server (`server.js`) for seamless remote GCS result viewing.

### Key Changes

1. **Trace Configuration (`includeTrace`)**:
   - Renamed `includeTraceAndScreenshot` to `includeTrace` across harness configuration (`harness/config.ts`) and Playwright configuration (`guides/playwright.config.ts`).
   - Playwright trace capture is toggled on failure (`trace: includeTrace ? 'retain-on-failure' : 'off'`), while failure screenshot recording has been removed to streamline grading outputs.
   - Updated the Evaluation UI toggle control (`eval-view/eval-ui.html` and `eval-view/eval-ui.js`).

2. **Clean Staging & Disk Management**:
   - Added automatic cleanup of intermediate raw `test-results/` directories in `guides/run-grader.ts` immediately after Playwright HTML grade report packaging completes.

3. **Local Reverse Proxy for Remote GCS Evaluation Results**:
   - Added an authenticated `/gcs-proxy/*` route in `eval-view/server.js` that streams remote Google Cloud Storage evaluation objects (`guidance-evals` bucket) using local GCP credentials (`gcloud auth application-default print-access-token`).
   - Overrides `Content-Disposition` and sets proper `Content-Type` headers (`text/html`, `image/png`, etc.) so Playwright reports (`grade-report/index.html`) and app previews load **inline directly inside browser tabs** without triggering file downloads.
   - Handles relative referer links so nested trace zips and grade report assets resolve seamlessly when viewing remote evaluations on `http://localhost:8081`.