### PR TITLE
Make web-feature ids optional across all guides

### DIFF
--- a/guides/sync-use-cases.test.ts
+++ b/guides/sync-use-cases.test.ts
@@ -70,7 +70,7 @@ Body content.
     assert.ok(result.errors.some((e: string) => /Missing "description"/.test(e)));
   });
 
-  test('returns error for missing web-feature-ids', () => {
+  test('allows missing web-feature-ids (now optional)', () => {
     const filePath = writeTempGuide(`---
 name: my-use-case
 description: A description
@@ -78,7 +78,7 @@ description: A description
 Body content.
 `);
     const result = validateGuide(filePath);
-    assert.ok(result.errors.some((e: string) => /Missing "web-feature-ids"/.test(e)));
+    assert.ok(!result.errors.some((e: string) => /web-feature-ids/.test(e)));
   });
 
   test('returns error when web-feature-ids is not an array', () => {
@@ -155,7 +155,6 @@ web-feature-ids:
     const result = validateGuide(filePath);
     assert.ok(result.errors.some((e: string) => /Missing "name"/.test(e)));
     assert.ok(result.errors.some((e: string) => /Missing "description"/.test(e)));
-    assert.ok(result.errors.some((e: string) => /Missing "web-feature-ids"/.test(e)));
   });
 
   test('returns error for BASELINE_STATUS macro with invalid feature ID', () => {

--- a/lib/guide-validation.ts
+++ b/lib/guide-validation.ts
@@ -99,14 +99,12 @@ export function validateGuide(filePath: string): ValidationResult {
     errors.push(`Missing "description" in frontmatter for ${relativePath}.`);
   }
 
+  // web-feature-ids is optional: a use case may be proposed before its features
+  // are known, or may not map to a specific feature. Validate only when present.
   const featureIds = data['web-feature-ids'];
-  if (featureIds === undefined) {
-    errors.push(
-      `Missing "web-feature-ids" in frontmatter for ${relativePath}.`,
-    );
-  } else if (!Array.isArray(featureIds)) {
+  if (featureIds !== undefined && !Array.isArray(featureIds)) {
     errors.push(`"web-feature-ids" must be an array in ${relativePath}.`);
-  } else {
+  } else if (Array.isArray(featureIds)) {
     for (const id of featureIds) {
       const result = validateFeature(id);
       if (!result.isValid) {
@@ -218,8 +216,9 @@ export function processGuideInventory(guides: GuideInventory[]): GuideInventoryR
       guideBody = validation.body;
 
       if (isDisciplineSkill || isDisciplineGuide) {
-        // Discipline skills/guides don't require the same frontmatter as use cases
-        guideErrors = guideErrors.filter(e => !e.includes('Missing "web-feature-ids"') && !e.includes('Missing "description"'));
+        // Discipline skills/guides don't require a description like use cases do.
+        // (web-feature-ids is now optional for everyone, so no longer filtered here.)
+        guideErrors = guideErrors.filter(e => !e.includes('Missing "description"'));
       }
 
       if (guideErrors.length > 0) {


### PR DESCRIPTION
Alternative of #1003 (which only makes web-feature ids optional for stubs), depending on the outcome of the discussion around #1002.

Small change: +3/-7 excluding comments and tests.