### PR TITLE
Skip metadata validation for stubs

### DIFF
--- a/lib/guide-validation.ts
+++ b/lib/guide-validation.ts
@@ -217,8 +217,8 @@ export function processGuideInventory(guides: GuideInventory[]): GuideInventoryR
       guideData = validation.data;
       guideBody = validation.body;
 
-      if (isDisciplineSkill || isDisciplineGuide) {
-        // Discipline skills/guides don't require the same frontmatter as use cases
+      if (isDisciplineSkill || isDisciplineGuide || !hasGuide) {
+        // Discipline skills/guides and stubs don't require the same frontmatter as use cases
         guideErrors = guideErrors.filter(e => !e.includes('Missing "web-feature-ids"') && !e.includes('Missing "description"'));
       }
 


### PR DESCRIPTION
Skips errors about missing web feature ids or description from stub guides. See #1002 for discussion about relaxing this check further.

Alternative of #1004, which makes web-feature ids optional across all guides (and keeps the description check).

If we want to keep the description check and only drop the web-feature-ids check, it's an easy fix.

Tiny PR, only +2/-2.