### PR TITLE
feat: Add search query to telemetry logging

### DIFF
--- a/serving/bin/modern-web.ts
+++ b/serving/bin/modern-web.ts
@@ -63,7 +63,7 @@ async function main() {
 
   if (command === "search") {
     if (!arg) {
-      await getLogger().logSearchResult(0, false, []);
+      await getLogger().logSearchResult("", 0, false, []);
       console.error("No search query provided.");
       process.exit(1);
     }
@@ -78,7 +78,7 @@ async function main() {
         guide_id: r.id,
         similarity: Number(r.similarity),
       }));
-      await getLogger().logSearchResult(latencyMs, true, searchItems);
+      await getLogger().logSearchResult(arg, latencyMs, true, searchItems);
 
       if (results.length === 0) {
         console.log("[]");
@@ -90,7 +90,7 @@ async function main() {
       }
     } catch (error) {
       const latencyMs = Date.now() - startTime;
-      await getLogger().logSearchResult(latencyMs, false, []);
+      await getLogger().logSearchResult(arg, latencyMs, false, []);
       console.error("Search failed:", error);
       process.exit(1);
     }

--- a/serving/skills-cli/telemetry/ClearcutLogger.test.ts
+++ b/serving/skills-cli/telemetry/ClearcutLogger.test.ts
@@ -118,6 +118,30 @@ describe('ClearcutLogger', () => {
       sendMock.mock.restore();
     }
   });
+
+  it('logs search results correctly via watchdog', async () => {
+    const sentMessages: any[] = [];
+    const sendMock = mock.method(WatchdogClient.prototype, 'send', (msg: any) => {
+      sentMessages.push(msg);
+    });
+
+    try {
+      const logger = new ClearcutLogger({ skillVersion: '2026_05_14-search' });
+      await logger.logSearchResult('address form', 80, true, [{ guide_id: 'guide-1', similarity: 0.9 }]);
+
+      assert.ok(sentMessages.length > 0, 'Should send at least one message to watchdog');
+      const payload = sentMessages[sentMessages.length - 1].payload;
+      assert.deepStrictEqual(payload.search_result, {
+        query: 'address form',
+        search_items: [{ guide_id: 'guide-1', similarity: 0.9 }]
+      });
+      assert.strictEqual(payload.success, true);
+      assert.strictEqual(payload.latency_ms, 100); // 80 bucketized to 100
+      assert.strictEqual(payload.skill_version, '2026_05_14-search');
+    } finally {
+      sendMock.mock.restore();
+    }
+  });
 });
 
 describe('Installation output parser regex', () => {

--- a/serving/skills-cli/telemetry/ClearcutLogger.ts
+++ b/serving/skills-cli/telemetry/ClearcutLogger.ts
@@ -61,13 +61,14 @@ export class ClearcutLogger {
     });
   }
 
-  async logSearchResult(latencyMs: number, success: boolean, searchItems: SearchItem[]): Promise<void> {
+  async logSearchResult(query: string, latencyMs: number, success: boolean, searchItems: SearchItem[]): Promise<void> {
     if (!this.#watchdog) {
       return;
     }
 
     const payload: ChromeModernWebGuidance = {
       search_result: {
+        query,
         search_items: searchItems,
       },
       os: detectOS(),

--- a/serving/skills-cli/telemetry/types.ts
+++ b/serving/skills-cli/telemetry/types.ts
@@ -11,6 +11,7 @@ export interface SearchItem {
 }
 
 export interface SearchResult {
+  query?: string;
   search_items?: SearchItem[];
 }
 


### PR DESCRIPTION
Add the agent's search query to SearchResult so that we can track what real-world agent queries are returning no guides