### PR TITLE
feat(harness): standardize agent model selection via environment variables

### DIFF
--- a/EVALS.md
+++ b/EVALS.md
@@ -55,3 +55,16 @@ harness/node_modules/.bin/codex
 
 1. This request should file a bug similar to [`b/492300931`](https://b.corp.google.com/issues/492300931).
 2. After approval, restart the CLI locally and log in to your account.
+3. Set your preferred model in your environment:
+   ```bash
+   CODEX_MODEL='gpt-5.5'
+   ```
+
+---
+
+### Jetski CLI
+
+Set your preferred model in your environment:
+```bash
+JETSKI_MODEL='Gemini 3.5 Flash'
+```

--- a/harness/agents/codex-cli-agent.ts
+++ b/harness/agents/codex-cli-agent.ts
@@ -104,11 +104,12 @@ async function run() {
     console.log(`Starting Codex agent in: ${workDir}`);
 
     const command = config.environment.codexCliBin;
+    const model = process.env.CODEX_MODEL;
     const commandArgs = [
       'exec', 
       userPrompt,
       '--yolo',
-      '--model', process.env.CODEX_MODEL || 'gpt-5.5'
+      ...(model ? ['--model', model] : [])
     ];
 
     console.log(`Executing: ${command} ${commandArgs.join(' ')}`);

--- a/harness/agents/jetski-cli-agent.ts
+++ b/harness/agents/jetski-cli-agent.ts
@@ -73,8 +73,10 @@ async function run() {
     console.log(`Starting Jetski CLI agent in ${workDir}`);
 
     const command = config.environment.jetskiCliBin;
+    const model = process.env.JETSKI_MODEL;
     const commandArgs = [
-      '-p', userPrompt
+      '-p', userPrompt,
+      ...(model ? ['--model', model] : [])
     ];
 
     console.log(`Executing: ${command} ${commandArgs.join(' ')}`);


### PR DESCRIPTION
## Summary & Motivation

Standardize model selection across all CLI agent runners in the evaluation harness to use environment variables (`CODEX_MODEL`, `JETSKI_MODEL`, `ANTHROPIC_MODEL`, `GEMINI_MODEL`).

All model selection now happens in environment variables, allowing seamless model overrides when running evaluation benchmarks.

## Changes Made

- **`harness/agents/jetski-cli-agent.ts`**: Append `--model` flag dynamically when `JETSKI_MODEL` is set.
- **`harness/agents/codex-cli-agent.ts`**: Append `--model` flag dynamically when `CODEX_MODEL` is set instead of using a hardcoded default.
- **`EVALS.md`**: Document environment variables for model selection across agent runners.

## Model Environment Variable Examples

Model overrides for each supported agent runner can be specified in your environment:

```bash
CODEX_MODEL='gpt-5.5'
JETSKI_MODEL='Gemini 3.5 Flash'
ANTHROPIC_MODEL='claude-sonnet-5'
GEMINI_MODEL='gemini-flash-latest'
```