### PR TITLE
Content ATL docs

### DIFF
--- a/.agents/skills/project-use-cases/SKILL.md
+++ b/.agents/skills/project-use-cases/SKILL.md
@@ -25,6 +25,9 @@ A "use case" in this project is not a description of a feature; it's a task that
 * **Break down complex features**: Conversely, do not cram multi-step, intricate features (like passkeys) into a single generic guide. Split them into logical, detailed use cases.
 * **UX-Driven, Not Feature-Driven**: Do not simply list every method, property, or option of an API as a separate use case. A use case must represent a distinct user experience goal or a distinct developer problem, not just a variation in API usage. If the implementation across proposed use cases is 90% identical, consolidate them.
 * **Avoid Forcing Use Cases on Low-Level Utilities**: If a feature is a low-level utility (like a new Promise method or a general object cloning function) that primarily acts as a drop-in replacement for legacy patterns, avoid forcing it into multiple outcome-oriented use cases. Instead, consider recommending a single 'Fundamental Guide' (e.g., "Deep cloning complex objects") or placing it in a top-level discipline skill file.
+* **Granular Guide Decomposition (Avoid Monoliths)**: For discipline-level guides, ensure the guidance is broken down into granular "subskills" (i.e., smaller, focused guides) rather than a single monolithic guide. Monolithic guides are too complex to evaluate in the harness, as they present too many best practices to test simultaneously. The primary discipline-level guide (e.g., `guides/css/css/guide.md` or `guides/performance/performance/guide.md`) should serve as a conceptual "hub" that establishes the agent's mental model for the discipline, explaining when and how to reference each granular subskill guide, and linking them via the `{{ GUIDE_REF("guide-slug") }}` macro.
+
+
 
 
 ## Minimizing overlap

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -17,7 +17,8 @@ Last updated: 2026-03-06.
 
 ### People involved
 
-- **~15 subject matter experts**: Google engineers with deep knowledge of specific web features. They write the guides, demo files, and expectations. They contribute via PRs into the `guides/` directory.
+- **Content Area Tech Leads (Content ATLs)**: Domain experts who oversee individual categories (Performance, Forms, Accessibility, etc.), review PRs, triage content quality issues, and manage the category's health.
+- **~15 subject matter experts (SMEs)**: Google engineers with deep knowledge of specific web features. They write the guides, demo files, and expectations. They contribute via PRs into the `guides/` directory.
 - **~3 infrastructure engineers** (Paul, Rick, Micah, and others): Maintain the CLI tooling, eval harness, MCP server, dashboard, and grader generation pipeline.
 
 ### Repository structure
@@ -303,11 +304,13 @@ The architecture is designed so that each group can work independently without n
 
 **Subject Matter Experts (SMEs)** focus exclusively on technical accuracy: understanding edge cases of a web feature, writing clear guidance, building a canonical demo, and defining testable expectations. They are shielded from the underlying Playwright infrastructure and do not need to be functional test engineers. Their deliverables are `guide.md`, `expectations.md`, and `demo.html`.
 
+**Content Area Tech Leads (Content ATLs)** act as domain-level owners for entire categories (Performance, Layout, Forms, etc.). They ensure category health, research gaps, triage content quality/failures, and author or review all guidance written in their area.
+
 **Infrastructure Engineers** focus on the reliability of the `gd` CLI, the evaluation harness, LLM invocation stability, MCP server correctness, and diagnosing systemic issues (e.g., why guided vs. unguided pass rates show no delta for a particular category of guide).
 
-**The LLM Pipeline (`gd dev`)** bridges the gap between human-authored guidance and the automated evaluation harness. It translates natural-language expectations into executable Playwright test assertions and scaffolds negative test cases, absorbing the friction of maintaining the testing infrastructure. When calibration fails, the retry loop handles most issues automatically — the SME should not need to understand why a Playwright selector was flaky.
+**The LLM Pipeline (`gd dev`)** bridges the gap between human-authored guidance and the automated evaluation harness. It translates natural-language expectations into executable Playwright test assertions and scaffolds negative test cases, absorbing the friction of maintaining the testing infrastructure. When calibration fails, the retry loop handles most issues automatically — the SME/ATL should not need to understand why a Playwright selector was flaky.
 
-The boundary is intentionally drawn so that SMEs never need to write or debug Playwright code, and infra engineers rarely need to understand the specifics of a web feature. The `gd dev` pipeline is the interface between these two worlds.
+The boundary is intentionally drawn so that SMEs/ATLs never need to write or debug Playwright code, and infra engineers rarely need to understand the specifics of a web feature. The `gd dev` pipeline is the interface between these two worlds.
 
 ---
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -304,7 +304,9 @@ The architecture is designed so that each group can work independently without n
 
 **Subject Matter Experts (SMEs)** focus exclusively on technical accuracy: understanding edge cases of a web feature, writing clear guidance, building a canonical demo, and defining testable expectations. They are shielded from the underlying Playwright infrastructure and do not need to be functional test engineers. Their deliverables are `guide.md`, `expectations.md`, and `demo.html`.
 
