### PR TITLE
fix(tooling): accept a `guide.md` stub without `demo.html` as a use case proposal

### DIFF
--- a/lib/guide-validation.ts
+++ b/lib/guide-validation.ts
@@ -185,8 +185,9 @@ export function processGuideInventory(guides: GuideInventory[]): GuideInventoryR
     const guideExists = hasGuide || inv.isStub;
     const isDisciplineGuide = inv.name === inv.category;
     
-    // Discipline skills don't need demo.html
-    if (!isDisciplineSkill && !isDisciplineGuide && guideExists !== hasDemo) {
+    // Discipline skills don't need demo.html; a frontmatter-only stub
+    // (a proposed use case) doesn't need one either
+    if (!isDisciplineSkill && !isDisciplineGuide && ((hasGuide && !hasDemo) || (hasDemo && !guideExists))) {
       const missingFile = guideExists ? DEMO_FILE : GUIDE_FILE;
       const msg = `❌ Error in ${relativeSubdir}: Missing ${missingFile}. Must have BOTH ${GUIDE_FILE} and ${DEMO_FILE}.`;
       console.error(msg);
@@ -231,7 +232,7 @@ export function processGuideInventory(guides: GuideInventory[]): GuideInventoryR
       }
     }
 
-    const isIncomplete = (!hasGuide && !inv.isStub) || !hasDemo;
+    const isIncomplete = (!hasGuide && !inv.isStub) || (hasGuide && !hasDemo);
     const featureIds = isIncomplete ? inv.featureIds : (guideData['web-feature-ids'] || []) as string[];
     const statusName = !isIncomplete && guideErrors.length === 0 ? getStatusName(guideBody, hasGrader, hasTask) : null;
     const isActive = isIncomplete || guideErrors.length > 0 || statusName !== null;


### PR DESCRIPTION
A frontmatter-only stub no longer errors or gets skipped as incomplete; it syncs as a use case with "Needs guidance" status. demo.html is still required once guide.md has body content.

Per discussion with @rviscomi where he expressed desire to do this down the line.

Tiny PR: only +4/-3

For later: I wonder if it would be a good idea to key stub-ness exactly on the presence of a `demo.html`: instead of using no content = stub, we could simply assume that _any_ guide without a `demo.html` is a stub, which allows us to iterate on guidance separately, without risking publishing incomplete guides or having to author `demo.html` files before the guidance is ready.