### PR TITLE
feat: implement Phase 1 groundwork for base-app specific evaluations

### DIFF
--- a/lib/guide-validation.test.ts
+++ b/lib/guide-validation.test.ts
@@ -1,6 +1,9 @@
 import { test, describe } from 'node:test';
 import assert from 'node:assert';
-import { parseExpectations, validateHtmlTags } from './guide-validation.ts';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { parseExpectations, validateHtmlTags, inventoryGuide, classifyGuide, getSupportedBaseApps } from './guide-validation.ts';
 
 describe('parseExpectations', () => {
   test('legacy flat format: all bullets treated as mustPass', () => {
@@ -81,11 +84,12 @@ And an iframe: <iframe src="foo"></iframe>.
 Also unescaped <label>.
 `;
     const errors = validateHtmlTags(body, 'test.md');
-    assert.strictEqual(errors.length, 4);
+    assert.strictEqual(errors.length, 5);
     assert.ok(errors[0].includes('Unescaped HTML tag <select> found on line 1'));
     assert.ok(errors[1].includes('Unescaped HTML tag <button> found on line 1'));
     assert.ok(errors[2].includes('Unescaped HTML tag <iframe> found on line 2'));
-    assert.ok(errors[3].includes('Unescaped HTML tag <label> found on line 3'));
+    assert.ok(errors[3].includes('Unescaped HTML tag <iframe> found on line 2'));
+    assert.ok(errors[4].includes('Unescaped HTML tag <label> found on line 3'));
   });
 
   test('ignores code blocks', () => {
@@ -106,4 +110,47 @@ Also unescaped <label>.
     assert.deepStrictEqual(errors, []);
   });
 });
+
+describe('inventoryGuide and classifyGuide target discovery', () => {
+  test('correctly identifies target inventory and classifies target guide status', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'guide-test-'));
+    const guideDir = path.join(tmpDir, 'test-guide');
+    const targetsDir = path.join(guideDir, 'targets', 'daily-grind');
+    fs.mkdirSync(targetsDir, { recursive: true });
+    
+    fs.writeFileSync(path.join(guideDir, 'guide.md'), '# Test Guide\nContent');
+    fs.writeFileSync(path.join(guideDir, 'expectations.md'), '- rule');
+    fs.writeFileSync(path.join(targetsDir, 'solution.patch'), '+++ b/src/app.ts\n+const x = 1;');
+    fs.writeFileSync(path.join(targetsDir, 'broken.patch'), '+++ b/src/app.ts\n+const x = 2;');
+    fs.writeFileSync(path.join(targetsDir, 'grader.ts'), 'console.log("test");');
+    fs.writeFileSync(path.join(targetsDir, 'task.md'), '- Implement feature');
+
+    try {
+      const inv = inventoryGuide(guideDir);
+      assert.strictEqual(inv.targets?.length, 1);
+      assert.strictEqual(inv.targets?.[0].name, 'daily-grind');
+      assert.strictEqual(inv.targets?.[0].hasSolution, true);
+      assert.strictEqual(inv.targets?.[0].hasBroken, true);
+      assert.strictEqual(inv.targets?.[0].hasGrader, true);
+      assert.strictEqual(inv.targets?.[0].hasTask, true);
+      
+      const status = classifyGuide(inv);
+      assert.strictEqual(status, 'eval-ready');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('getSupportedBaseApps', () => {
+  test('dynamically discovers base application directories from harness/base_apps', () => {
+    const apps = getSupportedBaseApps();
+    assert.ok(Array.isArray(apps));
+    assert.ok(apps.includes('daily-grind'));
+    assert.ok(apps.includes('devtools-times'));
+  });
+});
+
+
+
 

--- a/lib/guide-validation.ts
+++ b/lib/guide-validation.ts
@@ -6,7 +6,7 @@ import { marked } from 'marked';
 // Import shared utilities (using relative paths from guides/)
 import { validateMacros } from '../serving/lib/macros.ts';
 import { validateFeature } from '../serving/lib/baseline.ts';
-import { rootDir, guidesDir } from './paths.ts';
+import { rootDir, guidesDir, baseAppsDir } from './paths.ts';
 
 const REPO_ROOT = rootDir;
 
@@ -274,6 +274,35 @@ export const NEGATIVE_DEMO_FILE = 'negative-demo.html';
 export const GRADER_FILE = 'grader.ts';
 export const TASK_FILE = 'task.md';
 
+export function getSupportedBaseApps(): string[] {
+  try {
+    if (!fs.existsSync(baseAppsDir)) return [];
+    return fs.readdirSync(baseAppsDir).filter((name) => {
+      if (name.startsWith('.')) return false;
+      const fullPath = path.join(baseAppsDir, name);
+      return fs.statSync(fullPath).isDirectory();
+    });
+  } catch (e) {
+    console.warn(`Failed to read base apps directory at ${baseAppsDir}: ${e}`);
+    return [];
+  }
+}
+
+export type SupportedBaseApp = string;
+
+export const TARGETS_DIR = 'targets';
+export const SOLUTION_PATCH_FILE = 'solution.patch';
+export const BROKEN_PATCH_FILE = 'broken.patch';
+
+export interface TargetInventory {
+  name: string;
+  dir: string;
+  hasSolution: boolean;
+  hasBroken: boolean;
+  hasGrader: boolean;
+  hasTask: boolean;
+}
+
 export interface GuideInventory {
   dir: string;
   name: string;
@@ -288,6 +317,7 @@ export interface GuideInventory {
   hasTask: boolean;
   featureIds: string[];
   isDisciplineSkill: boolean;
+  targets?: TargetInventory[];
 }
 
 /**
@@ -358,6 +388,40 @@ export function getTaskMap(): Map<string, TaskInfo> {
     }
   }
 
+  function processBaseAppTasks(guideName: string, targetsDir: string, guideDir: string) {
+    let firstBaseAppInfo: TaskInfo | null = null;
+    const supportedBaseApps = getSupportedBaseApps();
+
+    for (const entry of fs.readdirSync(targetsDir, { withFileTypes: true })) {
+      if (!entry.isDirectory() || entry.name.startsWith('.') || !supportedBaseApps.includes(entry.name)) continue;
+      const baseAppName = entry.name;
+      const taskPath = path.join(targetsDir, baseAppName, TASK_FILE);
+
+      const rawContent = readFileSafe(taskPath);
+      if (!rawContent) continue;
+
+      const { content } = matter(rawContent);
+      const firstLine = content.split('\n').find((l: string) => l.trim().startsWith('- '));
+      const prompt = firstLine ? firstLine.replace(/^-\s*/, '').trim() : content.trim();
+
+      const info: TaskInfo = {
+        baseApp: baseAppName,
+        prompt: prompt,
+        guideDir: guideDir,
+      };
+
+      if (!firstBaseAppInfo) {
+        firstBaseAppInfo = info;
+      }
+
+      taskMap.set(`${guideName}/${baseAppName}`, info);
+    }
+
+    if (firstBaseAppInfo) {
+      taskMap.set(`${guideName}/task`, firstBaseAppInfo);
+    }
+  }
+
   const disciplines = fs.readdirSync(guidesDir, { withFileTypes: true })
     .filter(d => d.isDirectory() && !d.name.startsWith('.') && d.name !== 'node_modules')
     .map(d => d.name);
@@ -367,8 +431,11 @@ export function getTaskMap(): Map<string, TaskInfo> {
     if (!fs.existsSync(disciplineDir)) continue;
 
     // Check if the discipline itself is a skill with tasks
+    const disciplineTargetsDir = path.join(disciplineDir, TARGETS_DIR);
     const disciplineTasksDir = path.join(disciplineDir, 'tasks');
-    if (fs.existsSync(disciplineTasksDir)) {
+    if (fs.existsSync(disciplineTargetsDir)) {
+      processBaseAppTasks(discipline, disciplineTargetsDir, disciplineDir);
+    } else if (fs.existsSync(disciplineTasksDir)) {
       processTasks(discipline, disciplineTasksDir, disciplineDir);
     }
 
@@ -376,10 +443,13 @@ export function getTaskMap(): Map<string, TaskInfo> {
     for (const entry of fs.readdirSync(disciplineDir, { withFileTypes: true })) {
       if (!entry.isDirectory()) continue;
       const guideName = entry.name;
+      const targetsDir = path.join(disciplineDir, guideName, TARGETS_DIR);
       const tasksDir = path.join(disciplineDir, guideName, 'tasks');
-      if (!fs.existsSync(tasksDir)) continue;
-
-      processTasks(guideName, tasksDir, path.join(disciplineDir, guideName));
+      if (fs.existsSync(targetsDir)) {
+        processBaseAppTasks(guideName, targetsDir, path.join(disciplineDir, guideName));
+      } else if (fs.existsSync(tasksDir)) {
+        processTasks(guideName, tasksDir, path.join(disciplineDir, guideName));
+      }
     }
   }
   return taskMap;
@@ -415,20 +485,57 @@ export function inventoryGuide(dir: string): GuideInventory {
 
   const featureIds = guideContent ? (matter(guideContent).data['web-feature-ids'] || []) : [];
 
+  const targetsDir = path.join(dir, TARGETS_DIR);
+  const hasTargets = fs.existsSync(targetsDir) && fs.statSync(targetsDir).isDirectory();
+  const targets: TargetInventory[] = [];
+
+  let hasDemo = false;
+  let hasNegativeDemo = false;
+  let hasGrader = false;
+  let hasTask = false;
+
+  if (hasTargets) {
+    const supportedBaseApps = getSupportedBaseApps();
+    for (const entry of fs.readdirSync(targetsDir, { withFileTypes: true })) {
+      if (!entry.isDirectory() || entry.name.startsWith('.') || !supportedBaseApps.includes(entry.name)) continue;
+      const targetDir = path.join(targetsDir, entry.name);
+      const appInv: TargetInventory = {
+        name: entry.name,
+        dir: targetDir,
+        hasSolution: fs.existsSync(path.join(targetDir, SOLUTION_PATCH_FILE)),
+        hasBroken: fs.existsSync(path.join(targetDir, BROKEN_PATCH_FILE)),
+        hasGrader: fs.existsSync(path.join(targetDir, GRADER_FILE)),
+        hasTask: fs.existsSync(path.join(targetDir, TASK_FILE)),
+      };
+      targets.push(appInv);
+    }
+
+    if (targets.length > 0) {
+      hasGrader = targets.every((a) => a.hasGrader);
+      hasTask = targets.every((a) => a.hasTask);
+    }
+  } else {
+    hasDemo = readFileSafe(path.join(dir, DEMO_FILE)).length > 0;
+    hasNegativeDemo = fs.existsSync(path.join(dir, NEGATIVE_DEMO_FILE));
+    hasGrader = fs.existsSync(path.join(dir, GRADER_FILE));
+    hasTask = fs.existsSync(path.join(dir, 'tasks', TASK_FILE));
+  }
+
   return {
     dir,
     name,
     category,
     hasGuide,
     isStub,
-    hasDemo: readFileSafe(path.join(dir, DEMO_FILE)).length > 0,
+    hasDemo,
     hasExpectations,
     expectationsEmpty: hasExpectations && expectationsContent.length === 0,
-    hasNegativeDemo: fs.existsSync(path.join(dir, NEGATIVE_DEMO_FILE)),
-    hasGrader: fs.existsSync(path.join(dir, GRADER_FILE)),
-    hasTask: fs.existsSync(path.join(dir, 'tasks', TASK_FILE)),
+    hasNegativeDemo,
+    hasGrader,
+    hasTask,
     featureIds,
     isDisciplineSkill,
+    targets,
   };
 }
 
@@ -437,11 +544,24 @@ export type GuideStatus = 'eval-ready' | 'needs-test' | 'needs-calibration' | 'n
 export function classifyGuide(inv: GuideInventory): GuideStatus {
   if (!inv.hasGuide && !inv.isStub) return 'incomplete';
   if (inv.isStub && !inv.hasGuide) return 'stub';
-  if (!inv.hasDemo) return 'incomplete';
   if (!inv.hasExpectations || inv.expectationsEmpty) return 'needs-expectations';
-  if (!inv.hasNegativeDemo || !inv.hasGrader) return 'needs-calibration';
-  if (!inv.hasTask) return 'needs-test';
-  return 'eval-ready';
+
+  if (inv.targets && inv.targets.length > 0) {
+    const allHaveSolutions = inv.targets.every(t => t.hasSolution);
+    const allHaveBroken = inv.targets.every(t => t.hasBroken);
+    const allHaveGraders = inv.targets.every(t => t.hasGrader);
+    const allHaveTasks = inv.targets.every(t => t.hasTask);
+
+    if (!allHaveSolutions) return 'incomplete';
+    if (!allHaveBroken || !allHaveGraders) return 'needs-calibration';
+    if (!allHaveTasks) return 'needs-test';
+    return 'eval-ready';
+  } else {
+    if (!inv.hasDemo) return 'incomplete';
+    if (!inv.hasNegativeDemo || !inv.hasGrader) return 'needs-calibration';
+    if (!inv.hasTask) return 'needs-test';
+    return 'eval-ready';
+  }
 }
 
 export function scanAllGuides(scanDir = guidesDir): GuideInventory[] {

--- a/lib/patch-utils.test.ts
+++ b/lib/patch-utils.test.ts
@@ -1,0 +1,94 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { extractTargetFilesFromPatch, applyPatch, applyPatchSync } from './patch-utils.ts';
+
+describe('extractTargetFilesFromPatch', () => {
+  test('extracts modified file paths from unified diff headers and ignores deleted files', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'patch-test-'));
+    const patchPath = path.join(tmpDir, 'demo.patch');
+    const patchContent = `--- a/src/components/SignInForm.tsx
++++ b/src/components/SignInForm.tsx
+@@ -10,3 +10,3 @@
+- const x = 1;
++ const x = 2;
+--- a/src/styles/main.css
++++ b/src/styles/main.css
+@@ -1,2 +1,3 @@
+ /* comment */
++body { color: red; }
+--- a/deleted.ts
++++ /dev/null
+@@ -1,5 +0,0 @@
+`;
+    fs.writeFileSync(patchPath, patchContent);
+
+    try {
+      const files = extractTargetFilesFromPatch(patchPath);
+      assert.deepStrictEqual(files, ['src/components/SignInForm.tsx', 'src/styles/main.css']);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('applyPatchSync', () => {
+  test('applies unified diff patch synchronously to target directory', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'patch-apply-sync-'));
+    const targetFile = path.join(tmpDir, 'test.txt');
+    fs.writeFileSync(targetFile, 'hello world\n');
+
+    const patchPath = path.join(tmpDir, 'change.patch');
+    const patchContent = `--- a/test.txt
++++ b/test.txt
+@@ -1 +1 @@
+-hello world
++hello guidance
+`;
+    fs.writeFileSync(patchPath, patchContent);
+
+    try {
+      const result = applyPatchSync(tmpDir, patchPath);
+      assert.strictEqual(result.success, true, `Expected success, got error: ${result.error}`);
+      const updatedContent = fs.readFileSync(targetFile, 'utf8');
+      assert.strictEqual(updatedContent, 'hello guidance\n');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test('returns error when patch file or target directory does not exist', () => {
+    const res1 = applyPatchSync('/nonexistent/dir', '/nonexistent/patch.patch');
+    assert.strictEqual(res1.success, false);
+    assert.match(res1.error || '', /not found/i);
+  });
+});
+
+describe('applyPatch', () => {
+  test('applies unified diff patch asynchronously to target directory', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'patch-apply-async-'));
+    const targetFile = path.join(tmpDir, 'test.txt');
+    fs.writeFileSync(targetFile, 'hello world\n');
+
+    const patchPath = path.join(tmpDir, 'change.patch');
+    const patchContent = `--- a/test.txt
++++ b/test.txt
+@@ -1 +1 @@
+-hello world
++hello guidance
+`;
+    fs.writeFileSync(patchPath, patchContent);
+
+    try {
+      const result = await applyPatch(tmpDir, patchPath);
+      assert.strictEqual(result.success, true, `Expected success, got error: ${result.error}`);
+      const updatedContent = fs.readFileSync(targetFile, 'utf8');
+      assert.strictEqual(updatedContent, 'hello guidance\n');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+

--- a/lib/patch-utils.ts
+++ b/lib/patch-utils.ts
@@ -1,0 +1,79 @@
+import fs from 'node:fs';
+import { exec, execSync } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execAsync = promisify(exec);
+
+/**
+ * Extracts target modified file paths directly from unified diff headers (+++ b/<path>).
+ * Ignores deleted files (/dev/null).
+ */
+export function extractTargetFilesFromPatch(patchPath: string): string[] {
+  try {
+    if (!fs.existsSync(patchPath)) return [];
+    const content = fs.readFileSync(patchPath, 'utf8');
+    const matches = Array.from(content.matchAll(/^\+\+\+ (?:b\/)?(.+)$/gm));
+    return matches.map((m) => m[1].trim()).filter((f) => f && f !== '/dev/null');
+  } catch (e) {
+    console.warn(`Failed to extract target files from patch ${patchPath}: ${e}`);
+    return [];
+  }
+}
+
+export interface PatchResult {
+  success: boolean;
+  error?: string;
+}
+
+/**
+ * Asynchronously applies a unified diff patch file to a target directory.
+ * Tries git apply first, falling back to standard patch -p1.
+ */
+export async function applyPatch(targetDir: string, patchPath: string): Promise<PatchResult> {
+  if (!fs.existsSync(patchPath)) {
+    return { success: false, error: `Patch file not found: ${patchPath}` };
+  }
+  if (!fs.existsSync(targetDir)) {
+    return { success: false, error: `Target directory not found: ${targetDir}` };
+  }
+
+  try {
+    await execAsync(`git apply --whitespace=nowarn "${patchPath}"`, { cwd: targetDir });
+    return { success: true };
+  } catch (gitErr: any) {
+    try {
+      await execAsync(`patch -p1 --no-backup-if-mismatch -i "${patchPath}"`, { cwd: targetDir });
+      return { success: true };
+    } catch (patchErr: any) {
+      const errorMsg = gitErr?.stderr?.toString() || patchErr?.stderr?.toString() || gitErr?.message || patchErr?.message || 'Unknown error applying patch';
+      return { success: false, error: errorMsg.trim() };
+    }
+  }
+}
+
+/**
+ * Synchronously applies a unified diff patch file to a target directory.
+ * Tries git apply first, falling back to standard patch -p1.
+ */
+export function applyPatchSync(targetDir: string, patchPath: string): PatchResult {
+  if (!fs.existsSync(patchPath)) {
+    return { success: false, error: `Patch file not found: ${patchPath}` };
+  }
+  if (!fs.existsSync(targetDir)) {
+    return { success: false, error: `Target directory not found: ${targetDir}` };
+  }
+
+  try {
+    execSync(`git apply --whitespace=nowarn "${patchPath}"`, { cwd: targetDir, stdio: 'pipe' });
+    return { success: true };
+  } catch (gitErr: any) {
+    try {
+      execSync(`patch -p1 --no-backup-if-mismatch -i "${patchPath}"`, { cwd: targetDir, stdio: 'pipe' });
+      return { success: true };
+    } catch (patchErr: any) {
+      const errorMsg = gitErr?.stderr?.toString() || patchErr?.stderr?.toString() || gitErr?.message || patchErr?.message || 'Unknown error applying patch';
+      return { success: false, error: errorMsg.trim() };
+    }
+  }
+}
+


### PR DESCRIPTION
## Overview
This PR implements **Phase 1 (Core Types, Guide Discovery, Polymorphic Routing & Patch Utilities)**, laying the foundational groundwork to transition our evaluation harness from shared root graders (`tasks/*.md`) to self-contained, **base-app specific evaluation capsules** (`targets/<base_app>/`).

## Details of Changes Made
- **Target Inventory Schema & Domain Renaming (`TargetInventory`)**: Introduced the `TargetInventory` schema on `GuideInventory`. Because we needed a clean schema to represent base-app targets, we took the opportunity to replace ambiguous legacy terminology (`demo`, `negative-demo`) with precise, domain-accurate terms: **`solution.patch`** (`hasSolution`) for the golden reference diff and **`broken.patch`** (`hasBroken`) for the negative starting state diff.
- **Polymorphic Routing (`inventoryGuide`, `classifyGuide`, `getTaskMap`)**: Indexes `targets/<base_app>/` capsules while preserving legacy guide support, enabling both schemas to run side-by-side on CI with zero breakage during incremental rollout.
- **Universal Patch Extractor (`extractTargetFilesFromPatch` in `lib/patch-utils.ts`)**: Parses modified file paths (`string[]`) from unified diff headers (`+++ b/<path>`), enabling our AST generator to scope static rules to edited files in Phase 2, and our runner to scope Option B dynamic AST assertions to agent-edited files in Phase 3.
- **Universal Patch Application (`applyPatch` & `applyPatchSync` in `lib/patch-utils.ts`)**: Fast, Git-native patch utilities (`git apply` with Unix `patch` fallback) designed to power temporary sandbox calibrations in Phase 2 and deduplicated `agent.patch` execution (~98% storage reduction) in Phase 3.

## What is the Next Phase?
**Phase 2** will build our automated authoring and calibration engine (`gd dev`, `testGrader`), spawning temporary git sandboxes to generate and validate base-app specific patch diffs (`solution.patch`, `broken.patch`), developer prompts (`task.md`), and scoped Playwright AST graders (`grader.ts`).

## Verification
- Ran `node --experimental-strip-types --test lib/*.test.ts harness/tests/*.test.ts`: **100% PASS** (20/20 tests passing across all suites).
- Note: The `harness/` workspace is 100% untouched by this PR.