### PR TITLE
fix: Ignore comments when detecting stubs, fixes #982

### DIFF
--- a/lib/guide-validation.ts
+++ b/lib/guide-validation.ts
@@ -400,7 +400,7 @@ export function inventoryGuide(dir: string): GuideInventory {
   if (guideContent) {
     const parsed = matter(guideContent);
     const hasFrontmatter = Object.keys(parsed.data).length > 0 || guideContent.startsWith('---');
-    const hasContent = parsed.content.trim().length > 0;
+    const hasContent = parsed.content.replace(/<!--[\s\S]*?-->/g, '').trim().length > 0;
 
     if (hasFrontmatter) {
       isStub = true;

--- a/serving/scripts/build-guides.ts
+++ b/serving/scripts/build-guides.ts
@@ -271,7 +271,7 @@ async function processSingleGuideFile(
     throw new Error(`Missing frontmatter or description in ${filePath}`);
   }
 
-  if (markdownBody.trim().length === 0) {
+  if (markdownBody.replace(/<!--[\s\S]*?-->/g, '').trim().length === 0) {
     // Just a stub guide. No content to index.
     return;
   }


### PR DESCRIPTION
A Markdown guide with just a frontmatter and HTML comments and **nothing else** should still be counted as a stub.

Tiny PR, only +2/-2!

Note: stripping HTML comments (per #983) from guides that _do_ have content is more involved and requires full Markdown parsing, so is out of scope for this PR.

 