### PR TITLE
fix: improve eval harness PATH interception, collection deduplication, and dashboard UX

### DIFF
--- a/eval-view/dashboard.js
+++ b/eval-view/dashboard.js
@@ -1138,6 +1138,10 @@ function renderBackButton() {
     btn.className = 'secondary-btn';
     btn.style.cssText = 'margin-bottom: 20px; padding: 5px 15px; font-size: 0.9em;';
     btn.onclick = () => {
+        const modal = $('dialog#modal');
+        if (modal && modal.open) {
+            modal.close();
+        }
         if (currentDetails) {
             showDetails(currentDetails.testName, currentDetails.runs, currentDetails.stats, currentDetails.testId);
         }
@@ -1237,7 +1241,17 @@ async function viewDiff(setupPath, resultPath, testName, runNumber) {
 
     modal.dataset.runNumber = runNumber;
 
-    title.textContent = `Diff: ${formatTestName(testName)} (Run ${runNumber})`;
+    let fileName = '';
+    if (resultPath && resultPath.includes('/guided/')) {
+        fileName = resultPath.split('/guided/')[1];
+    } else if (resultPath && resultPath.includes('/unguided/')) {
+        fileName = resultPath.split('/unguided/')[1];
+    } else if (setupPath && setupPath.includes('/base_app/')) {
+        fileName = setupPath.split('/base_app/')[1];
+    } else if (resultPath) {
+        fileName = resultPath.split('/').pop();
+    }
+    title.textContent = fileName || 'index.html';
     body.innerHTML = '<div style="text-align:center; padding: 20px;">Computing diff...</div>';
 
     // Optional: Make modal wider for diff

--- a/eval-view/dashboard.js
+++ b/eval-view/dashboard.js
@@ -1251,7 +1251,7 @@ async function viewDiff(setupPath, resultPath, testName, runNumber) {
     } else if (resultPath) {
         fileName = resultPath.split('/').pop();
     }
-    title.textContent = fileName || 'index.html';
+    title.textContent = fileName;
     body.innerHTML = '<div style="text-align:center; padding: 20px;">Computing diff...</div>';
 
     // Optional: Make modal wider for diff

--- a/eval-view/dashboard.spec.js
+++ b/eval-view/dashboard.spec.js
@@ -71,8 +71,8 @@ test.describe('Eval View Dashboard', () => {
     await expect(modal).toBeVisible();
 
     // Verify diff content is displayed
-    // The title changes to "Diff: ..."
-    await expect(page.locator('#modal-title')).toContainText('Diff:');
+    // The title displays the filename (e.g. "index.html")
+    await expect(page.locator('#modal-title')).toHaveText('index.html');
     
     // Check for diff-container and some expected diff classes
     const diffContainer = page.locator('.diff-container');

--- a/harness/agents/claude-code-agent.ts
+++ b/harness/agents/claude-code-agent.ts
@@ -22,8 +22,8 @@ function getSessionFiles(dir: string, recursive = false): string[] {
  * Sets up an isolated HOME and work directory to ensure test isolation.
  * @returns {string} The path to the temporary work directory.
  */
-function setupIsolatedWorkDir(templateDir: string, runType: string): string {
-  const tempHome = createIsolatedHome('ghh-claude');
+function setupIsolatedWorkDir(templateDir: string, runType: string, targetDir?: string): string {
+  const tempHome = createIsolatedHome('ghh-claude', targetDir);
   const workDir = createWorkDir(templateDir, tempHome, runType);
 
   // Copy GCP credentials (for Vertex auth)
@@ -102,7 +102,7 @@ function exportClaudeCodeTrajectories(workDir: string, targetDir: string): void 
  */
 async function run() {
   const { userPrompt, runType, targetDir, templateDir } = parseAgentArgs('claude-code-agent.ts');
-  const workDir = setupIsolatedWorkDir(templateDir, runType);
+  const workDir = setupIsolatedWorkDir(templateDir, runType, targetDir);
 
   if (!workDir || !fs.existsSync(workDir)) {
     throw new Error(`Failed to initialize working directory: ${workDir}`);

--- a/harness/agents/codex-cli-agent.ts
+++ b/harness/agents/codex-cli-agent.ts
@@ -18,8 +18,8 @@ function getSessionFiles(dir: string, recursive = false): string[] {
  * Sets up an isolated HOME and work directory to ensure test isolation.
  * @returns {string} The path to the temporary work directory.
  */
-function setupIsolatedWorkDir(templateDir: string, runType: string): string {
-  const tempHome = createIsolatedHome('ghh-codex');
+function setupIsolatedWorkDir(templateDir: string, runType: string, targetDir?: string): string {
+  const tempHome = createIsolatedHome('ghh-codex', targetDir);
   const workDir = createWorkDir(templateDir, tempHome, runType);
 
   // Copy Codex auth file
@@ -94,7 +94,7 @@ function exportCodexTrajectories(workDir: string, targetDir: string): void {
 
 async function run() {
   const { userPrompt, runType, targetDir, templateDir } = parseAgentArgs('codex-cli-agent.ts');
-  const workDir = setupIsolatedWorkDir(templateDir, runType);
+  const workDir = setupIsolatedWorkDir(templateDir, runType, targetDir);
 
   if (!workDir || !fs.existsSync(workDir)) {
     throw new Error(`Failed to initialize working directory: ${workDir}`);

--- a/harness/agents/gemini-cli-agent.ts
+++ b/harness/agents/gemini-cli-agent.ts
@@ -26,8 +26,8 @@ function getSessionFiles(dir: string, recursive = false): string[] {
  * Sets up an isolated HOME and work directory to ensure test isolation.
  * @returns {string} The path to the temporary work directory.
  */
-function setupIsolatedWorkDir(templateDir: string, runType: string): string {
-  const tempHome = createIsolatedHome('ghh-gemini');
+function setupIsolatedWorkDir(templateDir: string, runType: string, targetDir?: string): string {
+  const tempHome = createIsolatedHome('ghh-gemini', targetDir);
   const workDir = createWorkDir(templateDir, tempHome, runType);
 
   const geminiSource = path.join(os.homedir(), '.gemini');
@@ -77,7 +77,7 @@ function setupIsolatedWorkDir(templateDir: string, runType: string): string {
  */
 async function run() {
   const { userPrompt, runType, targetDir, templateDir } = parseAgentArgs('gemini-cli-agent.ts');
-  const workDir = setupIsolatedWorkDir(templateDir, runType);
+  const workDir = setupIsolatedWorkDir(templateDir, runType, targetDir);
 
   if (!workDir || !fs.existsSync(workDir)) {
     throw new Error(`Failed to initialize working directory: ${workDir}`);

--- a/harness/agents/jetski-agent.ts
+++ b/harness/agents/jetski-agent.ts
@@ -16,7 +16,7 @@ import { MODERN_WEB_LOG_FILE } from '../../constants.ts';
  * @returns {string} The path to the temporary work directory.
  */
 function setupIsolatedWorkDir(templateDir: string, runType: string, targetDir: string): string {
-  const tempHome = createIsolatedHome('ghh-jetski');
+  const tempHome = createIsolatedHome('ghh-jetski', targetDir);
   const workDir = createWorkDir(templateDir, tempHome, runType);
 
   const appSupportSource = path.join(os.homedir(), 'Library/Application Support/Jetski');

--- a/harness/agents/jetski-cli-agent.ts
+++ b/harness/agents/jetski-cli-agent.ts
@@ -13,8 +13,8 @@ import { MODERN_WEB_LOG_FILE } from '../../constants.ts';
  * Sets up an isolated HOME and work directory to ensure test isolation.
  * @returns {string} The path to the temporary work directory.
  */
-function setupIsolatedWorkDir(templateDir: string, runType: string): string {
-  const tempHome = createIsolatedHome('ghh-jetski-cli');
+function setupIsolatedWorkDir(templateDir: string, runType: string, targetDir?: string): string {
+  const tempHome = createIsolatedHome('ghh-jetski-cli', targetDir);
   const workDir = createWorkDir(templateDir, tempHome, runType);
 
   const jetskiSource = path.join(os.homedir(), '.gemini', 'jetski');
@@ -63,7 +63,7 @@ function setupIsolatedWorkDir(templateDir: string, runType: string): string {
  */
 async function run() {
   const { userPrompt, runType, targetDir, templateDir } = parseAgentArgs('jetski-cli-agent.ts');
-  const workDir = setupIsolatedWorkDir(templateDir, runType);
+  const workDir = setupIsolatedWorkDir(templateDir, runType, targetDir);
 
   if (!workDir || !fs.existsSync(workDir)) {
     throw new Error(`Failed to initialize working directory: ${workDir}`);

--- a/harness/lib/agent-shared.ts
+++ b/harness/lib/agent-shared.ts
@@ -38,15 +38,39 @@ export function spawnAsync(command: string, args: string[], options: SpawnOption
 }
 
 /**
+ * Sets up shell profile files (.bashrc, .bash_profile, .zshrc, .zprofile, .profile) in the isolated HOME directory
+ * to ensure that targetDir (containing our npx interceptor shim) remains at the front of PATH even if
+ * an external binary or login shell invokes /usr/libexec/path_helper and resets PATH.
+ * @param homeDir Path to the isolated HOME directory
+ * @param targetDir Path to the directory containing our intercepted binaries (like npx)
+ */
+export function setupIsolatedShellProfiles(homeDir: string, targetDir: string): void {
+  try {
+    const profileContent = `export PATH="${targetDir}:$PATH"\n`;
+    const profileFiles = ['.bashrc', '.bash_profile', '.zshrc', '.zprofile', '.profile'];
+    for (const file of profileFiles) {
+      fs.writeFileSync(path.join(homeDir, file), profileContent, 'utf8');
+    }
+  } catch (err) {
+    console.warn('Warning: Failed to create isolated shell profiles in HOME:', err);
+  }
+}
+
+/**
  * Creates a unique isolated HOME directory in /tmp.
  * @param prefix The prefix for the directory name
+ * @param targetDir Optional path to the target directory containing intercepted binaries
  * @returns The path to the created directory.
  */
-export function createIsolatedHome(prefix: string): string {
+export function createIsolatedHome(prefix: string, targetDir?: string): string {
   // Use /tmp/ deliberately because os.tmpdir() on macOS can return paths that are 
   // too long for valid Unix socket paths, which causes issues for some JetSki/VS Code components.
   const tempHome = `/tmp/${prefix}-${Math.random().toString(36).substring(7)}`;
   fs.mkdirSync(tempHome, { recursive: true });
+
+  if (targetDir) {
+    setupIsolatedShellProfiles(tempHome, targetDir);
+  }
 
   // Provide authentication to the isolated environment so npm tasks work
   const originalHome = process.env.HOME || process.cwd();

--- a/harness/lib/collection.ts
+++ b/harness/lib/collection.ts
@@ -46,7 +46,8 @@ function extractErrorMessage(dir: string, targetFile: string): string {
   const stderrPath = path.join(dir, 'agent_stderr.log');
   
   if (!fs.existsSync(stderrPath)) {
-    return fs.existsSync(targetFile) ? 'Generation failed' : 'index.html not found';
+    const fileName = path.relative(dir, targetFile) || path.basename(targetFile) || 'index.html';
+    return fs.existsSync(targetFile) ? 'Generation failed' : `${fileName} not found`;
   }
 
   return fs.readFileSync(stderrPath, 'utf8')
@@ -169,54 +170,107 @@ function getTaskRunDirs(runPath: string): string[] {
   ];
 }
 
-function setupGraderForTask(
+interface TaskRunContext {
+  guide: string;
+  taskName: string;
+  runType: string;
+  taskInfo: any;
+  targetModifiedFile: string | undefined;
+  targetFile: string;
+  targetPkgJson: string;
+  graderPath: string;
+  graderResults: string;
+  targetAppExists: boolean;
+}
+
+function getTaskRunContext(
   dir: string,
   runPath: string,
-  resultsDir: string,
-  taskMap: Map<string, any>
-): string | null {
+  taskMap: Map<string, any>,
+  warnIfMissing = false
+): TaskRunContext | null {
   const relPath = path.relative(runPath, dir);
   const parsed = parseResultPath(relPath);
   if (!parsed) return null;
   const { guide, taskName, runType } = parsed;
   if (runType === 'base_app') return null; // Skip the base app setup folder
 
-  const targetFile = path.join(dir, 'index.html');
-  const targetPkgJson = path.join(dir, 'package.json');
-
   const taskInfo = taskMap.get(`${guide}/${taskName}`);
-  if (!taskInfo) return null;
+  if (!taskInfo) {
+    if (warnIfMissing) {
+      console.warn(`Skipping grading: Task ${guide} not found in task map`);
+    }
+    return null;
+  }
 
+  const targetModifiedFile = extractTargetModifiedFile(dir, taskInfo.prompt);
+  const targetFile = path.join(dir, targetModifiedFile || 'index.html');
+  const targetPkgJson = path.join(dir, 'package.json');
   const graderPath = path.join(taskInfo.guideDir, 'grader.ts');
   const graderResults = path.join(dir, `${guide}_results.json`);
   const targetAppExists = isTargetAppPresent(targetFile, targetPkgJson);
+
+  return {
+    guide,
+    taskName,
+    runType,
+    taskInfo,
+    targetModifiedFile,
+    targetFile,
+    targetPkgJson,
+    graderPath,
+    graderResults,
+    targetAppExists,
+  };
+}
+
+function getTaskDirsForRuns(resultsDir: string, runDirs: string[]): { dir: string; runPath: string; runDir: string }[] {
+  const items: { dir: string; runPath: string; runDir: string }[] = [];
+  for (const runDir of runDirs) {
+    const runPath = path.join(resultsDir, runDir);
+    for (const dir of getTaskRunDirs(runPath)) {
+      items.push({ dir, runPath, runDir });
+    }
+  }
+  return items;
+}
+
+function setupGraderForTask(
+  dir: string,
+  runPath: string,
+  resultsDir: string,
+  taskMap: Map<string, any>
+): string | null {
+  const ctx = getTaskRunContext(dir, runPath, taskMap);
+  if (!ctx) return null;
+
   const failureFile = path.join(dir, 'generation_failed.json');
 
   // If grader is missing, generation failed, target file is missing, or results already exist, skip generating a runner.
-  if (!fs.existsSync(graderPath) || fs.existsSync(failureFile) || !targetAppExists || fs.existsSync(graderResults)) {
+  if (!fs.existsSync(ctx.graderPath) || fs.existsSync(failureFile) || !ctx.targetAppExists || fs.existsSync(ctx.graderResults)) {
     return null;
   }
 
   // Generate a runner script to be picked up by pnpm -r run-grader
-  const gradeScript = getGraderScriptContent(dir, graderPath, guide);
+  const gradeScript = getGraderScriptContent(dir, ctx.graderPath, ctx.guide);
   const relativeId = path.relative(resultsDir, dir); // e.g. "1/guideName/guided"
   fs.writeFileSync(path.join(dir, 'grade.mjs'), gradeScript);
 
   let pkgJsonObj: any = {
-    name: `${guide.substring(0, 30)}-${runType}-grader`,
+    name: `${ctx.guide.substring(0, 30)}-${ctx.runType}-grader`,
     type: "module",
     scripts: {}
   };
-  if (fs.existsSync(targetPkgJson)) {
+  if (fs.existsSync(ctx.targetPkgJson)) {
     try {
-      pkgJsonObj = JSON.parse(fs.readFileSync(targetPkgJson, 'utf-8'));
+      pkgJsonObj = JSON.parse(fs.readFileSync(ctx.targetPkgJson, 'utf-8'));
       if (!pkgJsonObj.scripts) pkgJsonObj.scripts = {};
     } catch (e) {
       console.warn("Failed to parse existing package.json, overwriting...");
     }
   }
   pkgJsonObj.scripts["run-grader"] = `node --experimental-strip-types grade.mjs --id ${relativeId}`;
-  fs.writeFileSync(targetPkgJson, JSON.stringify(pkgJsonObj, null, 2));
+  fs.writeFileSync(ctx.targetPkgJson, JSON.stringify(pkgJsonObj, null, 2));
 
   return relativeId;
 }
@@ -384,15 +438,10 @@ function prepareGradersForRuns(
   taskMap: Map<string, any>
 ): string[] {
   const pnpmWorkspacePackages: string[] = [];
-  for (const runDir of runDirs) {
-    const runPath = path.join(resultsDir, runDir);
-    const taskDirs = getTaskRunDirs(runPath);
-
-    for (const dir of taskDirs) {
-      const pkgId = setupGraderForTask(dir, runPath, resultsDir, taskMap);
-      if (pkgId) {
-        pnpmWorkspacePackages.push(pkgId);
-      }
+  for (const { dir, runPath } of getTaskDirsForRuns(resultsDir, runDirs)) {
+    const pkgId = setupGraderForTask(dir, runPath, resultsDir, taskMap);
+    if (pkgId) {
+      pnpmWorkspacePackages.push(pkgId);
     }
   }
   return pnpmWorkspacePackages;
@@ -405,49 +454,33 @@ async function collectTaskRunEntry(
   taskMap: Map<string, any>,
   suiteConfig: SuiteConfig
 ): Promise<{ testName: string; payload: any } | null> {
-  const relPath = path.relative(runPath, dir);
-  const parsed = parseResultPath(relPath);
-  if (!parsed) return null;
-  const { guide, taskName, runType } = parsed;
-  if (runType === 'base_app') return null; // Skip the base app setup folder
+  const ctx = getTaskRunContext(dir, runPath, taskMap, true);
+  if (!ctx) return null;
 
-  const taskInfo = taskMap.get(`${guide}/${taskName}`);
-  if (!taskInfo) {
-    console.warn(`Skipping grading: Task ${guide} not found in task map`);
-    return null;
-  }
+  const usage = await collectGuideUsage(dir, ctx.runType, suiteConfig);
 
-  const usage = await collectGuideUsage(dir, runType, suiteConfig);
-
-  const targetFile = path.join(dir, 'index.html');
-  const targetPkgJson = path.join(dir, 'package.json');
-  const graderPath = path.join(taskInfo.guideDir, 'grader.ts');
-  const graderResults = path.join(dir, `${guide}_results.json`);
-  const targetAppExists = isTargetAppPresent(targetFile, targetPkgJson);
-
-  const isDisciplineSkill = isDisciplineSkillDir(taskInfo.guideDir);
+  const isDisciplineSkill = isDisciplineSkillDir(ctx.taskInfo.guideDir);
   const taskCategory = isDisciplineSkill
-    ? path.basename(taskInfo.guideDir)
-    : path.basename(path.dirname(taskInfo.guideDir));
+    ? path.basename(ctx.taskInfo.guideDir)
+    : path.basename(path.dirname(ctx.taskInfo.guideDir));
   const expectedToolPrefixes = isDisciplineSkill
     ? [taskCategory].filter(Boolean)
     : ['modern-web'].filter(Boolean);
 
   const scenarioResults = evaluateScenarioResults(
     dir,
-    guide,
-    graderPath,
-    graderResults,
-    targetAppExists,
-    targetFile
+    ctx.guide,
+    ctx.graderPath,
+    ctx.graderResults,
+    ctx.targetAppExists,
+    ctx.targetFile
   );
 
   // For skills, placing the discipline name (`guide`) first ensures it is correctly identified 
   // and displayed as the main category in the dashboard's transposed layout.
-  const testName = isDisciplineSkill ? `${guide} - ${taskName} - ${runType}` : `${taskName} - ${guide} - ${runType}`;
+  const testName = isDisciplineSkill ? `${ctx.guide} - ${ctx.taskName} - ${ctx.runType}` : `${ctx.taskName} - ${ctx.guide} - ${ctx.runType}`;
   const tokenUsage = extractTokenUsageFromResults(dir, suiteConfig.agent);
   const runtimeData = readRuntimeData(dir);
-  const targetModifiedFile = extractTargetModifiedFile(dir, taskInfo.prompt);
 
   const payload = {
     runNumber,
@@ -459,11 +492,11 @@ async function collectTaskRunEntry(
     discipline: taskCategory,
     isDisciplineSkill,
     expectedToolPrefixes,
-    guideName: guide,
-    baseApp: taskInfo.baseApp,
-    taskName,
-    prompt: taskInfo.prompt,
-    targetFile: targetModifiedFile,
+    guideName: ctx.guide,
+    baseApp: ctx.taskInfo.baseApp,
+    taskName: ctx.taskName,
+    prompt: ctx.taskInfo.prompt,
+    targetFile: ctx.targetModifiedFile,
     files: fs.readdirSync(dir).filter(f => !fs.statSync(path.join(dir, f)).isDirectory()),
     runtime: runtimeData,
     tokenUsage,
@@ -480,19 +513,14 @@ async function collectAllResults(
 ): Promise<Record<string, any[]>> {
   const allResults: Record<string, any[]> = {};
 
-  for (const runDir of runDirs) {
-    const runPath = path.join(resultsDir, runDir);
-    const taskDirs = getTaskRunDirs(runPath);
+  for (const { dir, runPath, runDir } of getTaskDirsForRuns(resultsDir, runDirs)) {
+    const entry = await collectTaskRunEntry(dir, runPath, parseInt(runDir), taskMap, suiteConfig);
+    if (!entry) continue;
 
-    for (const dir of taskDirs) {
-      const entry = await collectTaskRunEntry(dir, runPath, parseInt(runDir), taskMap, suiteConfig);
-      if (!entry) continue;
-
-      if (!allResults[entry.testName]) {
-        allResults[entry.testName] = [];
-      }
-      allResults[entry.testName].push(entry.payload);
+    if (!allResults[entry.testName]) {
+      allResults[entry.testName] = [];
     }
+    allResults[entry.testName].push(entry.payload);
   }
 
   return allResults;

--- a/harness/tests/isolated-shell-profiles.test.ts
+++ b/harness/tests/isolated-shell-profiles.test.ts
@@ -1,0 +1,102 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { spawnSync } from 'child_process';
+import { setupIsolatedShellProfiles, createIsolatedHome, cleanupIsolatedHome } from '../lib/agent-shared.ts';
+
+const PROFILE_FILES = ['.bashrc', '.bash_profile', '.zshrc', '.zprofile', '.profile'];
+
+test('setupIsolatedShellProfiles creates all expected profile files with PATH export', () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'test-profiles-'));
+  const mockTargetDir = '/mock/target/dir';
+
+  try {
+    setupIsolatedShellProfiles(tempDir, mockTargetDir);
+
+    for (const file of PROFILE_FILES) {
+      const filePath = path.join(tempDir, file);
+      assert.ok(fs.existsSync(filePath), `${file} should be created in home directory`);
+      const content = fs.readFileSync(filePath, 'utf8');
+      assert.strictEqual(content, `export PATH="${mockTargetDir}:$PATH"\n`, `${file} should contain correct PATH export`);
+    }
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('createIsolatedHome automatically calls setupIsolatedShellProfiles when targetDir is provided', () => {
+  const mockTargetDir = '/mock/auto/dir';
+  let homeDir = '';
+
+  try {
+    homeDir = createIsolatedHome('test-profiles-auto', mockTargetDir);
+    assert.ok(fs.existsSync(homeDir), 'Isolated home should be created');
+
+    for (const file of PROFILE_FILES) {
+      const filePath = path.join(homeDir, file);
+      assert.ok(fs.existsSync(filePath), `${file} should exist in isolated home when targetDir is passed`);
+      const content = fs.readFileSync(filePath, 'utf8');
+      assert.strictEqual(content, `export PATH="${mockTargetDir}:$PATH"\n`);
+    }
+  } finally {
+    if (homeDir) cleanupIsolatedHome(homeDir);
+  }
+});
+
+test('createIsolatedHome does NOT create profile files when targetDir is omitted', () => {
+  let homeDir = '';
+
+  try {
+    homeDir = createIsolatedHome('test-profiles-omitted');
+    assert.ok(fs.existsSync(homeDir), 'Isolated home should be created');
+
+    for (const file of PROFILE_FILES) {
+      const filePath = path.join(homeDir, file);
+      assert.strictEqual(fs.existsSync(filePath), false, `${file} should NOT exist when targetDir is omitted`);
+    }
+  } finally {
+    if (homeDir) cleanupIsolatedHome(homeDir);
+  }
+});
+
+test('login shell in isolated HOME correctly prepends targetDir to PATH and executes shim binary', { skip: process.platform === 'win32' }, () => {
+  const targetDir = fs.mkdtempSync(path.join(os.tmpdir(), 'test-target-bin-'));
+  let homeDir = '';
+
+  try {
+    // Create a mock executable binary inside targetDir
+    const mockBinName = 'mock-intercepted-tool';
+    const mockBinPath = path.join(targetDir, mockBinName);
+    fs.writeFileSync(mockBinPath, '#!/bin/sh\necho "intercepted-by-profile"\n', { mode: 0o755 });
+    fs.chmodSync(mockBinPath, 0o755);
+
+    // Create isolated home configured with our targetDir
+    homeDir = createIsolatedHome('test-shell-exec', targetDir);
+
+    // Test with bash login shell (-l triggers profile evaluation and path_helper reset on macOS)
+    const bashResult = spawnSync('bash', ['-l', '-c', mockBinName], {
+      env: { ...process.env, HOME: homeDir },
+      encoding: 'utf8',
+      timeout: 5000,
+    });
+
+    assert.strictEqual(bashResult.status, 0, `bash login shell should succeed: ${bashResult.stderr}`);
+    assert.strictEqual(bashResult.stdout.trim(), 'intercepted-by-profile', 'bash login shell should execute mock tool from targetDir');
+
+    // If on macOS, also verify zsh login shell (-l triggers zprofile evaluation and path_helper reset)
+    if (process.platform === 'darwin') {
+      const zshResult = spawnSync('zsh', ['-l', '-c', mockBinName], {
+        env: { ...process.env, HOME: homeDir },
+        encoding: 'utf8',
+        timeout: 5000,
+      });
+      assert.strictEqual(zshResult.status, 0, `zsh login shell should succeed: ${zshResult.stderr}`);
+      assert.strictEqual(zshResult.stdout.trim(), 'intercepted-by-profile', 'zsh login shell should execute mock tool from targetDir');
+    }
+  } finally {
+    if (homeDir) cleanupIsolatedHome(homeDir);
+    fs.rmSync(targetDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Overview of Changes

This pull request implements key bug fixes, code deduplication, and architectural improvements across the evaluation harness (`harness/`) and evaluation dashboard (`eval-view/`).

### 1. Fix Back button on dashboard, show Diff filename
- **Modal Back Button Fix**: Updated `renderBackButton()` so that clicking "← Back" from inside modal views (Diff, Runtime, Log, JSON) closes `dialog#modal`. This triggers cleanup of URL search parameters (`view`, `run`, etc.) and returns the user to the underlying dashboard/accordion view without requiring a page reload.
- **Diff View Filename Title**: Updated `viewDiff()` to display simply the relative filename in the modal title (`fileName`, e.g., `src/App.jsx`), matching the clean titling convention used by `viewContent()`.

### 2. DRY collection.ts, fix target file extraction
- **Consolidated Helpers**: Created `getTaskRunContext()` and `getTaskDirsForRuns()` to eliminate duplicated path resolution, task map lookups, and nested directory traversal loops across `setupGraderForTask()`, `collectTaskRunEntry()`, `prepareGradersForRuns()`, and `collectAllResults()`.
- **Dynamic Target File Resolution**: Replaced hardcoded `'index.html'` assumptions with `extractTargetModifiedFile(dir, taskInfo.prompt) || 'index.html'`. Updated `extractErrorMessage()` to report `${path.relative(dir, targetFile) || path.basename(targetFile) || 'index.html'} not found` dynamically when target files are missing.

### 3. Fix env CLI bin usage (search/retrieve bypassing local interceptor shim and pushing public dist)
- **Problem**: When external agent binaries configured via environment variables (such as `CODEX_CLI_BIN` pointing to a custom Santa-whitelisted binary) spawn login shells (`bash -l` / `zsh -l`), macOS executes `/usr/libexec/path_helper`. This resets `PATH` and pushes system directories (`/usr/local/bin`) ahead of our injected `targetDir`, causing `npx` calls to bypass our local interceptor shim and fetch from the public npm registry.
- **Solution**: Created `setupIsolatedShellProfiles()` to write `.bashrc`, `.bash_profile`, `.zshrc`, `.zprofile`, and `.profile` inside each agent's isolated temporary home directory (`tempHome`) with `export PATH="<targetDir>:$PATH"`. When `/usr/libexec/path_helper` finishes during login shell startup, these profile files immediately re-assert `targetDir` at the front of `PATH`.
- **Agent Integration**: Updated `createIsolatedHome()` and all five agent scripts (`codex-cli-agent.ts`, `gemini-cli-agent.ts`, `claude-code-agent.ts`, `jetski-agent.ts`, `jetski-cli-agent.ts`) to accept and pass `targetDir` during workspace initialization.
- **Test Coverage**: Created a new unit and integration test suite (`harness/tests/isolated-shell-profiles.test.ts`) covering profile generation, `createIsolatedHome()` integration, and end-to-end login shell (`bash -l` / `zsh -l`) execution verification.

### Verification
- Ran `pnpm typecheck` across all workspace projects: 0 errors.
- Ran `pnpm -r --parallel test`: All test suites across `eval-view`, `guides`, `harness`, and `serving` passed cleanly.