-**Content Area Tech Leads (Content ATLs)** act as domain-level owners for entire categories (Performance, Layout, Forms, etc.). They ensure category health, research gaps, triage content quality/failures, and author or review all guidance written in their area.
+**Content Area Tech Leads (Content ATLs)** act as domain-level owners for entire categories (Performance, Layout, Forms, etc.). They ensure category health, research gaps, triage content quality/failures, author or review all guidance written in their area, and are responsible for ensuring that all guidance is eval-ready. Their full expectations and responsibilities are detailed in [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+
 
 **Infrastructure Engineers** focus on the reliability of the `gd` CLI, the evaluation harness, LLM invocation stability, MCP server correctness, and diagnosing systemic issues (e.g., why guided vs. unguided pass rates show no delta for a particular category of guide).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,13 @@ Content ATLs are responsible for the overall quality, completeness, and health o
   * Troubleshoot and resolve bug reports or quality feedback reported by the developer community.
 * **Use Case Validation**:
   * Triage and align on proposed new use cases within their category before authoring begins.
+* **Evaluation Readiness & Expectations Sync**:
+  * Ensure all guides within their category are fully "eval-ready". While the engineering team is responsible for implementing/maintaining the evaluation harness and tasks, Content ATLs must verify that the natural-language assertions in `expectations.md` are kept perfectly in sync with the recommendations and code examples in `guide.md`, as the harness uses these expectations to generate the automated Playwright grader.
+* **Baseline & Fallback Alignment**:
+  * Align all guidance and expectations with a **Baseline Widely available** target. If a recommended feature is not yet widely available, the guide **must** specify (and the expectations/grader **must** test for) proper fallback strategies and progressive enhancement.
+* **Discipline Guide Decomposition**:
+  * Ensure discipline-level skills (e.g., CSS, JS) are broken up into modular "subskills" (i.e., smaller, focused guides) rather than structured as a single monolithic guide. Monolithic guides are too complex to evaluate in the harness, as they present too many best practices to test simultaneously.
+  * The primary discipline-level guide (e.g., `guides/css/css/guide.md` or `guides/performance/performance/guide.md`) should serve as a conceptual "hub" that establishes the agent's mental model for how to approach the discipline, explaining when and how to reference each granular subskill guide, and linking them via the `{{ GUIDE_REF("guide-slug") }}` macro.
 
 ### Infrastructure Engineers
 Infrastructure engineers focus on the tooling, CLI, test harness reliability, LLM generation pipelines, and dashboard interfaces. They ensure that the evaluation runner is stable, calibration retries function correctly, and maintain the MCP and CLI distribution paths.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,36 @@ To foster an open-source contributor environment while maintaining a stable, cle
 We want to encourage contributions while maintaining high standards. Our policy is:
 * **Proposal first**: For non-trivial changes, contributors need to to [open an issue first](https://github.com/GoogleChrome/modern-web-guidance-src/issues) to align on design before coding.
 
+## Project Roles
+
+To maintain high quality and coordinate efforts across the repository, the project defines the following key roles:
+
+### Subject Matter Experts (SMEs)
+SMEs focus on the technical accuracy and completeness of individual guides. They understand the edge cases of specific web features, write clear guidance, build canonical HTML/CSS/JS demos, and define testable expectations. Their primary deliverables are `guide.md`, `expectations.md`, and `demo.html`.
+
+### Content Area Tech Leads (Content ATLs)
+Content ATLs are responsible for the overall quality, completeness, and health of guidance within a specific domain category (e.g., Performance, CSS Layout, Forms & UI, Accessibility). Their expectations and responsibilities include:
+* **Subject Matter Expertise**:
+  * Possess domain-level expertise spanning the entire scope of their category.
+  * Serve as the primary technical point of contact to weigh in on any related architectural or technical questions.
+* **Authoring & Peer Review**:
+  * Act as the primary author or designated reviewer/approver for all guide content created within their area.
+  * Author high-quality guidance for new use cases.
+  * Review and approve guidance pull requests submitted by other contributors.
+* **Coverage Strategy**:
+  * Research and identify gaps where new guidance needs to be developed to address low agent performance or quality issues.
+* **Continuous Content Maintenance**:
+  * Update and evolve guidance as new web standards, browser features, and best practices emerge.
+  * Refactor or prune guidance if evaluation metrics indicate it is redundant or no longer necessary (e.g., if modern models naturally follow the best practice without guidance).
+* **Issue & Quality Triage**:
+  * Actively investigate and triage evaluation failures related to content quality or accuracy.
+  * Troubleshoot and resolve bug reports or quality feedback reported by the developer community.
+* **Use Case Validation**:
+  * Triage and align on proposed new use cases within their category before authoring begins.
+
+### Infrastructure Engineers
+Infrastructure engineers focus on the tooling, CLI, test harness reliability, LLM generation pipelines, and dashboard interfaces. They ensure that the evaluation runner is stable, calibration retries function correctly, and maintain the MCP and CLI distribution paths.
+
 ## Development Setup
 
 This project is managed as a **pnpm workspace**. To set up your local environment:


### PR DESCRIPTION
Introduce and document a new contributor role called Content Area Tech Lead (Content ATL)

Next step is to start naming contributors as the Content ATLs for specific categories