### PR TITLE
feat(eval-view): add run comparison dashboard UI (3/3)

### DIFF
--- a/eval-view/README.md
+++ b/eval-view/README.md
@@ -39,6 +39,27 @@ To ensure your changes will work on the static deployment host, you can run the 
 STATIC=true gd dashboard
 ```
 
+## Guide Run Comparison Architecture
+
+The Guide Run Comparison feature (`gd compare` CLI and the `compare.html` UI) enables side-by-side behavioral, assertion, code diff, and diagnostic comparisons between two evaluation runs (e.g., comparing a local development run against a nightly baseline, or comparing guided vs. unguided runs).
+
+**NOTE:** Guide Run comparison works on local runs only. This will get fixed in the future.
+
+### Backend Pipeline (`gd compare` & `harness/lib/compare-evals.ts`)
+* **Data Extraction & Preprocessing:** Loads run metadata (`score`, `agent`, `model`, `initialPrompt`), Playwright assertion results (`*_results.json`), execution logs (`modern-web.log`, `.db`, `chat_log.txt`), and trajectory steps (`trajectory_summary.json`). Categorizes steps into milestones: Guide Retrieval, Skill Search, Code Mutation, Mandatory Rule Adoption, and Context Noise.
+* **Three-Way Unified LCS Diffing:** Generates aligned unified diffs (`Base App vs Run A`, `Base App vs Run B`, and `Run A vs Run B`) via `generateUnifiedDiff` to prevent diagnostic models from hallucinating deleted or corrupted code relative to the base application.
+* **Three-Phase Modular Diagnostic (`runComparison`):**
+  - **Guide Compliance Auditor (Sub-Agent 1):** Evaluates skill discovery specificity, guide retrieval confirmation, launch prompt validity, and mandatory rule adoption against `guide.md` and `expectations.md`.
+  - **Code & Friction Diagnostic (Sub-Agent 2):** Audits initial launch prompts (`initialPrompt` / `ARGUMENTS:`), inspects exact `grader.ts` failure traces, verifies tool execution status (`status: success`), and separates structural test harness mismatches (e.g., `button:visible` vs `<a>`) from genuine capability loss.
+  - **Synthesizer:** Merges fact-grounded outputs into a standardized 4-section executive report (`First Meaningful Divergence`, `Guide Compliance Matrix`, `Root Cause & Friction Analysis`, and `Actionable Fix Recommendations`).
+
+### Frontend Comparison UI (`compare.html` & `compare.js`)
+* **Split-Pane Navigation Tabs:**
+  - **Assertions Comparison:** Side-by-side check of Playwright test assertions (`PASSED` vs `FAILED`) with drill-downs into exact error traces.
+  - **Trajectory Timeline:** Side-by-side step visualizer displaying agent reasoning (`step-thought`), tool executions (`step-action`), and enriched tool results (`step-outcome.output` / `modern-web.log`) alongside direct deep-links (`Open Full Step Result`) into complete trajectory HTML sessions (`session-*.html`).
+  - **Code Diffs:** Interactive rendering of unified diff hunks across all three comparison axes.
+* **Live LLM Diagnosis:** Displays the 4-section executive diagnostic report. When running locally (`gd dashboard`), users can trigger on-the-fly diagnoses (`/api/run-comparison`) that stream terminal execution progress and markdown synthesis directly into the browser in real time.
+
 ## Deploying Changes
 
 If you make modifications to the `eval-view` code (HTML, CSS, JS), you can deploy your changes directly to the live GitHub Pages site using the built-in deploy script.

--- a/eval-view/compare.html
+++ b/eval-view/compare.html
@@ -1,0 +1,712 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Cross-Run Performance Variance Diagnosis</title>
+  <link rel="stylesheet" href="dashboard.css">
+  <style>
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background-color: #f8fafc;
+      color: #0f172a;
+    }
+    .compare-container {
+      max-width: 100%;
+      width: 100%;
+      margin: 0;
+      padding: 20px 30px;
+      box-sizing: border-box;
+    }
+
+    .header-bar {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 20px;
+      padding-bottom: 15px;
+      border-bottom: 1px solid #e2e8f0;
+    }
+    .back-btn {
+      background-color: #f1f5f9;
+      color: #475569;
+      border: 1px solid #cbd5e1;
+      padding: 8px 16px;
+      border-radius: 6px;
+      cursor: pointer;
+      text-decoration: none;
+      font-weight: 500;
+      font-size: 0.9em;
+      transition: all 0.2s;
+    }
+    .back-btn:hover {
+      background-color: #e2e8f0;
+    }
+    .page-title {
+      font-size: 1.5rem;
+      font-weight: 700;
+      margin: 0;
+      color: #1e293b;
+    }
+    
+    /* Executive Summary Panel */
+    .exec-summary {
+      background-color: #ffffff;
+      border: 1px solid #e2e8f0;
+      border-radius: 12px;
+      padding: 20px;
+      margin-bottom: 20px;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+    }
+    .summary-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 20px;
+      margin-top: 15px;
+    }
+    .summary-card {
+      background-color: #f8fafc;
+      border: 1px solid #f1f5f9;
+      border-radius: 8px;
+      padding: 15px;
+    }
+    .summary-card h4 {
+      margin: 0 0 10px 0;
+      color: #64748b;
+      font-size: 0.85em;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+    .trial-title {
+      font-size: 1.1em;
+      font-weight: 600;
+      color: #1e293b;
+      margin-bottom: 5px;
+    }
+    .trial-meta {
+      font-size: 0.85em;
+      color: #64748b;
+    }
+    .score-badge {
+      display: inline-block;
+      padding: 6px 12px;
+      border-radius: 9999px;
+      font-weight: 700;
+      font-size: 1.1em;
+      margin-top: 10px;
+    }
+    .score-high { background-color: #dcfce7; color: #166534; }
+    .score-low { background-color: #fee2e2; color: #991b1b; }
+    
+    /* LLM Diagnosis Report */
+    .diagnosis-report {
+      background-color: #fffbeb;
+      border: 1px solid #fde68a;
+      border-radius: 12px;
+      padding: 25px;
+      margin-bottom: 20px;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+    }
+    .diagnosis-title {
+      font-size: 1.25rem;
+      font-weight: 700;
+      color: #92400e;
+      margin-top: 0;
+      margin-bottom: 15px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .diagnosis-content {
+      line-height: 1.6;
+      color: #78350f;
+    }
+    .diagnosis-content p {
+      margin-top: 0;
+      margin-bottom: 15px;
+    }
+    .diagnosis-content pre {
+      background: #fff;
+      border: 1px solid #fef3c7;
+      padding: 12px;
+      border-radius: 6px;
+      overflow-x: auto;
+    }
+    .diagnosis-content h3 {
+      font-size: 1.1em;
+      margin-top: 20px;
+      margin-bottom: 10px;
+      color: #92400e;
+    }
+    
+    /* Horizontal Task Selector Bar */
+    .task-bar-container {
+      background-color: #ffffff;
+      border: 1px solid #e2e8f0;
+      border-radius: 12px;
+      padding: 12px 20px;
+      display: flex;
+      align-items: center;
+      gap: 15px;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+    }
+    .task-bar-label {
+      font-size: 0.82em;
+      font-weight: 700;
+      color: #64748b;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      white-space: nowrap;
+    }
+    .task-list {
+      display: flex;
+      flex-direction: row;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+    .task-btn {
+      background-color: #f8fafc;
+      border: 1px solid #cbd5e1;
+      padding: 6px 14px;
+      border-radius: 6px;
+      text-align: center;
+      cursor: pointer;
+      font-size: 0.88em;
+      font-weight: 500;
+      color: #475569;
+      transition: all 0.2s;
+    }
+    .task-btn:hover {
+      background-color: #f1f5f9;
+      color: #1e293b;
+    }
+    .task-btn.active {
+      background-color: #eff6ff;
+      border-color: #2563eb;
+      color: #1d4ed8;
+      font-weight: 600;
+    }
+    
+    /* Diagnostic Tabs & Content */
+    .diagnostic-pane {
+      background-color: #ffffff;
+      border: 1px solid #e2e8f0;
+      border-radius: 12px;
+      padding: 20px;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+      width: 100%;
+    }
+    .tab-bar {
+      display: flex;
+      gap: 8px;
+      border-bottom: 1px solid #e2e8f0;
+      padding-bottom: 12px;
+      margin-bottom: 20px;
+    }
+    .tab-btn {
+      background-color: #f8fafc;
+      border: 1px solid #e2e8f0;
+      padding: 8px 16px;
+      border-radius: 6px;
+      cursor: pointer;
+      font-size: 0.9em;
+      font-weight: 500;
+      color: #64748b;
+      transition: all 0.2s;
+    }
+    .tab-btn:hover {
+      background-color: #f1f5f9;
+      color: #334155;
+    }
+    .tab-btn.active {
+      background-color: #2563eb;
+      border-color: #2563eb;
+      color: #ffffff;
+    }
+    
+    /* Side-by-Side Split View */
+    .split-view {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+      gap: 20px;
+      width: 100%;
+    }
+    .split-col {
+      border: 1px solid #e2e8f0;
+      border-radius: 8px;
+      padding: 15px;
+      background-color: #f8fafc;
+    }
+    .split-col-title {
+      font-weight: 600;
+      font-size: 1em;
+      color: #1e293b;
+      margin-bottom: 12px;
+      padding-bottom: 8px;
+      border-bottom: 2px solid #e2e8f0;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    
+    /* Code Diff Styles */
+    .code-container {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      font-size: 0.85em;
+      background-color: #0f172a;
+      color: #f8fafc;
+      padding: 15px;
+      border-radius: 6px;
+      overflow-x: auto;
+      white-space: pre;
+    }
+    
+    /* Hide scrollbars visually while keeping scroll functionality */
+    .no-scrollbar::-webkit-scrollbar {
+      display: none;
+    }
+    .no-scrollbar {
+      -ms-overflow-style: none;  /* IE and Edge */
+      scrollbar-width: none;  /* Firefox */
+    }
+    
+    /* Trajectory Timeline Styles */
+    .timeline-header-row {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+      gap: 20px;
+      margin-bottom: 15px;
+      width: 100%;
+    }
+    .timeline-header-col {
+      font-weight: 700;
+      font-size: 1.05em;
+      color: #1e293b;
+      padding-bottom: 8px;
+      border-bottom: 2px solid #cbd5e1;
+    }
+    .timeline-step-row {
+      margin-bottom: 24px;
+      width: 100%;
+    }
+    .timeline-cols-grid {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+      gap: 20px;
+      align-items: flex-start;
+      width: 100%;
+    }
+    .timeline-col {
+      display: flex;
+      flex-direction: column;
+      min-width: 0;
+    }
+    .timeline-step {
+      background-color: #ffffff;
+      border: 1px solid #cbd5e1;
+      border-radius: 10px;
+      padding: 14px 16px;
+      position: relative;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+      height: auto !important;
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-start;
+    }
+    .timeline-step.error {
+      border-left: 6px solid #ef4444;
+    }
+    .timeline-step.success {
+      border-left: 6px solid #22c55e;
+    }
+    .timeline-step.divergence-card {
+      border: 2px solid #f59e0b;
+      border-left: 6px solid #d97706;
+      background-color: #fffbeb;
+      box-shadow: 0 4px 14px rgba(245, 158, 11, 0.2);
+    }
+    
+    /* Divergence Point Indicator Banner */
+    .divergence-banner {
+      grid-column: 1 / -1;
+      background-color: #fef3c7;
+      border: 1px solid #fde68a;
+      border-left: 5px solid #d97706;
+      border-radius: 8px;
+      padding: 10px 16px;
+      margin-bottom: 12px;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      box-shadow: 0 2px 6px rgba(217, 119, 6, 0.1);
+    }
+    .divergence-banner.primary {
+      background-color: #fef2f2;
+      border-color: #fecaca;
+      border-left-color: #dc2626;
+    }
+    .divergence-badge {
+      font-weight: 800;
+      font-size: 0.85em;
+      color: #991b1b;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      background: #fee2e2;
+      padding: 4px 10px;
+      border-radius: 4px;
+      border: 1px solid #fca5a5;
+    }
+    .divergence-desc {
+      font-size: 0.9em;
+      color: #7f1d1d;
+      font-weight: 500;
+    }
+
+    .timeline-empty-card {
+      background-color: #f8fafc;
+      border: 1px dashed #cbd5e1;
+      border-radius: 10px;
+      padding: 20px;
+      text-align: center;
+      color: #94a3b8;
+      font-size: 0.9em;
+      font-style: italic;
+    }
+
+    .step-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      font-size: 0.9em;
+      color: #475569;
+      margin-bottom: 12px;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      border-bottom: 1px solid #f1f5f9;
+      padding-bottom: 6px;
+    }
+    .step-thought {
+      font-size: 0.92rem;
+      line-height: 1.45;
+      color: #0f172a;
+      margin-bottom: 10px;
+      background-color: #f0f9ff;
+      border: 1px solid #bae6fd;
+      border-left: 4px solid #0284c7;
+      padding: 8px 12px;
+      border-radius: 6px;
+      white-space: pre-wrap;
+      word-break: break-word;
+      height: auto !important;
+      max-height: none;
+      flex-grow: 0 !important;
+    }
+    .step-thought-header {
+      font-weight: 800;
+      color: #0284c7;
+      font-size: 0.82em;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 4px;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+    .step-action {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      background-color: #f8fafc;
+      padding: 10px 14px;
+      border-radius: 8px;
+      font-size: 0.92em;
+      line-height: 1.5;
+      color: #1e293b;
+      margin-bottom: 10px;
+      border: 1px solid #e2e8f0;
+    }
+    .step-action-title {
+      font-weight: 700;
+      color: #2563eb;
+    }
+    .step-outcome {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      font-size: 0.88em;
+      line-height: 1.5;
+      color: #334155;
+      background-color: #f8fafc;
+      padding: 12px 14px;
+      border-radius: 8px;
+      border: 1px solid #cbd5e1;
+      white-space: pre-wrap;
+      word-break: break-word;
+      max-height: 400px;
+      overflow-y: auto;
+    }
+    .step-outcome.error {
+      color: #991b1b;
+      background-color: #fef2f2;
+      border-color: #fecaca;
+    }
+
+    /* Final Assistant Answer Card */
+    .final-answer-card {
+      background-color: #0f172a;
+      border: 1px solid #1e293b;
+      border-left: 6px solid #22c55e;
+      border-radius: 10px;
+      padding: 18px 20px;
+      color: #f8fafc;
+      box-shadow: 0 4px 14px rgba(0,0,0,0.15);
+      height: 100%;
+    }
+    .final-answer-header {
+      font-size: 0.85em;
+      font-weight: 800;
+      color: #94a3b8;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-bottom: 12px;
+      padding-bottom: 8px;
+      border-bottom: 1px solid #334155;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    .final-answer-body {
+      font-size: 0.95em;
+      line-height: 1.6;
+      color: #e2e8f0;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+    .final-answer-banner {
+      grid-column: 1 / -1;
+      background-color: #f0fdf4;
+      border: 1px solid #bbf7d0;
+      border-left: 5px solid #16a34a;
+      border-radius: 8px;
+      padding: 10px 16px;
+      margin-bottom: 12px;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+    .final-answer-badge {
+      font-weight: 800;
+      font-size: 0.85em;
+      color: #14532d;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      background: #dcfce7;
+      padding: 4px 10px;
+      border-radius: 4px;
+      border: 1px solid #86efac;
+    }
+
+    /* Assertion Table */
+    .assert-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.9em;
+    }
+    .assert-table th, .assert-table td {
+      padding: 10px;
+      border-bottom: 1px solid #e2e8f0;
+      text-align: left;
+    }
+    .assert-table th {
+      background-color: #f1f5f9;
+      color: #475569;
+      font-weight: 600;
+    }
+    .pass-icon { color: #22c55e; font-weight: bold; }
+    .fail-icon { color: #ef4444; font-weight: bold; }
+
+    /* Markdown Table Styles */
+    .markdown-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 15px;
+      margin-bottom: 15px;
+      font-size: 0.9em;
+      background-color: #ffffff;
+      border: 1px solid #cbd5e1;
+      border-radius: 8px;
+      overflow: hidden;
+    }
+    .markdown-table th, .markdown-table td {
+      padding: 10px 12px;
+      border-bottom: 1px solid #cbd5e1;
+    }
+    .markdown-table th {
+      background-color: #f1f5f9;
+      color: #475569;
+      font-weight: 600;
+      font-size: 0.85em;
+      text-transform: uppercase;
+      letter-spacing: 0.02em;
+    }
+    .markdown-table tr:last-child td {
+      border-bottom: none;
+    }
+    .markdown-table tbody tr:hover {
+      background-color: #f8fafc;
+    }
+
+    /* Loading Spinner */
+    .loading-container {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 100px 0;
+    }
+    .spinner {
+      border: 4px solid rgba(0, 0, 0, 0.1);
+      width: 48px;
+      height: 48px;
+      border-radius: 50%;
+      border-left-color: #3b82f6;
+      animation: spin 1s linear infinite;
+      margin-bottom: 20px;
+    }
+    @keyframes spin {
+      0% { transform: rotate(0deg); }
+      100% { transform: rotate(360deg); }
+    }
+  </style>
+</head>
+<body>
+  <div class="compare-container">
+    <div class="header-bar">
+      <div>
+        <a href="#" id="back-btn" class="back-btn">← Back to Guide Timeline</a>
+        <h1 class="page-title" id="compare-title">Cross-Run Variance Diagnosis</h1>
+      </div>
+      <div style="display:flex; align-items:center; gap:12px;">
+        <button id="export-btn" class="back-btn" style="background-color:#2563eb; color:#ffffff; border-color:#1d4ed8; cursor:pointer;" onclick="exportCompareReport()">📥 Export LLM Report</button>
+        <div id="loader-status" class="trial-meta"></div>
+      </div>
+    </div>
+
+    <!-- Executive Summary Panel -->
+    <div class="exec-summary">
+      <h2 style="margin-top:0; font-size:1.2rem; color:#1e293b; border-bottom:1px solid #f1f5f9; padding-bottom:8px;">Executive Comparison Summary</h2>
+      <div class="summary-grid">
+        <div class="summary-card" id="card-trial-a">
+          <h4>Trial A</h4>
+          <div class="trial-title" id="title-a">Loading...</div>
+          <div class="trial-meta" id="meta-a">-</div>
+          <div class="trial-agent-model" id="agent-model-a" style="font-size:0.85em; color:#475569; margin-top:5px; font-weight:500; word-break:break-all;">-</div>
+          <div style="display:flex; align-items:center; gap:6px; margin-top:8px;">
+            <span style="font-size:0.8em; color:#64748b; font-weight:600;">Type:</span>
+            <select id="run-type-a" style="padding:2px 6px; border-radius:4px; border:1px solid #cbd5e1; font-size:0.8em; background:#fff; color:#334155; font-weight:600; cursor:pointer;">
+              <option value="guided" selected>Guided</option>
+              <option value="unguided">Unguided</option>
+            </select>
+          </div>
+          <div id="score-badge-a" class="score-badge">--</div>
+        </div>
+        <div class="summary-card" id="card-trial-b">
+          <h4>Trial B</h4>
+          <div class="trial-title" id="title-b">Loading...</div>
+          <div class="trial-meta" id="meta-b">-</div>
+          <div class="trial-agent-model" id="agent-model-b" style="font-size:0.85em; color:#475569; margin-top:5px; font-weight:500; word-break:break-all;">-</div>
+          <div style="display:flex; align-items:center; gap:6px; margin-top:8px;">
+            <span style="font-size:0.8em; color:#64748b; font-weight:600;">Type:</span>
+            <select id="run-type-b" style="padding:2px 6px; border-radius:4px; border:1px solid #cbd5e1; font-size:0.8em; background:#fff; color:#334155; font-weight:600; cursor:pointer;">
+              <option value="guided" selected>Guided</option>
+              <option value="unguided">Unguided</option>
+            </select>
+          </div>
+          <div id="score-badge-b" class="score-badge">--</div>
+        </div>
+        <div class="summary-card">
+          <h4>Comparison Context</h4>
+          <div style="font-size: 0.95em; color:#334155; margin-top:5px;">
+            <div><strong>Guide:</strong> <a id="summary-guide-link" href="#" target="_blank" style="color:#2563eb; font-weight:600; text-decoration:underline;">-</a></div>
+            <div style="margin-top:8px;"><strong>Score Delta:</strong> <span id="summary-delta" style="font-weight:700;">-</span></div>
+            <div style="margin-top:8px;"><strong>Diagnosis Status:</strong> <span id="summary-status" style="font-weight:600; color:#475569;">Checking...</span></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- LLM Diagnosis Report -->
+    <div class="diagnosis-report" id="diagnosis-box" style="display:none;">
+      <div class="diagnosis-title">
+        <svg style="width:24px; height:24px;" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"></path>
+        </svg>
+        AI Diagnostic Explanation (Variance Diagnosis)
+      </div>
+      <div class="diagnosis-content" id="diagnosis-text">
+        Analyzing both runs and generating explanation. This may take up to 20 seconds...
+      </div>
+    </div>
+
+    <!-- Horizontal Task Selector Bar -->
+    <div class="task-bar-container">
+      <span class="task-bar-label">Tasks in Guide:</span>
+      <div class="task-list" id="task-sidebar-list">
+        <!-- Populated by JS -->
+      </div>
+    </div>
+
+    <!-- Main workspace -->
+    <div class="diagnostic-pane" style="margin-top: 20px;">
+        <div class="tab-bar">
+          <button class="tab-btn active" data-tab="assertions" onclick="switchTab('assertions')">Assertions Comparison</button>
+          <button class="tab-btn" data-tab="timeline" onclick="switchTab('timeline')">Trajectory Timeline</button>
+          <button class="tab-btn" data-tab="code" onclick="switchTab('code')">Code Output Diff</button>
+        </div>
+
+        <!-- Content sections -->
+        <div id="compare-loading" class="loading-container">
+          <div class="spinner"></div>
+          <div style="color:#64748b; font-weight:500;">Loading task details...</div>
+        </div>
+
+        <div id="tab-content-assertions" style="display:none;">
+          <table class="assert-table">
+            <thead>
+              <tr>
+                <th style="width: 50%;">Assertion Check</th>
+                <th style="width: 25%;" id="header-assert-a">Trial A</th>
+                <th style="width: 25%;" id="header-assert-b">Trial B</th>
+              </tr>
+            </thead>
+            <tbody id="assert-tbody">
+              <!-- Populated by JS -->
+            </tbody>
+          </table>
+        </div>
+
+        <!-- Trajectory Timeline Section -->
+        <div id="tab-content-timeline" style="display:none; width: 100%;">
+          <!-- Populated as aligned step rows by JS -->
+        </div>
+
+        <!-- Code Output Diff Section -->
+        <div id="tab-content-code" style="display:none; width: 100%;">
+          <div class="split-view">
+            <div class="split-col">
+              <div class="split-col-title" id="code-title-a">Trial A Code Output</div>
+              <div class="code-container" id="code-a">
+                <!-- Code -->
+              </div>
+            </div>
+            <div class="split-col">
+              <div class="split-col-title" id="code-title-b">Trial B Code Output</div>
+              <div class="code-container" id="code-b">
+                <!-- Code -->
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  <script type="module" src="compare.js"></script>
+</body>
+</html>

--- a/eval-view/compare.html
+++ b/eval-view/compare.html
@@ -633,15 +633,22 @@
     </div>
 
     <!-- LLM Diagnosis Report -->
-    <div class="diagnosis-report" id="diagnosis-box" style="display:none;">
-      <div class="diagnosis-title">
-        <svg style="width:24px; height:24px;" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"></path>
-        </svg>
-        AI Diagnostic Explanation (Variance Diagnosis)
+    <div class="diagnosis-report" id="diagnosis-box" style="display:block;">
+      <div style="display:flex; justify-content:space-between; align-items:center; flex-wrap:wrap; gap:10px;">
+        <div class="diagnosis-title" style="margin-bottom:0;">
+          <svg style="width:24px; height:24px;" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"></path>
+          </svg>
+          AI Diagnostic Explanation (Variance Diagnosis)
+        </div>
+        <button id="run-diagnosis-btn" class="back-btn" style="background-color:#7c3aed; color:#ffffff; border-color:#6d28d9; font-weight:600; cursor:pointer; display:flex; align-items:center; gap:8px;" onclick="runDiagnosticAgent()">
+          ✨ Run AI Diagnosis
+        </button>
       </div>
-      <div class="diagnosis-content" id="diagnosis-text">
-        Analyzing both runs and generating explanation. This may take up to 20 seconds...
+      <div class="diagnosis-content" id="diagnosis-text" style="margin-top:12px;">
+        <div style="color:#64748b; font-size:0.95em;">
+          Click <strong>"Run AI Diagnosis"</strong> above to dispatch the 3-phase AI variance analysis (Compliance Audit + Code & Friction Diagnostic) for this task comparison.
+        </div>
       </div>
     </div>
 

--- a/eval-view/compare.js
+++ b/eval-view/compare.js
@@ -299,12 +299,12 @@ function initParams() {
 }
 
 /**
- * Handles reloading of workspace files and running diagnosis when run type is toggled.
+ * Handles reloading of workspace files and resetting diagnosis state when run type is toggled.
  */
 async function handleRunTypeChange() {
   updateExecutiveSummary();
   await loadActiveTaskDetails();
-  await runDiagnosticAgent();
+  resetDiagnosisUI();
 }
 
 async function ensureRunDirectories(dirA, dirB) {
@@ -456,8 +456,8 @@ async function loadTrialMetadata() {
   // Load active task details
   await loadActiveTaskDetails();
 
-  // Trigger Diagnosis
-  await runDiagnosticAgent();
+  // Reset Diagnosis UI state
+  resetDiagnosisUI();
 }
 
 function checkTaskInSuite(suiteData, task) {
@@ -581,7 +581,7 @@ async function switchTask(task) {
   });
 
   await loadActiveTaskDetails();
-  await runDiagnosticAgent();
+  resetDiagnosisUI();
 }
 
 function getRunDateString(trialId) {
@@ -1325,10 +1325,44 @@ function switchTab(tab) {
   }
 }
 
+function resetDiagnosisUI() {
+  const diagnosisText = document.getElementById('diagnosis-text');
+  const statusSpan = document.getElementById('summary-status');
+  const runBtn = /** @type {HTMLButtonElement | null} */ (document.getElementById('run-diagnosis-btn'));
+
+  if (runBtn) {
+    runBtn.disabled = false;
+    runBtn.innerHTML = '✨ Run AI Diagnosis';
+  }
+  if (statusSpan) {
+    statusSpan.innerText = 'Ready';
+    statusSpan.style.color = '#64748b';
+  }
+  if (diagnosisText) {
+    diagnosisText.innerHTML = `
+      <div style="color:#64748b; font-size:0.95em;">
+        Click <strong>"Run AI Diagnosis"</strong> above to dispatch the 3-phase AI variance analysis (Compliance Audit + Code & Friction Diagnostic) for this task comparison.
+      </div>
+    `;
+  }
+}
+
 async function runDiagnosticAgent() {
   const diagnosisBox = document.getElementById('diagnosis-box');
   const diagnosisText = document.getElementById('diagnosis-text');
   const statusSpan = document.getElementById('summary-status');
+  const runBtn = /** @type {HTMLButtonElement | null} */ (document.getElementById('run-diagnosis-btn'));
+
+  const relativeA = `${trialA}/${runNumA}/${guideName}/${activeTask}/${runTypeA}`;
+  const relativeB = `${trialB}/${runNumB}/${guideName}/${activeTask}/${runTypeB}`;
+
+  if (runBtn) {
+    runBtn.disabled = true;
+    runBtn.innerHTML = `
+      <div class="spinner" style="width:14px; height:14px; border-width:2px; margin-bottom:0; display:inline-block; vertical-align:middle; border-left-color:#fff;"></div>
+      <span>Running Diagnosis...</span>
+    `;
+  }
 
   diagnosisBox.style.display = 'block';
   diagnosisText.innerHTML = `
@@ -1340,66 +1374,60 @@ async function runDiagnosticAgent() {
   statusSpan.innerText = 'Analyzing Runs...';
   statusSpan.style.color = '#d97706';
 
-  // If in static mode, we fetch pre-generated markdown
-  if (isStatic) {
-    const resultsBase = 'results';
-    // Format is results/test_xxx/variance_diagnoses/guideName-taskName-guided.md
-    // Since we don't know the exact taskName or runType, we'll construct the filename:
-    const fileName = `${guideName}-${activeTask}-guided.md`;
-    const url = `${resultsBase}/${trialA}/variance_diagnoses/${fileName}`;
-    
-    try {
-      const response = await fetch(url);
-      if (response.ok) {
-        const markdown = await response.text();
-        diagnosisText.innerHTML = renderMarkdown(markdown);
-        statusSpan.innerText = 'Completed';
-        statusSpan.style.color = '#166534';
-      } else {
-        diagnosisText.innerHTML = `
-          <div style="color:#b91c1c; font-weight:600;">Diagnostic report not pre-generated for this run combination.</div>
-          <div style="font-size:0.9em; margin-top:5px; color:#475569;">
-            Running in STATIC mode. On-the-fly LLM comparison is only available when running the dashboard locally via <code>pnpm dashboard</code>.
-            To generate this report locally, run:
-            <pre style="background:#fff; border:1px solid #fecaca; margin-top:8px; padding:10px; border-radius:4px; font-family:monospace;">gd compare ${trialA}/${runNumA}/${guideName}/${activeTask}/guided ${trialB}/${runNumB}/${guideName}/${activeTask}/guided</pre>
-          </div>
-        `;
-        statusSpan.innerText = 'Not Pre-generated';
-        statusSpan.style.color = '#b91c1c';
-      }
-    } catch (e) {
-      diagnosisText.innerText = 'Failed to load pre-generated diagnostic report.';
-      statusSpan.innerText = 'Error';
-    }
-    return;
-  }
-
-  // Local Mode: Call Node dev server API to run comparison on the fly!
-  const hasTaskA = suiteDataA ? checkTaskInSuite(suiteDataA, activeTask) : true;
-  const hasTaskB = suiteDataB ? checkTaskInSuite(suiteDataB, activeTask) : true;
-
-  if (suiteDataA && suiteDataB && (!hasTaskA || !hasTaskB)) {
-    const missingIn = !hasTaskA && !hasTaskB ? 'both trials' : !hasTaskA ? 'Trial A' : 'Trial B';
-    const presentIn = !hasTaskA ? 'Trial B' : 'Trial A';
-    diagnosisText.innerHTML = `
-      <div style="color:#92400e; font-weight:600;">Cross-trial comparison unavailable for this task.</div>
-      <div style="font-size:0.9em; margin-top:5px; color:#78350f;">
-        Task <code>${escapeHtml(activeTask)}</code> was only executed in ${presentIn} and is not present in ${missingIn}.
-        To run an AI variance diagnosis, select a task that was executed in both trials.
-      </div>
-    `;
-    statusSpan.innerText = 'Single Trial Only';
-    statusSpan.style.color = '#64748b';
-    return;
-  }
-
-  // Use dynamic runTypeA and runTypeB values
-  const relativeA = `${trialA}/${runNumA}/${guideName}/${activeTask}/${runTypeA}`;
-  const relativeB = `${trialB}/${runNumB}/${guideName}/${activeTask}/${runTypeB}`;
-
-  const apiUrl = `/api/compare?runDirA=${encodeURIComponent(relativeA)}&runDirB=${encodeURIComponent(relativeB)}`;
-  
   try {
+    // If in static mode, we fetch pre-generated markdown
+    if (isStatic) {
+      const resultsBase = 'results';
+      const fileName = `${guideName}-${activeTask}-guided.md`;
+      const url = `${resultsBase}/${trialA}/variance_diagnoses/${fileName}`;
+      
+      try {
+        const response = await fetch(url);
+        if (response.ok) {
+          const markdown = await response.text();
+          diagnosisText.innerHTML = renderMarkdown(markdown);
+          statusSpan.innerText = 'Completed';
+          statusSpan.style.color = '#166534';
+        } else {
+          diagnosisText.innerHTML = `
+            <div style="color:#b91c1c; font-weight:600;">Diagnostic report not pre-generated for this run combination.</div>
+            <div style="font-size:0.9em; margin-top:5px; color:#475569;">
+              Running in STATIC mode. On-the-fly LLM comparison is only available when running the dashboard locally via <code>pnpm dashboard</code>.
+              To generate this report locally, run:
+              <pre style="background:#fff; border:1px solid #fecaca; margin-top:8px; padding:10px; border-radius:4px; font-family:monospace;">gd compare ${trialA}/${runNumA}/${guideName}/${activeTask}/guided ${trialB}/${runNumB}/${guideName}/${activeTask}/guided</pre>
+            </div>
+          `;
+          statusSpan.innerText = 'Not Pre-generated';
+          statusSpan.style.color = '#b91c1c';
+        }
+      } catch (e) {
+        diagnosisText.innerText = 'Failed to load pre-generated diagnostic report.';
+        statusSpan.innerText = 'Error';
+      }
+      return;
+    }
+
+    // Local Mode: Call Node dev server API to run comparison on the fly!
+    const hasTaskA = suiteDataA ? checkTaskInSuite(suiteDataA, activeTask) : true;
+    const hasTaskB = suiteDataB ? checkTaskInSuite(suiteDataB, activeTask) : true;
+
+    if (suiteDataA && suiteDataB && (!hasTaskA || !hasTaskB)) {
+      const missingIn = !hasTaskA && !hasTaskB ? 'both trials' : !hasTaskA ? 'Trial A' : 'Trial B';
+      const presentIn = !hasTaskA ? 'Trial B' : 'Trial A';
+      diagnosisText.innerHTML = `
+        <div style="color:#92400e; font-weight:600;">Cross-trial comparison unavailable for this task.</div>
+        <div style="font-size:0.9em; margin-top:5px; color:#78350f;">
+          Task <code>${escapeHtml(activeTask)}</code> was only executed in ${presentIn} and is not present in ${missingIn}.
+          To run an AI variance diagnosis, select a task that was executed in both trials.
+        </div>
+      `;
+      statusSpan.innerText = 'Single Trial Only';
+      statusSpan.style.color = '#64748b';
+      return;
+    }
+
+    const apiUrl = `/api/compare?runDirA=${encodeURIComponent(relativeA)}&runDirB=${encodeURIComponent(relativeB)}`;
+    
     /** @type {Record<string, string>} */
     const headers = {};
     const token = getAccessToken();
@@ -1503,6 +1531,11 @@ async function runDiagnosticAgent() {
     `;
     statusSpan.innerText = 'Failed';
     statusSpan.style.color = '#b91c1c';
+  } finally {
+    if (runBtn) {
+      runBtn.disabled = false;
+      runBtn.innerHTML = '🔄 Re-run Diagnosis';
+    }
   }
 }
 
@@ -1525,6 +1558,7 @@ window.onload = async () => {
 // Expose module functions globally for inline HTML event handlers (since compare.js is loaded as a module)
 /** @type {any} */ (window).switchTab = switchTab;
 /** @type {any} */ (window).switchTask = switchTask;
+/** @type {any} */ (window).runDiagnosticAgent = runDiagnosticAgent;
 
 function switchTimelineMode(mode) {
   timelineViewMode = mode;

--- a/eval-view/compare.js
+++ b/eval-view/compare.js
@@ -1,4 +1,4 @@
-import { getAccessToken, capitalize, normalizeTrajectoryClient, parseResultKey } from './utils.js';
+import { getAccessToken, capitalize, normalizeTrajectoryClient, parseResultKey, escapeHtml } from './utils.js';
 
 // Cross-Run Performance Variance Diagnosis Dashboard JavaScript
 
@@ -44,8 +44,7 @@ function renderMarkdown(md) {
   if (!md) return '';
   
   // Strip ANSI escape sequences (e.g. \x1b[36m)
-  const ansiRegex = new RegExp('[' + String.fromCharCode(27) + String.fromCharCode(155) + '][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]', 'g');
-  let cleanMd = md.replace(ansiRegex, '').trim();
+  const cleanMd = md.replace(new RegExp(String.fromCharCode(27) + '\\[[0-9;]*[a-zA-Z]', 'g'), '').trim();
   
   const lines = cleanMd.split('\n');
   let html = '';
@@ -307,6 +306,51 @@ async function handleRunTypeChange() {
   resetDiagnosisUI();
 }
 
+/**
+ * Streams a ReadableStream response into a <pre> element with throttled rendering.
+ * @param {ReadableStream<Uint8Array>} body
+ * @param {HTMLElement | null} logElement
+ * @returns {Promise<string>}
+ */
+async function streamBodyToElement(body, logElement) {
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let accumulatedText = '';
+  let lastUpdate = 0;
+  let updatePending = false;
+
+  function updateDOM() {
+    if (logElement) {
+      logElement.textContent = accumulatedText;
+      logElement.scrollTop = logElement.scrollHeight;
+    }
+    updatePending = false;
+  }
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    accumulatedText += decoder.decode(value, { stream: true });
+
+    const now = performance.now();
+    if (now - lastUpdate > 100) {
+      updateDOM();
+      lastUpdate = now;
+    } else if (!updatePending) {
+      updatePending = true;
+      requestAnimationFrame(() => {
+        if (updatePending) {
+          updateDOM();
+          lastUpdate = performance.now();
+        }
+      });
+    }
+  }
+  updateDOM();
+  return accumulatedText;
+}
+
 async function ensureRunDirectories(dirA, dirB) {
   if (isStatic) return;
   try {
@@ -338,39 +382,7 @@ async function ensureRunDirectories(dirA, dirB) {
       }
 
       const logPre = document.getElementById('compare-log-stream');
-      const reader = response.body.getReader();
-      const decoder = new TextDecoder();
-      let accumulatedText = '';
-      let lastUpdate = 0;
-      let updatePending = false;
-
-      function updateDOM() {
-        if (logPre) {
-          logPre.textContent = accumulatedText;
-          logPre.scrollTop = logPre.scrollHeight;
-        }
-        updatePending = false;
-      }
-
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-
-        const chunk = decoder.decode(value, { stream: true });
-        accumulatedText += chunk;
-
-        const now = performance.now();
-        if (now - lastUpdate > 100) {
-          updateDOM();
-          lastUpdate = now;
-        } else if (!updatePending) {
-          updatePending = true;
-          requestAnimationFrame(() => {
-            if (updatePending) updateDOM();
-          });
-        }
-      }
-      updateDOM();
+      await streamBodyToElement(response.body, logPre);
     }
   } catch (e) {
     console.warn('Failed to ensure run directories locally:', e);
@@ -1450,46 +1462,7 @@ async function runDiagnosticAgent() {
       <pre id="compare-log-stream" style="font-family:monospace; font-size:0.85em; background:#ffffff; border:1px solid #fde68a; padding:12px; border-radius:6px; overflow-x:auto; max-height:250px; overflow-y:auto; margin:0; white-space:pre-wrap; color:#334155; line-height:1.4; box-shadow:inset 0 1px 2px rgba(0,0,0,0.05);"></pre>
     `;
     const logPre = document.getElementById('compare-log-stream');
-    
-    const reader = response.body.getReader();
-    const decoder = new TextDecoder();
-    let accumulatedText = '';
-
-    let lastUpdate = 0;
-    let updatePending = false;
-
-    function updateDOM() {
-      if (logPre) {
-        logPre.textContent = accumulatedText;
-        logPre.scrollTop = logPre.scrollHeight;
-      }
-      updatePending = false;
-    }
-
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-
-      const chunk = decoder.decode(value, { stream: true });
-      accumulatedText += chunk;
-      
-      const now = performance.now();
-      if (now - lastUpdate > 100) { // Limit DOM rendering to at most once per 100ms
-        updateDOM();
-        lastUpdate = now;
-      } else if (!updatePending) {
-        updatePending = true;
-        // Schedule trailing update on the next animation frame to keep CPU load low
-        requestAnimationFrame(() => {
-          if (updatePending) {
-            updateDOM();
-            lastUpdate = performance.now();
-          }
-        });
-      }
-    }
-    // Guarantee final, complete update when stream completes
-    updateDOM();
+    const accumulatedText = await streamBodyToElement(response.body, logPre);
 
     // Extraction of the final report from the accumulated stream text
     const startMarker = '--- DIAGNOSTIC REPORT ---';
@@ -1537,15 +1510,6 @@ async function runDiagnosticAgent() {
       runBtn.innerHTML = '🔄 Re-run Diagnosis';
     }
   }
-}
-
-function escapeHtml(str) {
-  return (str || '').toString()
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
 }
 
 // Global initialization

--- a/eval-view/compare.js
+++ b/eval-view/compare.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { getAccessToken, capitalize, normalizeTrajectoryClient, parseResultKey, escapeHtml } from './utils.js';
 
 // Cross-Run Performance Variance Diagnosis Dashboard JavaScript

--- a/eval-view/compare.js
+++ b/eval-view/compare.js
@@ -1,13 +1,63 @@
-// @ts-nocheck
-import { getAccessToken, capitalize, normalizeTrajectoryClient, parseResultKey, escapeHtml } from './utils.js';
+/// <reference path="./evals.d.ts" />
+import { getAccessToken, capitalize, normalizeTrajectoryClient, parseResultKey, escapeHtml, $ } from './utils.js';
+
+/**
+ * @typedef {import('../harness/lib/metrics.ts').EvalsReport & {
+ *   enableSkills?: boolean;
+ * }} SuiteReport
+ *
+ * @typedef {Omit<import('../harness/lib/trajectory-normalizer.ts').StandardizedStep, 'action' | 'outcome'> & {
+ *   action?: {
+ *     type?: string;
+ *     name?: string;
+ *     params?: any;
+ *     canonicalCategory?: string;
+ *   };
+ *   outcome?: any;
+ *   output?: any;
+ *   result?: any;
+ * }} CompareStep
+ *
+ * @typedef {import('../harness/lib/trajectory-normalizer.ts').TrajectorySummary & {
+ *   steps: CompareStep[];
+ * }} CompareTrajectory
+ *
+ * @typedef {Object} AlignedStepPair
+ * @property {CompareStep | null} stepA
+ * @property {CompareStep | null} stepB
+ *
+ * @typedef {Object} DivergenceInfo
+ * @property {number | null} primaryStepA
+ * @property {number | null} primaryStepB
+ *
+ * @typedef {Object} AssertionResult
+ * @property {string} message
+ * @property {boolean} passed
+ *
+ * @typedef {Object} PlaywrightSpec
+ * @property {string} title
+ * @property {boolean} [ok]
+ *
+ * @typedef {Object} PlaywrightSuite
+ * @property {PlaywrightSpec[]} [specs]
+ * @property {PlaywrightSuite[]} [suites]
+ *
+ * @typedef {Object} PlaywrightReport
+ * @property {PlaywrightSuite[]} [suites]
+ */
 
 // Cross-Run Performance Variance Diagnosis Dashboard JavaScript
 
+/** @type {'assertions' | 'timeline' | 'code'} */
 let currentTab = 'assertions';
 let activeTask = '';
+/** @type {string[]} */
 let availableTasks = [];
+/** @type {'milestone' | 'raw'} */
 let timelineViewMode = 'milestone'; // 'milestone' | 'raw'
+/** @type {CompareTrajectory | null} */
 let _loadedTrajA = null;
+/** @type {CompareTrajectory | null} */
 let _loadedTrajB = null;
 let _loadedChatA = '';
 let _loadedChatB = '';
@@ -23,9 +73,11 @@ let guideName = '';
 let isStatic = false;
 let agentA = '';
 let modelA = '';
+/** @type {string | null} */
 let scoreAParam = null;
 let agentB = '';
 let modelB = '';
+/** @type {string | null} */
 let scoreBParam = null;
 
 // Live Run Types & Scores
@@ -37,10 +89,16 @@ let currentScoreB = 0;
 // Parsed run data
 let _runDirA = '';
 let _runDirB = '';
+/** @type {SuiteReport | null} */
 let suiteDataA = null;
+/** @type {SuiteReport | null} */
 let suiteDataB = null;
 
-// Robust line-by-line markdown to HTML compiler with ANSI stripping & GFM Table support
+/**
+ * Robust line-by-line markdown to HTML compiler with ANSI stripping & GFM Table support
+ * @param {string | null | undefined} md
+ * @returns {string}
+ */
 function renderMarkdown(md) {
   if (!md) return '';
   
@@ -54,9 +112,13 @@ function renderMarkdown(md) {
   let inCodeBlock = false;
   let inTable = false;
   let codeLanguage = '';
+  /** @type {string[]} */
   let codeContent = [];
+  /** @type {string[]} */
   let tableHeaders = [];
+  /** @type {string[]} */
   let tableAlignments = [];
+  /** @type {string[][]} */
   let tableRows = [];
   
   for (let i = 0; i < lines.length; i++) {
@@ -132,10 +194,10 @@ function renderMarkdown(md) {
           inTable = true;
           tableRows = [];
           
-          const cells = line.split('|').map(c => c.trim()).filter((c, idx, arr) => idx > 0 && idx < arr.length - 1);
+          const cells = line.split('|').map(c => c.trim()).filter((_c, idx, arr) => idx > 0 && idx < arr.length - 1);
           tableHeaders = cells;
           
-          const dividerCells = escapedNextLine.split('|').map(c => c.trim()).filter((c, idx, arr) => idx > 0 && idx < arr.length - 1);
+          const dividerCells = escapedNextLine.split('|').map(c => c.trim()).filter((_c, idx, arr) => idx > 0 && idx < arr.length - 1);
           tableAlignments = dividerCells.map(cell => {
             const left = cell.startsWith(':');
             const right = cell.endsWith(':');
@@ -148,7 +210,7 @@ function renderMarkdown(md) {
           continue;
         }
       } else {
-        const cells = line.split('|').map(c => c.trim()).filter((c, idx, arr) => idx > 0 && idx < arr.length - 1);
+        const cells = line.split('|').map(c => c.trim()).filter((_c, idx, arr) => idx > 0 && idx < arr.length - 1);
         tableRows.push(cells);
         continue;
       }
@@ -204,7 +266,13 @@ function renderMarkdown(md) {
   return html;
 }
 
-// Helper to compile a parsed markdown table into structured HTML
+/**
+ * Helper to compile a parsed markdown table into structured HTML
+ * @param {string[]} headers
+ * @param {string[]} alignments
+ * @param {string[][]} rows
+ * @returns {string}
+ */
 function renderTableHtml(headers, alignments, rows) {
   let html = '<table class="markdown-table">';
   
@@ -232,6 +300,10 @@ function renderTableHtml(headers, alignments, rows) {
   return html;
 }
 
+/**
+ * @param {string} text
+ * @returns {string}
+ */
 function parseInline(text) {
   // Bold: **text**
   text = text.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
@@ -242,7 +314,10 @@ function parseInline(text) {
   return text;
 }
 
-// Extract query parameters
+/**
+ * Extract query parameters
+ * @returns {boolean}
+ */
 function initParams() {
   const urlParams = new URLSearchParams(window.location.search);
   trialA = urlParams.get('trialA') || '';
@@ -272,12 +347,18 @@ function initParams() {
 
   // Set up dropdown change listeners
   elA?.addEventListener('change', async (e) => {
-    runTypeA = /** @type {HTMLSelectElement} */ (e.target).value;
-    await handleRunTypeChange();
+    const target = /** @type {HTMLSelectElement | null} */ (e.target);
+    if (target) {
+      runTypeA = target.value;
+      await handleRunTypeChange();
+    }
   });
   elB?.addEventListener('change', async (e) => {
-    runTypeB = /** @type {HTMLSelectElement} */ (e.target).value;
-    await handleRunTypeChange();
+    const target = /** @type {HTMLSelectElement | null} */ (e.target);
+    if (target) {
+      runTypeB = target.value;
+      await handleRunTypeChange();
+    }
   });
 
   // Back button setup
@@ -287,19 +368,20 @@ function initParams() {
   }
 
   if (!trialA || !guideName) {
-    document.getElementById('compare-title').innerText = 'Error: Missing Parameters';
+    $('#compare-title').innerText = 'Error: Missing Parameters';
     alert('Missing required parameters: trialA and guide are required.');
     return false;
   }
 
   // Update browser tab title with active guide name
   document.title = `${guideName} - AI Variance Diagnosis`;
-  document.getElementById('compare-title').innerHTML = `Cross-Run Variance Diagnosis <span style="font-weight: 400; color: #64748b;">(${guideName})</span>`;
+  $('#compare-title').innerHTML = `Cross-Run Variance Diagnosis <span style="font-weight: 400; color: #64748b;">(${guideName})</span>`;
   return true;
 }
 
 /**
  * Handles reloading of workspace files and resetting diagnosis state when run type is toggled.
+ * @returns {Promise<void>}
  */
 async function handleRunTypeChange() {
   updateExecutiveSummary();
@@ -352,6 +434,11 @@ async function streamBodyToElement(body, logElement) {
   return accumulatedText;
 }
 
+/**
+ * @param {string} dirA
+ * @param {string} dirB
+ * @returns {Promise<void>}
+ */
 async function ensureRunDirectories(dirA, dirB) {
   if (isStatic) return;
   try {
@@ -390,6 +477,9 @@ async function ensureRunDirectories(dirA, dirB) {
   }
 }
 
+/**
+ * @returns {Promise<void>}
+ */
 async function loadTrialMetadata() {
   const resultsBase = isStatic ? 'results' : '';
   const srcParam = isStatic ? '' : '?source=local';
@@ -407,7 +497,7 @@ async function loadTrialMetadata() {
   try {
     const responseA = await fetch(`${resultsBase}/${trialA}/evals.json${srcParam}`);
     if (responseA.ok) {
-      suiteDataA = await responseA.json();
+      suiteDataA = /** @type {SuiteReport} */ (await responseA.json());
     }
   } catch (e) {
     console.error('Failed to load Trial A suite data:', e);
@@ -418,7 +508,7 @@ async function loadTrialMetadata() {
     if (trialA !== trialB) {
       const responseB = await fetch(`${resultsBase}/${trialB}/evals.json${srcParam}`);
       if (responseB.ok) {
-        suiteDataB = await responseB.json();
+        suiteDataB = /** @type {SuiteReport} */ (await responseB.json());
       }
     } else {
       suiteDataB = suiteDataA;
@@ -428,7 +518,9 @@ async function loadTrialMetadata() {
   }
 
   // Determine tasks belonging to this guide in Trial A and Trial B
+  /** @type {Set<string>} */
   const tasksA = new Set();
+  /** @type {Set<string>} */
   const tasksB = new Set();
 
   if (suiteDataA?.results) {
@@ -473,6 +565,11 @@ async function loadTrialMetadata() {
   resetDiagnosisUI();
 }
 
+/**
+ * @param {SuiteReport | null | undefined} suiteData
+ * @param {string} task
+ * @returns {boolean}
+ */
 function checkTaskInSuite(suiteData, task) {
   if (!suiteData || !suiteData.results) return false;
   return Object.keys(suiteData.results).some(key => {
@@ -481,8 +578,11 @@ function checkTaskInSuite(suiteData, task) {
   });
 }
 
+/**
+ * @returns {void}
+ */
 function populateSidebar() {
-  const sidebarList = document.getElementById('task-sidebar-list');
+  const sidebarList = $('#task-sidebar-list');
   sidebarList.innerHTML = '';
   availableTasks.forEach(task => {
     const btn = document.createElement('button');
@@ -504,46 +604,49 @@ function populateSidebar() {
   });
 }
 
+/**
+ * @returns {void}
+ */
 function updateExecutiveSummary() {
   const displayRunA = runIndexA ? runIndexA : runNumA;
   const displayRunB = runIndexB ? runIndexB : runNumB;
 
   // Trial A
-  document.getElementById('title-a').innerText = `${trialA.slice(0, 18)} (Run ${displayRunA})`;
-  document.getElementById('meta-a').innerText = trialA.includes('test-') ? `Date: ${trialA.replace('test-', '').slice(0, 10)}` : 'Historical Suite';
+  $('#title-a').innerText = `${trialA.slice(0, 18)} (Run ${displayRunA})`;
+  $('#meta-a').innerText = trialA.includes('test-') ? `Date: ${trialA.replace('test-', '').slice(0, 10)}` : 'Historical Suite';
   
   const displayAgentA = agentA || suiteDataA?.agent || 'Unknown';
   const displayModelA = modelA || suiteDataA?.model || 'Unknown';
-  document.getElementById('agent-model-a').innerText = `Agent: ${displayAgentA} | Model: ${displayModelA}`;
+  $('#agent-model-a').innerText = `Agent: ${displayAgentA} | Model: ${displayModelA}`;
 
   // Trial B
   if (trialA === trialB) {
-    document.getElementById('title-b').innerText = `${trialA.slice(0, 18)} (Run ${displayRunB})`;
-    document.getElementById('meta-b').innerText = 'Within-Trial Non-determinism Check';
+    $('#title-b').innerText = `${trialA.slice(0, 18)} (Run ${displayRunB})`;
+    $('#meta-b').innerText = 'Within-Trial Non-determinism Check';
   } else {
-    document.getElementById('title-b').innerText = `${trialB.slice(0, 18)} (Run ${displayRunB})`;
-    document.getElementById('meta-b').innerText = trialB.includes('test-') ? `Date: ${trialB.replace('test-', '').slice(0, 10)}` : 'Historical Suite';
+    $('#title-b').innerText = `${trialB.slice(0, 18)} (Run ${displayRunB})`;
+    $('#meta-b').innerText = trialB.includes('test-') ? `Date: ${trialB.replace('test-', '').slice(0, 10)}` : 'Historical Suite';
   }
   
   const displayAgentB = agentB || suiteDataB?.agent || 'Unknown';
   const displayModelB = modelB || suiteDataB?.model || 'Unknown';
-  document.getElementById('agent-model-b').innerText = `Agent: ${displayAgentB} | Model: ${displayModelB}`;
+  $('#agent-model-b').innerText = `Agent: ${displayAgentB} | Model: ${displayModelB}`;
 
   // Calculate Scores for the specific guide across active run types and runs
-  currentScoreA = suiteDataA ? calculateGuideScore(suiteDataA, runNumA, runTypeA) : (scoreAParam !== null ? parseInt(scoreAParam) : 0);
-  currentScoreB = suiteDataB ? calculateGuideScore(suiteDataB, runNumB, runTypeB) : (scoreBParam !== null ? parseInt(scoreBParam) : 0);
+  currentScoreA = suiteDataA ? calculateGuideScore(suiteDataA, runNumA, runTypeA) : (scoreAParam !== null ? parseInt(scoreAParam, 10) : 0);
+  currentScoreB = suiteDataB ? calculateGuideScore(suiteDataB, runNumB, runTypeB) : (scoreBParam !== null ? parseInt(scoreBParam, 10) : 0);
 
-  const badgeA = document.getElementById('score-badge-a');
+  const badgeA = $('#score-badge-a');
   badgeA.innerText = `${currentScoreA}%`;
   badgeA.className = `score-badge ${currentScoreA >= 70 ? 'score-high' : 'score-low'}`;
 
-  const badgeB = document.getElementById('score-badge-b');
+  const badgeB = $('#score-badge-b');
   badgeB.innerText = `${currentScoreB}%`;
   badgeB.className = `score-badge ${currentScoreB >= 70 ? 'score-high' : 'score-low'}`;
 
   const delta = currentScoreB - currentScoreA;
   const deltaText = delta === 0 ? 'No change (0%)' : delta > 0 ? `+${delta}% Improvement` : `${delta}% Regression`;
-  const deltaSpan = document.getElementById('summary-delta');
+  const deltaSpan = $('#summary-delta');
   deltaSpan.innerText = deltaText;
   deltaSpan.style.color = delta === 0 ? '#475569' : delta > 0 ? '#166534' : '#991b1b';
 
@@ -554,6 +657,12 @@ function updateExecutiveSummary() {
   }
 }
 
+/**
+ * @param {SuiteReport | null | undefined} suiteData
+ * @param {string | number} runNum
+ * @param {string} [runType]
+ * @returns {number}
+ */
 function calculateGuideScore(suiteData, runNum, runType) {
   if (!suiteData || !suiteData.results) return 0;
   
@@ -561,7 +670,7 @@ function calculateGuideScore(suiteData, runNum, runType) {
   let passedAsserts = 0;
   
   const targetRunType = runType || 'guided';
-  const targetRunNum = parseInt(runNum, 10);
+  const targetRunNum = typeof runNum === 'number' ? runNum : parseInt(runNum, 10);
 
   Object.keys(suiteData.results).forEach(key => {
     const parsedKey = parseResultKey(key);
@@ -584,19 +693,27 @@ function calculateGuideScore(suiteData, runNum, runType) {
   return totalAsserts > 0 ? Math.round((passedAsserts / totalAsserts) * 100) : 0;
 }
 
+/**
+ * @param {string} task
+ * @returns {Promise<void>}
+ */
 async function switchTask(task) {
   if (activeTask === task) return;
   activeTask = task;
   
   // Update sidebar active state
   document.querySelectorAll('.task-btn').forEach(btn => {
-    btn.classList.toggle('active', btn.textContent.trim() === activeTask);
+    btn.classList.toggle('active', (btn.textContent || '').trim() === activeTask);
   });
 
   await loadActiveTaskDetails();
   resetDiagnosisUI();
 }
 
+/**
+ * @param {string | null | undefined} trialId
+ * @returns {string}
+ */
 function getRunDateString(trialId) {
   if (!trialId) return 'Unknown Date';
   const match = trialId.match(/\d{4}-\d{2}-\d{2}/);
@@ -605,6 +722,18 @@ function getRunDateString(trialId) {
   return trialId.slice(0, 12);
 }
 
+/**
+ * @param {string} label
+ * @param {string} trialId
+ * @param {string | number} runNum
+ * @param {string} [runType]
+ * @param {string} [agent]
+ * @param {string} [model]
+ * @param {CompareTrajectory | null} [traj]
+ * @param {SuiteReport | null} [suiteData]
+ * @param {string | number} [overrideRunIndex]
+ * @returns {string}
+ */
 function getFormattedTrialTitle(label, trialId, runNum, runType, agent, model, traj, suiteData, overrideRunIndex) {
   const dateStr = getRunDateString(trialId);
   const resolvedAgent = agent && agent !== 'unknown' ? agent : (traj?.agent || suiteData?.agent || 'Unknown Agent');
@@ -613,11 +742,14 @@ function getFormattedTrialTitle(label, trialId, runNum, runType, agent, model, t
   return `${label} (Run ${activeRunNum} - ${capitalize(runType || 'guided')}) — agent: ${resolvedAgent} model: ${resolvedModel} (${dateStr})`;
 }
 
+/**
+ * @returns {Promise<void>}
+ */
 async function loadActiveTaskDetails() {
-  document.getElementById('compare-loading').style.display = 'flex';
-  document.getElementById('tab-content-assertions').style.display = 'none';
-  document.getElementById('tab-content-timeline').style.display = 'none';
-  document.getElementById('tab-content-code').style.display = 'none';
+  $('#compare-loading').style.display = 'flex';
+  $('#tab-content-assertions').style.display = 'none';
+  $('#tab-content-timeline').style.display = 'none';
+  $('#tab-content-code').style.display = 'none';
 
   const resultsBase = isStatic ? 'results' : '';
   
@@ -632,12 +764,18 @@ async function loadActiveTaskDetails() {
   const titleAStr = getFormattedTrialTitle('Trial A', trialA, runNumA, runTypeA, agentA, modelA, null, suiteDataA, runIndexA);
   const titleBStr = getFormattedTrialTitle('Trial B', trialB, runNumB, runTypeB, agentB, modelB, null, suiteDataB, runIndexB);
 
-  if (document.getElementById('timeline-title-a')) document.getElementById('timeline-title-a').innerText = titleAStr;
-  if (document.getElementById('timeline-title-b')) document.getElementById('timeline-title-b').innerText = titleBStr;
-  if (document.getElementById('code-title-a')) document.getElementById('code-title-a').innerText = titleAStr;
-  if (document.getElementById('code-title-b')) document.getElementById('code-title-b').innerText = titleBStr;
-  if (document.getElementById('header-assert-a')) document.getElementById('header-assert-a').innerText = titleAStr;
-  if (document.getElementById('header-assert-b')) document.getElementById('header-assert-b').innerText = titleBStr;
+  const timelineTitleA = document.getElementById('timeline-title-a');
+  if (timelineTitleA) timelineTitleA.innerText = titleAStr;
+  const timelineTitleB = document.getElementById('timeline-title-b');
+  if (timelineTitleB) timelineTitleB.innerText = titleBStr;
+  const codeTitleA = document.getElementById('code-title-a');
+  if (codeTitleA) codeTitleA.innerText = titleAStr;
+  const codeTitleB = document.getElementById('code-title-b');
+  if (codeTitleB) codeTitleB.innerText = titleBStr;
+  const headerAssertA = document.getElementById('header-assert-a');
+  if (headerAssertA) headerAssertA.innerText = titleAStr;
+  const headerAssertB = document.getElementById('header-assert-b');
+  if (headerAssertB) headerAssertB.innerText = titleBStr;
 
   // 0. Ensure run directories exist locally before fetching tab data
   await ensureRunDirectories(pathPartA, pathPartB);
@@ -651,19 +789,25 @@ async function loadActiveTaskDetails() {
   // 3. Load Code Output Diffs
   await loadCodeOutputs(pathPartA, pathPartB);
 
-  document.getElementById('compare-loading').style.display = 'none';
+  $('#compare-loading').style.display = 'none';
   switchTab(currentTab);
 }
 
 /**
  * Recursively parses Playwright's JSON report and extracts a flat array of assertions.
+ * @param {PlaywrightReport | null | undefined} report
+ * @returns {AssertionResult[]}
  */
 function parsePlaywrightResults(report) {
+  /** @type {AssertionResult[]} */
   const assertions = [];
   if (!report || !Array.isArray(report.suites)) {
     return assertions;
   }
   
+  /**
+   * @param {PlaywrightSuite} suite
+   */
   function collectSpecs(suite) {
     if (Array.isArray(suite.specs)) {
       suite.specs.forEach((spec) => {
@@ -682,13 +826,20 @@ function parsePlaywrightResults(report) {
   return assertions;
 }
 
+/**
+ * @param {string} pathA
+ * @param {string} pathB
+ * @returns {Promise<void>}
+ */
 async function loadAssertions(pathA, pathB) {
   const resultsBase = isStatic ? 'results' : '';
   const srcParam = isStatic ? '' : '?source=local';
-  const tbody = document.getElementById('assert-tbody');
+  const tbody = $('tbody#assert-tbody');
   tbody.innerHTML = '';
 
+  /** @type {AssertionResult[]} */
   let resultsA = [];
+  /** @type {AssertionResult[]} */
   let resultsB = [];
 
   // Fetch Run A results JSON
@@ -697,13 +848,14 @@ async function loadAssertions(pathA, pathB) {
     if (!resA.ok) {
       const filesResA = await fetch(`/api/run-files?dir=${encodeURIComponent(pathA)}&source=local`);
       if (filesResA.ok) {
+        /** @type {string[]} */
         const filesA = (await filesResA.json()).files || [];
-        const resFile = filesA.find(f => f.endsWith('_results.json'));
+        const resFile = filesA.find((/** @type {string} */ f) => f.endsWith('_results.json'));
         if (resFile) resA = await fetch(`${resultsBase}/${pathA}/${resFile}${srcParam}`);
       }
     }
     if (resA.ok) {
-      const rawA = await resA.json();
+      const rawA = /** @type {PlaywrightReport} */ (await resA.json());
       resultsA = parsePlaywrightResults(rawA);
     }
   } catch (e) {}
@@ -714,13 +866,14 @@ async function loadAssertions(pathA, pathB) {
     if (!resB.ok) {
       const filesResB = await fetch(`/api/run-files?dir=${encodeURIComponent(pathB)}&source=local`);
       if (filesResB.ok) {
+        /** @type {string[]} */
         const filesB = (await filesResB.json()).files || [];
-        const resFile = filesB.find(f => f.endsWith('_results.json'));
+        const resFile = filesB.find((/** @type {string} */ f) => f.endsWith('_results.json'));
         if (resFile) resB = await fetch(`${resultsBase}/${pathB}/${resFile}${srcParam}`);
       }
     }
     if (resB.ok) {
-      const rawB = await resB.json();
+      const rawB = /** @type {PlaywrightReport} */ (await resB.json());
       resultsB = parsePlaywrightResults(rawB);
     }
   } catch (e) {}
@@ -785,26 +938,21 @@ async function loadAssertions(pathA, pathB) {
   });
 }
 
-async function loadTrajectories(pathA, pathB) {
-  const resultsBase = isStatic ? 'results' : '';
-  const srcParam = isStatic ? '' : '?source=local';
-  const container = document.getElementById('tab-content-timeline');
-  container.innerHTML = '<div style="padding:20px; text-align:center; color:#64748b;">Loading aligned trajectories...</div>';
-
-  let trajA = null;
-  let trajB = null;
-  let chatA = '';
-  let chatB = '';
-  let sessionUrlA = '';
-  let sessionUrlB = '';
-
+/**
+ * @param {CompareTrajectory | null | undefined} traj
+ * @param {string} pathStr
+ * @param {string} resultsBase
+ * @returns {Promise<void>}
+ */
 async function enrichTrajectorySteps(traj, pathStr, resultsBase) {
   if (!traj || !Array.isArray(traj.steps)) return;
+  const srcParam = isStatic ? '' : '?source=local';
   try {
     const logRes = await fetch(`${resultsBase}/${pathStr}/modern-web.log${srcParam}`);
     if (logRes.ok) {
       const logText = await logRes.text();
       const lines = logText.split('\n').filter(Boolean);
+      /** @type {any[]} */
       const logCalls = [];
       for (const line of lines) {
         if (line.trim().startsWith('{')) {
@@ -816,7 +964,9 @@ async function enrichTrajectorySteps(traj, pathStr, resultsBase) {
         if (step.action && (step.action.name === 'get_best_practices' || step.action.type === 'web_search' || step.action.name === 'search_use_cases')) {
           if (logCalls[searchIdx]) {
             if (!step.outcome) step.outcome = { status: 'success' };
-            step.outcome.output = logCalls[searchIdx].result;
+            if (typeof step.outcome !== 'string') {
+              step.outcome.output = logCalls[searchIdx].result;
+            }
             searchIdx++;
           }
         }
@@ -825,10 +975,30 @@ async function enrichTrajectorySteps(traj, pathStr, resultsBase) {
   } catch (e) {}
 }
 
+/**
+ * @param {string} pathA
+ * @param {string} pathB
+ * @returns {Promise<void>}
+ */
+async function loadTrajectories(pathA, pathB) {
+  const resultsBase = isStatic ? 'results' : '';
+  const srcParam = isStatic ? '' : '?source=local';
+  const container = $('#tab-content-timeline');
+  container.innerHTML = '<div style="padding:20px; text-align:center; color:#64748b;">Loading aligned trajectories...</div>';
+
+  /** @type {CompareTrajectory | null} */
+  let trajA = null;
+  /** @type {CompareTrajectory | null} */
+  let trajB = null;
+  let chatA = '';
+  let chatB = '';
+  let sessionUrlA = '';
+  let sessionUrlB = '';
+
   try {
     const resA = await fetch(`${resultsBase}/${pathA}/trajectory_summary.json${srcParam}`);
     if (resA.ok) {
-      trajA = normalizeTrajectoryClient(await resA.json());
+      trajA = /** @type {CompareTrajectory} */ (normalizeTrajectoryClient(await resA.json()));
       await enrichTrajectorySteps(trajA, pathA, resultsBase);
     }
   } catch (e) {}
@@ -836,7 +1006,7 @@ async function enrichTrajectorySteps(traj, pathStr, resultsBase) {
   try {
     const resB = await fetch(`${resultsBase}/${pathB}/trajectory_summary.json${srcParam}`);
     if (resB.ok) {
-      trajB = normalizeTrajectoryClient(await resB.json());
+      trajB = /** @type {CompareTrajectory} */ (normalizeTrajectoryClient(await resB.json()));
       await enrichTrajectorySteps(trajB, pathB, resultsBase);
     }
   } catch (e) {}
@@ -854,8 +1024,9 @@ async function enrichTrajectorySteps(traj, pathStr, resultsBase) {
   try {
     const filesResA = await fetch(`/api/run-files?dir=${encodeURIComponent(pathA)}&source=local`);
     if (filesResA.ok) {
+      /** @type {string[]} */
       const filesA = (await filesResA.json()).files || [];
-      const sessionFileA = filesA.find(f => f.startsWith('session-') && !f.includes('-subagents-') && f.endsWith('.html')) || filesA.find(f => f.startsWith('session-') && f.endsWith('.html'));
+      const sessionFileA = filesA.find((/** @type {string} */ f) => f.startsWith('session-') && !f.includes('-subagents-') && f.endsWith('.html')) || filesA.find((/** @type {string} */ f) => f.startsWith('session-') && f.endsWith('.html'));
       if (sessionFileA) sessionUrlA = `${resultsBase}/${pathA}/${sessionFileA}`;
     }
   } catch (e) {}
@@ -863,8 +1034,9 @@ async function enrichTrajectorySteps(traj, pathStr, resultsBase) {
   try {
     const filesResB = await fetch(`/api/run-files?dir=${encodeURIComponent(pathB)}&source=local`);
     if (filesResB.ok) {
+      /** @type {string[]} */
       const filesB = (await filesResB.json()).files || [];
-      const sessionFileB = filesB.find(f => f.startsWith('session-') && !f.includes('-subagents-') && f.endsWith('.html')) || filesB.find(f => f.startsWith('session-') && f.endsWith('.html'));
+      const sessionFileB = filesB.find((/** @type {string} */ f) => f.startsWith('session-') && !f.includes('-subagents-') && f.endsWith('.html')) || filesB.find((/** @type {string} */ f) => f.startsWith('session-') && f.endsWith('.html'));
       if (sessionFileB) sessionUrlB = `${resultsBase}/${pathB}/${sessionFileB}`;
     }
   } catch (e) {}
@@ -876,15 +1048,23 @@ async function enrichTrajectorySteps(traj, pathStr, resultsBase) {
   renderTimelineRows(container, trajA, trajB, chatA, chatB, sessionUrlA, sessionUrlB);
 }
 
+/**
+ * @param {CompareTrajectory | CompareStep[] | null | undefined} trajOrStepsA
+ * @param {CompareTrajectory | CompareStep[] | null | undefined} trajOrStepsB
+ * @param {'milestone' | 'raw'} [mode='milestone']
+ * @returns {AlignedStepPair[]}
+ */
 function alignTrajectorySteps(trajOrStepsA, trajOrStepsB, mode = 'milestone') {
+  /** @type {{ steps: CompareStep[], initialPrompt?: string }} */
   const trajAObj = (trajOrStepsA && !Array.isArray(trajOrStepsA)) ? trajOrStepsA : { steps: Array.isArray(trajOrStepsA) ? trajOrStepsA : [] };
+  /** @type {{ steps: CompareStep[], initialPrompt?: string }} */
   const trajBObj = (trajOrStepsB && !Array.isArray(trajOrStepsB)) ? trajOrStepsB : { steps: Array.isArray(trajOrStepsB) ? trajOrStepsB : [] };
 
   let listA = trajAObj.steps || [];
   let listB = trajBObj.steps || [];
 
   if (mode === 'milestone') {
-    const filterFn = s => s.action?.canonicalCategory && s.action.canonicalCategory !== 'incidental_noise' && s.action.canonicalCategory !== 'launch';
+    const filterFn = (/** @type {CompareStep} */ s) => s.action?.canonicalCategory && s.action.canonicalCategory !== 'incidental_noise' && s.action.canonicalCategory !== 'launch';
     const filteredA = listA.filter(filterFn);
     const filteredB = listB.filter(filterFn);
     if (filteredA.length > 0 || filteredB.length > 0) {
@@ -900,6 +1080,11 @@ function alignTrajectorySteps(trajOrStepsA, trajOrStepsB, mode = 'milestone') {
   const dp = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0));
   const gapPenalty = -2;
 
+  /**
+   * @param {CompareStep} sA
+   * @param {CompareStep} sB
+   * @returns {number}
+   */
   function matchScore(sA, sB) {
     let score = 0;
     const catA = sA.action?.canonicalCategory || 'other';
@@ -928,6 +1113,7 @@ function alignTrajectorySteps(trajOrStepsA, trajOrStepsB, mode = 'milestone') {
     }
   }
 
+  /** @type {AlignedStepPair[]} */
   const aligned = [];
   let i = m, j = n;
   while (i > 0 || j > 0) {
@@ -951,12 +1137,14 @@ function alignTrajectorySteps(trajOrStepsA, trajOrStepsB, mode = 'milestone') {
     const promptA = trajAObj.initialPrompt || '';
     const promptB = trajBObj.initialPrompt || '';
     if (promptA || promptB) {
+      /** @type {CompareStep | null} */
       const step0A = promptA ? {
         stepNumber: 0,
         thought: 'Harness launched agent with initial prompt',
         action: { type: 'launch', name: 'Starting Prompt / Launch', params: { prompt: promptA }, canonicalCategory: 'launch' },
         outcome: { status: 'success', output: promptA }
       } : null;
+      /** @type {CompareStep | null} */
       const step0B = promptB ? {
         stepNumber: 0,
         thought: 'Harness launched agent with initial prompt',
@@ -970,10 +1158,17 @@ function alignTrajectorySteps(trajOrStepsA, trajOrStepsB, mode = 'milestone') {
   return alignedResult;
 }
 
+/**
+ * @param {CompareTrajectory | null | undefined} trajA
+ * @param {CompareTrajectory | null | undefined} trajB
+ * @returns {DivergenceInfo}
+ */
 function findDivergenceInfo(trajA, trajB) {
   const aligned = alignTrajectorySteps(trajA, trajB, timelineViewMode);
 
+  /** @type {number | null} */
   let primaryStepA = null;
+  /** @type {number | null} */
   let primaryStepB = null;
 
   const diagnosisTextElement = document.getElementById('diagnosis-text');
@@ -1019,8 +1214,8 @@ function findDivergenceInfo(trajA, trajB) {
       }
 
       if (sA.stepNumber === 0 && sB.stepNumber === 0) {
-        const pA = (sA.outcome?.output || '').trim();
-        const pB = (sB.outcome?.output || '').trim();
+        const pA = (sA.outcome && typeof sA.outcome === 'object' ? sA.outcome.output || '' : '').trim();
+        const pB = (sB.outcome && typeof sB.outcome === 'object' ? sB.outcome.output || '' : '').trim();
         if (pA && pB && pA !== pB) {
           primaryStepA = 0;
           primaryStepB = 0;
@@ -1033,8 +1228,8 @@ function findDivergenceInfo(trajA, trajB) {
       const aB = (sB.action?.name || '').toLowerCase();
       const catA = sA.action?.canonicalCategory || 'other';
       const catB = sB.action?.canonicalCategory || 'other';
-      const isErrA = sA.outcome?.status === 'error';
-      const isErrB = sB.outcome?.status === 'error';
+      const isErrA = typeof sA.outcome === 'object' && sA.outcome !== null ? sA.outcome.status === 'error' : false;
+      const isErrB = typeof sB.outcome === 'object' && sB.outcome !== null ? sB.outcome.status === 'error' : false;
 
       if (aA !== aB || catA !== catB || isErrA !== isErrB) {
         if (primaryStepA === null) primaryStepA = sA.stepNumber;
@@ -1047,6 +1242,16 @@ function findDivergenceInfo(trajA, trajB) {
   return { primaryStepA, primaryStepB };
 }
 
+/**
+ * @param {HTMLElement} container
+ * @param {CompareTrajectory | null} trajA
+ * @param {CompareTrajectory | null} trajB
+ * @param {string} [chatA='']
+ * @param {string} [chatB='']
+ * @param {string} [sessionUrlA='']
+ * @param {string} [sessionUrlB='']
+ * @returns {void}
+ */
 function renderTimelineRows(container, trajA, trajB, chatA = '', chatB = '', sessionUrlA = '', sessionUrlB = '') {
   container.innerHTML = '';
 
@@ -1062,12 +1267,18 @@ function renderTimelineRows(container, trajA, trajB, chatA = '', chatB = '', ses
   const titleAStr = getFormattedTrialTitle('Trial A', trialA, runNumA, runTypeA, agentA, modelA, trajA, suiteDataA, runIndexA);
   const titleBStr = getFormattedTrialTitle('Trial B', trialB, runNumB, runTypeB, agentB, modelB, trajB, suiteDataB, runIndexB);
 
-  if (document.getElementById('timeline-title-a')) document.getElementById('timeline-title-a').innerText = titleAStr;
-  if (document.getElementById('timeline-title-b')) document.getElementById('timeline-title-b').innerText = titleBStr;
-  if (document.getElementById('code-title-a')) document.getElementById('code-title-a').innerText = titleAStr;
-  if (document.getElementById('code-title-b')) document.getElementById('code-title-b').innerText = titleBStr;
-  if (document.getElementById('header-assert-a')) document.getElementById('header-assert-a').innerText = titleAStr;
-  if (document.getElementById('header-assert-b')) document.getElementById('header-assert-b').innerText = titleBStr;
+  const timelineTitleA = document.getElementById('timeline-title-a');
+  if (timelineTitleA) timelineTitleA.innerText = titleAStr;
+  const timelineTitleB = document.getElementById('timeline-title-b');
+  if (timelineTitleB) timelineTitleB.innerText = titleBStr;
+  const codeTitleA = document.getElementById('code-title-a');
+  if (codeTitleA) codeTitleA.innerText = titleAStr;
+  const codeTitleB = document.getElementById('code-title-b');
+  if (codeTitleB) codeTitleB.innerText = titleBStr;
+  const headerAssertA = document.getElementById('header-assert-a');
+  if (headerAssertA) headerAssertA.innerText = titleAStr;
+  const headerAssertB = document.getElementById('header-assert-b');
+  if (headerAssertB) headerAssertB.innerText = titleBStr;
 
   // Top header row
   const headerRow = document.createElement('div');
@@ -1178,10 +1389,17 @@ function renderTimelineRows(container, trajA, trajB, chatA = '', chatB = '', ses
   }
 }
 
+/**
+ * @param {CompareStep} step
+ * @param {boolean} [isDivergent=false]
+ * @param {string} [sessionUrl='']
+ * @returns {string}
+ */
 function renderStepCardHtml(step, isDivergent = false, sessionUrl = '') {
-  const isErr = step.outcome?.status === 'error';
+  const isErr = typeof step.outcome === 'object' && step.outcome !== null ? step.outcome.status === 'error' : false;
   const cardClass = `timeline-step ${isErr ? 'error' : 'success'} ${isDivergent ? 'divergence-card' : ''}`;
   const stepAnchorUrl = sessionUrl ? `${sessionUrl}#step-${step.stepNumber}` : '';
+  const outcomeStatus = typeof step.outcome === 'object' && step.outcome !== null && step.outcome.status ? step.outcome.status : 'UNKNOWN';
 
   let html = `
     <div class="${cardClass}">
@@ -1194,7 +1412,7 @@ function renderStepCardHtml(step, isDivergent = false, sessionUrl = '') {
             </a>
           ` : ''}
         </div>
-        <span style="color:${isErr ? '#ef4444' : '#22c55e'}">${(step.outcome?.status || 'UNKNOWN').toUpperCase()}</span>
+        <span style="color:${isErr ? '#ef4444' : '#22c55e'}">${outcomeStatus.toUpperCase()}</span>
       </div>
   `;
 
@@ -1228,14 +1446,17 @@ function renderStepCardHtml(step, isDivergent = false, sessionUrl = '') {
   if (step.outcome) {
     if (typeof step.outcome === 'string') {
       outcomeText = step.outcome;
-    } else if (step.outcome.output || step.outcome.result || step.outcome.message || step.outcome.content || step.outcome.text || step.outcome.stdout || step.outcome.stderr) {
-      outcomeText = step.outcome.output || step.outcome.result || step.outcome.message || step.outcome.content || step.outcome.text || step.outcome.stdout || step.outcome.stderr;
-      if (typeof outcomeText === 'object') outcomeText = JSON.stringify(outcomeText, null, 2);
-    } else {
-      const keys = Object.keys(step.outcome);
-      const onlyStatus = keys.every(k => k === 'status' || k === 'exitCode');
-      if (!onlyStatus) {
-        outcomeText = JSON.stringify(step.outcome, null, 2);
+    } else if (typeof step.outcome === 'object' && step.outcome !== null) {
+      const outcomeObj = /** @type {Record<string, any>} */ (step.outcome);
+      if (outcomeObj.output || outcomeObj.result || outcomeObj.message || outcomeObj.content || outcomeObj.text || outcomeObj.stdout || outcomeObj.stderr) {
+        outcomeText = outcomeObj.output || outcomeObj.result || outcomeObj.message || outcomeObj.content || outcomeObj.text || outcomeObj.stdout || outcomeObj.stderr;
+        if (typeof outcomeText === 'object') outcomeText = JSON.stringify(outcomeText, null, 2);
+      } else {
+        const keys = Object.keys(outcomeObj);
+        const onlyStatus = keys.every(k => k === 'status' || k === 'exitCode');
+        if (!onlyStatus) {
+          outcomeText = JSON.stringify(outcomeObj, null, 2);
+        }
       }
     }
   } else if (step.output || step.result) {
@@ -1273,12 +1494,17 @@ function renderStepCardHtml(step, isDivergent = false, sessionUrl = '') {
   return html;
 }
 
+/**
+ * @param {string} pathA
+ * @param {string} pathB
+ * @returns {Promise<void>}
+ */
 async function loadCodeOutputs(pathA, pathB) {
   const resultsBase = isStatic ? 'results' : '';
   const srcParam = isStatic ? '' : '?source=local';
   
-  const containerA = document.getElementById('code-a');
-  const containerB = document.getElementById('code-b');
+  const containerA = $('#code-a');
+  const containerB = $('#code-b');
   
   containerA.innerHTML = 'Loading output file...';
   containerB.innerHTML = 'Loading output file...';
@@ -1314,8 +1540,12 @@ async function loadCodeOutputs(pathA, pathB) {
   containerB.innerText = codeTextB;
 }
 
+/**
+ * @param {string} tab
+ * @returns {void}
+ */
 function switchTab(tab) {
-  currentTab = tab;
+  currentTab = /** @type {'assertions' | 'timeline' | 'code'} */ (tab);
   
   // Update tab buttons active state using data-tab attribute
   document.querySelectorAll('.tab-btn').forEach(btn => {
@@ -1324,20 +1554,23 @@ function switchTab(tab) {
   });
 
   // Hide all tab contents
-  document.getElementById('tab-content-assertions').style.display = 'none';
-  document.getElementById('tab-content-timeline').style.display = 'none';
-  document.getElementById('tab-content-code').style.display = 'none';
+  $('#tab-content-assertions').style.display = 'none';
+  $('#tab-content-timeline').style.display = 'none';
+  $('#tab-content-code').style.display = 'none';
 
   // Show active tab content
   if (currentTab === 'assertions') {
-    document.getElementById('tab-content-assertions').style.display = 'block';
+    $('#tab-content-assertions').style.display = 'block';
   } else if (currentTab === 'timeline') {
-    document.getElementById('tab-content-timeline').style.display = 'block';
+    $('#tab-content-timeline').style.display = 'block';
   } else if (currentTab === 'code') {
-    document.getElementById('tab-content-code').style.display = 'flex';
+    $('#tab-content-code').style.display = 'flex';
   }
 }
 
+/**
+ * @returns {void}
+ */
 function resetDiagnosisUI() {
   const diagnosisText = document.getElementById('diagnosis-text');
   const statusSpan = document.getElementById('summary-status');
@@ -1360,10 +1593,13 @@ function resetDiagnosisUI() {
   }
 }
 
+/**
+ * @returns {Promise<void>}
+ */
 async function runDiagnosticAgent() {
-  const diagnosisBox = document.getElementById('diagnosis-box');
-  const diagnosisText = document.getElementById('diagnosis-text');
-  const statusSpan = document.getElementById('summary-status');
+  const diagnosisBox = $('#diagnosis-box');
+  const diagnosisText = $('#diagnosis-text');
+  const statusSpan = $('#summary-status');
   const runBtn = /** @type {HTMLButtonElement | null} */ (document.getElementById('run-diagnosis-btn'));
 
   const relativeA = `${trialA}/${runNumA}/${guideName}/${activeTask}/${runTypeA}`;
@@ -1453,6 +1689,9 @@ async function runDiagnosticAgent() {
       const errorText = await response.text();
       throw new Error(errorText || `HTTP error ${response.status}`);
     }
+    if (!response.body) {
+      throw new Error('Response body is null');
+    }
 
     // Set up a scrollable log container to stream raw output in real-time
     diagnosisText.innerHTML = `
@@ -1494,10 +1733,11 @@ async function runDiagnosticAgent() {
       }
     }
   } catch (e) {
+    const errorMsg = e instanceof Error ? e.message : String(e);
     console.error('LLM Diagnosis error:', e);
     diagnosisText.innerHTML = `
       <div style="color:#b91c1c; font-weight:600;">On-the-fly LLM diagnosis failed.</div>
-      <div style="font-size:0.9em; color:#64748b; margin-top:5px;">Error: ${escapeHtml(e.message)}</div>
+      <div style="font-size:0.9em; color:#64748b; margin-top:5px;">Error: ${escapeHtml(errorMsg)}</div>
       <div style="font-size:0.9em; margin-top:10px; color:#475569;">
         You can try running the comparison manually in your terminal:
         <pre style="background:#fff; border:1px solid #fecaca; margin-top:8px; padding:10px; border-radius:4px; font-family:monospace;">gd compare ../harness/results/${relativeA} ../harness/results/${relativeB}</pre>
@@ -1521,18 +1761,25 @@ window.onload = async () => {
 };
 
 // Expose module functions globally for inline HTML event handlers (since compare.js is loaded as a module)
-/** @type {any} */ (window).switchTab = switchTab;
-/** @type {any} */ (window).switchTask = switchTask;
-/** @type {any} */ (window).runDiagnosticAgent = runDiagnosticAgent;
+window.switchTab = switchTab;
+window.switchTask = switchTask;
+window.runDiagnosticAgent = runDiagnosticAgent;
 
+/**
+ * @param {'milestone' | 'raw'} mode
+ * @returns {void}
+ */
 function switchTimelineMode(mode) {
   timelineViewMode = mode;
   const pathPartA = `${trialA}/${runNumA}/${guideName}/${activeTask}/${runTypeA}`;
   const pathPartB = `${trialB}/${runNumB}/${guideName}/${activeTask}/${runTypeB}`;
   loadTrajectories(pathPartA, pathPartB);
 }
-/** @type {any} */ (window).switchTimelineMode = switchTimelineMode;
+window.switchTimelineMode = switchTimelineMode;
 
+/**
+ * @returns {void}
+ */
 function exportCompareReport() {
   const titleAStr = getFormattedTrialTitle('Trial A', trialA, runNumA, runTypeA, agentA, modelA, _loadedTrajA, suiteDataA, runIndexA);
   const titleBStr = getFormattedTrialTitle('Trial B', trialB, runNumB, runTypeB, agentB, modelB, _loadedTrajB, suiteDataB, runIndexB);
@@ -1593,7 +1840,8 @@ function exportCompareReport() {
       // Trial A
       report += `#### Trial A (Step ${pair.stepA?.stepNumber === 0 ? '0 - Starting Prompt / Launch' : pair.stepA?.stepNumber || 'N/A'})${markerA}\n`;
       if (pair.stepA) {
-        report += `- **Status**: ${pair.stepA.outcome?.status?.toUpperCase() || 'UNKNOWN'}\n`;
+        const outcomeStatus = typeof pair.stepA.outcome === 'object' && pair.stepA.outcome !== null && pair.stepA.outcome.status ? pair.stepA.outcome.status : 'UNKNOWN';
+        report += `- **Status**: ${outcomeStatus.toUpperCase()}\n`;
         if (pair.stepA.thought) {
           report += `- **Thinking / Reasoning**:\n\`\`\`\n${pair.stepA.thought.trim()}\n\`\`\`\n`;
         }
@@ -1607,7 +1855,9 @@ function exportCompareReport() {
           }
         }
         if (pair.stepA.outcome) {
-          const out = pair.stepA.outcome.output || pair.stepA.outcome.result || pair.stepA.outcome.message || pair.stepA.outcome.content || pair.stepA.outcome.text || pair.stepA.outcome.stdout || pair.stepA.outcome.stderr || '';
+          const out = typeof pair.stepA.outcome === 'object' && pair.stepA.outcome !== null
+            ? (pair.stepA.outcome.output || pair.stepA.outcome.result || pair.stepA.outcome.message || pair.stepA.outcome.content || pair.stepA.outcome.text || pair.stepA.outcome.stdout || pair.stepA.outcome.stderr || '')
+            : pair.stepA.outcome;
           if (out && typeof out !== 'object' || (typeof out === 'object' && Object.keys(out).length > 0)) {
             const outStr = typeof out === 'object' ? JSON.stringify(out, null, 2) : String(out);
             if (outStr !== '{}' && outStr !== 'null') {
@@ -1623,7 +1873,8 @@ function exportCompareReport() {
       // Trial B
       report += `#### Trial B (Step ${pair.stepB?.stepNumber === 0 ? '0 - Starting Prompt / Launch' : pair.stepB?.stepNumber || 'N/A'})${markerB}\n`;
       if (pair.stepB) {
-        report += `- **Status**: ${pair.stepB.outcome?.status?.toUpperCase() || 'UNKNOWN'}\n`;
+        const outcomeStatus = typeof pair.stepB.outcome === 'object' && pair.stepB.outcome !== null && pair.stepB.outcome.status ? pair.stepB.outcome.status : 'UNKNOWN';
+        report += `- **Status**: ${outcomeStatus.toUpperCase()}\n`;
         if (pair.stepB.thought) {
           report += `- **Thinking / Reasoning**:\n\`\`\`\n${pair.stepB.thought.trim()}\n\`\`\`\n`;
         }
@@ -1637,7 +1888,9 @@ function exportCompareReport() {
           }
         }
         if (pair.stepB.outcome) {
-          const out = pair.stepB.outcome.output || pair.stepB.outcome.result || pair.stepB.outcome.message || pair.stepB.outcome.content || pair.stepB.outcome.text || pair.stepB.outcome.stdout || pair.stepB.outcome.stderr || '';
+          const out = typeof pair.stepB.outcome === 'object' && pair.stepB.outcome !== null
+            ? (pair.stepB.outcome.output || pair.stepB.outcome.result || pair.stepB.outcome.message || pair.stepB.outcome.content || pair.stepB.outcome.text || pair.stepB.outcome.stdout || pair.stepB.outcome.stderr || '')
+            : pair.stepB.outcome;
           if (out && typeof out !== 'object' || (typeof out === 'object' && Object.keys(out).length > 0)) {
             const outStr = typeof out === 'object' ? JSON.stringify(out, null, 2) : String(out);
             if (outStr !== '{}' && outStr !== 'null') {
@@ -1678,4 +1931,4 @@ function exportCompareReport() {
   document.body.removeChild(a);
   URL.revokeObjectURL(url);
 }
-/** @type {any} */ (window).exportCompareReport = exportCompareReport;
+window.exportCompareReport = exportCompareReport;

--- a/eval-view/compare.js
+++ b/eval-view/compare.js
@@ -1193,8 +1193,8 @@ function findDivergenceInfo(trajA, trajB) {
       }
 
       if (sA.stepNumber === 0 && sB.stepNumber === 0) {
-        const pA = (sA.outcome && typeof sA.outcome === 'object' ? sA.outcome.output || '' : '').trim();
-        const pB = (sB.outcome && typeof sB.outcome === 'object' ? sB.outcome.output || '' : '').trim();
+        const pA = String(sA.outcome && typeof sA.outcome === 'object' ? sA.outcome.output || '' : '').trim();
+        const pB = String(sB.outcome && typeof sB.outcome === 'object' ? sB.outcome.output || '' : '').trim();
         if (pA && pB && pA !== pB) {
           primaryStepA = 0;
           primaryStepB = 0;

--- a/eval-view/compare.js
+++ b/eval-view/compare.js
@@ -2,25 +2,9 @@
 import { getAccessToken, capitalize, normalizeTrajectoryClient, parseResultKey, escapeHtml, $ } from './utils.js';
 
 /**
- * @typedef {import('../harness/lib/metrics.ts').EvalsReport & {
- *   enableSkills?: boolean;
- * }} SuiteReport
- *
- * @typedef {Omit<import('../harness/lib/trajectory-normalizer.ts').StandardizedStep, 'action' | 'outcome'> & {
- *   action?: {
- *     type?: string;
- *     name?: string;
- *     params?: any;
- *     canonicalCategory?: string;
- *   };
- *   outcome?: any;
- *   output?: any;
- *   result?: any;
- * }} CompareStep
- *
- * @typedef {import('../harness/lib/trajectory-normalizer.ts').TrajectorySummary & {
- *   steps: CompareStep[];
- * }} CompareTrajectory
+ * @import { EvalsReport } from '../harness/lib/metrics.ts'
+ * @import { StandardizedStep, TrajectorySummary } from '../harness/lib/trajectory-normalizer.ts'
+ * @import { SelectedTrialPoint, CompareSide, SuiteReport, CompareStep, CompareTrajectory } from './evals.d.ts'
  *
  * @typedef {Object} AlignedStepPair
  * @property {CompareStep | null} stepA
@@ -55,44 +39,37 @@ let activeTask = '';
 let availableTasks = [];
 /** @type {'milestone' | 'raw'} */
 let timelineViewMode = 'milestone'; // 'milestone' | 'raw'
-/** @type {CompareTrajectory | null} */
-let _loadedTrajA = null;
-/** @type {CompareTrajectory | null} */
-let _loadedTrajB = null;
-let _loadedChatA = '';
-let _loadedChatB = '';
-
-// Context parameters
-let trialA = '';
-let trialB = '';
-let runNumA = '1';
-let runNumB = '1';
-let runIndexA = '';
-let runIndexB = '';
 let guideName = '';
 let isStatic = false;
-let agentA = '';
-let modelA = '';
-/** @type {string | null} */
-let scoreAParam = null;
-let agentB = '';
-let modelB = '';
-/** @type {string | null} */
-let scoreBParam = null;
 
-// Live Run Types & Scores
-let runTypeA = 'guided';
-let runTypeB = 'guided';
-let currentScoreA = 0;
-let currentScoreB = 0;
+/**
+ * Factory for creating a side of the trial comparison
+ * @param {'A' | 'B'} key
+ * @param {string} label
+ * @returns {CompareSide}
+ */
+function createCompareSide(key, label) {
+  return {
+    key,
+    label,
+    testId: '',
+    trialId: '',
+    runNum: '1',
+    runIndex: undefined,
+    agent: '',
+    model: '',
+    scoreParam: null,
+    score: 0,
+    runType: 'guided',
+    runDir: '',
+    suiteData: null,
+    trajectory: null,
+    chatLog: '',
+  };
+}
 
-// Parsed run data
-let _runDirA = '';
-let _runDirB = '';
-/** @type {SuiteReport | null} */
-let suiteDataA = null;
-/** @type {SuiteReport | null} */
-let suiteDataB = null;
+const sideA = createCompareSide('A', 'Trial A');
+const sideB = createCompareSide('B', 'Trial B');
 
 /**
  * Robust line-by-line markdown to HTML compiler with ANSI stripping & GFM Table support
@@ -315,48 +292,52 @@ function parseInline(text) {
 }
 
 /**
+ * @param {CompareSide} side
+ * @param {'A' | 'B'} key
+ * @param {URLSearchParams} urlParams
+ */
+function initSideFromParams(side, key, urlParams) {
+  side.trialId = urlParams.get(`trial${key}`) || (key === 'B' ? sideA.trialId : '');
+  side.testId = side.trialId;
+  const rawRunIndex = urlParams.get(`runIndex${key}`);
+  side.runIndex = rawRunIndex ? parseInt(rawRunIndex, 10) : undefined;
+  side.agent = urlParams.get(`agent${key}`) || '';
+  side.model = urlParams.get(`model${key}`) || '';
+  side.scoreParam = urlParams.get(`score${key}`);
+  side.runType = /** @type {'guided' | 'unguided'} */ (urlParams.get(`runType${key}`) || 'guided');
+  side.runNum = urlParams.get(`run${key}`) || (side.runIndex !== undefined ? String(side.runIndex) : (key === 'B' && sideA.trialId === side.trialId ? '2' : '1'));
+}
+
+/**
  * Extract query parameters
  * @returns {boolean}
  */
 function initParams() {
   const urlParams = new URLSearchParams(window.location.search);
-  trialA = urlParams.get('trialA') || '';
-  trialB = urlParams.get('trialB') || trialA;
-  runIndexA = urlParams.get('runIndexA') || '';
-  runIndexB = urlParams.get('runIndexB') || '';
-  runNumA = urlParams.get('runA') || runIndexA || '1';
-  runNumB = urlParams.get('runB') || runIndexB || (trialA === trialB ? '2' : '1');
   guideName = urlParams.get('guide') || '';
   isStatic = urlParams.get('source') === 'static' || window.location.hostname.includes('github.io');
 
-  agentA = urlParams.get('agentA') || '';
-  modelA = urlParams.get('modelA') || '';
-  scoreAParam = urlParams.get('scoreA');
-  agentB = urlParams.get('agentB') || '';
-  modelB = urlParams.get('modelB') || '';
-  scoreBParam = urlParams.get('scoreB');
-
-  runTypeA = urlParams.get('runTypeA') || 'guided';
-  runTypeB = urlParams.get('runTypeB') || 'guided';
+  initSideFromParams(sideA, 'A', urlParams);
+  initSideFromParams(sideB, 'B', urlParams);
 
   // Initialize dropdown selections
   const elA = /** @type {HTMLSelectElement | null} */ (document.getElementById('run-type-a'));
   const elB = /** @type {HTMLSelectElement | null} */ (document.getElementById('run-type-b'));
-  if (elA) elA.value = runTypeA;
-  if (elB) elB.value = runTypeB;
+  if (elA) elA.value = sideA.runType;
+  if (elB) elB.value = sideB.runType;
 
   // Set up dropdown change listeners
   elA?.addEventListener('change', async (e) => {
     const target = /** @type {HTMLSelectElement | null} */ (e.target);
     if (target) {
-      runTypeA = target.value;
+      sideA.runType = /** @type {'guided' | 'unguided'} */ (target.value);
       await handleRunTypeChange();
     }
   });
   elB?.addEventListener('change', async (e) => {
     const target = /** @type {HTMLSelectElement | null} */ (e.target);
     if (target) {
-      runTypeB = target.value;
+      sideB.runType = /** @type {'guided' | 'unguided'} */ (target.value);
       await handleRunTypeChange();
     }
   });
@@ -367,7 +348,7 @@ function initParams() {
     backBtn.href = `guide.html?guide=${guideName}&source=${isStatic ? 'static' : 'local'}`;
   }
 
-  if (!trialA || !guideName) {
+  if (!sideA.trialId || !guideName) {
     $('#compare-title').innerText = 'Error: Missing Parameters';
     alert('Missing required parameters: trialA and guide are required.');
     return false;
@@ -491,13 +472,13 @@ async function loadTrialMetadata() {
   }
   
   // Ensure suite directories exist locally
-  await ensureRunDirectories(trialA, trialB);
+  await ensureRunDirectories(sideA.trialId, sideB.trialId);
 
   // Fetch Trial A suite metadata
   try {
-    const responseA = await fetch(`${resultsBase}/${trialA}/evals.json${srcParam}`);
+    const responseA = await fetch(`${resultsBase}/${sideA.trialId}/evals.json${srcParam}`);
     if (responseA.ok) {
-      suiteDataA = /** @type {SuiteReport} */ (await responseA.json());
+      sideA.suiteData = /** @type {SuiteReport} */ (await responseA.json());
     }
   } catch (e) {
     console.error('Failed to load Trial A suite data:', e);
@@ -505,13 +486,13 @@ async function loadTrialMetadata() {
 
   // Fetch Trial B suite metadata
   try {
-    if (trialA !== trialB) {
-      const responseB = await fetch(`${resultsBase}/${trialB}/evals.json${srcParam}`);
+    if (sideA.trialId !== sideB.trialId) {
+      const responseB = await fetch(`${resultsBase}/${sideB.trialId}/evals.json${srcParam}`);
       if (responseB.ok) {
-        suiteDataB = /** @type {SuiteReport} */ (await responseB.json());
+        sideB.suiteData = /** @type {SuiteReport} */ (await responseB.json());
       }
     } else {
-      suiteDataB = suiteDataA;
+      sideB.suiteData = sideA.suiteData;
     }
   } catch (e) {
     console.error('Failed to load Trial B suite data:', e);
@@ -523,8 +504,8 @@ async function loadTrialMetadata() {
   /** @type {Set<string>} */
   const tasksB = new Set();
 
-  if (suiteDataA?.results) {
-    Object.keys(suiteDataA.results).forEach(key => {
+  if (sideA.suiteData?.results) {
+    Object.keys(sideA.suiteData.results).forEach(key => {
       const parsedKey = parseResultKey(key);
       if (parsedKey && parsedKey.guide === guideName) {
         tasksA.add(parsedKey.task);
@@ -532,8 +513,8 @@ async function loadTrialMetadata() {
     });
   }
 
-  if (suiteDataB?.results) {
-    Object.keys(suiteDataB.results).forEach(key => {
+  if (sideB.suiteData?.results) {
+    Object.keys(sideB.suiteData.results).forEach(key => {
       const parsedKey = parseResultKey(key);
       if (parsedKey && parsedKey.guide === guideName) {
         tasksB.add(parsedKey.task);
@@ -588,8 +569,8 @@ function populateSidebar() {
     const btn = document.createElement('button');
     btn.className = `task-btn ${task === activeTask ? 'active' : ''}`;
     
-    const inA = suiteDataA ? checkTaskInSuite(suiteDataA, task) : true;
-    const inB = suiteDataB ? checkTaskInSuite(suiteDataB, task) : true;
+    const inA = sideA.suiteData ? checkTaskInSuite(sideA.suiteData, task) : true;
+    const inB = sideB.suiteData ? checkTaskInSuite(sideB.suiteData, task) : true;
     
     let taskLabel = task;
     if (!inA && inB) {
@@ -608,43 +589,43 @@ function populateSidebar() {
  * @returns {void}
  */
 function updateExecutiveSummary() {
-  const displayRunA = runIndexA ? runIndexA : runNumA;
-  const displayRunB = runIndexB ? runIndexB : runNumB;
+  const displayRunA = sideA.runIndex !== undefined ? sideA.runIndex : sideA.runNum;
+  const displayRunB = sideB.runIndex !== undefined ? sideB.runIndex : sideB.runNum;
 
   // Trial A
-  $('#title-a').innerText = `${trialA.slice(0, 18)} (Run ${displayRunA})`;
-  $('#meta-a').innerText = trialA.includes('test-') ? `Date: ${trialA.replace('test-', '').slice(0, 10)}` : 'Historical Suite';
+  $('#title-a').innerText = `${sideA.trialId.slice(0, 18)} (Run ${displayRunA})`;
+  $('#meta-a').innerText = sideA.trialId.includes('test-') ? `Date: ${sideA.trialId.replace('test-', '').slice(0, 10)}` : 'Historical Suite';
   
-  const displayAgentA = agentA || suiteDataA?.agent || 'Unknown';
-  const displayModelA = modelA || suiteDataA?.model || 'Unknown';
+  const displayAgentA = sideA.agent || sideA.suiteData?.agent || 'Unknown';
+  const displayModelA = sideA.model || sideA.suiteData?.model || 'Unknown';
   $('#agent-model-a').innerText = `Agent: ${displayAgentA} | Model: ${displayModelA}`;
 
   // Trial B
-  if (trialA === trialB) {
-    $('#title-b').innerText = `${trialA.slice(0, 18)} (Run ${displayRunB})`;
+  if (sideA.trialId === sideB.trialId) {
+    $('#title-b').innerText = `${sideA.trialId.slice(0, 18)} (Run ${displayRunB})`;
     $('#meta-b').innerText = 'Within-Trial Non-determinism Check';
   } else {
-    $('#title-b').innerText = `${trialB.slice(0, 18)} (Run ${displayRunB})`;
-    $('#meta-b').innerText = trialB.includes('test-') ? `Date: ${trialB.replace('test-', '').slice(0, 10)}` : 'Historical Suite';
+    $('#title-b').innerText = `${sideB.trialId.slice(0, 18)} (Run ${displayRunB})`;
+    $('#meta-b').innerText = sideB.trialId.includes('test-') ? `Date: ${sideB.trialId.replace('test-', '').slice(0, 10)}` : 'Historical Suite';
   }
   
-  const displayAgentB = agentB || suiteDataB?.agent || 'Unknown';
-  const displayModelB = modelB || suiteDataB?.model || 'Unknown';
+  const displayAgentB = sideB.agent || sideB.suiteData?.agent || 'Unknown';
+  const displayModelB = sideB.model || sideB.suiteData?.model || 'Unknown';
   $('#agent-model-b').innerText = `Agent: ${displayAgentB} | Model: ${displayModelB}`;
 
   // Calculate Scores for the specific guide across active run types and runs
-  currentScoreA = suiteDataA ? calculateGuideScore(suiteDataA, runNumA, runTypeA) : (scoreAParam !== null ? parseInt(scoreAParam, 10) : 0);
-  currentScoreB = suiteDataB ? calculateGuideScore(suiteDataB, runNumB, runTypeB) : (scoreBParam !== null ? parseInt(scoreBParam, 10) : 0);
+  sideA.score = sideA.suiteData ? calculateGuideScore(sideA.suiteData, sideA.runNum, sideA.runType) : (sideA.scoreParam !== null ? parseInt(sideA.scoreParam, 10) : 0);
+  sideB.score = sideB.suiteData ? calculateGuideScore(sideB.suiteData, sideB.runNum, sideB.runType) : (sideB.scoreParam !== null ? parseInt(sideB.scoreParam, 10) : 0);
 
   const badgeA = $('#score-badge-a');
-  badgeA.innerText = `${currentScoreA}%`;
-  badgeA.className = `score-badge ${currentScoreA >= 70 ? 'score-high' : 'score-low'}`;
+  badgeA.innerText = `${sideA.score}%`;
+  badgeA.className = `score-badge ${sideA.score >= 70 ? 'score-high' : 'score-low'}`;
 
   const badgeB = $('#score-badge-b');
-  badgeB.innerText = `${currentScoreB}%`;
-  badgeB.className = `score-badge ${currentScoreB >= 70 ? 'score-high' : 'score-low'}`;
+  badgeB.innerText = `${sideB.score}%`;
+  badgeB.className = `score-badge ${sideB.score >= 70 ? 'score-high' : 'score-low'}`;
 
-  const delta = currentScoreB - currentScoreA;
+  const delta = sideB.score - sideA.score;
   const deltaText = delta === 0 ? 'No change (0%)' : delta > 0 ? `+${delta}% Improvement` : `${delta}% Regression`;
   const deltaSpan = $('#summary-delta');
   deltaSpan.innerText = deltaText;
@@ -723,23 +704,18 @@ function getRunDateString(trialId) {
 }
 
 /**
- * @param {string} label
- * @param {string} trialId
- * @param {string | number} runNum
- * @param {string} [runType]
- * @param {string} [agent]
- * @param {string} [model]
- * @param {CompareTrajectory | null} [traj]
- * @param {SuiteReport | null} [suiteData]
- * @param {string | number} [overrideRunIndex]
+ * Helper to format human-readable title for split-pane views
+ * @param {CompareSide} side
+ * @param {CompareTrajectory | null} [trajOverride]
  * @returns {string}
  */
-function getFormattedTrialTitle(label, trialId, runNum, runType, agent, model, traj, suiteData, overrideRunIndex) {
-  const dateStr = getRunDateString(trialId);
-  const resolvedAgent = agent && agent !== 'unknown' ? agent : (traj?.agent || suiteData?.agent || 'Unknown Agent');
-  const resolvedModel = (model && model !== 'unknown' ? model : (traj?.model || suiteData?.model || 'Unknown Model')).replace(/^models\//, '');
-  const activeRunNum = overrideRunIndex || runNum;
-  return `${label} (Run ${activeRunNum} - ${capitalize(runType || 'guided')}) — agent: ${resolvedAgent} model: ${resolvedModel} (${dateStr})`;
+function getFormattedTrialTitle(side, trajOverride) {
+  const traj = trajOverride !== undefined ? trajOverride : side.trajectory;
+  const dateStr = getRunDateString(side.trialId);
+  const resolvedAgent = side.agent && side.agent !== 'unknown' ? side.agent : (traj?.agent || side.suiteData?.agent || 'Unknown Agent');
+  const resolvedModel = (side.model && side.model !== 'unknown' ? side.model : (traj?.model || side.suiteData?.model || 'Unknown Model')).replace(/^models\//, '');
+  const activeRunNum = side.runIndex !== undefined ? side.runIndex : side.runNum;
+  return `${side.label} (Run ${activeRunNum} - ${capitalize(side.runType || 'guided')}) — agent: ${resolvedAgent} model: ${resolvedModel} (${dateStr})`;
 }
 
 /**
@@ -754,15 +730,15 @@ async function loadActiveTaskDetails() {
   const resultsBase = isStatic ? 'results' : '';
   
   // Format run directory paths using active run types
-  const pathPartA = `${trialA}/${runNumA}/${guideName}/${activeTask}/${runTypeA}`;
-  const pathPartB = `${trialB}/${runNumB}/${guideName}/${activeTask}/${runTypeB}`;
+  const pathPartA = `${sideA.trialId}/${sideA.runNum}/${guideName}/${activeTask}/${sideA.runType}`;
+  const pathPartB = `${sideB.trialId}/${sideB.runNum}/${guideName}/${activeTask}/${sideB.runType}`;
   
-  _runDirA = `${resultsBase}/${pathPartA}`;
-  _runDirB = `${resultsBase}/${pathPartB}`;
+  sideA.runDir = `${resultsBase}/${pathPartA}`;
+  sideB.runDir = `${resultsBase}/${pathPartB}`;
 
   // Update split-pane column titles to display both run number and run type
-  const titleAStr = getFormattedTrialTitle('Trial A', trialA, runNumA, runTypeA, agentA, modelA, null, suiteDataA, runIndexA);
-  const titleBStr = getFormattedTrialTitle('Trial B', trialB, runNumB, runTypeB, agentB, modelB, null, suiteDataB, runIndexB);
+  const titleAStr = getFormattedTrialTitle(sideA);
+  const titleBStr = getFormattedTrialTitle(sideB);
 
   const timelineTitleA = document.getElementById('timeline-title-a');
   if (timelineTitleA) timelineTitleA.innerText = titleAStr;
@@ -879,8 +855,8 @@ async function loadAssertions(pathA, pathB) {
   } catch (e) {}
 
   // Update Assertion table column headers with task-specific pass rate
-  const titleAStr = getFormattedTrialTitle('Trial A', trialA, runNumA, runTypeA, agentA, modelA, null, suiteDataA, runIndexA);
-  const titleBStr = getFormattedTrialTitle('Trial B', trialB, runNumB, runTypeB, agentB, modelB, null, suiteDataB, runIndexB);
+  const titleAStr = getFormattedTrialTitle(sideA);
+  const titleBStr = getFormattedTrialTitle(sideB);
   if (resultsA.length > 0) {
     const passedA = resultsA.filter(r => r.passed).length;
     const taskScoreA = Math.round((passedA / resultsA.length) * 100);
@@ -1041,10 +1017,10 @@ async function loadTrajectories(pathA, pathB) {
     }
   } catch (e) {}
 
-  _loadedTrajA = trajA;
-  _loadedTrajB = trajB;
-  _loadedChatA = chatA;
-  _loadedChatB = chatB;
+  sideA.trajectory = trajA;
+  sideB.trajectory = trajB;
+  sideA.chatLog = chatA;
+  sideB.chatLog = chatB;
   renderTimelineRows(container, trajA, trajB, chatA, chatB, sessionUrlA, sessionUrlB);
 }
 
@@ -1264,8 +1240,8 @@ function renderTimelineRows(container, trajA, trajB, chatA = '', chatB = '', ses
 
   const { primaryStepA, primaryStepB } = findDivergenceInfo(trajA, trajB);
 
-  const titleAStr = getFormattedTrialTitle('Trial A', trialA, runNumA, runTypeA, agentA, modelA, trajA, suiteDataA, runIndexA);
-  const titleBStr = getFormattedTrialTitle('Trial B', trialB, runNumB, runTypeB, agentB, modelB, trajB, suiteDataB, runIndexB);
+  const titleAStr = getFormattedTrialTitle(sideA, trajA);
+  const titleBStr = getFormattedTrialTitle(sideB, trajB);
 
   const timelineTitleA = document.getElementById('timeline-title-a');
   if (timelineTitleA) timelineTitleA.innerText = titleAStr;
@@ -1602,8 +1578,8 @@ async function runDiagnosticAgent() {
   const statusSpan = $('#summary-status');
   const runBtn = /** @type {HTMLButtonElement | null} */ (document.getElementById('run-diagnosis-btn'));
 
-  const relativeA = `${trialA}/${runNumA}/${guideName}/${activeTask}/${runTypeA}`;
-  const relativeB = `${trialB}/${runNumB}/${guideName}/${activeTask}/${runTypeB}`;
+  const relativeA = `${sideA.trialId}/${sideA.runNum}/${guideName}/${activeTask}/${sideA.runType}`;
+  const relativeB = `${sideB.trialId}/${sideB.runNum}/${guideName}/${activeTask}/${sideB.runType}`;
 
   if (runBtn) {
     runBtn.disabled = true;
@@ -1628,7 +1604,7 @@ async function runDiagnosticAgent() {
     if (isStatic) {
       const resultsBase = 'results';
       const fileName = `${guideName}-${activeTask}-guided.md`;
-      const url = `${resultsBase}/${trialA}/variance_diagnoses/${fileName}`;
+      const url = `${resultsBase}/${sideA.trialId}/variance_diagnoses/${fileName}`;
       
       try {
         const response = await fetch(url);
@@ -1643,7 +1619,7 @@ async function runDiagnosticAgent() {
             <div style="font-size:0.9em; margin-top:5px; color:#475569;">
               Running in STATIC mode. On-the-fly LLM comparison is only available when running the dashboard locally via <code>pnpm dashboard</code>.
               To generate this report locally, run:
-              <pre style="background:#fff; border:1px solid #fecaca; margin-top:8px; padding:10px; border-radius:4px; font-family:monospace;">gd compare ${trialA}/${runNumA}/${guideName}/${activeTask}/guided ${trialB}/${runNumB}/${guideName}/${activeTask}/guided</pre>
+              <pre style="background:#fff; border:1px solid #fecaca; margin-top:8px; padding:10px; border-radius:4px; font-family:monospace;">gd compare ${sideA.trialId}/${sideA.runNum}/${guideName}/${activeTask}/guided ${sideB.trialId}/${sideB.runNum}/${guideName}/${activeTask}/guided</pre>
             </div>
           `;
           statusSpan.innerText = 'Not Pre-generated';
@@ -1657,10 +1633,10 @@ async function runDiagnosticAgent() {
     }
 
     // Local Mode: Call Node dev server API to run comparison on the fly!
-    const hasTaskA = suiteDataA ? checkTaskInSuite(suiteDataA, activeTask) : true;
-    const hasTaskB = suiteDataB ? checkTaskInSuite(suiteDataB, activeTask) : true;
+    const hasTaskA = sideA.suiteData ? checkTaskInSuite(sideA.suiteData, activeTask) : true;
+    const hasTaskB = sideB.suiteData ? checkTaskInSuite(sideB.suiteData, activeTask) : true;
 
-    if (suiteDataA && suiteDataB && (!hasTaskA || !hasTaskB)) {
+    if (sideA.suiteData && sideB.suiteData && (!hasTaskA || !hasTaskB)) {
       const missingIn = !hasTaskA && !hasTaskB ? 'both trials' : !hasTaskA ? 'Trial A' : 'Trial B';
       const presentIn = !hasTaskA ? 'Trial B' : 'Trial A';
       diagnosisText.innerHTML = `
@@ -1771,8 +1747,8 @@ window.runDiagnosticAgent = runDiagnosticAgent;
  */
 function switchTimelineMode(mode) {
   timelineViewMode = mode;
-  const pathPartA = `${trialA}/${runNumA}/${guideName}/${activeTask}/${runTypeA}`;
-  const pathPartB = `${trialB}/${runNumB}/${guideName}/${activeTask}/${runTypeB}`;
+  const pathPartA = `${sideA.trialId}/${sideA.runNum}/${guideName}/${activeTask}/${sideA.runType}`;
+  const pathPartB = `${sideB.trialId}/${sideB.runNum}/${guideName}/${activeTask}/${sideB.runType}`;
   loadTrajectories(pathPartA, pathPartB);
 }
 window.switchTimelineMode = switchTimelineMode;
@@ -1781,8 +1757,8 @@ window.switchTimelineMode = switchTimelineMode;
  * @returns {void}
  */
 function exportCompareReport() {
-  const titleAStr = getFormattedTrialTitle('Trial A', trialA, runNumA, runTypeA, agentA, modelA, _loadedTrajA, suiteDataA, runIndexA);
-  const titleBStr = getFormattedTrialTitle('Trial B', trialB, runNumB, runTypeB, agentB, modelB, _loadedTrajB, suiteDataB, runIndexB);
+  const titleAStr = getFormattedTrialTitle(sideA);
+  const titleBStr = getFormattedTrialTitle(sideB);
 
   let report = `# Cross-Run Variance Diagnosis & Trajectory Comparison Report\n`;
   report += `Generated: ${new Date().toISOString()}\n`;
@@ -1790,9 +1766,9 @@ function exportCompareReport() {
   report += `Active Task: ${activeTask}\n\n`;
 
   report += `## 1. Executive Summary\n`;
-  report += `- **Trial A**: ${titleAStr} | Score: ${currentScoreA}%\n`;
-  report += `- **Trial B**: ${titleBStr} | Score: ${currentScoreB}%\n`;
-  const delta = currentScoreB - currentScoreA;
+  report += `- **Trial A**: ${titleAStr} | Score: ${sideA.score}%\n`;
+  report += `- **Trial B**: ${titleBStr} | Score: ${sideB.score}%\n`;
+  const delta = sideB.score - sideA.score;
   report += `- **Score Delta**: ${delta === 0 ? 'No change (0%)' : delta > 0 ? `+${delta}% Improvement` : `${delta}% Regression`}\n\n`;
 
   report += `## 2. AI Variance Diagnosis\n`;
@@ -1801,7 +1777,7 @@ function exportCompareReport() {
   report += `${diagText.trim()}\n\n`;
 
   report += `## 3. Assertions Comparison Table\n`;
-  report += `| Assertion Check | Trial A (${currentScoreA}%) | Trial B (${currentScoreB}%) |\n`;
+  report += `| Assertion Check | Trial A (${sideA.score}%) | Trial B (${sideB.score}%) |\n`;
   report += `| :--- | :---: | :---: |\n`;
   const assertRows = document.querySelectorAll('#assert-tbody tr');
   if (assertRows && assertRows.length > 0) {
@@ -1822,11 +1798,11 @@ function exportCompareReport() {
   report += `\n`;
 
   report += `## 4. Trajectory Comparison (${timelineViewMode.toUpperCase()} Mode)\n`;
-  const aligned = alignTrajectorySteps(_loadedTrajA, _loadedTrajB, timelineViewMode);
+  const aligned = alignTrajectorySteps(sideA.trajectory, sideB.trajectory, timelineViewMode);
   if (aligned.length === 0) {
     report += `No trajectory steps available.\n\n`;
   } else {
-    const { primaryStepA, primaryStepB } = findDivergenceInfo(_loadedTrajA, _loadedTrajB);
+    const { primaryStepA, primaryStepB } = findDivergenceInfo(sideA.trajectory, sideB.trajectory);
     aligned.forEach((pair, idx) => {
       const stepNum = idx + 1;
       const isPrimaryA = Boolean(pair.stepA && (typeof pair.stepA.stepNumber === 'number' ? pair.stepA.stepNumber === primaryStepA : stepNum === primaryStepA));
@@ -1905,10 +1881,10 @@ function exportCompareReport() {
     });
   }
 
-  if (_loadedChatA || _loadedChatB) {
+  if (sideA.chatLog || sideB.chatLog) {
     report += `### Final Assistant Output\n\n`;
-    report += `#### Trial A Final Response:\n\`\`\`\n${(_loadedChatA || 'No final response recorded.').trim()}\n\`\`\`\n\n`;
-    report += `#### Trial B Final Response:\n\`\`\`\n${(_loadedChatB || 'No final response recorded.').trim()}\n\`\`\`\n\n`;
+    report += `#### Trial A Final Response:\n\`\`\`\n${(sideA.chatLog || 'No final response recorded.').trim()}\n\`\`\`\n\n`;
+    report += `#### Trial B Final Response:\n\`\`\`\n${(sideB.chatLog || 'No final response recorded.').trim()}\n\`\`\`\n\n`;
   }
 
   report += `## 5. Code Output Comparison\n\n`;

--- a/eval-view/compare.js
+++ b/eval-view/compare.js
@@ -4,11 +4,11 @@ import { getAccessToken, capitalize, normalizeTrajectoryClient, parseResultKey, 
 /**
  * @import { EvalsReport } from '../harness/lib/metrics.ts'
  * @import { StandardizedStep, TrajectorySummary } from '../harness/lib/trajectory-normalizer.ts'
- * @import { SelectedTrialPoint, CompareSide, SuiteReport, CompareStep, CompareTrajectory } from './evals.d.ts'
+ * @import { CompareSide, TrialSelection } from './evals.d.ts'
  *
  * @typedef {Object} AlignedStepPair
- * @property {CompareStep | null} stepA
- * @property {CompareStep | null} stepB
+ * @property {StandardizedStep | null} stepA
+ * @property {StandardizedStep | null} stepB
  *
  * @typedef {Object} DivergenceInfo
  * @property {number | null} primaryStepA
@@ -45,31 +45,34 @@ let isStatic = false;
 /**
  * Factory for creating a side of the trial comparison
  * @param {'A' | 'B'} key
- * @param {string} label
  * @returns {CompareSide}
  */
-function createCompareSide(key, label) {
+function createCompareSide(key) {
   return {
     key,
-    label,
     testId: '',
-    trialId: '',
-    runNum: '1',
-    runIndex: undefined,
+    runNumber: 1,
+    runType: 'guided',
     agent: '',
     model: '',
-    scoreParam: null,
     score: 0,
-    runType: 'guided',
-    runDir: '',
     suiteData: null,
     trajectory: null,
     chatLog: '',
   };
 }
 
-const sideA = createCompareSide('A', 'Trial A');
-const sideB = createCompareSide('B', 'Trial B');
+const sideA = createCompareSide('A');
+const sideB = createCompareSide('B');
+
+/**
+ * Encapsulates the relative directory path for a trial run.
+ * @param {CompareSide} side
+ * @returns {string}
+ */
+function getTrialPath(side) {
+  return `${side.testId}/${side.runNumber}/${guideName}/${activeTask}/${side.runType}`;
+}
 
 /**
  * Robust line-by-line markdown to HTML compiler with ANSI stripping & GFM Table support
@@ -292,20 +295,27 @@ function parseInline(text) {
 }
 
 /**
+ * Parses URL query parameters into a validated CompareSide domain object.
  * @param {CompareSide} side
  * @param {'A' | 'B'} key
  * @param {URLSearchParams} urlParams
+ * @param {CompareSide} [fallbackSide]
  */
-function initSideFromParams(side, key, urlParams) {
-  side.trialId = urlParams.get(`trial${key}`) || (key === 'B' ? sideA.trialId : '');
-  side.testId = side.trialId;
-  const rawRunIndex = urlParams.get(`runIndex${key}`);
-  side.runIndex = rawRunIndex ? parseInt(rawRunIndex, 10) : undefined;
+function parseSideFromUrl(side, key, urlParams, fallbackSide) {
+  const testId = urlParams.get(`trial${key}`) || fallbackSide?.testId || '';
+  const rawRun = urlParams.get(`runIndex${key}`) || urlParams.get(`run${key}`);
+  const defaultRun = fallbackSide && fallbackSide.testId === testId ? 2 : 1;
+  const parsedRun = rawRun ? parseInt(rawRun, 10) : defaultRun;
+  const rawScore = urlParams.get(`score${key}`);
+  const parsedScore = rawScore !== null ? parseInt(rawScore, 10) : 0;
+  const rawType = urlParams.get(`runType${key}`);
+
+  side.testId = testId;
+  side.runNumber = Number.isNaN(parsedRun) ? defaultRun : parsedRun;
+  side.runType = rawType === 'unguided' ? 'unguided' : 'guided';
   side.agent = urlParams.get(`agent${key}`) || '';
   side.model = urlParams.get(`model${key}`) || '';
-  side.scoreParam = urlParams.get(`score${key}`);
-  side.runType = /** @type {'guided' | 'unguided'} */ (urlParams.get(`runType${key}`) || 'guided');
-  side.runNum = urlParams.get(`run${key}`) || (side.runIndex !== undefined ? String(side.runIndex) : (key === 'B' && sideA.trialId === side.trialId ? '2' : '1'));
+  side.score = Number.isNaN(parsedScore) ? 0 : parsedScore;
 }
 
 /**
@@ -317,8 +327,8 @@ function initParams() {
   guideName = urlParams.get('guide') || '';
   isStatic = urlParams.get('source') === 'static' || window.location.hostname.includes('github.io');
 
-  initSideFromParams(sideA, 'A', urlParams);
-  initSideFromParams(sideB, 'B', urlParams);
+  parseSideFromUrl(sideA, 'A', urlParams);
+  parseSideFromUrl(sideB, 'B', urlParams, sideA);
 
   // Initialize dropdown selections
   const elA = /** @type {HTMLSelectElement | null} */ (document.getElementById('run-type-a'));
@@ -348,7 +358,7 @@ function initParams() {
     backBtn.href = `guide.html?guide=${guideName}&source=${isStatic ? 'static' : 'local'}`;
   }
 
-  if (!sideA.trialId || !guideName) {
+  if (!sideA.testId || !guideName) {
     $('#compare-title').innerText = 'Error: Missing Parameters';
     alert('Missing required parameters: trialA and guide are required.');
     return false;
@@ -459,6 +469,24 @@ async function ensureRunDirectories(dirA, dirB) {
 }
 
 /**
+ * Helper to fetch suite metadata for a test ID.
+ * @param {string} testId
+ * @param {string} resultsBase
+ * @param {string} srcParam
+ * @returns {Promise<EvalsReport | null>}
+ */
+async function loadSuiteData(testId, resultsBase, srcParam) {
+  if (!testId) return null;
+  try {
+    const res = await fetch(`${resultsBase}/${testId}/evals.json${srcParam}`);
+    if (res.ok) return /** @type {EvalsReport} */ (await res.json());
+  } catch (e) {
+    console.error(`Failed to load suite data for ${testId}:`, e);
+  }
+  return null;
+}
+
+/**
  * @returns {Promise<void>}
  */
 async function loadTrialMetadata() {
@@ -470,33 +498,15 @@ async function loadTrialMetadata() {
     guideLinkEl.innerText = guideName;
     guideLinkEl.href = `guide.html?guide=${encodeURIComponent(guideName)}&source=${encodeURIComponent(isStatic ? 'local' : (new URLSearchParams(window.location.search).get('source') || 'local'))}`;
   }
-  
+
   // Ensure suite directories exist locally
-  await ensureRunDirectories(sideA.trialId, sideB.trialId);
+  await ensureRunDirectories(sideA.testId, sideB.testId);
 
-  // Fetch Trial A suite metadata
-  try {
-    const responseA = await fetch(`${resultsBase}/${sideA.trialId}/evals.json${srcParam}`);
-    if (responseA.ok) {
-      sideA.suiteData = /** @type {SuiteReport} */ (await responseA.json());
-    }
-  } catch (e) {
-    console.error('Failed to load Trial A suite data:', e);
-  }
-
-  // Fetch Trial B suite metadata
-  try {
-    if (sideA.trialId !== sideB.trialId) {
-      const responseB = await fetch(`${resultsBase}/${sideB.trialId}/evals.json${srcParam}`);
-      if (responseB.ok) {
-        sideB.suiteData = /** @type {SuiteReport} */ (await responseB.json());
-      }
-    } else {
-      sideB.suiteData = sideA.suiteData;
-    }
-  } catch (e) {
-    console.error('Failed to load Trial B suite data:', e);
-  }
+  // Fetch suite metadata for Side A and Side B
+  sideA.suiteData = await loadSuiteData(sideA.testId, resultsBase, srcParam);
+  sideB.suiteData = sideA.testId === sideB.testId
+    ? sideA.suiteData
+    : await loadSuiteData(sideB.testId, resultsBase, srcParam);
 
   // Determine tasks belonging to this guide in Trial A and Trial B
   /** @type {Set<string>} */
@@ -547,7 +557,7 @@ async function loadTrialMetadata() {
 }
 
 /**
- * @param {SuiteReport | null | undefined} suiteData
+ * @param {EvalsReport | null | undefined} suiteData
  * @param {string} task
  * @returns {boolean}
  */
@@ -589,24 +599,21 @@ function populateSidebar() {
  * @returns {void}
  */
 function updateExecutiveSummary() {
-  const displayRunA = sideA.runIndex !== undefined ? sideA.runIndex : sideA.runNum;
-  const displayRunB = sideB.runIndex !== undefined ? sideB.runIndex : sideB.runNum;
-
   // Trial A
-  $('#title-a').innerText = `${sideA.trialId.slice(0, 18)} (Run ${displayRunA})`;
-  $('#meta-a').innerText = sideA.trialId.includes('test-') ? `Date: ${sideA.trialId.replace('test-', '').slice(0, 10)}` : 'Historical Suite';
+  $('#title-a').innerText = `${sideA.testId.slice(0, 18)} (Run ${sideA.runNumber})`;
+  $('#meta-a').innerText = sideA.testId.includes('test-') ? `Date: ${sideA.testId.replace('test-', '').slice(0, 10)}` : 'Historical Suite';
   
   const displayAgentA = sideA.agent || sideA.suiteData?.agent || 'Unknown';
   const displayModelA = sideA.model || sideA.suiteData?.model || 'Unknown';
   $('#agent-model-a').innerText = `Agent: ${displayAgentA} | Model: ${displayModelA}`;
 
   // Trial B
-  if (sideA.trialId === sideB.trialId) {
-    $('#title-b').innerText = `${sideA.trialId.slice(0, 18)} (Run ${displayRunB})`;
+  if (sideA.testId === sideB.testId) {
+    $('#title-b').innerText = `${sideA.testId.slice(0, 18)} (Run ${sideB.runNumber})`;
     $('#meta-b').innerText = 'Within-Trial Non-determinism Check';
   } else {
-    $('#title-b').innerText = `${sideB.trialId.slice(0, 18)} (Run ${displayRunB})`;
-    $('#meta-b').innerText = sideB.trialId.includes('test-') ? `Date: ${sideB.trialId.replace('test-', '').slice(0, 10)}` : 'Historical Suite';
+    $('#title-b').innerText = `${sideB.testId.slice(0, 18)} (Run ${sideB.runNumber})`;
+    $('#meta-b').innerText = sideB.testId.includes('test-') ? `Date: ${sideB.testId.replace('test-', '').slice(0, 10)}` : 'Historical Suite';
   }
   
   const displayAgentB = sideB.agent || sideB.suiteData?.agent || 'Unknown';
@@ -614,8 +621,12 @@ function updateExecutiveSummary() {
   $('#agent-model-b').innerText = `Agent: ${displayAgentB} | Model: ${displayModelB}`;
 
   // Calculate Scores for the specific guide across active run types and runs
-  sideA.score = sideA.suiteData ? calculateGuideScore(sideA.suiteData, sideA.runNum, sideA.runType) : (sideA.scoreParam !== null ? parseInt(sideA.scoreParam, 10) : 0);
-  sideB.score = sideB.suiteData ? calculateGuideScore(sideB.suiteData, sideB.runNum, sideB.runType) : (sideB.scoreParam !== null ? parseInt(sideB.scoreParam, 10) : 0);
+  if (sideA.suiteData) {
+    sideA.score = calculateGuideScore(sideA.suiteData, sideA.runNumber, sideA.runType);
+  }
+  if (sideB.suiteData) {
+    sideB.score = calculateGuideScore(sideB.suiteData, sideB.runNumber, sideB.runType);
+  }
 
   const badgeA = $('#score-badge-a');
   badgeA.innerText = `${sideA.score}%`;
@@ -639,27 +650,26 @@ function updateExecutiveSummary() {
 }
 
 /**
- * @param {SuiteReport | null | undefined} suiteData
- * @param {string | number} runNum
+ * @param {EvalsReport | null | undefined} suiteData
+ * @param {number} runNumber
  * @param {string} [runType]
  * @returns {number}
  */
-function calculateGuideScore(suiteData, runNum, runType) {
+function calculateGuideScore(suiteData, runNumber, runType) {
   if (!suiteData || !suiteData.results) return 0;
   
   let totalAsserts = 0;
   let passedAsserts = 0;
   
   const targetRunType = runType || 'guided';
-  const targetRunNum = typeof runNum === 'number' ? runNum : parseInt(runNum, 10);
 
   Object.keys(suiteData.results).forEach(key => {
     const parsedKey = parseResultKey(key);
     if (!parsedKey) return;
     if (parsedKey.guide === guideName && parsedKey.runType === targetRunType) {
       const runs = suiteData.results[key] || [];
-      const matchingRuns = (!isNaN(targetRunNum) && runs.some(r => r.runNumber === targetRunNum))
-        ? runs.filter(r => r.runNumber === targetRunNum)
+      const matchingRuns = (!isNaN(runNumber) && runs.some(r => r.runNumber === runNumber))
+        ? runs.filter(r => r.runNumber === runNumber)
         : runs;
 
       matchingRuns.forEach(r => {
@@ -692,30 +702,29 @@ async function switchTask(task) {
 }
 
 /**
- * @param {string | null | undefined} trialId
+ * @param {string | null | undefined} testId
  * @returns {string}
  */
-function getRunDateString(trialId) {
-  if (!trialId) return 'Unknown Date';
-  const match = trialId.match(/\d{4}-\d{2}-\d{2}/);
+function getRunDateString(testId) {
+  if (!testId) return 'Unknown Date';
+  const match = testId.match(/\d{4}-\d{2}-\d{2}/);
   if (match) return match[0];
-  if (trialId.includes('test-')) return trialId.replace('test-', '').slice(0, 10);
-  return trialId.slice(0, 12);
+  if (testId.includes('test-')) return testId.replace('test-', '').slice(0, 10);
+  return testId.slice(0, 12);
 }
 
 /**
  * Helper to format human-readable title for split-pane views
  * @param {CompareSide} side
- * @param {CompareTrajectory | null} [trajOverride]
+ * @param {TrajectorySummary | null} [trajOverride]
  * @returns {string}
  */
 function getFormattedTrialTitle(side, trajOverride) {
   const traj = trajOverride !== undefined ? trajOverride : side.trajectory;
-  const dateStr = getRunDateString(side.trialId);
+  const dateStr = getRunDateString(side.testId);
   const resolvedAgent = side.agent && side.agent !== 'unknown' ? side.agent : (traj?.agent || side.suiteData?.agent || 'Unknown Agent');
   const resolvedModel = (side.model && side.model !== 'unknown' ? side.model : (traj?.model || side.suiteData?.model || 'Unknown Model')).replace(/^models\//, '');
-  const activeRunNum = side.runIndex !== undefined ? side.runIndex : side.runNum;
-  return `${side.label} (Run ${activeRunNum} - ${capitalize(side.runType || 'guided')}) — agent: ${resolvedAgent} model: ${resolvedModel} (${dateStr})`;
+  return `Trial ${side.key} (Run ${side.runNumber} - ${capitalize(side.runType)}) — agent: ${resolvedAgent} model: ${resolvedModel} (${dateStr})`;
 }
 
 /**
@@ -727,14 +736,8 @@ async function loadActiveTaskDetails() {
   $('#tab-content-timeline').style.display = 'none';
   $('#tab-content-code').style.display = 'none';
 
-  const resultsBase = isStatic ? 'results' : '';
-  
-  // Format run directory paths using active run types
-  const pathPartA = `${sideA.trialId}/${sideA.runNum}/${guideName}/${activeTask}/${sideA.runType}`;
-  const pathPartB = `${sideB.trialId}/${sideB.runNum}/${guideName}/${activeTask}/${sideB.runType}`;
-  
-  sideA.runDir = `${resultsBase}/${pathPartA}`;
-  sideB.runDir = `${resultsBase}/${pathPartB}`;
+  const pathPartA = getTrialPath(sideA);
+  const pathPartB = getTrialPath(sideB);
 
   // Update split-pane column titles to display both run number and run type
   const titleAStr = getFormattedTrialTitle(sideA);
@@ -915,7 +918,7 @@ async function loadAssertions(pathA, pathB) {
 }
 
 /**
- * @param {CompareTrajectory | null | undefined} traj
+ * @param {TrajectorySummary | null | undefined} traj
  * @param {string} pathStr
  * @param {string} resultsBase
  * @returns {Promise<void>}
@@ -962,9 +965,9 @@ async function loadTrajectories(pathA, pathB) {
   const container = $('#tab-content-timeline');
   container.innerHTML = '<div style="padding:20px; text-align:center; color:#64748b;">Loading aligned trajectories...</div>';
 
-  /** @type {CompareTrajectory | null} */
+  /** @type {TrajectorySummary | null} */
   let trajA = null;
-  /** @type {CompareTrajectory | null} */
+  /** @type {TrajectorySummary | null} */
   let trajB = null;
   let chatA = '';
   let chatB = '';
@@ -974,7 +977,7 @@ async function loadTrajectories(pathA, pathB) {
   try {
     const resA = await fetch(`${resultsBase}/${pathA}/trajectory_summary.json${srcParam}`);
     if (resA.ok) {
-      trajA = /** @type {CompareTrajectory} */ (normalizeTrajectoryClient(await resA.json()));
+      trajA = /** @type {TrajectorySummary} */ (normalizeTrajectoryClient(await resA.json()));
       await enrichTrajectorySteps(trajA, pathA, resultsBase);
     }
   } catch (e) {}
@@ -982,7 +985,7 @@ async function loadTrajectories(pathA, pathB) {
   try {
     const resB = await fetch(`${resultsBase}/${pathB}/trajectory_summary.json${srcParam}`);
     if (resB.ok) {
-      trajB = /** @type {CompareTrajectory} */ (normalizeTrajectoryClient(await resB.json()));
+      trajB = /** @type {TrajectorySummary} */ (normalizeTrajectoryClient(await resB.json()));
       await enrichTrajectorySteps(trajB, pathB, resultsBase);
     }
   } catch (e) {}
@@ -1025,22 +1028,22 @@ async function loadTrajectories(pathA, pathB) {
 }
 
 /**
- * @param {CompareTrajectory | CompareStep[] | null | undefined} trajOrStepsA
- * @param {CompareTrajectory | CompareStep[] | null | undefined} trajOrStepsB
+ * @param {TrajectorySummary | StandardizedStep[] | null | undefined} trajOrStepsA
+ * @param {TrajectorySummary | StandardizedStep[] | null | undefined} trajOrStepsB
  * @param {'milestone' | 'raw'} [mode='milestone']
  * @returns {AlignedStepPair[]}
  */
 function alignTrajectorySteps(trajOrStepsA, trajOrStepsB, mode = 'milestone') {
-  /** @type {{ steps: CompareStep[], initialPrompt?: string }} */
+  /** @type {{ steps: StandardizedStep[], initialPrompt?: string }} */
   const trajAObj = (trajOrStepsA && !Array.isArray(trajOrStepsA)) ? trajOrStepsA : { steps: Array.isArray(trajOrStepsA) ? trajOrStepsA : [] };
-  /** @type {{ steps: CompareStep[], initialPrompt?: string }} */
+  /** @type {{ steps: StandardizedStep[], initialPrompt?: string }} */
   const trajBObj = (trajOrStepsB && !Array.isArray(trajOrStepsB)) ? trajOrStepsB : { steps: Array.isArray(trajOrStepsB) ? trajOrStepsB : [] };
 
   let listA = trajAObj.steps || [];
   let listB = trajBObj.steps || [];
 
   if (mode === 'milestone') {
-    const filterFn = (/** @type {CompareStep} */ s) => s.action?.canonicalCategory && s.action.canonicalCategory !== 'incidental_noise' && s.action.canonicalCategory !== 'launch';
+    const filterFn = (/** @type {StandardizedStep} */ s) => s.action?.canonicalCategory && s.action.canonicalCategory !== 'incidental_noise';
     const filteredA = listA.filter(filterFn);
     const filteredB = listB.filter(filterFn);
     if (filteredA.length > 0 || filteredB.length > 0) {
@@ -1057,8 +1060,8 @@ function alignTrajectorySteps(trajOrStepsA, trajOrStepsB, mode = 'milestone') {
   const gapPenalty = -2;
 
   /**
-   * @param {CompareStep} sA
-   * @param {CompareStep} sB
+   * @param {StandardizedStep} sA
+   * @param {StandardizedStep} sB
    * @returns {number}
    */
   function matchScore(sA, sB) {
@@ -1113,18 +1116,18 @@ function alignTrajectorySteps(trajOrStepsA, trajOrStepsB, mode = 'milestone') {
     const promptA = trajAObj.initialPrompt || '';
     const promptB = trajBObj.initialPrompt || '';
     if (promptA || promptB) {
-      /** @type {CompareStep | null} */
+      /** @type {StandardizedStep | null} */
       const step0A = promptA ? {
         stepNumber: 0,
         thought: 'Harness launched agent with initial prompt',
-        action: { type: 'launch', name: 'Starting Prompt / Launch', params: { prompt: promptA }, canonicalCategory: 'launch' },
+        action: { type: 'other', name: 'Starting Prompt / Launch', params: { prompt: promptA }, canonicalCategory: 'other' },
         outcome: { status: 'success', output: promptA }
       } : null;
-      /** @type {CompareStep | null} */
+      /** @type {StandardizedStep | null} */
       const step0B = promptB ? {
         stepNumber: 0,
         thought: 'Harness launched agent with initial prompt',
-        action: { type: 'launch', name: 'Starting Prompt / Launch', params: { prompt: promptB }, canonicalCategory: 'launch' },
+        action: { type: 'other', name: 'Starting Prompt / Launch', params: { prompt: promptB }, canonicalCategory: 'other' },
         outcome: { status: 'success', output: promptB }
       } : null;
       alignedResult.unshift({ stepA: step0A, stepB: step0B });
@@ -1135,8 +1138,8 @@ function alignTrajectorySteps(trajOrStepsA, trajOrStepsB, mode = 'milestone') {
 }
 
 /**
- * @param {CompareTrajectory | null | undefined} trajA
- * @param {CompareTrajectory | null | undefined} trajB
+ * @param {TrajectorySummary | null | undefined} trajA
+ * @param {TrajectorySummary | null | undefined} trajB
  * @returns {DivergenceInfo}
  */
 function findDivergenceInfo(trajA, trajB) {
@@ -1220,8 +1223,8 @@ function findDivergenceInfo(trajA, trajB) {
 
 /**
  * @param {HTMLElement} container
- * @param {CompareTrajectory | null} trajA
- * @param {CompareTrajectory | null} trajB
+ * @param {TrajectorySummary | null} trajA
+ * @param {TrajectorySummary | null} trajB
  * @param {string} [chatA='']
  * @param {string} [chatB='']
  * @param {string} [sessionUrlA='']
@@ -1366,7 +1369,7 @@ function renderTimelineRows(container, trajA, trajB, chatA = '', chatB = '', ses
 }
 
 /**
- * @param {CompareStep} step
+ * @param {StandardizedStep} step
  * @param {boolean} [isDivergent=false]
  * @param {string} [sessionUrl='']
  * @returns {string}
@@ -1435,9 +1438,12 @@ function renderStepCardHtml(step, isDivergent = false, sessionUrl = '') {
         }
       }
     }
-  } else if (step.output || step.result) {
-    outcomeText = step.output || step.result;
-    if (typeof outcomeText === 'object') outcomeText = JSON.stringify(outcomeText, null, 2);
+  } else {
+    const unnormalizedStep = /** @type {Record<string, any>} */ (step);
+    if (unnormalizedStep.output || unnormalizedStep.result) {
+      outcomeText = unnormalizedStep.output || unnormalizedStep.result;
+      if (typeof outcomeText === 'object') outcomeText = JSON.stringify(outcomeText, null, 2);
+    }
   }
 
   const cleanText = String(outcomeText || '').trim().replace(/\s+/g, '');
@@ -1578,8 +1584,8 @@ async function runDiagnosticAgent() {
   const statusSpan = $('#summary-status');
   const runBtn = /** @type {HTMLButtonElement | null} */ (document.getElementById('run-diagnosis-btn'));
 
-  const relativeA = `${sideA.trialId}/${sideA.runNum}/${guideName}/${activeTask}/${sideA.runType}`;
-  const relativeB = `${sideB.trialId}/${sideB.runNum}/${guideName}/${activeTask}/${sideB.runType}`;
+  const relativeA = getTrialPath(sideA);
+  const relativeB = getTrialPath(sideB);
 
   if (runBtn) {
     runBtn.disabled = true;
@@ -1604,7 +1610,7 @@ async function runDiagnosticAgent() {
     if (isStatic) {
       const resultsBase = 'results';
       const fileName = `${guideName}-${activeTask}-guided.md`;
-      const url = `${resultsBase}/${sideA.trialId}/variance_diagnoses/${fileName}`;
+      const url = `${resultsBase}/${sideA.testId}/variance_diagnoses/${fileName}`;
       
       try {
         const response = await fetch(url);
@@ -1619,7 +1625,7 @@ async function runDiagnosticAgent() {
             <div style="font-size:0.9em; margin-top:5px; color:#475569;">
               Running in STATIC mode. On-the-fly LLM comparison is only available when running the dashboard locally via <code>pnpm dashboard</code>.
               To generate this report locally, run:
-              <pre style="background:#fff; border:1px solid #fecaca; margin-top:8px; padding:10px; border-radius:4px; font-family:monospace;">gd compare ${sideA.trialId}/${sideA.runNum}/${guideName}/${activeTask}/guided ${sideB.trialId}/${sideB.runNum}/${guideName}/${activeTask}/guided</pre>
+              <pre style="background:#fff; border:1px solid #fecaca; margin-top:8px; padding:10px; border-radius:4px; font-family:monospace;">gd compare ${getTrialPath(sideA)} ${getTrialPath(sideB)}</pre>
             </div>
           `;
           statusSpan.innerText = 'Not Pre-generated';
@@ -1747,9 +1753,7 @@ window.runDiagnosticAgent = runDiagnosticAgent;
  */
 function switchTimelineMode(mode) {
   timelineViewMode = mode;
-  const pathPartA = `${sideA.trialId}/${sideA.runNum}/${guideName}/${activeTask}/${sideA.runType}`;
-  const pathPartB = `${sideB.trialId}/${sideB.runNum}/${guideName}/${activeTask}/${sideB.runType}`;
-  loadTrajectories(pathPartA, pathPartB);
+  loadTrajectories(getTrialPath(sideA), getTrialPath(sideB));
 }
 window.switchTimelineMode = switchTimelineMode;
 
@@ -1831,8 +1835,9 @@ function exportCompareReport() {
           }
         }
         if (pair.stepA.outcome) {
+          const outcomeObj = /** @type {Record<string, any>} */ (pair.stepA.outcome);
           const out = typeof pair.stepA.outcome === 'object' && pair.stepA.outcome !== null
-            ? (pair.stepA.outcome.output || pair.stepA.outcome.result || pair.stepA.outcome.message || pair.stepA.outcome.content || pair.stepA.outcome.text || pair.stepA.outcome.stdout || pair.stepA.outcome.stderr || '')
+            ? (outcomeObj.output || outcomeObj.result || outcomeObj.message || outcomeObj.content || outcomeObj.text || outcomeObj.stdout || outcomeObj.stderr || '')
             : pair.stepA.outcome;
           if (out && typeof out !== 'object' || (typeof out === 'object' && Object.keys(out).length > 0)) {
             const outStr = typeof out === 'object' ? JSON.stringify(out, null, 2) : String(out);
@@ -1864,8 +1869,9 @@ function exportCompareReport() {
           }
         }
         if (pair.stepB.outcome) {
+          const outcomeObj = /** @type {Record<string, any>} */ (pair.stepB.outcome);
           const out = typeof pair.stepB.outcome === 'object' && pair.stepB.outcome !== null
-            ? (pair.stepB.outcome.output || pair.stepB.outcome.result || pair.stepB.outcome.message || pair.stepB.outcome.content || pair.stepB.outcome.text || pair.stepB.outcome.stdout || pair.stepB.outcome.stderr || '')
+            ? (outcomeObj.output || outcomeObj.result || outcomeObj.message || outcomeObj.content || outcomeObj.text || outcomeObj.stdout || outcomeObj.stderr || '')
             : pair.stepB.outcome;
           if (out && typeof out !== 'object' || (typeof out === 'object' && Object.keys(out).length > 0)) {
             const outStr = typeof out === 'object' ? JSON.stringify(out, null, 2) : String(out);

--- a/eval-view/compare.js
+++ b/eval-view/compare.js
@@ -1,0 +1,1634 @@
+import { getAccessToken, capitalize, normalizeTrajectoryClient } from './utils.js';
+
+// Cross-Run Performance Variance Diagnosis Dashboard JavaScript
+
+let currentTab = 'assertions';
+let activeTask = '';
+let availableTasks = [];
+let timelineViewMode = 'milestone'; // 'milestone' | 'raw'
+let _loadedTrajA = null;
+let _loadedTrajB = null;
+let _loadedChatA = '';
+let _loadedChatB = '';
+
+// Context parameters
+let trialA = '';
+let trialB = '';
+let runNumA = '1';
+let runNumB = '1';
+let runIndexA = '';
+let runIndexB = '';
+let guideName = '';
+let isStatic = false;
+let agentA = '';
+let modelA = '';
+let scoreAParam = null;
+let agentB = '';
+let modelB = '';
+let scoreBParam = null;
+
+// Live Run Types & Scores
+let runTypeA = 'guided';
+let runTypeB = 'guided';
+let currentScoreA = 0;
+let currentScoreB = 0;
+
+// Parsed run data
+let _runDirA = '';
+let _runDirB = '';
+let suiteDataA = null;
+let suiteDataB = null;
+
+// Robust line-by-line markdown to HTML compiler with ANSI stripping & GFM Table support
+function renderMarkdown(md) {
+  if (!md) return '';
+  
+  // Strip ANSI escape sequences (e.g. \x1b[36m)
+  let cleanMd = md.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '').trim();
+  
+  const lines = cleanMd.split('\n');
+  let html = '';
+  let inList = false;
+  let inParagraph = false;
+  let inCodeBlock = false;
+  let inTable = false;
+  let codeLanguage = '';
+  let codeContent = [];
+  let tableHeaders = [];
+  let tableAlignments = [];
+  let tableRows = [];
+  
+  for (let i = 0; i < lines.length; i++) {
+    let line = lines[i].trim();
+    
+    // 1. Handle Code Blocks
+    if (line.startsWith('```')) {
+      if (inCodeBlock) {
+        html += `<pre><code class="language-${codeLanguage}">${codeContent.join('\n')}</code></pre>`;
+        inCodeBlock = false;
+        codeContent = [];
+      } else {
+        inCodeBlock = true;
+        codeLanguage = line.substring(3).trim();
+      }
+      continue;
+    }
+    
+    if (inCodeBlock) {
+      codeContent.push(line);
+      continue;
+    }
+    
+    // Escape HTML in non-code lines
+    line = line
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+      
+    if (!line) {
+      if (inTable) {
+        html += renderTableHtml(tableHeaders, tableAlignments, tableRows);
+        inTable = false;
+        tableHeaders = [];
+        tableAlignments = [];
+        tableRows = [];
+      }
+      if (inList) {
+        html += '</ul>';
+        inList = false;
+      }
+      if (inParagraph) {
+        html += '</p>';
+        inParagraph = false;
+      }
+      continue;
+    }
+
+    // 2. Handle Tables
+    const isTableLine = line.startsWith('|') && line.endsWith('|');
+    if (inTable && !isTableLine) {
+      html += renderTableHtml(tableHeaders, tableAlignments, tableRows);
+      inTable = false;
+      tableHeaders = [];
+      tableAlignments = [];
+      tableRows = [];
+    }
+
+    if (isTableLine) {
+      if (inParagraph) { html += '</p>'; inParagraph = false; }
+      if (inList) { html += '</ul>'; inList = false; }
+      
+      if (!inTable) {
+        // Look ahead to check if the next line is a divider
+        const nextLine = (lines[i+1] || '').trim();
+        const escapedNextLine = nextLine
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;');
+        const isNextDivider = escapedNextLine.startsWith('|') && /^[\s|:-]+$/.test(escapedNextLine);
+        
+        if (isNextDivider) {
+          inTable = true;
+          tableRows = [];
+          
+          const cells = line.split('|').map(c => c.trim()).filter((c, idx, arr) => idx > 0 && idx < arr.length - 1);
+          tableHeaders = cells;
+          
+          const dividerCells = escapedNextLine.split('|').map(c => c.trim()).filter((c, idx, arr) => idx > 0 && idx < arr.length - 1);
+          tableAlignments = dividerCells.map(cell => {
+            const left = cell.startsWith(':');
+            const right = cell.endsWith(':');
+            if (left && right) return 'center';
+            if (right) return 'right';
+            return 'left';
+          });
+          
+          i++; // Skip the divider line
+          continue;
+        }
+      } else {
+        const cells = line.split('|').map(c => c.trim()).filter((c, idx, arr) => idx > 0 && idx < arr.length - 1);
+        tableRows.push(cells);
+        continue;
+      }
+    }
+    
+    // 3. Handle Headings
+    if (line.startsWith('#')) {
+      const match = line.match(/^(#{1,6})\s+(.*)$/);
+      if (match) {
+        if (inList) { html += '</ul>'; inList = false; }
+        if (inParagraph) { html += '</p>'; inParagraph = false; }
+        const level = match[1].length;
+        html += `<h${level}>${parseInline(match[2])}</h${level}>`;
+        continue;
+      }
+    }
+    
+    // 4. Handle Lists
+    const listMatch = line.match(/^([-*+])\s+(.*)$/);
+    if (listMatch) {
+      if (inParagraph) { html += '</p>'; inParagraph = false; }
+      if (!inList) {
+        html += '<ul>';
+        inList = true;
+      }
+      html += `<li>${parseInline(listMatch[2])}</li>`;
+      continue;
+    }
+    
+    // 5. Handle Horizontal Rules
+    if (line === '---' || line === '***') {
+      if (inList) { html += '</ul>'; inList = false; }
+      if (inParagraph) { html += '</p>'; inParagraph = false; }
+      html += '<hr>';
+      continue;
+    }
+    
+    // 6. Handle Paragraphs
+    if (!inParagraph) {
+      html += '<p>';
+      inParagraph = true;
+      html += parseInline(line);
+    } else {
+      html += '<br>' + parseInline(line);
+    }
+  }
+  
+  if (inTable) html += renderTableHtml(tableHeaders, tableAlignments, tableRows);
+  if (inList) html += '</ul>';
+  if (inParagraph) html += '</p>';
+  if (inCodeBlock) html += `<pre><code>${codeContent.join('\n')}</code></pre>`;
+  
+  return html;
+}
+
+// Helper to compile a parsed markdown table into structured HTML
+function renderTableHtml(headers, alignments, rows) {
+  let html = '<table class="markdown-table">';
+  
+  // Header Row
+  html += '<thead><tr>';
+  headers.forEach((h, idx) => {
+    const align = alignments[idx] || 'left';
+    html += `<th style="text-align:${align}">${parseInline(h)}</th>`;
+  });
+  html += '</tr></thead>';
+  
+  // Body Rows
+  html += '<tbody>';
+  rows.forEach(row => {
+    html += '<tr>';
+    for (let idx = 0; idx < headers.length; idx++) {
+      const cell = row[idx] || '';
+      const align = alignments[idx] || 'left';
+      html += `<td style="text-align:${align}">${parseInline(cell)}</td>`;
+    }
+    html += '</tr>';
+  });
+  html += '</tbody></table>';
+  
+  return html;
+}
+
+function parseInline(text) {
+  // Bold: **text**
+  text = text.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+  // Italic: *text*
+  text = text.replace(/\*([^*]+)\*/g, '<em>$1</em>');
+  // Inline code: `code`
+  text = text.replace(/`([^`]+)`/g, '<code>$1</code>');
+  return text;
+}
+
+// Extract query parameters
+function initParams() {
+  const urlParams = new URLSearchParams(window.location.search);
+  trialA = urlParams.get('trialA') || '';
+  trialB = urlParams.get('trialB') || trialA;
+  runIndexA = urlParams.get('runIndexA') || '';
+  runIndexB = urlParams.get('runIndexB') || '';
+  runNumA = urlParams.get('runA') || runIndexA || '1';
+  runNumB = urlParams.get('runB') || runIndexB || (trialA === trialB ? '2' : '1');
+  guideName = urlParams.get('guide') || '';
+  isStatic = urlParams.get('source') === 'static' || window.location.hostname.includes('github.io');
+
+  agentA = urlParams.get('agentA') || '';
+  modelA = urlParams.get('modelA') || '';
+  scoreAParam = urlParams.get('scoreA');
+  agentB = urlParams.get('agentB') || '';
+  modelB = urlParams.get('modelB') || '';
+  scoreBParam = urlParams.get('scoreB');
+
+  runTypeA = urlParams.get('runTypeA') || 'guided';
+  runTypeB = urlParams.get('runTypeB') || 'guided';
+
+  // Initialize dropdown selections
+  const elA = /** @type {HTMLSelectElement | null} */ (document.getElementById('run-type-a'));
+  const elB = /** @type {HTMLSelectElement | null} */ (document.getElementById('run-type-b'));
+  if (elA) elA.value = runTypeA;
+  if (elB) elB.value = runTypeB;
+
+  // Set up dropdown change listeners
+  elA?.addEventListener('change', async (e) => {
+    runTypeA = /** @type {HTMLSelectElement} */ (e.target).value;
+    await handleRunTypeChange();
+  });
+  elB?.addEventListener('change', async (e) => {
+    runTypeB = /** @type {HTMLSelectElement} */ (e.target).value;
+    await handleRunTypeChange();
+  });
+
+  // Back button setup
+  const backBtn = /** @type {HTMLAnchorElement | null} */ (document.getElementById('back-btn'));
+  if (backBtn) {
+    backBtn.href = `guide.html?guide=${guideName}&source=${isStatic ? 'static' : 'local'}`;
+  }
+
+  if (!trialA || !guideName) {
+    document.getElementById('compare-title').innerText = 'Error: Missing Parameters';
+    alert('Missing required parameters: trialA and guide are required.');
+    return false;
+  }
+
+  // Update browser tab title with active guide name
+  document.title = `${guideName} - AI Variance Diagnosis`;
+  document.getElementById('compare-title').innerHTML = `Cross-Run Variance Diagnosis <span style="font-weight: 400; color: #64748b;">(${guideName})</span>`;
+  return true;
+}
+
+/**
+ * Handles reloading of workspace files and running diagnosis when run type is toggled.
+ */
+async function handleRunTypeChange() {
+  await loadActiveTaskDetails();
+  await runDiagnosticAgent();
+}
+
+async function ensureRunDirectories(dirA, dirB) {
+  if (isStatic) return;
+  try {
+    /** @type {Record<string, string>} */
+    const headers = {};
+    const token = typeof getAccessToken === 'function' ? getAccessToken() : null;
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`;
+    }
+    const response = await fetch(`/api/ensure-run?dirA=${encodeURIComponent(dirA)}&dirB=${encodeURIComponent(dirB)}`, { headers });
+    if (!response.ok || !response.body) return;
+
+    const diagnosisBox = document.getElementById('diagnosis-box');
+    const diagnosisText = document.getElementById('diagnosis-text');
+    const compareLoading = document.getElementById('compare-loading');
+
+    if (diagnosisBox && diagnosisText) {
+      diagnosisBox.style.display = 'block';
+      diagnosisText.innerHTML = `
+        <div style="font-size:0.9em; font-weight:600; color:#2563eb; margin-bottom:8px; display:flex; align-items:center; gap:8px;">
+          <div class="spinner" style="width:16px; height:16px; border-width:2px; margin-bottom:0; border-top-color:#2563eb;"></div>
+          <span>Synchronizing run files from GCS (Downloading if missing)...</span>
+        </div>
+        <pre id="compare-log-stream" style="font-family:monospace; font-size:0.85em; background:#ffffff; border:1px solid #bfdbfe; padding:12px; border-radius:6px; overflow-x:auto; max-height:250px; overflow-y:auto; margin:0; white-space:pre-wrap; color:#334155; line-height:1.4; box-shadow:inset 0 1px 2px rgba(0,0,0,0.05);"></pre>
+      `;
+      if (compareLoading) {
+        const loadingMsg = compareLoading.querySelector('div:last-child');
+        if (loadingMsg) loadingMsg.textContent = 'Downloading required run files from GCS... (See progress below)';
+      }
+
+      const logPre = document.getElementById('compare-log-stream');
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let accumulatedText = '';
+      let lastUpdate = 0;
+      let updatePending = false;
+
+      function updateDOM() {
+        if (logPre) {
+          logPre.textContent = accumulatedText;
+          logPre.scrollTop = logPre.scrollHeight;
+        }
+        updatePending = false;
+      }
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        const chunk = decoder.decode(value, { stream: true });
+        accumulatedText += chunk;
+
+        const now = performance.now();
+        if (now - lastUpdate > 100) {
+          updateDOM();
+          lastUpdate = now;
+        } else if (!updatePending) {
+          updatePending = true;
+          requestAnimationFrame(() => {
+            if (updatePending) updateDOM();
+          });
+        }
+      }
+      updateDOM();
+    }
+  } catch (e) {
+    console.warn('Failed to ensure run directories locally:', e);
+  }
+}
+
+async function loadTrialMetadata() {
+  const resultsBase = isStatic ? 'results' : '';
+  const srcParam = isStatic ? '' : '?source=local';
+  
+  const guideLinkEl = /** @type {HTMLAnchorElement | null} */ (document.getElementById('summary-guide-link'));
+  if (guideLinkEl) {
+    guideLinkEl.innerText = guideName;
+    guideLinkEl.href = `guide.html?guide=${encodeURIComponent(guideName)}&source=${encodeURIComponent(isStatic ? 'local' : (new URLSearchParams(window.location.search).get('source') || 'local'))}`;
+  }
+  
+  // Ensure suite directories exist locally
+  await ensureRunDirectories(trialA, trialB);
+
+  // Fetch Trial A suite metadata
+  try {
+    const responseA = await fetch(`${resultsBase}/${trialA}/evals.json${srcParam}`);
+    if (responseA.ok) {
+      suiteDataA = await responseA.json();
+    }
+  } catch (e) {
+    console.error('Failed to load Trial A suite data:', e);
+  }
+
+  // Fetch Trial B suite metadata
+  try {
+    if (trialA !== trialB) {
+      const responseB = await fetch(`${resultsBase}/${trialB}/evals.json${srcParam}`);
+      if (responseB.ok) {
+        suiteDataB = await responseB.json();
+      }
+    } else {
+      suiteDataB = suiteDataA;
+    }
+  } catch (e) {
+    console.error('Failed to load Trial B suite data:', e);
+  }
+
+  // Determine tasks belonging to this guide
+  // Filter the evaluations to find tasks matching this guide
+  const tasksSet = new Set();
+  const allEvals = [...(suiteDataA?.evaluations || []), ...(suiteDataB?.evaluations || [])];
+  allEvals.forEach(ev => {
+    // ev.task is usually "guideName/taskName"
+    if (ev.task && ev.task.startsWith(`${guideName}/`)) {
+      tasksSet.add(ev.task.split('/')[1]);
+    }
+  });
+
+  availableTasks = Array.from(tasksSet);
+  if (availableTasks.length === 0) {
+    // Fallback: search the directories or use guideName/task
+    availableTasks = ['task'];
+  }
+
+  activeTask = availableTasks[0];
+  
+  // Populate sidebar
+  populateSidebar();
+
+  // Populate Executive Cards
+  updateExecutiveSummary();
+
+  // Load active task details
+  await loadActiveTaskDetails();
+
+  // Trigger Diagnosis
+  await runDiagnosticAgent();
+}
+
+function populateSidebar() {
+  const sidebarList = document.getElementById('task-sidebar-list');
+  sidebarList.innerHTML = '';
+  availableTasks.forEach(task => {
+    const btn = document.createElement('button');
+    btn.className = `task-btn ${task === activeTask ? 'active' : ''}`;
+    btn.innerText = task;
+    btn.onclick = () => switchTask(task);
+    sidebarList.appendChild(btn);
+  });
+}
+
+function updateExecutiveSummary() {
+  const _resultsBase = isStatic ? 'results' : '';
+  
+  const displayRunA = runIndexA ? runIndexA : runNumA;
+  const displayRunB = runIndexB ? runIndexB : runNumB;
+
+  // Trial A
+  document.getElementById('title-a').innerText = `${trialA.slice(0, 18)} (Run ${displayRunA})`;
+  document.getElementById('meta-a').innerText = trialA.includes('test-') ? `Date: ${trialA.replace('test-', '').slice(0, 10)}` : 'Historical Suite';
+  
+  const displayAgentA = agentA || 'Unknown';
+  const displayModelA = modelA || 'Unknown';
+  document.getElementById('agent-model-a').innerText = `Agent: ${displayAgentA} | Model: ${displayModelA}`;
+
+  // Trial B
+  if (trialA === trialB) {
+    document.getElementById('title-b').innerText = `${trialA.slice(0, 18)} (Run ${displayRunB})`;
+    document.getElementById('meta-b').innerText = 'Within-Trial Non-determinism Check';
+  } else {
+    document.getElementById('title-b').innerText = `${trialB.slice(0, 18)} (Run ${displayRunB})`;
+    document.getElementById('meta-b').innerText = trialB.includes('test-') ? `Date: ${trialB.replace('test-', '').slice(0, 10)}` : 'Historical Suite';
+  }
+  
+  const displayAgentB = agentB || 'Unknown';
+  const displayModelB = modelB || 'Unknown';
+  document.getElementById('agent-model-b').innerText = `Agent: ${displayAgentB} | Model: ${displayModelB}`;
+
+  // Calculate Scores for the specific guide
+  // Fall back to forwarded score parameters if evals.json is missing
+  const scoreA = suiteDataA ? calculateGuideScore(suiteDataA, runNumA) : (scoreAParam !== null ? parseInt(scoreAParam) : 0);
+  const scoreB = suiteDataB ? calculateGuideScore(suiteDataB, runNumB) : (scoreBParam !== null ? parseInt(scoreBParam) : 0);
+
+  const badgeA = document.getElementById('score-badge-a');
+  badgeA.innerText = `${scoreA}%`;
+  badgeA.className = `score-badge ${scoreA >= 70 ? 'score-high' : 'score-low'}`;
+
+  const badgeB = document.getElementById('score-badge-b');
+  badgeB.innerText = `${scoreB}%`;
+  badgeB.className = `score-badge ${scoreB >= 70 ? 'score-high' : 'score-low'}`;
+
+  const delta = scoreB - scoreA;
+  const deltaText = delta === 0 ? 'No change (0%)' : delta > 0 ? `+${delta}% Improvement` : `${delta}% Regression`;
+  const deltaSpan = document.getElementById('summary-delta');
+  deltaSpan.innerText = deltaText;
+  deltaSpan.style.color = delta === 0 ? '#475569' : delta > 0 ? '#166534' : '#991b1b';
+
+  const guideLinkEl = /** @type {HTMLAnchorElement | null} */ (document.getElementById('summary-guide-link'));
+  if (guideLinkEl) {
+    guideLinkEl.innerText = guideName;
+    guideLinkEl.href = `guide.html?guide=${encodeURIComponent(guideName)}&source=${encodeURIComponent(isStatic ? 'local' : (new URLSearchParams(window.location.search).get('source') || 'local'))}`;
+  }
+}
+
+function calculateGuideScore(suiteData, runNum) {
+  if (!suiteData || !suiteData.evaluations) return 0;
+  const guideEvals = suiteData.evaluations.filter(ev => ev.task.startsWith(`${guideName}/`) && String(ev.run) === String(runNum));
+  if (guideEvals.length === 0) return 0;
+  
+  let totalAsserts = 0;
+  let passedAsserts = 0;
+  
+  guideEvals.forEach(ev => {
+    if (ev.results && Array.isArray(ev.results)) {
+      totalAsserts += ev.results.length;
+      passedAsserts += ev.results.filter(r => r.passed).length;
+    }
+  });
+
+  return totalAsserts > 0 ? Math.round((passedAsserts / totalAsserts) * 100) : 0;
+}
+async function switchTask(task) {
+  activeTask = task;
+  
+  // Update sidebar active state
+  document.querySelectorAll('.task-btn').forEach(btn => {
+    btn.classList.toggle('active', btn.textContent.trim() === activeTask);
+  });
+
+}
+
+function getRunDateString(trialId) {
+  if (!trialId) return 'Unknown Date';
+  const match = trialId.match(/\d{4}-\d{2}-\d{2}/);
+  if (match) return match[0];
+  if (trialId.includes('test-')) return trialId.replace('test-', '').slice(0, 10);
+  return trialId.slice(0, 12);
+}
+
+function getFormattedTrialTitle(label, trialId, runNum, runType, agent, model, traj, suiteData, overrideRunIndex) {
+  const dateStr = getRunDateString(trialId);
+  const resolvedAgent = agent && agent !== 'unknown' ? agent : (traj?.agent || suiteData?.agent || 'Unknown Agent');
+  const resolvedModel = (model && model !== 'unknown' ? model : (traj?.model || suiteData?.model || 'Unknown Model')).replace(/^models\//, '');
+  const activeRunNum = overrideRunIndex || runNum;
+  return `${label} (Run ${activeRunNum} - ${capitalize(runType || 'guided')}) — agent: ${resolvedAgent} model: ${resolvedModel} (${dateStr})`;
+}
+
+async function loadActiveTaskDetails() {
+  document.getElementById('compare-loading').style.display = 'flex';
+  document.getElementById('tab-content-assertions').style.display = 'none';
+  document.getElementById('tab-content-timeline').style.display = 'none';
+  document.getElementById('tab-content-code').style.display = 'none';
+
+  const resultsBase = isStatic ? 'results' : '';
+  
+  // Format run directory paths using active run types
+  const pathPartA = `${trialA}/${runNumA}/${guideName}/${activeTask}/${runTypeA}`;
+  const pathPartB = `${trialB}/${runNumB}/${guideName}/${activeTask}/${runTypeB}`;
+  
+  _runDirA = `${resultsBase}/${pathPartA}`;
+  _runDirB = `${resultsBase}/${pathPartB}`;
+
+  // Update split-pane column titles to display both run number and run type
+  const titleAStr = getFormattedTrialTitle('Trial A', trialA, runNumA, runTypeA, agentA, modelA, null, suiteDataA, runIndexA);
+  const titleBStr = getFormattedTrialTitle('Trial B', trialB, runNumB, runTypeB, agentB, modelB, null, suiteDataB, runIndexB);
+
+  if (document.getElementById('timeline-title-a')) document.getElementById('timeline-title-a').innerText = titleAStr;
+  if (document.getElementById('timeline-title-b')) document.getElementById('timeline-title-b').innerText = titleBStr;
+  if (document.getElementById('code-title-a')) document.getElementById('code-title-a').innerText = titleAStr;
+  if (document.getElementById('code-title-b')) document.getElementById('code-title-b').innerText = titleBStr;
+  if (document.getElementById('header-assert-a')) document.getElementById('header-assert-a').innerText = titleAStr;
+  if (document.getElementById('header-assert-b')) document.getElementById('header-assert-b').innerText = titleBStr;
+
+  // 0. Ensure run directories exist locally before fetching tab data
+  await ensureRunDirectories(pathPartA, pathPartB);
+
+  // 1. Load Assertions Comparison
+  await loadAssertions(pathPartA, pathPartB);
+
+  // 2. Load Trajectory Timelines
+  await loadTrajectories(pathPartA, pathPartB);
+
+  // 3. Load Code Output Diffs
+  await loadCodeOutputs(pathPartA, pathPartB);
+
+  document.getElementById('compare-loading').style.display = 'none';
+  switchTab(currentTab);
+}
+
+/**
+ * Recursively parses Playwright's JSON report and extracts a flat array of assertions.
+ */
+function parsePlaywrightResults(report) {
+  const assertions = [];
+  if (!report || !Array.isArray(report.suites)) {
+    return assertions;
+  }
+  
+  function collectSpecs(suite) {
+    if (Array.isArray(suite.specs)) {
+      suite.specs.forEach((spec) => {
+        assertions.push({
+          message: spec.title,
+          passed: !!spec.ok
+        });
+      });
+    }
+    if (Array.isArray(suite.suites)) {
+      suite.suites.forEach(collectSpecs);
+    }
+  }
+
+  report.suites.forEach(collectSpecs);
+  return assertions;
+}
+
+async function loadAssertions(pathA, pathB) {
+  const resultsBase = isStatic ? 'results' : '';
+  const srcParam = isStatic ? '' : '?source=local';
+  const tbody = document.getElementById('assert-tbody');
+  tbody.innerHTML = '';
+
+  let resultsA = [];
+  let resultsB = [];
+
+  // Fetch Run A results JSON
+  try {
+    let resA = await fetch(`${resultsBase}/${pathA}/${guideName}_results.json${srcParam}`);
+    if (!resA.ok) {
+      const filesResA = await fetch(`/api/run-files?dir=${encodeURIComponent(pathA)}&source=local`);
+      if (filesResA.ok) {
+        const filesA = (await filesResA.json()).files || [];
+        const resFile = filesA.find(f => f.endsWith('_results.json'));
+        if (resFile) resA = await fetch(`${resultsBase}/${pathA}/${resFile}${srcParam}`);
+      }
+    }
+    if (resA.ok) {
+      const rawA = await resA.json();
+      resultsA = parsePlaywrightResults(rawA);
+    }
+  } catch (e) {}
+
+  // Fetch Run B results JSON
+  try {
+    let resB = await fetch(`${resultsBase}/${pathB}/${guideName}_results.json${srcParam}`);
+    if (!resB.ok) {
+      const filesResB = await fetch(`/api/run-files?dir=${encodeURIComponent(pathB)}&source=local`);
+      if (filesResB.ok) {
+        const filesB = (await filesResB.json()).files || [];
+        const resFile = filesB.find(f => f.endsWith('_results.json'));
+        if (resFile) resB = await fetch(`${resultsBase}/${pathB}/${resFile}${srcParam}`);
+      }
+    }
+    if (resB.ok) {
+      const rawB = await resB.json();
+      resultsB = parsePlaywrightResults(rawB);
+    }
+  } catch (e) {}
+
+  // Calculate live scores from parsed assertions and update badges dynamically
+  if (resultsA.length > 0) {
+    const passedA = resultsA.filter(r => r.passed).length;
+    currentScoreA = Math.round((passedA / resultsA.length) * 100);
+    const badgeA = document.getElementById('score-badge-a');
+    badgeA.innerText = `${currentScoreA}%`;
+    badgeA.className = `score-badge ${currentScoreA >= 70 ? 'score-high' : 'score-low'}`;
+  } else {
+    currentScoreA = scoreAParam !== null ? parseInt(scoreAParam) : 0;
+    const badgeA = document.getElementById('score-badge-a');
+    badgeA.innerText = `${currentScoreA}%`;
+    badgeA.className = `score-badge ${currentScoreA >= 70 ? 'score-high' : 'score-low'}`;
+  }
+
+  if (resultsB.length > 0) {
+    const passedB = resultsB.filter(r => r.passed).length;
+    currentScoreB = Math.round((passedB / resultsB.length) * 100);
+    const badgeB = document.getElementById('score-badge-b');
+    badgeB.innerText = `${currentScoreB}%`;
+    badgeB.className = `score-badge ${currentScoreB >= 70 ? 'score-high' : 'score-low'}`;
+  } else {
+    currentScoreB = scoreBParam !== null ? parseInt(scoreBParam) : 0;
+    const badgeB = document.getElementById('score-badge-b');
+    badgeB.innerText = `${currentScoreB}%`;
+    badgeB.className = `score-badge ${currentScoreB >= 70 ? 'score-high' : 'score-low'}`;
+  }
+
+  // Update Score Delta dynamically
+  const delta = currentScoreB - currentScoreA;
+  const deltaText = delta === 0 ? 'No change (0%)' : delta > 0 ? `+${delta}% Improvement` : `${delta}% Regression`;
+  const deltaSpan = document.getElementById('summary-delta');
+  deltaSpan.innerText = deltaText;
+  deltaSpan.style.color = delta === 0 ? '#475569' : delta > 0 ? '#166534' : '#991b1b';
+
+  // Merge assertions list to compare side-by-side
+  const allAssertionMessages = Array.from(new Set([
+    ...resultsA.map(r => r.message),
+    ...resultsB.map(r => r.message)
+  ]));
+
+  if (allAssertionMessages.length === 0) {
+    tbody.innerHTML = '<tr><td colspan="3" style="text-align:center; color:#64748b;">No assertion results found for this task.</td></tr>';
+    return;
+  }
+
+  allAssertionMessages.forEach(msg => {
+    const checkA = resultsA.find(r => r.message === msg);
+    const checkB = resultsB.find(r => r.message === msg);
+
+    const tr = document.createElement('tr');
+    
+    // Check text
+    const tdMsg = document.createElement('td');
+    tdMsg.innerText = msg;
+    tr.appendChild(tdMsg);
+
+    // Trial A status
+    const tdA = document.createElement('td');
+    if (checkA) {
+      tdA.innerHTML = checkA.passed ? '<span class="pass-icon">✓ PASS</span>' : '<span class="fail-icon">✗ FAIL</span>';
+    } else {
+      tdA.innerText = 'N/A';
+    }
+    tr.appendChild(tdA);
+
+    // Trial B status
+    const tdB = document.createElement('td');
+    if (checkB) {
+      tdB.innerHTML = checkB.passed ? '<span class="pass-icon">✓ PASS</span>' : '<span class="fail-icon">✗ FAIL</span>';
+    } else {
+      tdB.innerText = 'N/A';
+    }
+    tr.appendChild(tdB);
+
+    tbody.appendChild(tr);
+  });
+}
+
+async function loadTrajectories(pathA, pathB) {
+  const resultsBase = isStatic ? 'results' : '';
+  const srcParam = isStatic ? '' : '?source=local';
+  const container = document.getElementById('tab-content-timeline');
+  container.innerHTML = '<div style="padding:20px; text-align:center; color:#64748b;">Loading aligned trajectories...</div>';
+
+  let trajA = null;
+  let trajB = null;
+  let chatA = '';
+  let chatB = '';
+  let sessionUrlA = '';
+  let sessionUrlB = '';
+
+async function enrichTrajectorySteps(traj, pathStr, resultsBase) {
+  if (!traj || !Array.isArray(traj.steps)) return;
+  try {
+    const logRes = await fetch(`${resultsBase}/${pathStr}/modern-web.log${srcParam}`);
+    if (logRes.ok) {
+      const logText = await logRes.text();
+      const lines = logText.split('\n').filter(Boolean);
+      const logCalls = [];
+      for (const line of lines) {
+        if (line.trim().startsWith('{')) {
+          try { logCalls.push(JSON.parse(line)); } catch {}
+        }
+      }
+      let searchIdx = 0;
+      for (const step of traj.steps) {
+        if (step.action && (step.action.name === 'get_best_practices' || step.action.type === 'web_search' || step.action.name === 'search_use_cases')) {
+          if (logCalls[searchIdx]) {
+            if (!step.outcome) step.outcome = { status: 'success' };
+            step.outcome.output = logCalls[searchIdx].result;
+            searchIdx++;
+          }
+        }
+      }
+    }
+  } catch (e) {}
+}
+
+  try {
+    const resA = await fetch(`${resultsBase}/${pathA}/trajectory_summary.json${srcParam}`);
+    if (resA.ok) {
+      trajA = normalizeTrajectoryClient(await resA.json());
+      await enrichTrajectorySteps(trajA, pathA, resultsBase);
+    }
+  } catch (e) {}
+
+  try {
+    const resB = await fetch(`${resultsBase}/${pathB}/trajectory_summary.json${srcParam}`);
+    if (resB.ok) {
+      trajB = normalizeTrajectoryClient(await resB.json());
+      await enrichTrajectorySteps(trajB, pathB, resultsBase);
+    }
+  } catch (e) {}
+
+  try {
+    const chatResA = await fetch(`${resultsBase}/${pathA}/chat_log.txt${srcParam}`);
+    if (chatResA.ok) chatA = await chatResA.text();
+  } catch (e) {}
+
+  try {
+    const chatResB = await fetch(`${resultsBase}/${pathB}/chat_log.txt${srcParam}`);
+    if (chatResB.ok) chatB = await chatResB.text();
+  } catch (e) {}
+
+  try {
+    const filesResA = await fetch(`/api/run-files?dir=${encodeURIComponent(pathA)}&source=local`);
+    if (filesResA.ok) {
+      const filesA = (await filesResA.json()).files || [];
+      const sessionFileA = filesA.find(f => f.startsWith('session-') && !f.includes('-subagents-') && f.endsWith('.html')) || filesA.find(f => f.startsWith('session-') && f.endsWith('.html'));
+      if (sessionFileA) sessionUrlA = `${resultsBase}/${pathA}/${sessionFileA}`;
+    }
+  } catch (e) {}
+
+  try {
+    const filesResB = await fetch(`/api/run-files?dir=${encodeURIComponent(pathB)}&source=local`);
+    if (filesResB.ok) {
+      const filesB = (await filesResB.json()).files || [];
+      const sessionFileB = filesB.find(f => f.startsWith('session-') && !f.includes('-subagents-') && f.endsWith('.html')) || filesB.find(f => f.startsWith('session-') && f.endsWith('.html'));
+      if (sessionFileB) sessionUrlB = `${resultsBase}/${pathB}/${sessionFileB}`;
+    }
+  } catch (e) {}
+
+  _loadedTrajA = trajA;
+  _loadedTrajB = trajB;
+  _loadedChatA = chatA;
+  _loadedChatB = chatB;
+  renderTimelineRows(container, trajA, trajB, chatA, chatB, sessionUrlA, sessionUrlB);
+}
+
+function alignTrajectorySteps(trajOrStepsA, trajOrStepsB, mode = 'milestone') {
+  const trajAObj = (trajOrStepsA && !Array.isArray(trajOrStepsA)) ? trajOrStepsA : { steps: Array.isArray(trajOrStepsA) ? trajOrStepsA : [] };
+  const trajBObj = (trajOrStepsB && !Array.isArray(trajOrStepsB)) ? trajOrStepsB : { steps: Array.isArray(trajOrStepsB) ? trajOrStepsB : [] };
+
+  let listA = trajAObj.steps || [];
+  let listB = trajBObj.steps || [];
+
+  if (mode === 'milestone') {
+    const filterFn = s => s.action?.canonicalCategory && s.action.canonicalCategory !== 'incidental_noise' && s.action.canonicalCategory !== 'launch';
+    const filteredA = listA.filter(filterFn);
+    const filteredB = listB.filter(filterFn);
+    if (filteredA.length > 0 || filteredB.length > 0) {
+      listA = filteredA;
+      listB = filteredB;
+    }
+  }
+
+  const m = listA.length;
+  const n = listB.length;
+  if (m === 0 && n === 0 && !trajAObj.initialPrompt && !trajBObj.initialPrompt) return [];
+
+  const dp = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0));
+  const gapPenalty = -2;
+
+  function matchScore(sA, sB) {
+    let score = 0;
+    const catA = sA.action?.canonicalCategory || 'other';
+    const catB = sB.action?.canonicalCategory || 'other';
+    if (catA === catB && catA !== 'other' && catA !== 'incidental_noise') score += 5;
+    else if (catA !== catB && catA !== 'other' && catB !== 'other' && catA !== 'incidental_noise' && catB !== 'incidental_noise') score -= 6;
+
+    const nameA = (sA.action?.name || '').toLowerCase().split(' ')[0];
+    const nameB = (sB.action?.name || '').toLowerCase().split(' ')[0];
+    if (nameA && nameA === nameB) score += 3;
+
+    return score;
+  }
+
+  for (let i = 0; i <= m; i++) dp[i][0] = i * gapPenalty;
+  for (let j = 0; j <= n; j++) dp[0][j] = j * gapPenalty;
+
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      const score = matchScore(listA[i - 1], listB[j - 1]);
+      dp[i][j] = Math.max(
+        dp[i - 1][j - 1] + score,
+        dp[i - 1][j] + gapPenalty,
+        dp[i][j - 1] + gapPenalty
+      );
+    }
+  }
+
+  const aligned = [];
+  let i = m, j = n;
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && dp[i][j] === dp[i - 1][j - 1] + matchScore(listA[i - 1], listB[j - 1])) {
+      aligned.push({ stepA: listA[i - 1], stepB: listB[j - 1] });
+      i--;
+      j--;
+    } else if (i > 0 && (j === 0 || dp[i][j] === dp[i - 1][j] + gapPenalty)) {
+      aligned.push({ stepA: listA[i - 1], stepB: null });
+      i--;
+    } else {
+      aligned.push({ stepA: null, stepB: listB[j - 1] });
+      j--;
+    }
+  }
+
+  const alignedResult = aligned.reverse();
+
+  // Prepend Step 0 (Starting Prompt / Harness Launch) when initialPrompt exists
+  if (trajAObj.initialPrompt || trajBObj.initialPrompt || (!Array.isArray(trajOrStepsA) && !Array.isArray(trajOrStepsB))) {
+    const promptA = trajAObj.initialPrompt || '';
+    const promptB = trajBObj.initialPrompt || '';
+    if (promptA || promptB) {
+      const step0A = promptA ? {
+        stepNumber: 0,
+        thought: 'Harness launched agent with initial prompt',
+        action: { type: 'launch', name: 'Starting Prompt / Launch', params: { prompt: promptA }, canonicalCategory: 'launch' },
+        outcome: { status: 'success', output: promptA }
+      } : null;
+      const step0B = promptB ? {
+        stepNumber: 0,
+        thought: 'Harness launched agent with initial prompt',
+        action: { type: 'launch', name: 'Starting Prompt / Launch', params: { prompt: promptB }, canonicalCategory: 'launch' },
+        outcome: { status: 'success', output: promptB }
+      } : null;
+      alignedResult.unshift({ stepA: step0A, stepB: step0B });
+    }
+  }
+
+  return alignedResult;
+}
+
+function findDivergenceInfo(trajA, trajB) {
+  const aligned = alignTrajectorySteps(trajA, trajB, timelineViewMode);
+
+  let primaryStepA = null;
+  let primaryStepB = null;
+
+  const diagnosisTextElement = document.getElementById('diagnosis-text');
+  const diagnosisText = diagnosisTextElement ? diagnosisTextElement.innerText || '' : '';
+
+  if (diagnosisText) {
+    if (/Step 0/i.test(diagnosisText) || /Starting Prompt/i.test(diagnosisText) || /Harness Launch/i.test(diagnosisText) || /Initialization/i.test(diagnosisText)) {
+      primaryStepA = 0;
+      primaryStepB = 0;
+    } else {
+      const matchA = diagnosisText.match(/(?:Run|Trial)\s*A[^\d]*(?:Step|step)\s*(\d+)/i);
+      const matchB = diagnosisText.match(/(?:Run|Trial)\s*B[^\d]*(?:Step|step)\s*(\d+)/i);
+      if (matchA) primaryStepA = parseInt(matchA[1], 10);
+      if (matchB) primaryStepB = parseInt(matchB[1], 10);
+
+      if (primaryStepA === null && primaryStepB === null) {
+        const match = diagnosisText.match(/Step\s*(?:Number)?[^\d]*(\d+)/i) ||
+                      diagnosisText.match(/First\s+Meaningful\s+Divergence[^\d]*(\d+)/i) ||
+                      diagnosisText.match(/Divergence.*?(?:Step|step)\s*(\d+)/i) ||
+                      diagnosisText.match(/(?:Step|step)\s*(\d+)/i);
+        if (match) {
+          const stepVal = parseInt(match[1], 10);
+          primaryStepA = stepVal;
+          primaryStepB = stepVal;
+        }
+      }
+    }
+  }
+
+  if (primaryStepA === null || primaryStepB === null) {
+    for (let i = 0; i < aligned.length; i++) {
+      const sA = aligned[i].stepA;
+      const sB = aligned[i].stepB;
+
+      if (!sA || !sB) {
+        if (primaryStepA === null && sA) primaryStepA = sA.stepNumber;
+        if (primaryStepB === null && sB) primaryStepB = sB.stepNumber;
+        if (primaryStepA === null && primaryStepB === null) {
+          primaryStepA = i + 1;
+          primaryStepB = i + 1;
+        }
+        break;
+      }
+
+      if (sA.stepNumber === 0 && sB.stepNumber === 0) {
+        const pA = (sA.outcome?.output || '').trim();
+        const pB = (sB.outcome?.output || '').trim();
+        if (pA && pB && pA !== pB) {
+          primaryStepA = 0;
+          primaryStepB = 0;
+          break;
+        }
+        continue;
+      }
+
+      const aA = (sA.action?.name || '').toLowerCase();
+      const aB = (sB.action?.name || '').toLowerCase();
+      const catA = sA.action?.canonicalCategory || 'other';
+      const catB = sB.action?.canonicalCategory || 'other';
+      const isErrA = sA.outcome?.status === 'error';
+      const isErrB = sB.outcome?.status === 'error';
+
+      if (aA !== aB || catA !== catB || isErrA !== isErrB) {
+        if (primaryStepA === null) primaryStepA = sA.stepNumber;
+        if (primaryStepB === null) primaryStepB = sB.stepNumber;
+        break;
+      }
+    }
+  }
+
+  return { primaryStepA, primaryStepB };
+}
+
+function renderTimelineRows(container, trajA, trajB, chatA = '', chatB = '', sessionUrlA = '', sessionUrlB = '') {
+  container.innerHTML = '';
+
+  const aligned = alignTrajectorySteps(trajA, trajB, timelineViewMode);
+
+  if (aligned.length === 0 && !chatA && !chatB) {
+    container.innerHTML = '<div style="padding:30px; text-align:center; color:#64748b;">No normalized trajectory available. Ensure trajectory_summary.json is generated.</div>';
+    return;
+  }
+
+  const { primaryStepA, primaryStepB } = findDivergenceInfo(trajA, trajB);
+
+  const titleAStr = getFormattedTrialTitle('Trial A', trialA, runNumA, runTypeA, agentA, modelA, trajA, suiteDataA, runIndexA);
+  const titleBStr = getFormattedTrialTitle('Trial B', trialB, runNumB, runTypeB, agentB, modelB, trajB, suiteDataB, runIndexB);
+
+  if (document.getElementById('timeline-title-a')) document.getElementById('timeline-title-a').innerText = titleAStr;
+  if (document.getElementById('timeline-title-b')) document.getElementById('timeline-title-b').innerText = titleBStr;
+  if (document.getElementById('code-title-a')) document.getElementById('code-title-a').innerText = titleAStr;
+  if (document.getElementById('code-title-b')) document.getElementById('code-title-b').innerText = titleBStr;
+  if (document.getElementById('header-assert-a')) document.getElementById('header-assert-a').innerText = titleAStr;
+  if (document.getElementById('header-assert-b')) document.getElementById('header-assert-b').innerText = titleBStr;
+
+  // Top header row
+  const headerRow = document.createElement('div');
+  headerRow.className = 'timeline-header-row';
+  headerRow.innerHTML = `
+    <div class="timeline-header-col">${escapeHtml(titleAStr)}</div>
+    <div class="timeline-header-col">${escapeHtml(titleBStr)}</div>
+  `;
+  container.appendChild(headerRow);
+
+  // Add Timeline Mode Toggle bar
+  const toggleBar = document.createElement('div');
+  toggleBar.className = 'timeline-mode-toggle';
+  toggleBar.style.cssText = 'display:flex; justify-content:center; align-items:center; gap:12px; margin:14px 0; padding:10px; background:#f8fafc; border:1px solid #e2e8f0; border-radius:8px;';
+  toggleBar.innerHTML = `
+    <span style="font-size:0.88em; font-weight:600; color:#475569;">Alignment Mode:</span>
+    <button class="mode-btn ${timelineViewMode === 'milestone' ? 'active' : ''}" style="padding:6px 14px; border-radius:6px; border:1px solid ${timelineViewMode === 'milestone' ? '#2563eb' : '#cbd5e1'}; background:${timelineViewMode === 'milestone' ? '#2563eb' : '#ffffff'}; color:${timelineViewMode === 'milestone' ? '#ffffff' : '#334155'}; font-weight:600; font-size:0.85em; cursor:pointer; transition:all 0.2s;" onclick="switchTimelineMode('milestone')">🎯 Milestone View (Filtered & Aligned)</button>
+    <button class="mode-btn ${timelineViewMode === 'raw' ? 'active' : ''}" style="padding:6px 14px; border-radius:6px; border:1px solid ${timelineViewMode === 'raw' ? '#2563eb' : '#cbd5e1'}; background:${timelineViewMode === 'raw' ? '#2563eb' : '#ffffff'}; color:${timelineViewMode === 'raw' ? '#ffffff' : '#334155'}; font-weight:600; font-size:0.85em; cursor:pointer; transition:all 0.2s;" onclick="switchTimelineMode('raw')">📋 Raw Chronological View (All Steps)</button>
+  `;
+  container.appendChild(toggleBar);
+
+  // Render each step row
+  for (let i = 0; i < aligned.length; i++) {
+    const stepNum = i + 1;
+    const stepA = aligned[i].stepA;
+    const stepB = aligned[i].stepB;
+
+    const isStep0A = stepA?.stepNumber === 0;
+    const isStep0B = stepB?.stepNumber === 0;
+
+    const isPrimaryA = Boolean(stepA && (typeof stepA.stepNumber === 'number' ? stepA.stepNumber === primaryStepA : stepNum === primaryStepA));
+    const isPrimaryB = Boolean(stepB && (typeof stepB.stepNumber === 'number' ? stepB.stepNumber === primaryStepB : stepNum === primaryStepB));
+
+    const row = document.createElement('div');
+    row.className = `timeline-step-row ${(isPrimaryA || isPrimaryB) ? 'divergence-row' : ''}`;
+    row.id = `step-row-${stepNum}`;
+
+    let colAHtml = '';
+    if (stepA) {
+      if (isPrimaryA) {
+        colAHtml += `
+          <div class="divergence-banner primary track-banner" style="margin-bottom:8px;">
+            <span class="divergence-badge">🚨 PRIMARY DIVERGENCE (TRIAL A)</span>
+            <span class="divergence-desc">${isStep0A ? 'Starting prompt / launch parameters diverged' : `Divergent step in Trial A (Step ${stepA.stepNumber})`}</span>
+          </div>
+        `;
+      }
+      colAHtml += renderStepCardHtml(stepA, isPrimaryA, sessionUrlA);
+    } else {
+      colAHtml = '<div class="timeline-empty-card">No step in Trial A</div>';
+    }
+
+    let colBHtml = '';
+    if (stepB) {
+      if (isPrimaryB) {
+        colBHtml += `
+          <div class="divergence-banner primary track-banner" style="margin-bottom:8px;">
+            <span class="divergence-badge">🚨 PRIMARY DIVERGENCE (TRIAL B)</span>
+            <span class="divergence-desc">${isStep0B ? 'Starting prompt / launch parameters diverged' : `Divergent step in Trial B (Step ${stepB.stepNumber})`}</span>
+          </div>
+        `;
+      }
+      colBHtml += renderStepCardHtml(stepB, isPrimaryB, sessionUrlB);
+    } else {
+      colBHtml = '<div class="timeline-empty-card">No step in Trial B</div>';
+    }
+
+    row.innerHTML = `
+      <div class="timeline-cols-grid">
+        <div class="timeline-col col-a">${colAHtml}</div>
+        <div class="timeline-col col-b">${colBHtml}</div>
+      </div>
+    `;
+    container.appendChild(row);
+  }
+
+  // Render Final Assistant Response at the bottom of the timeline
+  if (chatA || chatB) {
+    const finalRow = document.createElement('div');
+    finalRow.className = 'timeline-step-row final-answer-row';
+    finalRow.innerHTML = `
+      <div class="final-answer-banner">
+        <span class="final-answer-badge">🏁 FINAL ASSISTANT OUTPUT</span>
+        <span style="font-size:0.9em; color:#15803d; font-weight:500;">Agent final response after completing or halting execution.</span>
+      </div>
+      <div class="timeline-cols-grid">
+        <div class="timeline-col col-a">
+          <div class="final-answer-card">
+            <div class="final-answer-header">
+              <span>ASSISTANT</span>
+              <span style="font-size:0.8em; color:#64748b;">Trial A</span>
+            </div>
+            <div class="final-answer-body">${escapeHtml(chatA || 'No final message recorded for Trial A.')}</div>
+          </div>
+        </div>
+        <div class="timeline-col col-b">
+          <div class="final-answer-card">
+            <div class="final-answer-header">
+              <span>ASSISTANT</span>
+              <span style="font-size:0.8em; color:#64748b;">Trial B</span>
+            </div>
+            <div class="final-answer-body">${escapeHtml(chatB || 'No final message recorded for Trial B.')}</div>
+          </div>
+        </div>
+      </div>
+    `;
+    container.appendChild(finalRow);
+  }
+}
+
+function renderStepCardHtml(step, isDivergent = false, sessionUrl = '') {
+  const isErr = step.outcome?.status === 'error';
+  const cardClass = `timeline-step ${isErr ? 'error' : 'success'} ${isDivergent ? 'divergence-card' : ''}`;
+  const stepAnchorUrl = sessionUrl ? `${sessionUrl}#step-${step.stepNumber}` : '';
+
+  let html = `
+    <div class="${cardClass}">
+      <div class="step-header">
+        <div style="display:flex; align-items:center; gap:8px;">
+          <span>STEP ${step.stepNumber}</span>
+          ${stepAnchorUrl ? `
+            <a href="${stepAnchorUrl}" target="_blank" title="Open source trajectory file at Step ${step.stepNumber}" style="font-size:0.82em; font-weight:600; color:#2563eb; text-decoration:none; display:inline-flex; align-items:center; gap:3px; background:#eff6ff; padding:2px 8px; border-radius:4px; border:1px solid #bfdbfe;">
+              <span>🔗 Source Trajectory</span>
+            </a>
+          ` : ''}
+        </div>
+        <span style="color:${isErr ? '#ef4444' : '#22c55e'}">${(step.outcome?.status || 'UNKNOWN').toUpperCase()}</span>
+      </div>
+  `;
+
+  if (step.thought && step.thought.trim()) {
+    html += `
+      <div class="step-thought">
+        <div class="step-thought-header">💡 AGENT THINKING / REASONING</div>
+        <div style="white-space: pre-wrap; word-break: break-word;">${escapeHtml(step.thought.trim())}</div>
+      </div>
+    `;
+  }
+
+  if (step.action) {
+    const argsStr = step.action.params ? JSON.stringify(step.action.params, null, 2) : '';
+    const actionName = step.action.name || 'Unknown Action';
+    const actionType = step.action.type ? ` (${step.action.type})` : '';
+    html += `
+      <div class="step-action">
+        <span class="step-action-title">🔧 Tool / Action:</span> ${escapeHtml(actionName)}${escapeHtml(actionType)}
+        ${argsStr ? `
+          <details style="margin-top:6px;">
+            <summary style="cursor:pointer; color:#2563eb; font-weight:600; font-size:0.9em;">View Action Parameters</summary>
+            <pre style="margin-top:5px; font-size:0.85em; background:#ffffff; border:1px solid #cbd5e1; padding:8px; border-radius:6px; white-space:pre-wrap; word-break:break-word; overflow-x:auto;">${escapeHtml(argsStr)}</pre>
+          </details>
+        ` : ''}
+      </div>
+    `;
+  }
+
+  let outcomeText = '';
+  if (step.outcome) {
+    if (typeof step.outcome === 'string') {
+      outcomeText = step.outcome;
+    } else if (step.outcome.output || step.outcome.result || step.outcome.message || step.outcome.content || step.outcome.text || step.outcome.stdout || step.outcome.stderr) {
+      outcomeText = step.outcome.output || step.outcome.result || step.outcome.message || step.outcome.content || step.outcome.text || step.outcome.stdout || step.outcome.stderr;
+      if (typeof outcomeText === 'object') outcomeText = JSON.stringify(outcomeText, null, 2);
+    } else {
+      const keys = Object.keys(step.outcome);
+      const onlyStatus = keys.every(k => k === 'status' || k === 'exitCode');
+      if (!onlyStatus) {
+        outcomeText = JSON.stringify(step.outcome, null, 2);
+      }
+    }
+  } else if (step.output || step.result) {
+    outcomeText = step.output || step.result;
+    if (typeof outcomeText === 'object') outcomeText = JSON.stringify(outcomeText, null, 2);
+  }
+
+  const cleanText = String(outcomeText || '').trim().replace(/\s+/g, '');
+  const hasOutputData = outcomeText && outcomeText !== '{}' && outcomeText !== 'null' && cleanText !== '{"status":"success"}' && cleanText !== '{"status":"error"}';
+
+  if (hasOutputData || stepAnchorUrl) {
+    const outcomeClass = isErr ? 'step-outcome error' : 'step-outcome';
+    html += `
+      <div style="margin-top: 8px; border-top: 1px dashed #e2e8f0; padding-top: 8px;">
+        <div style="display:flex; align-items:center; justify-content:space-between; flex-wrap:wrap; gap:8px;">
+          ${hasOutputData ? `
+            <details style="flex:1; min-width:200px;">
+              <summary style="cursor:pointer; color:#2563eb; font-size:0.88em; font-weight:700;">📄 View Step Output / Result</summary>
+              <div class="${outcomeClass}" style="margin-top:6px;">${escapeHtml(String(outcomeText).trim())}</div>
+            </details>
+          ` : `
+            <span style="font-size:0.85em; color:#64748b; font-style:italic;">No summary text (view full trajectory)</span>
+          `}
+          ${stepAnchorUrl ? `
+            <a href="${stepAnchorUrl}" target="_blank" title="View complete execution logs and tool output for Step ${step.stepNumber} in Trajectory Visualizer" style="font-size:0.84em; font-weight:600; color:#0f766e; background:#f0fdf4; border:1px solid #bbf7d0; padding:4px 10px; border-radius:6px; text-decoration:none; display:inline-flex; align-items:center; gap:4px; transition:all 0.2s;">
+              <span>🔗 Open Full Step Result</span>
+            </a>
+          ` : ''}
+        </div>
+      </div>
+    `;
+  }
+
+  html += `</div>`;
+  return html;
+}
+
+async function loadCodeOutputs(pathA, pathB) {
+  const resultsBase = isStatic ? 'results' : '';
+  const srcParam = isStatic ? '' : '?source=local';
+  
+  const containerA = document.getElementById('code-a');
+  const containerB = document.getElementById('code-b');
+  
+  containerA.innerHTML = 'Loading output file...';
+  containerB.innerHTML = 'Loading output file...';
+
+  // Find and load output code files
+  // We check candidates: dist/index.html, src/App.jsx, index.html
+  const candidates = ['dist/index.html', 'src/App.jsx', 'index.html'];
+  
+  let codeTextA = 'No generated code file found.';
+  let codeTextB = 'No generated code file found.';
+
+  for (const file of candidates) {
+    try {
+      const resA = await fetch(`${resultsBase}/${pathA}/${file}${srcParam}`);
+      if (resA.ok) {
+        codeTextA = await resA.text();
+        break;
+      }
+    } catch (e) {}
+  }
+
+  for (const file of candidates) {
+    try {
+      const resB = await fetch(`${resultsBase}/${pathB}/${file}${srcParam}`);
+      if (resB.ok) {
+        codeTextB = await resB.text();
+        break;
+      }
+    } catch (e) {}
+  }
+
+  containerA.innerText = codeTextA;
+  containerB.innerText = codeTextB;
+}
+
+function switchTab(tab) {
+  currentTab = tab;
+  
+  // Update tab buttons active state using data-tab attribute
+  document.querySelectorAll('.tab-btn').forEach(btn => {
+    const btnTab = btn.getAttribute('data-tab');
+    btn.classList.toggle('active', btnTab === currentTab);
+  });
+
+  // Hide all tab contents
+  document.getElementById('tab-content-assertions').style.display = 'none';
+  document.getElementById('tab-content-timeline').style.display = 'none';
+  document.getElementById('tab-content-code').style.display = 'none';
+
+  // Show active tab content
+  if (currentTab === 'assertions') {
+    document.getElementById('tab-content-assertions').style.display = 'block';
+  } else if (currentTab === 'timeline') {
+    document.getElementById('tab-content-timeline').style.display = 'block';
+  } else if (currentTab === 'code') {
+    document.getElementById('tab-content-code').style.display = 'flex';
+  }
+}
+
+async function runDiagnosticAgent() {
+  const diagnosisBox = document.getElementById('diagnosis-box');
+  const diagnosisText = document.getElementById('diagnosis-text');
+  const statusSpan = document.getElementById('summary-status');
+
+  diagnosisBox.style.display = 'block';
+  diagnosisText.innerHTML = `
+    <div style="display:flex; align-items:center; gap:10px;">
+      <div class="spinner" style="width:20px; height:20px; border-width:2px; margin-bottom:0;"></div>
+      <span>Running LLM variance diagnosis on the fly. This can take up to 20 seconds...</span>
+    </div>
+  `;
+  statusSpan.innerText = 'Analyzing Runs...';
+  statusSpan.style.color = '#d97706';
+
+  // If in static mode, we fetch pre-generated markdown
+  if (isStatic) {
+    const resultsBase = 'results';
+    // Format is results/test_xxx/variance_diagnoses/guideName-taskName-guided.md
+    // Since we don't know the exact taskName or runType, we'll construct the filename:
+    const fileName = `${guideName}-${activeTask}-guided.md`;
+    const url = `${resultsBase}/${trialA}/variance_diagnoses/${fileName}`;
+    
+    try {
+      const response = await fetch(url);
+      if (response.ok) {
+        const markdown = await response.text();
+        diagnosisText.innerHTML = renderMarkdown(markdown);
+        statusSpan.innerText = 'Completed';
+        statusSpan.style.color = '#166534';
+      } else {
+        diagnosisText.innerHTML = `
+          <div style="color:#b91c1c; font-weight:600;">Diagnostic report not pre-generated for this run combination.</div>
+          <div style="font-size:0.9em; margin-top:5px; color:#475569;">
+            Running in STATIC mode. On-the-fly LLM comparison is only available when running the dashboard locally via <code>pnpm dashboard</code>.
+            To generate this report locally, run:
+            <pre style="background:#fff; border:1px solid #fecaca; margin-top:8px; padding:10px; border-radius:4px; font-family:monospace;">gd compare ${trialA}/${runNumA}/${guideName}/${activeTask}/guided ${trialB}/${runNumB}/${guideName}/${activeTask}/guided</pre>
+          </div>
+        `;
+        statusSpan.innerText = 'Not Pre-generated';
+        statusSpan.style.color = '#b91c1c';
+      }
+    } catch (e) {
+      diagnosisText.innerText = 'Failed to load pre-generated diagnostic report.';
+      statusSpan.innerText = 'Error';
+    }
+    return;
+  }
+
+  // Local Mode: Call Node dev server API to run comparison on the fly!
+  // Use dynamic runTypeA and runTypeB values
+  const relativeA = `${trialA}/${runNumA}/${guideName}/${activeTask}/${runTypeA}`;
+  const relativeB = `${trialB}/${runNumB}/${guideName}/${activeTask}/${runTypeB}`;
+
+  const apiUrl = `/api/compare?runDirA=${encodeURIComponent(relativeA)}&runDirB=${encodeURIComponent(relativeB)}`;
+  
+  try {
+    /** @type {Record<string, string>} */
+    const headers = {};
+    const token = getAccessToken();
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`;
+    }
+    
+    const response = await fetch(apiUrl, { headers });
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(errorText || `HTTP error ${response.status}`);
+    }
+
+    // Set up a scrollable log container to stream raw output in real-time
+    diagnosisText.innerHTML = `
+      <div style="font-size:0.9em; font-weight:600; color:#d97706; margin-bottom:8px; display:flex; align-items:center; gap:8px;">
+        <div class="spinner" style="width:16px; height:16px; border-width:2px; margin-bottom:0;"></div>
+        <span>Streaming Gemini API diagnosis...</span>
+      </div>
+      <pre id="compare-log-stream" style="font-family:monospace; font-size:0.85em; background:#ffffff; border:1px solid #fde68a; padding:12px; border-radius:6px; overflow-x:auto; max-height:250px; overflow-y:auto; margin:0; white-space:pre-wrap; color:#334155; line-height:1.4; box-shadow:inset 0 1px 2px rgba(0,0,0,0.05);"></pre>
+    `;
+    const logPre = document.getElementById('compare-log-stream');
+    
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let accumulatedText = '';
+
+    let lastUpdate = 0;
+    let updatePending = false;
+
+    function updateDOM() {
+      if (logPre) {
+        logPre.textContent = accumulatedText;
+        logPre.scrollTop = logPre.scrollHeight;
+      }
+      updatePending = false;
+    }
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      const chunk = decoder.decode(value, { stream: true });
+      accumulatedText += chunk;
+      
+      const now = performance.now();
+      if (now - lastUpdate > 100) { // Limit DOM rendering to at most once per 100ms
+        updateDOM();
+        lastUpdate = now;
+      } else if (!updatePending) {
+        updatePending = true;
+        // Schedule trailing update on the next animation frame to keep CPU load low
+        requestAnimationFrame(() => {
+          if (updatePending) {
+            updateDOM();
+            lastUpdate = performance.now();
+          }
+        });
+      }
+    }
+    // Guarantee final, complete update when stream completes
+    updateDOM();
+
+    // Extraction of the final report from the accumulated stream text
+    const startMarker = '--- DIAGNOSTIC REPORT ---';
+    const endMarker = '-------------------------';
+    const startIdx = accumulatedText.indexOf(startMarker);
+    const endIdx = accumulatedText.indexOf(endMarker);
+
+    if (startIdx !== -1 && endIdx !== -1) {
+      const report = accumulatedText.slice(startIdx + startMarker.length, endIdx).trim();
+      diagnosisText.innerHTML = renderMarkdown(report);
+      statusSpan.innerText = 'Completed';
+      statusSpan.style.color = '#166534';
+    } else {
+      // If we failed or couldn't find the markers, check for errors in the stream
+      if (accumulatedText.includes('Comparison failed') || accumulatedText.includes('exited with code') || accumulatedText.includes('Server Error') || accumulatedText.includes('timed out')) {
+        statusSpan.innerText = 'Failed';
+        statusSpan.style.color = '#b91c1c';
+        diagnosisText.innerHTML = `
+          <div style="color:#b91c1c; font-weight:600;">On-the-fly LLM diagnosis failed.</div>
+          <div style="font-size:0.85em; color:#64748b; margin-top:4px;">Diagnostic run logs:</div>
+          <pre style="font-family:monospace; font-size:0.85em; background:#ffffff; border:1px solid #cbd5e1; padding:12px; border-radius:6px; overflow-x:auto; white-space:pre-wrap; margin-top:10px; color:#b91c1c; box-shadow:inset 0 1px 2px rgba(0,0,0,0.05);">${escapeHtml(accumulatedText)}</pre>
+        `;
+      } else {
+        // Fallback: just render the accumulated text
+        diagnosisText.innerHTML = renderMarkdown(accumulatedText);
+        statusSpan.innerText = 'Completed';
+        statusSpan.style.color = '#166534';
+      }
+    }
+  } catch (e) {
+    console.error('LLM Diagnosis error:', e);
+    diagnosisText.innerHTML = `
+      <div style="color:#b91c1c; font-weight:600;">On-the-fly LLM diagnosis failed.</div>
+      <div style="font-size:0.9em; color:#64748b; margin-top:5px;">Error: ${escapeHtml(e.message)}</div>
+      <div style="font-size:0.9em; margin-top:10px; color:#475569;">
+        You can try running the comparison manually in your terminal:
+        <pre style="background:#fff; border:1px solid #fecaca; margin-top:8px; padding:10px; border-radius:4px; font-family:monospace;">gd compare ../harness/results/${relativeA} ../harness/results/${relativeB}</pre>
+      </div>
+    `;
+    statusSpan.innerText = 'Failed';
+    statusSpan.style.color = '#b91c1c';
+  }
+}
+
+function escapeHtml(str) {
+  return (str || '').toString()
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+// Global initialization
+window.onload = async () => {
+  if (initParams()) {
+    await loadTrialMetadata();
+  }
+};
+
+// Expose module functions globally for inline HTML event handlers (since compare.js is loaded as a module)
+/** @type {any} */ (window).switchTab = switchTab;
+/** @type {any} */ (window).switchTask = switchTask;
+
+function switchTimelineMode(mode) {
+  timelineViewMode = mode;
+  const pathPartA = `${trialA}/${runNumA}/${guideName}/${activeTask}/${runTypeA}`;
+  const pathPartB = `${trialB}/${runNumB}/${guideName}/${activeTask}/${runTypeB}`;
+  loadTrajectories(pathPartA, pathPartB);
+}
+/** @type {any} */ (window).switchTimelineMode = switchTimelineMode;
+
+function exportCompareReport() {
+  const titleAStr = getFormattedTrialTitle('Trial A', trialA, runNumA, runTypeA, agentA, modelA, _loadedTrajA, suiteDataA, runIndexA);
+  const titleBStr = getFormattedTrialTitle('Trial B', trialB, runNumB, runTypeB, agentB, modelB, _loadedTrajB, suiteDataB, runIndexB);
+
+  let report = `# Cross-Run Variance Diagnosis & Trajectory Comparison Report\n`;
+  report += `Generated: ${new Date().toISOString()}\n`;
+  report += `Guide: ${guideName}\n`;
+  report += `Active Task: ${activeTask}\n\n`;
+
+  report += `## 1. Executive Summary\n`;
+  report += `- **Trial A**: ${titleAStr} | Score: ${currentScoreA}%\n`;
+  report += `- **Trial B**: ${titleBStr} | Score: ${currentScoreB}%\n`;
+  const delta = currentScoreB - currentScoreA;
+  report += `- **Score Delta**: ${delta === 0 ? 'No change (0%)' : delta > 0 ? `+${delta}% Improvement` : `${delta}% Regression`}\n\n`;
+
+  report += `## 2. AI Variance Diagnosis\n`;
+  const diagElem = document.getElementById('diagnosis-text');
+  const diagText = diagElem ? diagElem.innerText || 'No diagnosis generated.' : 'No diagnosis generated.';
+  report += `${diagText.trim()}\n\n`;
+
+  report += `## 3. Assertions Comparison Table\n`;
+  report += `| Assertion Check | Trial A (${currentScoreA}%) | Trial B (${currentScoreB}%) |\n`;
+  report += `| :--- | :---: | :---: |\n`;
+  const assertRows = document.querySelectorAll('#assert-tbody tr');
+  if (assertRows && assertRows.length > 0) {
+    assertRows.forEach(tr => {
+      const tds = tr.querySelectorAll('td');
+      if (tds.length >= 3) {
+        const msg = (tds[0].textContent || '').trim();
+        const statA = (tds[1].textContent || '').trim().replace(/\n/g, ' ');
+        const statB = (tds[2].textContent || '').trim().replace(/\n/g, ' ');
+        report += `| ${msg} | ${statA} | ${statB} |\n`;
+      } else {
+        report += `| ${(tr.textContent || '').trim()} | - | - |\n`;
+      }
+    });
+  } else {
+    report += `| No assertions found | - | - |\n`;
+  }
+  report += `\n`;
+
+  report += `## 4. Trajectory Comparison (${timelineViewMode.toUpperCase()} Mode)\n`;
+  const aligned = alignTrajectorySteps(_loadedTrajA, _loadedTrajB, timelineViewMode);
+  if (aligned.length === 0) {
+    report += `No trajectory steps available.\n\n`;
+  } else {
+    const { primaryStepA, primaryStepB } = findDivergenceInfo(_loadedTrajA, _loadedTrajB);
+    aligned.forEach((pair, idx) => {
+      const stepNum = idx + 1;
+      const isPrimaryA = Boolean(pair.stepA && (typeof pair.stepA.stepNumber === 'number' ? pair.stepA.stepNumber === primaryStepA : stepNum === primaryStepA));
+      const isPrimaryB = Boolean(pair.stepB && (typeof pair.stepB.stepNumber === 'number' ? pair.stepB.stepNumber === primaryStepB : stepNum === primaryStepB));
+
+      const markerA = isPrimaryA ? ' [🚨 TRIAL A PRIMARY DIVERGENCE]' : '';
+      const markerB = isPrimaryB ? ' [🚨 TRIAL B PRIMARY DIVERGENCE]' : '';
+
+      report += `### Row ${stepNum}\n\n`;
+
+      // Trial A
+      report += `#### Trial A (Step ${pair.stepA?.stepNumber === 0 ? '0 - Starting Prompt / Launch' : pair.stepA?.stepNumber || 'N/A'})${markerA}\n`;
+      if (pair.stepA) {
+        report += `- **Status**: ${pair.stepA.outcome?.status?.toUpperCase() || 'UNKNOWN'}\n`;
+        if (pair.stepA.thought) {
+          report += `- **Thinking / Reasoning**:\n\`\`\`\n${pair.stepA.thought.trim()}\n\`\`\`\n`;
+        }
+        if (pair.stepA.action) {
+          const actName = pair.stepA.action.name || 'Unknown Action';
+          const actType = pair.stepA.action.canonicalCategory ? ` [Category: ${pair.stepA.action.canonicalCategory}]` : '';
+          const paramsStr = pair.stepA.action.params ? JSON.stringify(pair.stepA.action.params, null, 2) : '';
+          report += `- **Action**: \`${actName}\`${actType}\n`;
+          if (paramsStr && paramsStr !== '{}') {
+            report += `  - **Parameters**:\n\`\`\`json\n${paramsStr}\n\`\`\`\n`;
+          }
+        }
+        if (pair.stepA.outcome) {
+          const out = pair.stepA.outcome.output || pair.stepA.outcome.result || pair.stepA.outcome.message || pair.stepA.outcome.content || pair.stepA.outcome.text || pair.stepA.outcome.stdout || pair.stepA.outcome.stderr || '';
+          if (out && typeof out !== 'object' || (typeof out === 'object' && Object.keys(out).length > 0)) {
+            const outStr = typeof out === 'object' ? JSON.stringify(out, null, 2) : String(out);
+            if (outStr !== '{}' && outStr !== 'null') {
+              report += `- **Outcome / Output**:\n\`\`\`\n${outStr.trim()}\n\`\`\`\n`;
+            }
+          }
+        }
+      } else {
+        report += `*No step in Trial A at this position.*\n`;
+      }
+      report += `\n`;
+
+      // Trial B
+      report += `#### Trial B (Step ${pair.stepB?.stepNumber === 0 ? '0 - Starting Prompt / Launch' : pair.stepB?.stepNumber || 'N/A'})${markerB}\n`;
+      if (pair.stepB) {
+        report += `- **Status**: ${pair.stepB.outcome?.status?.toUpperCase() || 'UNKNOWN'}\n`;
+        if (pair.stepB.thought) {
+          report += `- **Thinking / Reasoning**:\n\`\`\`\n${pair.stepB.thought.trim()}\n\`\`\`\n`;
+        }
+        if (pair.stepB.action) {
+          const actName = pair.stepB.action.name || 'Unknown Action';
+          const actType = pair.stepB.action.canonicalCategory ? ` [Category: ${pair.stepB.action.canonicalCategory}]` : '';
+          const paramsStr = pair.stepB.action.params ? JSON.stringify(pair.stepB.action.params, null, 2) : '';
+          report += `- **Action**: \`${actName}\`${actType}\n`;
+          if (paramsStr && paramsStr !== '{}') {
+            report += `  - **Parameters**:\n\`\`\`json\n${paramsStr}\n\`\`\`\n`;
+          }
+        }
+        if (pair.stepB.outcome) {
+          const out = pair.stepB.outcome.output || pair.stepB.outcome.result || pair.stepB.outcome.message || pair.stepB.outcome.content || pair.stepB.outcome.text || pair.stepB.outcome.stdout || pair.stepB.outcome.stderr || '';
+          if (out && typeof out !== 'object' || (typeof out === 'object' && Object.keys(out).length > 0)) {
+            const outStr = typeof out === 'object' ? JSON.stringify(out, null, 2) : String(out);
+            if (outStr !== '{}' && outStr !== 'null') {
+              report += `- **Outcome / Output**:\n\`\`\`\n${outStr.trim()}\n\`\`\`\n`;
+            }
+          }
+        }
+      } else {
+        report += `*No step in Trial B at this position.*\n`;
+      }
+      report += `\n---\n\n`;
+    });
+  }
+
+  if (_loadedChatA || _loadedChatB) {
+    report += `### Final Assistant Output\n\n`;
+    report += `#### Trial A Final Response:\n\`\`\`\n${(_loadedChatA || 'No final response recorded.').trim()}\n\`\`\`\n\n`;
+    report += `#### Trial B Final Response:\n\`\`\`\n${(_loadedChatB || 'No final response recorded.').trim()}\n\`\`\`\n\n`;
+  }
+
+  report += `## 5. Code Output Comparison\n\n`;
+  const codeElemA = document.getElementById('code-a');
+  const codeElemB = document.getElementById('code-b');
+  const codeTextA = codeElemA ? codeElemA.innerText || 'No code found.' : 'No code found.';
+  const codeTextB = codeElemB ? codeElemB.innerText || 'No code found.' : 'No code found.';
+  report += `### Trial A Generated Code:\n\`\`\`html\n${codeTextA.trim()}\n\`\`\`\n\n`;
+  report += `### Trial B Generated Code:\n\`\`\`html\n${codeTextB.trim()}\n\`\`\`\n`;
+
+  const blob = new Blob([report], { type: 'text/markdown;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  const filenameSafeTask = activeTask ? activeTask.replace(/[^a-zA-Z0-9_-]/g, '_') : 'task';
+  const filenameSafeGuide = guideName ? guideName.replace(/[^a-zA-Z0-9_-]/g, '_') : 'guide';
+  a.download = `compare_${filenameSafeGuide}_${filenameSafeTask}.md`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+/** @type {any} */ (window).exportCompareReport = exportCompareReport;

--- a/eval-view/compare.js
+++ b/eval-view/compare.js
@@ -1,4 +1,4 @@
-import { getAccessToken, capitalize, normalizeTrajectoryClient } from './utils.js';
+import { getAccessToken, capitalize, normalizeTrajectoryClient, parseResultKey } from './utils.js';
 
 // Cross-Run Performance Variance Diagnosis Dashboard JavaScript
 
@@ -44,7 +44,8 @@ function renderMarkdown(md) {
   if (!md) return '';
   
   // Strip ANSI escape sequences (e.g. \x1b[36m)
-  let cleanMd = md.replace(/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g, '').trim();
+  const ansiRegex = new RegExp('[' + String.fromCharCode(27) + String.fromCharCode(155) + '][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]', 'g');
+  let cleanMd = md.replace(ansiRegex, '').trim();
   
   const lines = cleanMd.split('\n');
   let html = '';
@@ -301,6 +302,7 @@ function initParams() {
  * Handles reloading of workspace files and running diagnosis when run type is toggled.
  */
 async function handleRunTypeChange() {
+  updateExecutiveSummary();
   await loadActiveTaskDetails();
   await runDiagnosticAgent();
 }
@@ -412,24 +414,38 @@ async function loadTrialMetadata() {
     console.error('Failed to load Trial B suite data:', e);
   }
 
-  // Determine tasks belonging to this guide
-  // Filter the evaluations to find tasks matching this guide
-  const tasksSet = new Set();
-  const allEvals = [...(suiteDataA?.evaluations || []), ...(suiteDataB?.evaluations || [])];
-  allEvals.forEach(ev => {
-    // ev.task is usually "guideName/taskName"
-    if (ev.task && ev.task.startsWith(`${guideName}/`)) {
-      tasksSet.add(ev.task.split('/')[1]);
-    }
-  });
+  // Determine tasks belonging to this guide in Trial A and Trial B
+  const tasksA = new Set();
+  const tasksB = new Set();
 
-  availableTasks = Array.from(tasksSet);
+  if (suiteDataA?.results) {
+    Object.keys(suiteDataA.results).forEach(key => {
+      const parsedKey = parseResultKey(key);
+      if (parsedKey && parsedKey.guide === guideName) {
+        tasksA.add(parsedKey.task);
+      }
+    });
+  }
+
+  if (suiteDataB?.results) {
+    Object.keys(suiteDataB.results).forEach(key => {
+      const parsedKey = parseResultKey(key);
+      if (parsedKey && parsedKey.guide === guideName) {
+        tasksB.add(parsedKey.task);
+      }
+    });
+  }
+
+  const allTasksSet = new Set([...tasksA, ...tasksB]);
+  const commonTasks = Array.from(tasksA).filter(t => tasksB.has(t)).sort();
+
+  availableTasks = Array.from(allTasksSet).sort();
   if (availableTasks.length === 0) {
-    // Fallback: search the directories or use guideName/task
     availableTasks = ['task'];
   }
 
-  activeTask = availableTasks[0];
+  // Prefer a common task that exists in both trials as the default active task
+  activeTask = commonTasks.length > 0 ? commonTasks[0] : availableTasks[0];
   
   // Populate sidebar
   populateSidebar();
@@ -444,21 +460,38 @@ async function loadTrialMetadata() {
   await runDiagnosticAgent();
 }
 
+function checkTaskInSuite(suiteData, task) {
+  if (!suiteData || !suiteData.results) return false;
+  return Object.keys(suiteData.results).some(key => {
+    const parsedKey = parseResultKey(key);
+    return parsedKey && parsedKey.guide === guideName && parsedKey.task === task;
+  });
+}
+
 function populateSidebar() {
   const sidebarList = document.getElementById('task-sidebar-list');
   sidebarList.innerHTML = '';
   availableTasks.forEach(task => {
     const btn = document.createElement('button');
     btn.className = `task-btn ${task === activeTask ? 'active' : ''}`;
-    btn.innerText = task;
+    
+    const inA = suiteDataA ? checkTaskInSuite(suiteDataA, task) : true;
+    const inB = suiteDataB ? checkTaskInSuite(suiteDataB, task) : true;
+    
+    let taskLabel = task;
+    if (!inA && inB) {
+      taskLabel = `${task} (Trial B only)`;
+    } else if (inA && !inB) {
+      taskLabel = `${task} (Trial A only)`;
+    }
+
+    btn.innerText = taskLabel;
     btn.onclick = () => switchTask(task);
     sidebarList.appendChild(btn);
   });
 }
 
 function updateExecutiveSummary() {
-  const _resultsBase = isStatic ? 'results' : '';
-  
   const displayRunA = runIndexA ? runIndexA : runNumA;
   const displayRunB = runIndexB ? runIndexB : runNumB;
 
@@ -466,8 +499,8 @@ function updateExecutiveSummary() {
   document.getElementById('title-a').innerText = `${trialA.slice(0, 18)} (Run ${displayRunA})`;
   document.getElementById('meta-a').innerText = trialA.includes('test-') ? `Date: ${trialA.replace('test-', '').slice(0, 10)}` : 'Historical Suite';
   
-  const displayAgentA = agentA || 'Unknown';
-  const displayModelA = modelA || 'Unknown';
+  const displayAgentA = agentA || suiteDataA?.agent || 'Unknown';
+  const displayModelA = modelA || suiteDataA?.model || 'Unknown';
   document.getElementById('agent-model-a').innerText = `Agent: ${displayAgentA} | Model: ${displayModelA}`;
 
   // Trial B
@@ -479,24 +512,23 @@ function updateExecutiveSummary() {
     document.getElementById('meta-b').innerText = trialB.includes('test-') ? `Date: ${trialB.replace('test-', '').slice(0, 10)}` : 'Historical Suite';
   }
   
-  const displayAgentB = agentB || 'Unknown';
-  const displayModelB = modelB || 'Unknown';
+  const displayAgentB = agentB || suiteDataB?.agent || 'Unknown';
+  const displayModelB = modelB || suiteDataB?.model || 'Unknown';
   document.getElementById('agent-model-b').innerText = `Agent: ${displayAgentB} | Model: ${displayModelB}`;
 
-  // Calculate Scores for the specific guide
-  // Fall back to forwarded score parameters if evals.json is missing
-  const scoreA = suiteDataA ? calculateGuideScore(suiteDataA, runNumA) : (scoreAParam !== null ? parseInt(scoreAParam) : 0);
-  const scoreB = suiteDataB ? calculateGuideScore(suiteDataB, runNumB) : (scoreBParam !== null ? parseInt(scoreBParam) : 0);
+  // Calculate Scores for the specific guide across active run types and runs
+  currentScoreA = suiteDataA ? calculateGuideScore(suiteDataA, runNumA, runTypeA) : (scoreAParam !== null ? parseInt(scoreAParam) : 0);
+  currentScoreB = suiteDataB ? calculateGuideScore(suiteDataB, runNumB, runTypeB) : (scoreBParam !== null ? parseInt(scoreBParam) : 0);
 
   const badgeA = document.getElementById('score-badge-a');
-  badgeA.innerText = `${scoreA}%`;
-  badgeA.className = `score-badge ${scoreA >= 70 ? 'score-high' : 'score-low'}`;
+  badgeA.innerText = `${currentScoreA}%`;
+  badgeA.className = `score-badge ${currentScoreA >= 70 ? 'score-high' : 'score-low'}`;
 
   const badgeB = document.getElementById('score-badge-b');
-  badgeB.innerText = `${scoreB}%`;
-  badgeB.className = `score-badge ${scoreB >= 70 ? 'score-high' : 'score-low'}`;
+  badgeB.innerText = `${currentScoreB}%`;
+  badgeB.className = `score-badge ${currentScoreB >= 70 ? 'score-high' : 'score-low'}`;
 
-  const delta = scoreB - scoreA;
+  const delta = currentScoreB - currentScoreA;
   const deltaText = delta === 0 ? 'No change (0%)' : delta > 0 ? `+${delta}% Improvement` : `${delta}% Regression`;
   const deltaSpan = document.getElementById('summary-delta');
   deltaSpan.innerText = deltaText;
@@ -509,24 +541,38 @@ function updateExecutiveSummary() {
   }
 }
 
-function calculateGuideScore(suiteData, runNum) {
-  if (!suiteData || !suiteData.evaluations) return 0;
-  const guideEvals = suiteData.evaluations.filter(ev => ev.task.startsWith(`${guideName}/`) && String(ev.run) === String(runNum));
-  if (guideEvals.length === 0) return 0;
+function calculateGuideScore(suiteData, runNum, runType) {
+  if (!suiteData || !suiteData.results) return 0;
   
   let totalAsserts = 0;
   let passedAsserts = 0;
   
-  guideEvals.forEach(ev => {
-    if (ev.results && Array.isArray(ev.results)) {
-      totalAsserts += ev.results.length;
-      passedAsserts += ev.results.filter(r => r.passed).length;
+  const targetRunType = runType || 'guided';
+  const targetRunNum = parseInt(runNum, 10);
+
+  Object.keys(suiteData.results).forEach(key => {
+    const parsedKey = parseResultKey(key);
+    if (!parsedKey) return;
+    if (parsedKey.guide === guideName && parsedKey.runType === targetRunType) {
+      const runs = suiteData.results[key] || [];
+      const matchingRuns = (!isNaN(targetRunNum) && runs.some(r => r.runNumber === targetRunNum))
+        ? runs.filter(r => r.runNumber === targetRunNum)
+        : runs;
+
+      matchingRuns.forEach(r => {
+        if (r.results && Array.isArray(r.results)) {
+          totalAsserts += r.results.length;
+          passedAsserts += r.results.filter(check => check.passed).length;
+        }
+      });
     }
   });
 
   return totalAsserts > 0 ? Math.round((passedAsserts / totalAsserts) * 100) : 0;
 }
+
 async function switchTask(task) {
+  if (activeTask === task) return;
   activeTask = task;
   
   // Update sidebar active state
@@ -534,6 +580,8 @@ async function switchTask(task) {
     btn.classList.toggle('active', btn.textContent.trim() === activeTask);
   });
 
+  await loadActiveTaskDetails();
+  await runDiagnosticAgent();
 }
 
 function getRunDateString(trialId) {
@@ -664,39 +712,21 @@ async function loadAssertions(pathA, pathB) {
     }
   } catch (e) {}
 
-  // Calculate live scores from parsed assertions and update badges dynamically
+  // Update Assertion table column headers with task-specific pass rate
+  const titleAStr = getFormattedTrialTitle('Trial A', trialA, runNumA, runTypeA, agentA, modelA, null, suiteDataA, runIndexA);
+  const titleBStr = getFormattedTrialTitle('Trial B', trialB, runNumB, runTypeB, agentB, modelB, null, suiteDataB, runIndexB);
   if (resultsA.length > 0) {
     const passedA = resultsA.filter(r => r.passed).length;
-    currentScoreA = Math.round((passedA / resultsA.length) * 100);
-    const badgeA = document.getElementById('score-badge-a');
-    badgeA.innerText = `${currentScoreA}%`;
-    badgeA.className = `score-badge ${currentScoreA >= 70 ? 'score-high' : 'score-low'}`;
-  } else {
-    currentScoreA = scoreAParam !== null ? parseInt(scoreAParam) : 0;
-    const badgeA = document.getElementById('score-badge-a');
-    badgeA.innerText = `${currentScoreA}%`;
-    badgeA.className = `score-badge ${currentScoreA >= 70 ? 'score-high' : 'score-low'}`;
+    const taskScoreA = Math.round((passedA / resultsA.length) * 100);
+    const headerA = document.getElementById('header-assert-a');
+    if (headerA) headerA.innerText = `${titleAStr} [Task: ${taskScoreA}%]`;
   }
-
   if (resultsB.length > 0) {
     const passedB = resultsB.filter(r => r.passed).length;
-    currentScoreB = Math.round((passedB / resultsB.length) * 100);
-    const badgeB = document.getElementById('score-badge-b');
-    badgeB.innerText = `${currentScoreB}%`;
-    badgeB.className = `score-badge ${currentScoreB >= 70 ? 'score-high' : 'score-low'}`;
-  } else {
-    currentScoreB = scoreBParam !== null ? parseInt(scoreBParam) : 0;
-    const badgeB = document.getElementById('score-badge-b');
-    badgeB.innerText = `${currentScoreB}%`;
-    badgeB.className = `score-badge ${currentScoreB >= 70 ? 'score-high' : 'score-low'}`;
+    const taskScoreB = Math.round((passedB / resultsB.length) * 100);
+    const headerB = document.getElementById('header-assert-b');
+    if (headerB) headerB.innerText = `${titleBStr} [Task: ${taskScoreB}%]`;
   }
-
-  // Update Score Delta dynamically
-  const delta = currentScoreB - currentScoreA;
-  const deltaText = delta === 0 ? 'No change (0%)' : delta > 0 ? `+${delta}% Improvement` : `${delta}% Regression`;
-  const deltaSpan = document.getElementById('summary-delta');
-  deltaSpan.innerText = deltaText;
-  deltaSpan.style.color = delta === 0 ? '#475569' : delta > 0 ? '#166534' : '#991b1b';
 
   // Merge assertions list to compare side-by-side
   const allAssertionMessages = Array.from(new Set([
@@ -1345,6 +1375,24 @@ async function runDiagnosticAgent() {
   }
 
   // Local Mode: Call Node dev server API to run comparison on the fly!
+  const hasTaskA = suiteDataA ? checkTaskInSuite(suiteDataA, activeTask) : true;
+  const hasTaskB = suiteDataB ? checkTaskInSuite(suiteDataB, activeTask) : true;
+
+  if (suiteDataA && suiteDataB && (!hasTaskA || !hasTaskB)) {
+    const missingIn = !hasTaskA && !hasTaskB ? 'both trials' : !hasTaskA ? 'Trial A' : 'Trial B';
+    const presentIn = !hasTaskA ? 'Trial B' : 'Trial A';
+    diagnosisText.innerHTML = `
+      <div style="color:#92400e; font-weight:600;">Cross-trial comparison unavailable for this task.</div>
+      <div style="font-size:0.9em; margin-top:5px; color:#78350f;">
+        Task <code>${escapeHtml(activeTask)}</code> was only executed in ${presentIn} and is not present in ${missingIn}.
+        To run an AI variance diagnosis, select a task that was executed in both trials.
+      </div>
+    `;
+    statusSpan.innerText = 'Single Trial Only';
+    statusSpan.style.color = '#64748b';
+    return;
+  }
+
   // Use dynamic runTypeA and runTypeB values
   const relativeA = `${trialA}/${runNumA}/${guideName}/${activeTask}/${runTypeA}`;
   const relativeB = `${trialB}/${runNumB}/${guideName}/${activeTask}/${runTypeB}`;

--- a/eval-view/dashboard.js
+++ b/eval-view/dashboard.js
@@ -992,7 +992,7 @@ async function fillAccordionDetails(container, scenarioName, unguidedRuns, guide
                  if (files.length === 0) files = run.files || [];
 
                  const patchFile = files.includes('agent.patch') ? 'agent.patch' : null;
-                 const sessionFile = files.find(f => f.startsWith('session-') && f.endsWith('.html'));
+                 const sessionFile = files.find(f => f.startsWith('session-') && !f.includes('-subagents-') && f.endsWith('.html')) || files.find(f => f.startsWith('session-') && f.endsWith('.html'));
                  const logFile = files.includes('mcp-server.log') ? 'mcp-server.log' : (files.includes('modern-web.log') ? 'modern-web.log' : null);
                  const jsonFile = files.find(f => f.endsWith('_results.json'));
                  const runtimeFile = files.includes('runtime.json') ? 'runtime.json' : null;

--- a/eval-view/evals.d.ts
+++ b/eval-view/evals.d.ts
@@ -1,54 +1,33 @@
 import type { EvalsReport } from '../harness/lib/metrics.ts';
-import type { StandardizedStep, TrajectorySummary } from '../harness/lib/trajectory-normalizer.ts';
-
-export type SuiteReport = EvalsReport & {
-  enableSkills?: boolean;
-};
-
-export type CompareStep = Omit<StandardizedStep, 'action' | 'outcome'> & {
-  action?: {
-    type?: string;
-    name?: string;
-    params?: any;
-    canonicalCategory?: string;
-  };
-  outcome?: any;
-  output?: any;
-  result?: any;
-};
-
-export type CompareTrajectory = TrajectorySummary & {
-  steps: CompareStep[];
-};
+import type { TrajectorySummary } from '../harness/lib/trajectory-normalizer.ts';
 
 /**
- * A trial point selected on the timeline in guide view for comparison.
+ * A trial run point selected on the timeline in guide view for comparison.
  */
-export interface SelectedTrialPoint {
+export interface TrialSelection {
   testId: string;
-  dateKey?: string;
-  combKey?: string;
-  runIndex?: number;
-  source?: string;
+  runNumber: number;
+  source?: 'local' | 'static';
   agent?: string;
   model?: string;
   score?: number;
+  dateKey?: string;
+  combKey?: string;
 }
 
 /**
  * State, configuration, and loaded artifacts for one side (A or B) of a comparison run.
  */
-export interface CompareSide extends SelectedTrialPoint {
+export interface CompareSide {
   key: 'A' | 'B';
-  label: string;
-  trialId: string;
-  runNum: string;
-  score: number;
-  scoreParam: string | null;
+  testId: string;
+  runNumber: number;
   runType: 'guided' | 'unguided';
-  runDir: string;
-  suiteData: SuiteReport | null;
-  trajectory: CompareTrajectory | null;
+  agent: string;
+  model: string;
+  score: number;
+  suiteData: EvalsReport | null;
+  trajectory: TrajectorySummary | null;
   chatLog: string;
 }
 

--- a/eval-view/evals.d.ts
+++ b/eval-view/evals.d.ts
@@ -11,5 +11,10 @@ declare global {
     viewContent?: (fileName: string, filePath: string) => Promise<void>;
     viewDiff?: (setupPath: string, resultPath: string, testName: string, runNumber: number) => Promise<void>;
     setInsightFilter?: (filterKey: 'agent' | 'serving' | 'model', value: string) => void;
+    switchTab?: (tab: string) => void;
+    switchTask?: (task: string) => Promise<void> | void;
+    runDiagnosticAgent?: () => Promise<void>;
+    switchTimelineMode?: (mode: 'milestone' | 'raw') => void;
+    exportCompareReport?: () => void;
   }
 }

--- a/eval-view/evals.d.ts
+++ b/eval-view/evals.d.ts
@@ -1,6 +1,56 @@
 import type { EvalsReport } from '../harness/lib/metrics.ts';
+import type { StandardizedStep, TrajectorySummary } from '../harness/lib/trajectory-normalizer.ts';
 
+export type SuiteReport = EvalsReport & {
+  enableSkills?: boolean;
+};
 
+export type CompareStep = Omit<StandardizedStep, 'action' | 'outcome'> & {
+  action?: {
+    type?: string;
+    name?: string;
+    params?: any;
+    canonicalCategory?: string;
+  };
+  outcome?: any;
+  output?: any;
+  result?: any;
+};
+
+export type CompareTrajectory = TrajectorySummary & {
+  steps: CompareStep[];
+};
+
+/**
+ * A trial point selected on the timeline in guide view for comparison.
+ */
+export interface SelectedTrialPoint {
+  testId: string;
+  dateKey?: string;
+  combKey?: string;
+  runIndex?: number;
+  source?: string;
+  agent?: string;
+  model?: string;
+  score?: number;
+}
+
+/**
+ * State, configuration, and loaded artifacts for one side (A or B) of a comparison run.
+ */
+export interface CompareSide extends SelectedTrialPoint {
+  key: 'A' | 'B';
+  label: string;
+  trialId: string;
+  runNum: string;
+  score: number;
+  scoreParam: string | null;
+  runType: 'guided' | 'unguided';
+  runDir: string;
+  suiteData: SuiteReport | null;
+  trajectory: CompareTrajectory | null;
+  chatLog: string;
+}
 
 declare global {
   interface Window {

--- a/eval-view/guide.html
+++ b/eval-view/guide.html
@@ -70,6 +70,7 @@
         </div>
       </div>
       <div style="display: flex; gap: 12px; justify-content: flex-end;">
+        <button id="compare-mode-btn" class="secondary-btn" style="margin-bottom: 0; background-color: #f1f5f9; border-color: #cbd5e1; color: #475569;">Compare Trials</button>
         <a href="./" class="secondary-btn" style="text-decoration: none; margin-bottom: 0;">← Back to Results</a>
         <button id="auth-btn" class="secondary-btn" style="display: none; margin-bottom: 0;">
           Sign in with Google
@@ -83,6 +84,15 @@
 
     <div id="empty-state" class="empty-state" style="display: none;">
       <p>No historical runs found for this guide.</p>
+    </div>
+  </div>
+
+  <!-- Floating Compare Banner -->
+  <div id="compare-banner" style="display:none; position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%); background-color: #1e293b; color: #ffffff; padding: 12px 20px; border-radius: 10px; box-shadow: 0 10px 25px -5px rgba(0,0,0,0.3); align-items: center; gap: 20px; z-index: 1000; font-family:-apple-system,BlinkMacSystemFont,sans-serif;">
+    <span id="compare-banner-text" style="font-weight:600; font-size:0.9em; min-width: 250px;">Select two trials on the chart to compare.</span>
+    <div style="display:flex; gap:8px;">
+      <button id="launch-compare-btn" class="secondary-btn" style="margin-bottom:0; background-color: #2563eb; color:#ffffff; border-color:#2563eb; font-weight:bold; padding:6px 12px; font-size:0.85em;" disabled>Compare & Diagnose</button>
+      <button id="cancel-compare-btn" class="secondary-btn" style="margin-bottom:0; background-color: transparent; color:#cbd5e1; border-color:#475569; padding:6px 12px; font-size:0.85em;">Cancel</button>
     </div>
   </div>
 

--- a/eval-view/guide.html
+++ b/eval-view/guide.html
@@ -59,7 +59,7 @@
 
         <div style="font-size: 0.9em; color: var(--text-secondary); margin-top: 8px;">Performance over time by agent and model combination</div>
 
-        <div class="timeline-filter-controls" style="display: flex; align-items: center; gap: 8px; margin-top: 12px; font-size: 0.85em; color: var(--text-primary);">
+        <div class="timeline-filter-controls" style="display: flex; align-items: center; gap: 8px; margin-top: 12px; font-size: 0.85em; color: var(--text-primary); flex-wrap: wrap;">
           <span>Show last</span>
           <input type="number" id="timeline-limit-input" value="30" min="1" style="width: 50px; padding: 4px 8px; border: 1px solid var(--border-color); border-radius: 4px; background: var(--bg-secondary); color: var(--text-primary); outline: none;">
           <span>days</span>
@@ -67,6 +67,10 @@
             <input type="checkbox" id="timeline-show-all-check">
             <span>Show all</span>
           </label>
+          <div style="display: flex; align-items: center; gap: 6px; margin-left: 12px;">
+            <label for="guide-run-filter-input" style="color: var(--text-secondary); font-weight: 500;">Filter run name:</label>
+            <input type="text" id="guide-run-filter-input" value="nightly" placeholder="e.g. nightly" style="width: 110px; padding: 4px 8px; border: 1px solid var(--border-color); border-radius: 4px; background: var(--bg-secondary); color: var(--text-primary); outline: none;">
+          </div>
         </div>
       </div>
       <div style="display: flex; gap: 12px; justify-content: flex-end;">

--- a/eval-view/guide.js
+++ b/eval-view/guide.js
@@ -4,6 +4,7 @@ import { extractSuiteSummary } from './summary-extractor.js';
 /** @type {Record<string, GuideSuiteSummary>} */
 let allTestData = {}; // Cache all test data by testId
 let isCompareMode = false;
+/** @type {Array<{ dateKey?: string, combKey?: string, testId: string, source?: string, group?: any, runIndex?: number, agent?: string, model?: string, score?: number }>} */
 let selectedPoints = []; // array of { testId, source, combKey }
 let currentRunFilter = 'nightly';
 
@@ -239,7 +240,7 @@ function setupNavigationControls(currentGuide) {
     const list = $('#autocomplete-list');
     const goBtn = /** @type {HTMLButtonElement} */ ($('#go-guide-btn'));
 
-    const getNavUrl = (targetGuide) => `guide.html?guide=${encodeURIComponent(targetGuide)}${currentRunFilter ? `&runFilter=${encodeURIComponent(currentRunFilter)}` : ''}`;
+    const getNavUrl = (/** @type {string} */ targetGuide) => `guide.html?guide=${encodeURIComponent(targetGuide)}${currentRunFilter ? `&runFilter=${encodeURIComponent(currentRunFilter)}` : ''}`;
 
     const backLink = document.querySelector('a[href^="./"]');
     if (backLink) {
@@ -422,6 +423,7 @@ function renderGraphs(guideName) {
 
         const runsByDateMap = Map.groupBy(runs, run => getDateKey(run.timestamp));
 
+        /** @type {Array<{ dateKey: string, latestRun: any, runsOnDate: any[] }>} */
         const dateEntries = [];
         runsByDateMap.forEach((runsOnDate, dateKey) => {
             runsOnDate.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
@@ -556,7 +558,7 @@ function renderGraphs(guideName) {
             const run = entry ? entry.latestRun : null;
             const runsOnDate = entry ? entry.runsOnDate : [];
             
-            const isHighlighted = run && runsOnDate.some(r => r.testId === highlightTestId);
+            const isHighlighted = run && runsOnDate.some((/** @type {any} */ r) => r.testId === highlightTestId);
             if (isHighlighted) {
                 svgContent += `
                     <rect x="${x - 12}" y="${paddingY - 5}" width="24" height="${plotHeight + 10}" fill="var(--color-primary)" style="opacity: 0.12; rx: 4px;" />
@@ -670,7 +672,7 @@ function renderGraphs(guideName) {
                                 ${runsOnDate.length} runs on this date:
                             </div>
                             <div style="display: flex; flex-direction: column; gap: 4px;">
-                                ${runsOnDate.map((r, idx) => {
+                                ${runsOnDate.map((/** @type {any} */ r, /** @type {number} */ idx) => {
                                     const rStats = r.guides[guideName];
                                     const timeStr = new Date(r.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
                                     const isLatest = idx === runsOnDate.length - 1;
@@ -789,7 +791,7 @@ function renderGraphs(guideName) {
                         select.style.fontWeight = '500';
                         select.style.cursor = 'pointer';
 
-                        runsOnDate.forEach((r, idx) => {
+                        runsOnDate.forEach((/** @type {any} */ r, /** @type {number} */ idx) => {
                             const timeStr = new Date(r.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
                             const rStats = r.guides[guideName];
                             const opt = document.createElement('option');
@@ -807,7 +809,7 @@ function renderGraphs(guideName) {
                             const chosenTestId = select.value;
                             const selectedOpt = select.options[select.selectedIndex];
                             const chosenRunIndex = parseInt(selectedOpt.getAttribute('data-runindex') || '1');
-                            const chosenRun = runsOnDate.find(r => r.testId === chosenTestId) || defaultRun;
+                            const chosenRun = runsOnDate.find((/** @type {any} */ r) => r.testId === chosenTestId) || defaultRun;
                             handlePointSelection(chosenRun, group, combKey, guideName, chosenRunIndex);
                         });
 
@@ -820,13 +822,15 @@ function renderGraphs(guideName) {
                     }
                 } else {
                     window.location.href = `dashboard.html?testId=${defaultRun.testId}&source=${defaultRun.source}#guide-${guideName}`;
->>>>>>> 45a3b374 (feat(eval-view): add run comparison dashboard and visualizer)
                 }
             });
         });
     });
 }
 
+/**
+ * @param {string} guideName
+ */
 function setupCompareMode(guideName) {
     const compareBtn = $('#compare-mode-btn');
     const banner = $('#compare-banner');
@@ -861,6 +865,9 @@ function setupCompareMode(guideName) {
     });
 }
 
+/**
+ * @param {boolean} on
+ */
 function toggleCompareMode(on) {
     isCompareMode = on;
     const compareBtn = $('#compare-mode-btn');
@@ -886,9 +893,16 @@ function clearSelections() {
     updateCompareBanner();
 }
 
+/**
+ * @param {any} runData
+ * @param {SVGElement} group
+ * @param {string} combKey
+ * @param {string} guideName
+ * @param {number} [runIndex]
+ */
 function handlePointSelection(runData, group, combKey, guideName, runIndex = 1) {
     const testId = runData.testId;
-    const dateKey = group.getAttribute('data-datekey');
+    const dateKey = group.getAttribute('data-datekey') || '';
     const existingIdx = selectedPoints.findIndex(p => p.dateKey === dateKey && p.combKey === combKey);
 
     if (existingIdx !== -1) {
@@ -911,8 +925,10 @@ function handlePointSelection(runData, group, combKey, guideName, runIndex = 1) 
     } else {
         if (selectedPoints.length >= 2) {
             const removed = selectedPoints.shift();
-            const oldGroup = document.querySelector(`[data-datekey="${removed.dateKey}"][data-comb="${removed.combKey}"]`);
-            if (oldGroup) oldGroup.querySelector('.compare-highlight')?.remove();
+            if (removed) {
+                const oldGroup = document.querySelector(`[data-datekey="${removed.dateKey}"][data-comb="${removed.combKey}"]`);
+                if (oldGroup) oldGroup.querySelector('.compare-highlight')?.remove();
+            }
         }
 
         const stats = runData.guides[guideName];
@@ -927,8 +943,8 @@ function handlePointSelection(runData, group, combKey, guideName, runIndex = 1) 
             score: stats ? stats.guidedRate : 0
         });
 
-        const x = parseFloat(group.getAttribute('data-x'));
-        const y = parseFloat(group.getAttribute('data-yg'));
+        const x = parseFloat(group.getAttribute('data-x') || '0');
+        const y = parseFloat(group.getAttribute('data-yg') || '0');
         
         if (!group.querySelector('.compare-highlight')) {
             const highlight = document.createElementNS('http://www.w3.org/2000/svg', 'circle');

--- a/eval-view/guide.js
+++ b/eval-view/guide.js
@@ -2,13 +2,13 @@ import { initGoogleAuth, authenticatedFetch, getAccessToken, escapeHtml, hasNigh
 import { extractSuiteSummary } from './summary-extractor.js';
 
 /**
- * @import { SelectedTrialPoint } from './evals.d.ts'
+ * @import { TrialSelection } from './evals.d.ts'
  */
 
 /** @type {Record<string, GuideSuiteSummary>} */
 let allTestData = {}; // Cache all test data by testId
 let isCompareMode = false;
-/** @type {SelectedTrialPoint[]} */
+/** @type {TrialSelection[]} */
 let selectedPoints = []; // array of selected trial points
 let currentRunFilter = 'nightly';
 
@@ -864,7 +864,7 @@ function setupCompareMode(guideName) {
             const urlParams = new URLSearchParams(window.location.search);
             const isStatic = urlParams.get('source') === 'static' || window.location.hostname.includes('github.io');
             
-            window.location.href = `compare.html?trialA=${pA.testId}&trialB=${pB.testId}&runIndexA=${pA.runIndex || 1}&runIndexB=${pB.runIndex || 1}&agentA=${encodeURIComponent(pA.agent || '')}&modelA=${encodeURIComponent(pA.model || '')}&scoreA=${pA.score || 0}&agentB=${encodeURIComponent(pB.agent || '')}&modelB=${encodeURIComponent(pB.model || '')}&scoreB=${pB.score || 0}&guide=${guideName}&source=${isStatic ? 'static' : 'local'}`;
+            window.location.href = `compare.html?trialA=${pA.testId}&trialB=${pB.testId}&runIndexA=${pA.runNumber || 1}&runIndexB=${pB.runNumber || 1}&agentA=${encodeURIComponent(pA.agent || '')}&modelA=${encodeURIComponent(pA.model || '')}&scoreA=${pA.score || 0}&agentB=${encodeURIComponent(pB.agent || '')}&modelB=${encodeURIComponent(pB.model || '')}&scoreB=${pB.score || 0}&guide=${guideName}&source=${isStatic ? 'static' : 'local'}`;
         }
     });
 }
@@ -898,13 +898,13 @@ function clearSelections() {
 }
 
 /**
- * @param {any} runData
+ * @param {GuideSuiteSummary} runData
  * @param {SVGElement} group
  * @param {string} combKey
  * @param {string} guideName
- * @param {number} [runIndex]
+ * @param {number} [runNumber=1]
  */
-function handlePointSelection(runData, group, combKey, guideName, runIndex = 1) {
+function handlePointSelection(runData, group, combKey, guideName, runNumber = 1) {
     const testId = runData.testId;
     const dateKey = group.getAttribute('data-datekey') || '';
     const existingIdx = selectedPoints.findIndex(p => p.dateKey === dateKey && p.combKey === combKey);
@@ -919,8 +919,8 @@ function handlePointSelection(runData, group, combKey, guideName, runIndex = 1) 
                 testId, 
                 dateKey,
                 combKey,
-                runIndex,
-                source: runData.source, 
+                runNumber,
+                source: /** @type {'local' | 'static' | undefined} */ (runData.source), 
                 agent: runData.agent, 
                 model: runData.model,
                 score: runData.guides[guideName] ? runData.guides[guideName].guidedRate : 0
@@ -940,8 +940,8 @@ function handlePointSelection(runData, group, combKey, guideName, runIndex = 1) 
             testId, 
             dateKey,
             combKey,
-            runIndex,
-            source: runData.source, 
+            runNumber,
+            source: /** @type {'local' | 'static' | undefined} */ (runData.source), 
             agent: runData.agent, 
             model: runData.model,
             score: stats ? stats.guidedRate : 0
@@ -977,12 +977,12 @@ function updateCompareBanner() {
         text.innerText = 'Select two trials on the chart to compare.';
         launchBtn.disabled = true;
     } else if (selectedPoints.length === 1) {
-        const label0 = selectedPoints[0].runIndex ? ` (Run ${selectedPoints[0].runIndex})` : '';
+        const label0 = selectedPoints[0].runNumber ? ` (Run ${selectedPoints[0].runNumber})` : '';
         text.innerHTML = `Selected 1 trial: <span style="font-family:monospace; color:#bfdbfe;">${selectedPoints[0].testId.slice(0, 15)}${label0}...</span>. Select one more.`;
         launchBtn.disabled = true;
     } else if (selectedPoints.length === 2) {
-        const label0 = selectedPoints[0].runIndex ? ` (Run ${selectedPoints[0].runIndex})` : '';
-        const label1 = selectedPoints[1].runIndex ? ` (Run ${selectedPoints[1].runIndex})` : '';
+        const label0 = selectedPoints[0].runNumber ? ` (Run ${selectedPoints[0].runNumber})` : '';
+        const label1 = selectedPoints[1].runNumber ? ` (Run ${selectedPoints[1].runNumber})` : '';
         text.innerHTML = `Ready to compare: <span style="font-family:monospace; color:#bfdbfe;">${selectedPoints[0].testId.slice(0, 10)}${label0}...</span> vs <span style="font-family:monospace; color:#bfdbfe;">${selectedPoints[1].testId.slice(0, 10)}${label1}...</span>`;
         launchBtn.disabled = false;
     }

--- a/eval-view/guide.js
+++ b/eval-view/guide.js
@@ -1,4 +1,4 @@
-import { initGoogleAuth, authenticatedFetch, getAccessToken, escapeHtml, $ } from './utils.js';
+import { initGoogleAuth, authenticatedFetch, getAccessToken, escapeHtml, hasNightlyRuns, $ } from './utils.js';
 import { extractSuiteSummary } from './summary-extractor.js';
 
 /** @type {Record<string, GuideSuiteSummary>} */
@@ -6,10 +6,6 @@ let allTestData = {}; // Cache all test data by testId
 let isCompareMode = false;
 let selectedPoints = []; // array of { testId, source, combKey }
 let currentRunFilter = 'nightly';
-
-function hasNightlyRuns() {
-    return Object.values(allTestData).some(t => (t.testId || '').toLowerCase().includes('nightly'));
-}
 
 document.addEventListener('DOMContentLoaded', async () => {
     const params = new URLSearchParams(window.location.search);
@@ -243,6 +239,8 @@ function setupNavigationControls(currentGuide) {
     const list = $('#autocomplete-list');
     const goBtn = /** @type {HTMLButtonElement} */ ($('#go-guide-btn'));
 
+    const getNavUrl = (targetGuide) => `guide.html?guide=${encodeURIComponent(targetGuide)}${currentRunFilter ? `&runFilter=${encodeURIComponent(currentRunFilter)}` : ''}`;
+
     const backLink = document.querySelector('a[href^="./"]');
     if (backLink) {
         backLink.setAttribute('href', `./${currentRunFilter ? `?runFilter=${encodeURIComponent(currentRunFilter)}` : ''}`);
@@ -257,20 +255,20 @@ function setupNavigationControls(currentGuide) {
         prevBtn.disabled = false;
         prevBtn.onclick = () => {
             const prevIndex = (currentIndex - 1 + allGuides.length) % allGuides.length;
-            window.location.href = `guide.html?guide=${encodeURIComponent(allGuides[prevIndex])}${currentRunFilter ? `&runFilter=${encodeURIComponent(currentRunFilter)}` : ''}`;
+            window.location.href = getNavUrl(allGuides[prevIndex]);
         };
 
         nextBtn.disabled = false;
         nextBtn.onclick = () => {
             const nextIndex = (currentIndex + 1) % allGuides.length;
-            window.location.href = `guide.html?guide=${encodeURIComponent(allGuides[nextIndex])}${currentRunFilter ? `&runFilter=${encodeURIComponent(currentRunFilter)}` : ''}`;
+            window.location.href = getNavUrl(allGuides[nextIndex]);
         };
     }
 
     goBtn.onclick = () => {
         const val = searchInput.value.trim();
         if (val) {
-            window.location.href = `guide.html?guide=${encodeURIComponent(val)}${currentRunFilter ? `&runFilter=${encodeURIComponent(currentRunFilter)}` : ''}`;
+            window.location.href = getNavUrl(val);
         }
     };
 
@@ -300,7 +298,7 @@ function setupNavigationControls(currentGuide) {
             div.onclick = () => {
                 searchInput.value = match;
                 list.classList.add('hidden');
-                window.location.href = `guide.html?guide=${encodeURIComponent(match)}${currentRunFilter ? `&runFilter=${encodeURIComponent(currentRunFilter)}` : ''}`;
+                window.location.href = getNavUrl(match);
             };
             list.appendChild(div);
         });
@@ -422,14 +420,7 @@ function renderGraphs(guideName) {
         const runs = combinations[combKey];
         runs.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
 
-        const runsByDateMap = new Map();
-        runs.forEach(run => {
-            const dateKey = getDateKey(run.timestamp);
-            if (!runsByDateMap.has(dateKey)) {
-                runsByDateMap.set(dateKey, []);
-            }
-            runsByDateMap.get(dateKey).push(run);
-        });
+        const runsByDateMap = Map.groupBy(runs, run => getDateKey(run.timestamp));
 
         const dateEntries = [];
         runsByDateMap.forEach((runsOnDate, dateKey) => {

--- a/eval-view/guide.js
+++ b/eval-view/guide.js
@@ -7,6 +7,10 @@ let isCompareMode = false;
 let selectedPoints = []; // array of { testId, source, combKey }
 let currentRunFilter = 'nightly';
 
+function hasNightlyRuns() {
+    return Object.values(allTestData).some(t => (t.testId || '').toLowerCase().includes('nightly'));
+}
+
 document.addEventListener('DOMContentLoaded', async () => {
     const params = new URLSearchParams(window.location.search);
     const guideName = params.get('guide');
@@ -27,6 +31,11 @@ document.addEventListener('DOMContentLoaded', async () => {
     try {
         initGoogleAuth(async () => {
             await loadRemoteTests();
+            if (runFilterParam === null && hasNightlyRuns()) {
+                currentRunFilter = 'nightly';
+                const runFilterInput = /** @type {HTMLInputElement | null} */ ($('#guide-run-filter-input'));
+                if (runFilterInput) runFilterInput.value = currentRunFilter;
+            }
             setupNavigationControls(guideName);
             renderGraphs(guideName);
         });
@@ -34,6 +43,11 @@ document.addEventListener('DOMContentLoaded', async () => {
         await loadLocalTests();
         if (getAccessToken()) {
             await loadRemoteTests();
+        }
+        if (runFilterParam === null) {
+            currentRunFilter = hasNightlyRuns() ? 'nightly' : '';
+            const runFilterInput = /** @type {HTMLInputElement | null} */ ($('#guide-run-filter-input'));
+            if (runFilterInput) runFilterInput.value = currentRunFilter;
         }
         setupNavigationControls(guideName);
         renderGraphs(guideName);

--- a/eval-view/guide.js
+++ b/eval-view/guide.js
@@ -1,11 +1,15 @@
 import { initGoogleAuth, authenticatedFetch, getAccessToken, escapeHtml, hasNightlyRuns, $ } from './utils.js';
 import { extractSuiteSummary } from './summary-extractor.js';
 
+/**
+ * @import { SelectedTrialPoint } from './evals.d.ts'
+ */
+
 /** @type {Record<string, GuideSuiteSummary>} */
 let allTestData = {}; // Cache all test data by testId
 let isCompareMode = false;
-/** @type {Array<{ dateKey?: string, combKey?: string, testId: string, source?: string, group?: any, runIndex?: number, agent?: string, model?: string, score?: number }>} */
-let selectedPoints = []; // array of { testId, source, combKey }
+/** @type {SelectedTrialPoint[]} */
+let selectedPoints = []; // array of selected trial points
 let currentRunFilter = 'nightly';
 
 document.addEventListener('DOMContentLoaded', async () => {

--- a/eval-view/guide.js
+++ b/eval-view/guide.js
@@ -5,6 +5,7 @@ import { extractSuiteSummary } from './summary-extractor.js';
 let allTestData = {}; // Cache all test data by testId
 let isCompareMode = false;
 let selectedPoints = []; // array of { testId, source, combKey }
+let currentRunFilter = 'nightly';
 
 document.addEventListener('DOMContentLoaded', async () => {
     const params = new URLSearchParams(window.location.search);
@@ -12,6 +13,11 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (!guideName) {
         window.location.href = './';
         return;
+    }
+
+    const runFilterParam = params.get('runFilter') ?? params.get('runName');
+    if (runFilterParam !== null) {
+        currentRunFilter = runFilterParam;
     }
 
     $('#guide-name-header').textContent = guideName;
@@ -153,28 +159,56 @@ async function loadRemoteTests() {
         console.error('Error loading remote suites:', error);
     }
 }
+/**
+ * @param {string} guideName
+ */
+function updateUrlParams(guideName) {
+    const url = new URL(window.location.href);
+    url.searchParams.set('guide', guideName);
+    if (currentRunFilter === 'nightly') {
+        url.searchParams.delete('runFilter');
+    } else {
+        url.searchParams.set('runFilter', currentRunFilter);
+    }
+    window.history.replaceState({}, '', url);
+}
 
 /**
  * @param {string} guideName
  */
 function setupTimelineFilterControls(guideName) {
-    const limitInput = /** @type {HTMLInputElement} */ ($('#timeline-limit-input'));
-    const showAllCheck = /** @type {HTMLInputElement} */ ($('#timeline-show-all-check'));
+    const limitInput = /** @type {HTMLInputElement | null} */ ($('#timeline-limit-input'));
+    const showAllCheck = /** @type {HTMLInputElement | null} */ ($('#timeline-show-all-check'));
+    const runFilterInput = /** @type {HTMLInputElement | null} */ ($('#guide-run-filter-input'));
 
-    if (!limitInput || !showAllCheck) return;
+    if (runFilterInput) {
+        runFilterInput.value = currentRunFilter;
+        runFilterInput.addEventListener('input', () => {
+            currentRunFilter = runFilterInput.value;
+            updateUrlParams(guideName);
+            setupNavigationControls(guideName);
+            renderGraphs(guideName);
+        });
+    }
 
-    limitInput.addEventListener('change', () => {
-        let val = parseInt(limitInput.value);
-        if (isNaN(val) || val < 1) {
-            limitInput.value = '30';
-        }
-        renderGraphs(guideName);
-    });
+    if (limitInput) {
+        limitInput.addEventListener('change', () => {
+            let val = parseInt(limitInput.value);
+            if (isNaN(val) || val < 1) {
+                limitInput.value = '30';
+            }
+            renderGraphs(guideName);
+        });
+    }
 
-    showAllCheck.addEventListener('change', () => {
-        limitInput.disabled = showAllCheck.checked;
-        renderGraphs(guideName);
-    });
+    if (showAllCheck) {
+        showAllCheck.addEventListener('change', () => {
+            if (limitInput) {
+                limitInput.disabled = showAllCheck.checked;
+            }
+            renderGraphs(guideName);
+        });
+    }
 }
 
 /**
@@ -195,6 +229,11 @@ function setupNavigationControls(currentGuide) {
     const list = $('#autocomplete-list');
     const goBtn = /** @type {HTMLButtonElement} */ ($('#go-guide-btn'));
 
+    const backLink = document.querySelector('a[href^="./"]');
+    if (backLink) {
+        backLink.setAttribute('href', `./${currentRunFilter ? `?runFilter=${encodeURIComponent(currentRunFilter)}` : ''}`);
+    }
+
     if (allGuides.length <= 1) {
         prevBtn.disabled = true;
         nextBtn.disabled = true;
@@ -204,20 +243,20 @@ function setupNavigationControls(currentGuide) {
         prevBtn.disabled = false;
         prevBtn.onclick = () => {
             const prevIndex = (currentIndex - 1 + allGuides.length) % allGuides.length;
-            window.location.href = `guide.html?guide=${encodeURIComponent(allGuides[prevIndex])}`;
+            window.location.href = `guide.html?guide=${encodeURIComponent(allGuides[prevIndex])}${currentRunFilter ? `&runFilter=${encodeURIComponent(currentRunFilter)}` : ''}`;
         };
 
         nextBtn.disabled = false;
         nextBtn.onclick = () => {
             const nextIndex = (currentIndex + 1) % allGuides.length;
-            window.location.href = `guide.html?guide=${encodeURIComponent(allGuides[nextIndex])}`;
+            window.location.href = `guide.html?guide=${encodeURIComponent(allGuides[nextIndex])}${currentRunFilter ? `&runFilter=${encodeURIComponent(currentRunFilter)}` : ''}`;
         };
     }
 
     goBtn.onclick = () => {
         const val = searchInput.value.trim();
         if (val) {
-            window.location.href = `guide.html?guide=${encodeURIComponent(val)}`;
+            window.location.href = `guide.html?guide=${encodeURIComponent(val)}${currentRunFilter ? `&runFilter=${encodeURIComponent(currentRunFilter)}` : ''}`;
         }
     };
 
@@ -247,7 +286,7 @@ function setupNavigationControls(currentGuide) {
             div.onclick = () => {
                 searchInput.value = match;
                 list.classList.add('hidden');
-                goBtn.click();
+                window.location.href = `guide.html?guide=${encodeURIComponent(match)}${currentRunFilter ? `&runFilter=${encodeURIComponent(currentRunFilter)}` : ''}`;
             };
             list.appendChild(div);
         });
@@ -311,14 +350,21 @@ function renderGraphs(guideName) {
 
     const testKeys = Object.keys(allTestData);
     
-    // Filter out suites that don't have this guide, or have 0 trials for it
+    // Filter out suites that don't have this guide, or have 0 trials for it, or don't match run filter
     const filteredKeys = testKeys.filter(key => {
         const run = allTestData[key];
         if (!run.guides || !run.guides[guideName]) return false;
         const g = run.guides[guideName];
         const gTotal = g.guidedTotal !== undefined ? g.guidedTotal : (g.guided?.total || 0);
         const uTotal = g.unguidedTotal !== undefined ? g.unguidedTotal : (g.unguided?.total || 0);
-        return gTotal > 0 || uTotal > 0;
+        if (gTotal === 0 && uTotal === 0) return false;
+
+        if (currentRunFilter && currentRunFilter.trim()) {
+            const query = currentRunFilter.trim().toLowerCase();
+            const testId = (run.testId || '').toLowerCase();
+            if (!testId.includes(query)) return false;
+        }
+        return true;
     });
 
     if (filteredKeys.length === 0) {

--- a/eval-view/guide.js
+++ b/eval-view/guide.js
@@ -3,6 +3,8 @@ import { extractSuiteSummary } from './summary-extractor.js';
 
 /** @type {Record<string, GuideSuiteSummary>} */
 let allTestData = {}; // Cache all test data by testId
+let isCompareMode = false;
+let selectedPoints = []; // array of { testId, source, combKey }
 
 document.addEventListener('DOMContentLoaded', async () => {
     const params = new URLSearchParams(window.location.search);
@@ -14,6 +16,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     $('#guide-name-header').textContent = guideName;
     setupTimelineFilterControls(guideName);
+    setupCompareMode(guideName);
 
     try {
         initGoogleAuth(async () => {
@@ -51,6 +54,12 @@ document.addEventListener('DOMContentLoaded', async () => {
  * @param {string} source
  */
 function registerSuiteSummary(summary, source) {
+    if (source === 'remote' && (allTestData[`${summary.testId}|||local`] || allTestData[`${summary.testId}|||static`])) {
+        return;
+    }
+    if ((source === 'local' || source === 'static') && allTestData[`${summary.testId}|||remote`]) {
+        delete allTestData[`${summary.testId}|||remote`];
+    }
     const compoundKey = `${summary.testId}|||${source}`;
 
     allTestData[compoundKey] = {
@@ -318,10 +327,17 @@ function renderGraphs(guideName) {
     }
     $('#empty-state').style.display = 'none';
 
-    /** @type {Record<string, GuideSuiteSummary[]>} */
-    const combinations = {};
+    const deduplicatedRunsMap = new Map();
     filteredKeys.forEach(compoundKey => {
         const run = allTestData[compoundKey];
+        if (!deduplicatedRunsMap.has(run.testId) || run.source === 'local' || run.source === 'static') {
+            deduplicatedRunsMap.set(run.testId, run);
+        }
+    });
+
+    /** @type {Record<string, any[]>} */
+    const combinations = {};
+    deduplicatedRunsMap.forEach(run => {
         const combKey = `${run.agent}|||${run.model}`;
         if (!combinations[combKey]) {
             combinations[combKey] = [];
@@ -341,33 +357,43 @@ function renderGraphs(guideName) {
         return `${year}-${month}-${day}`;
     };
 
-    // Group by date (keep latest run per day) and slice to last 50 for each combination
+    // Group runs by date for each agent/model combination
     Object.keys(combinations).forEach(combKey => {
         const runs = combinations[combKey];
         runs.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
-        
-        const runsByDate = new Map();
+
+        const runsByDateMap = new Map();
         runs.forEach(run => {
             const dateKey = getDateKey(run.timestamp);
-            runsByDate.set(dateKey, run);
+            if (!runsByDateMap.has(dateKey)) {
+                runsByDateMap.set(dateKey, []);
+            }
+            runsByDateMap.get(dateKey).push(run);
         });
-        
-        let uniqueRuns = Array.from(runsByDate.values());
-        if (uniqueRuns.length > 50) {
-            uniqueRuns = uniqueRuns.slice(-50);
+
+        const dateEntries = [];
+        runsByDateMap.forEach((runsOnDate, dateKey) => {
+            runsOnDate.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
+            const latestRun = runsOnDate[runsOnDate.length - 1];
+            dateEntries.push({ dateKey, latestRun, runsOnDate });
+        });
+
+        dateEntries.sort((a, b) => a.dateKey.localeCompare(b.dateKey));
+        let uniqueEntries = dateEntries;
+        if (uniqueEntries.length > 50) {
+            uniqueEntries = uniqueEntries.slice(-50);
         }
-        combinations[combKey] = uniqueRuns;
+        combinations[combKey] = uniqueEntries;
     });
 
-    // Build the global timeline of unique dates from the sliced runs across all combinations
+    // Build the global timeline of unique dates from the sliced entries across all combinations
     const globalDatesMap = new Map();
-    Object.values(combinations).forEach(runs => {
-        runs.forEach(run => {
-            const dateKey = getDateKey(run.timestamp);
-            if (!globalDatesMap.has(dateKey)) {
-                globalDatesMap.set(dateKey, {
-                    dateKey: dateKey,
-                    shortDate: new Date(run.timestamp).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+    Object.values(combinations).forEach(entries => {
+        entries.forEach(entry => {
+            if (!globalDatesMap.has(entry.dateKey)) {
+                globalDatesMap.set(entry.dateKey, {
+                    dateKey: entry.dateKey,
+                    shortDate: new Date(entry.latestRun.timestamp).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
                 });
             }
         });
@@ -388,19 +414,18 @@ function renderGraphs(guideName) {
     const globalWidth = Math.max(450, globalTimeline.length * 30);
 
     const sortedCombKeys = Object.keys(combinations).sort((keyA, keyB) => {
-        const runsA = combinations[keyA];
-        const runsB = combinations[keyB];
-        const newestA = new Date(runsA[runsA.length - 1].timestamp).getTime();
-        const newestB = new Date(runsB[runsB.length - 1].timestamp).getTime();
+        const entriesA = combinations[keyA];
+        const entriesB = combinations[keyB];
+        const newestA = new Date(entriesA[entriesA.length - 1].latestRun.timestamp).getTime();
+        const newestB = new Date(entriesB[entriesB.length - 1].latestRun.timestamp).getTime();
         return newestB - newestA;
     });
 
     // Filter out combinations that have no data points in the filtered timeline
     const activeCombKeys = sortedCombKeys.filter(combKey => {
-        const runs = combinations[combKey];
-        return runs.some(run => {
-            const runDateKey = getDateKey(run.timestamp);
-            return globalTimeline.some(t => t.dateKey === runDateKey);
+        const entries = combinations[combKey];
+        return entries.some(entry => {
+            return globalTimeline.some(t => t.dateKey === entry.dateKey);
         });
     });
 
@@ -412,7 +437,7 @@ function renderGraphs(guideName) {
 
     activeCombKeys.forEach(combKey => {
         const [agent, model] = combKey.split('|||');
-        const runs = combinations[combKey];
+        const entries = combinations[combKey];
 
         const card = document.createElement('div');
         card.className = 'stat-card';
@@ -421,20 +446,38 @@ function renderGraphs(guideName) {
         card.style.gap = '15px';
         card.style.padding = '20px';
         
+        const totalRunsCount = entries.reduce((sum, e) => sum + e.runsOnDate.length, 0);
         const header = document.createElement('div');
-        header.innerHTML = `
+        header.style.display = 'flex';
+        header.style.justifyContent = 'space-between';
+        header.style.alignItems = 'center';
+        header.style.flexWrap = 'wrap';
+        header.style.gap = '10px';
+
+        const titleDiv = document.createElement('div');
+        titleDiv.innerHTML = `
             <div style="font-weight: 600; font-size: 1rem; color: var(--text-primary);">
                 ${escapeHtml(agent)} <span style="font-weight: normal; color: var(--text-secondary);">on</span> ${escapeHtml(model)}
             </div>
             <div style="font-size: 0.8rem; color: var(--text-secondary); margin-top: 4px;">
-                ${runs.length} chronological trials
+                ${totalRunsCount} chronological trials (${entries.length} active dates)
             </div>
         `;
+        header.appendChild(titleDiv);
+
+        const runSelectorSlot = document.createElement('div');
+        runSelectorSlot.className = 'run-selector-slot';
+        runSelectorSlot.style.minHeight = '32px';
+        runSelectorSlot.style.display = 'flex';
+        runSelectorSlot.style.alignItems = 'center';
+        header.appendChild(runSelectorSlot);
+
         card.appendChild(header);
 
         const chartWrapper = document.createElement('div');
         chartWrapper.style.overflowX = 'auto';
         chartWrapper.style.width = '100%';
+        chartWrapper.style.position = 'relative';
 
         const height = 230;
         const paddingX = 40;
@@ -458,9 +501,11 @@ function renderGraphs(guideName) {
         globalTimeline.forEach((suite, i) => {
             const x = globalTimeline.length > 1 ? paddingX + i * stepX : globalWidth / 2;
             
-            const run = runs.find(r => getDateKey(r.timestamp) === suite.dateKey);
+            const entry = entries.find(e => e.dateKey === suite.dateKey);
+            const run = entry ? entry.latestRun : null;
+            const runsOnDate = entry ? entry.runsOnDate : [];
             
-            const isHighlighted = run && run.testId === highlightTestId;
+            const isHighlighted = run && runsOnDate.some(r => r.testId === highlightTestId);
             if (isHighlighted) {
                 svgContent += `
                     <rect x="${x - 12}" y="${paddingY - 5}" width="24" height="${plotHeight + 10}" fill="var(--color-primary)" style="opacity: 0.12; rx: 4px;" />
@@ -498,9 +543,22 @@ function renderGraphs(guideName) {
                     `;
                 }
 
+                // Visual badge indicator for multiple runs on the same day (+50% size increase, centered above arrow)
+                let multiRunIndicator = '';
+                if (runsOnDate.length > 1) {
+                    const topY = Math.min(yG, yU);
+                    multiRunIndicator = `
+                        <g transform="translate(${x - 13}, ${topY - 22})">
+                            <rect width="26" height="18" rx="4" fill="#2563eb" />
+                            <text x="13" y="13" font-size="0.85rem" font-weight="bold" fill="#ffffff" text-anchor="middle">${runsOnDate.length}x</text>
+                        </g>
+                    `;
+                }
+
                 svgContent += `
-                    <g class="timeline-point" data-testid="${run.testId}" data-comb="${combKey}" style="cursor: pointer;">
+                    <g class="timeline-point" data-testid="${run.testId}" data-comb="${combKey}" data-datekey="${suite.dateKey}" data-x="${x}" data-yg="${yG}" style="cursor: pointer;">
                         ${elementHtml}
+                        ${multiRunIndicator}
                         <text x="${x}" y="180" transform="rotate(90, ${x}, 180)" font-size="0.7rem" fill="var(--text-secondary)" text-anchor="start" dominant-baseline="middle">${suite.shortDate}</text>
                         <rect x="${x - 15}" y="${paddingY}" width="30" height="${plotHeight}" fill="transparent" />
                     </g>
@@ -539,18 +597,45 @@ function renderGraphs(guideName) {
         svg.querySelectorAll('.timeline-point').forEach(el => {
             const group = /** @type {SVGElement} */ (el);
             group.addEventListener('mouseenter', () => {
-                const combKey = group.getAttribute('data-comb');
-                const testId = group.getAttribute('data-testid');
-                if (!combKey || !testId) return;
-                const runData = combinations[combKey].find(r => r.testId === testId);
-                if (!runData) return;
+                const dateKey = group.getAttribute('data-datekey');
+                if (!combKey || !dateKey) return;
+                const entry = combinations[combKey]?.find(e => e.dateKey === dateKey);
+                if (!entry) return;
 
+                const runData = entry.latestRun;
+                const runsOnDate = entry.runsOnDate;
                 const stats = runData.guides[guideName];
                 const formattedDate = new Date(runData.timestamp).toLocaleString('en-US', { month: 'long', day: 'numeric', year: 'numeric', hour: '2-digit', minute: '2-digit' });
 
                 const tooltip = $('#tooltip-container');
                 const header = $('#tooltip-header');
                 const content = $('#tooltip-content');
+
+                let multiRunHtml = '';
+                if (runsOnDate.length > 1) {
+                    multiRunHtml = `
+                        <div style="margin-top: 10px; padding-top: 8px; border-top: 1px solid var(--border-color);">
+                            <div style="font-weight: 600; font-size: 0.75rem; color: var(--text-primary); margin-bottom: 6px;">
+                                ${runsOnDate.length} runs on this date:
+                            </div>
+                            <div style="display: flex; flex-direction: column; gap: 4px;">
+                                ${runsOnDate.map((r, idx) => {
+                                    const rStats = r.guides[guideName];
+                                    const timeStr = new Date(r.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+                                    const isLatest = idx === runsOnDate.length - 1;
+                                    return `
+                                        <div style="font-size: 0.75rem; display: flex; justify-content: space-between; align-items: center;">
+                                            <a href="dashboard.html?testId=${r.testId}&source=${r.source}#guide-${guideName}" style="color: var(--color-primary); font-weight: 600; text-decoration: none;">
+                                                Run ${idx + 1} (${timeStr})${isLatest ? ' <span style="color:#64748b; font-weight:normal;">(Latest)</span>' : ''}
+                                            </a>
+                                            <span style="font-size:0.7rem; color: var(--text-secondary);">${rStats ? rStats.guidedRate : 0}% guided</span>
+                                        </div>
+                                    `;
+                                }).join('')}
+                            </div>
+                        </div>
+                    `;
+                }
 
                 header.innerHTML = `
                     <div style="font-weight: bold; font-size: 0.9rem; color: var(--text-primary); word-break: break-all;">
@@ -581,6 +666,7 @@ function renderGraphs(guideName) {
                             </span>
                         </div>
                     </div>
+                    ${multiRunHtml}
                 `;
 
                 tooltip.classList.remove('hidden');
@@ -612,13 +698,223 @@ function renderGraphs(guideName) {
 
             group.addEventListener('click', () => {
                 const combKey = group.getAttribute('data-comb');
-                const testId = group.getAttribute('data-testid');
-                if (!combKey || !testId) return;
-                const runData = combinations[combKey].find(r => r.testId === testId);
-                if (runData) {
-                    window.location.href = `dashboard.html?testId=${runData.testId}&source=${runData.source}#guide-${guideName}`;
+                const dateKey = group.getAttribute('data-datekey');
+                if (!combKey || !dateKey) return;
+                const entry = combinations[combKey]?.find(e => e.dateKey === dateKey);
+                if (!entry) return;
+
+                const runsOnDate = entry.runsOnDate;
+                const defaultRun = entry.latestRun;
+                const defaultRunIndex = runsOnDate.length; // 1-indexed
+
+                if (isCompareMode) {
+                    // Render run selection dropdown ABOVE arrows inside the card header
+                    document.querySelectorAll('.run-selector-slot').forEach(slot => slot.innerHTML = '');
+
+                    if (runsOnDate.length > 1) {
+                        const selectorContainer = document.createElement('div');
+                        selectorContainer.style.display = 'flex';
+                        selectorContainer.style.alignItems = 'center';
+                        selectorContainer.style.gap = '8px';
+                        selectorContainer.style.background = 'var(--bg-secondary)';
+                        selectorContainer.style.padding = '4px 10px';
+                        selectorContainer.style.borderRadius = '6px';
+                        selectorContainer.style.border = '1px solid var(--border-color)';
+                        selectorContainer.style.fontSize = '0.85rem';
+
+                        const title = document.createElement('span');
+                        title.style.fontWeight = '600';
+                        title.style.color = 'var(--text-primary)';
+                        title.innerText = `Select run for ${dateKey}:`;
+                        selectorContainer.appendChild(title);
+
+                        const select = document.createElement('select');
+                        select.style.padding = '3px 8px';
+                        select.style.borderRadius = '4px';
+                        select.style.border = '1px solid var(--border-color)';
+                        select.style.background = '#ffffff';
+                        select.style.color = '#334155';
+                        select.style.fontSize = '0.8rem';
+                        select.style.fontWeight = '500';
+                        select.style.cursor = 'pointer';
+
+                        runsOnDate.forEach((r, idx) => {
+                            const timeStr = new Date(r.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+                            const rStats = r.guides[guideName];
+                            const opt = document.createElement('option');
+                            opt.value = r.testId;
+                            opt.setAttribute('data-runindex', (idx + 1).toString());
+                            const isLatest = idx === runsOnDate.length - 1;
+                            opt.innerText = `Run ${idx + 1} (${isLatest ? 'Latest - ' : ''}${timeStr}) [${rStats ? rStats.guidedRate : 0}% guided]`;
+                            if (r.testId === defaultRun.testId) {
+                                opt.selected = true;
+                            }
+                            select.appendChild(opt);
+                        });
+
+                        select.addEventListener('change', () => {
+                            const chosenTestId = select.value;
+                            const selectedOpt = select.options[select.selectedIndex];
+                            const chosenRunIndex = parseInt(selectedOpt.getAttribute('data-runindex') || '1');
+                            const chosenRun = runsOnDate.find(r => r.testId === chosenTestId) || defaultRun;
+                            handlePointSelection(chosenRun, group, combKey, guideName, chosenRunIndex);
+                        });
+
+                        selectorContainer.appendChild(select);
+                        runSelectorSlot.appendChild(selectorContainer);
+
+                        handlePointSelection(defaultRun, group, combKey, guideName, defaultRunIndex);
+                    } else {
+                        handlePointSelection(defaultRun, group, combKey, guideName, 1);
+                    }
+                } else {
+                    window.location.href = `dashboard.html?testId=${defaultRun.testId}&source=${defaultRun.source}#guide-${guideName}`;
+>>>>>>> 45a3b374 (feat(eval-view): add run comparison dashboard and visualizer)
                 }
             });
         });
     });
 }
+
+function setupCompareMode(guideName) {
+    const compareBtn = $('#compare-mode-btn');
+    const banner = $('#compare-banner');
+    const launchBtn = $('#launch-compare-btn');
+    const cancelBtn = $('#cancel-compare-btn');
+
+    if (!compareBtn || !banner || !launchBtn || !cancelBtn) return;
+
+    const urlParams = new URLSearchParams(window.location.search);
+    const isStatic = urlParams.get('source') === 'static' || window.location.hostname.includes('github.io') || window.location.hostname.includes('storage.googleapis.com');
+    if (isStatic) {
+        compareBtn.style.display = 'none';
+        return;
+    }
+
+    compareBtn.addEventListener('click', () => {
+        toggleCompareMode(!isCompareMode);
+    });
+
+    cancelBtn.addEventListener('click', () => {
+        toggleCompareMode(false);
+    });
+
+    launchBtn.addEventListener('click', () => {
+        if (selectedPoints.length === 2) {
+            const [pA, pB] = selectedPoints;
+            const urlParams = new URLSearchParams(window.location.search);
+            const isStatic = urlParams.get('source') === 'static' || window.location.hostname.includes('github.io');
+            
+            window.location.href = `compare.html?trialA=${pA.testId}&trialB=${pB.testId}&runIndexA=${pA.runIndex || 1}&runIndexB=${pB.runIndex || 1}&agentA=${encodeURIComponent(pA.agent || '')}&modelA=${encodeURIComponent(pA.model || '')}&scoreA=${pA.score || 0}&agentB=${encodeURIComponent(pB.agent || '')}&modelB=${encodeURIComponent(pB.model || '')}&scoreB=${pB.score || 0}&guide=${guideName}&source=${isStatic ? 'static' : 'local'}`;
+        }
+    });
+}
+
+function toggleCompareMode(on) {
+    isCompareMode = on;
+    const compareBtn = $('#compare-mode-btn');
+    const banner = $('#compare-banner');
+    
+    if (isCompareMode) {
+        compareBtn.textContent = 'Exit Compare';
+        compareBtn.style.backgroundColor = '#cbd5e1';
+        banner.style.display = 'flex';
+        clearSelections();
+    } else {
+        compareBtn.textContent = 'Compare Trials';
+        compareBtn.style.backgroundColor = '#f1f5f9';
+        banner.style.display = 'none';
+        clearSelections();
+    }
+}
+
+function clearSelections() {
+    document.querySelectorAll('.compare-highlight').forEach(el => el.remove());
+    document.querySelectorAll('.run-selector-slot').forEach(slot => slot.innerHTML = '');
+    selectedPoints = [];
+    updateCompareBanner();
+}
+
+function handlePointSelection(runData, group, combKey, guideName, runIndex = 1) {
+    const testId = runData.testId;
+    const dateKey = group.getAttribute('data-datekey');
+    const existingIdx = selectedPoints.findIndex(p => p.dateKey === dateKey && p.combKey === combKey);
+
+    if (existingIdx !== -1) {
+        const prev = selectedPoints[existingIdx];
+        if (prev.testId === testId) {
+            selectedPoints.splice(existingIdx, 1);
+            group.querySelector('.compare-highlight')?.remove();
+        } else {
+            selectedPoints[existingIdx] = { 
+                testId, 
+                dateKey,
+                combKey,
+                runIndex,
+                source: runData.source, 
+                agent: runData.agent, 
+                model: runData.model,
+                score: runData.guides[guideName] ? runData.guides[guideName].guidedRate : 0
+            };
+        }
+    } else {
+        if (selectedPoints.length >= 2) {
+            const removed = selectedPoints.shift();
+            const oldGroup = document.querySelector(`[data-datekey="${removed.dateKey}"][data-comb="${removed.combKey}"]`);
+            if (oldGroup) oldGroup.querySelector('.compare-highlight')?.remove();
+        }
+
+        const stats = runData.guides[guideName];
+        selectedPoints.push({ 
+            testId, 
+            dateKey,
+            combKey,
+            runIndex,
+            source: runData.source, 
+            agent: runData.agent, 
+            model: runData.model,
+            score: stats ? stats.guidedRate : 0
+        });
+
+        const x = parseFloat(group.getAttribute('data-x'));
+        const y = parseFloat(group.getAttribute('data-yg'));
+        
+        if (!group.querySelector('.compare-highlight')) {
+            const highlight = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+            highlight.setAttribute('class', 'compare-highlight');
+            highlight.setAttribute('cx', x.toString());
+            highlight.setAttribute('cy', y.toString());
+            highlight.setAttribute('r', '12');
+            highlight.setAttribute('stroke', '#2563eb');
+            highlight.setAttribute('stroke-width', '3');
+            highlight.setAttribute('fill', 'none');
+            highlight.setAttribute('style', 'stroke-dasharray: 2; transform-origin: center;');
+            
+            group.appendChild(highlight);
+        }
+    }
+
+    updateCompareBanner();
+}
+
+function updateCompareBanner() {
+    const text = $('#compare-banner-text');
+    const launchBtn = /** @type {HTMLButtonElement | null} */ ($('#launch-compare-btn'));
+    if (!text || !launchBtn) return;
+
+    if (selectedPoints.length === 0) {
+        text.innerText = 'Select two trials on the chart to compare.';
+        launchBtn.disabled = true;
+    } else if (selectedPoints.length === 1) {
+        const label0 = selectedPoints[0].runIndex ? ` (Run ${selectedPoints[0].runIndex})` : '';
+        text.innerHTML = `Selected 1 trial: <span style="font-family:monospace; color:#bfdbfe;">${selectedPoints[0].testId.slice(0, 15)}${label0}...</span>. Select one more.`;
+        launchBtn.disabled = true;
+    } else if (selectedPoints.length === 2) {
+        const label0 = selectedPoints[0].runIndex ? ` (Run ${selectedPoints[0].runIndex})` : '';
+        const label1 = selectedPoints[1].runIndex ? ` (Run ${selectedPoints[1].runIndex})` : '';
+        text.innerHTML = `Ready to compare: <span style="font-family:monospace; color:#bfdbfe;">${selectedPoints[0].testId.slice(0, 10)}${label0}...</span> vs <span style="font-family:monospace; color:#bfdbfe;">${selectedPoints[1].testId.slice(0, 10)}${label1}...</span>`;
+        launchBtn.disabled = false;
+    }
+}
+
+

--- a/eval-view/index.html
+++ b/eval-view/index.html
@@ -60,6 +60,10 @@
             <input type="checkbox" id="insights-show-all-check" style="cursor: pointer;">
             <span>Show all</span>
           </label>
+          <div style="display: flex; align-items: center; gap: 8px;">
+            <label for="insights-run-filter-input" style="font-size: 0.85rem; color: var(--text-secondary); font-weight: 500;">Filter run name:</label>
+            <input type="text" id="insights-run-filter-input" value="nightly" placeholder="e.g. nightly" style="width: 120px; padding: 4px 8px; border-radius: 4px; border: 1px solid var(--border-color); background: var(--bg-secondary); color: var(--text-primary); font-size: 0.85rem; outline: none;">
+          </div>
         </div>
         <div id="insights-container" class="insights-grid">
           <!-- Populated by JS -->

--- a/eval-view/landing.css
+++ b/eval-view/landing.css
@@ -711,16 +711,41 @@
 .tooltip-container {
   position: fixed;
   z-index: 2000;
-  max-width: 300px;
+  max-width: 340px;
   background: var(--card-bg);
   backdrop-filter: blur(8px);
   border: 1px solid var(--border-color);
   border-radius: 12px;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.15);
-  pointer-events: none;
+  pointer-events: auto;
   padding: 15px;
   transition: opacity 0.2s ease, transform 0.2s ease;
   transform: translateY(10px);
+}
+
+.multi-run-popover {
+  position: absolute;
+  z-index: 2500;
+  background: var(--card-bg, #ffffff);
+  border: 1px solid var(--border-color, #cbd5e1);
+  border-radius: 8px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.15);
+  padding: 8px;
+  font-size: 0.8rem;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.multi-run-popover select {
+  padding: 4px 8px;
+  border-radius: 4px;
+  border: 1px solid var(--border-color, #cbd5e1);
+  background: #ffffff;
+  color: #334155;
+  font-size: 0.8rem;
+  font-weight: 500;
+  cursor: pointer;
 }
 
 .tooltip-container.hidden {

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -1,4 +1,4 @@
-import { initGoogleAuth, authenticatedFetch, getAccessToken, escapeHtml, timeAgo, calculateChartData, $ } from './utils.js';
+import { initGoogleAuth, authenticatedFetch, getAccessToken, escapeHtml, hasNightlyRuns, timeAgo, calculateChartData, $ } from './utils.js';
 import { DumbbellChart } from './dumbbell-chart.js';
 import { extractSuiteSummary } from './summary-extractor.js';
 
@@ -35,10 +35,6 @@ let currentGuideSortDir = 'asc';
 
 function isRemoteDashboard() {
     return window.location.hostname !== 'localhost' && window.location.hostname !== '127.0.0.1';
-}
-
-function hasNightlyRuns() {
-    return Object.values(allTestData).some(t => (t.testId || '').toLowerCase().includes('nightly'));
 }
 
 /** @type {Record<string, string>} */

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -37,6 +37,10 @@ function isRemoteDashboard() {
     return window.location.hostname !== 'localhost' && window.location.hostname !== '127.0.0.1';
 }
 
+function hasNightlyRuns() {
+    return Object.values(allTestData).some(t => (t.testId || '').toLowerCase().includes('nightly'));
+}
+
 /** @type {Record<string, string>} */
 const servingDisplayNames = {
     'skills': 'Skills',
@@ -59,11 +63,23 @@ document.addEventListener('DOMContentLoaded', async () => {
         // Wait for auth before loading if remote is needed. We load local immediately, remote when auth'd
         initGoogleAuth(async () => {
              await loadRemoteTests();
+             if (runFilterParam === null && hasNightlyRuns()) {
+                 currentRunFilter = 'nightly';
+                 const runFilterInput = /** @type {HTMLInputElement | null} */ (document.getElementById('insights-run-filter-input'));
+                 if (runFilterInput) runFilterInput.value = currentRunFilter;
+                 renderPivotInsights();
+             }
         });
 
         await loadLocalTests();
         if (getAccessToken()) {
              await loadRemoteTests();
+        }
+
+        if (runFilterParam === null) {
+            currentRunFilter = hasNightlyRuns() ? 'nightly' : '';
+            const runFilterInput = /** @type {HTMLInputElement | null} */ (document.getElementById('insights-run-filter-input'));
+            if (runFilterInput) runFilterInput.value = currentRunFilter;
         }
 
         // Initialize with default states relative to compoundKeys instead of simple testIDs

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -406,6 +406,12 @@ async function loadRemoteTests() {
  * @param {import('./api.js').DataSource} source
  */
 function registerSuiteSummary(summary, source) {
+    if (source === 'remote' && (allTestData[`${summary.testId}|||local`] || allTestData[`${summary.testId}|||static`])) {
+        return;
+    }
+    if ((source === 'local' || source === 'static') && allTestData[`${summary.testId}|||remote`]) {
+        delete allTestData[`${summary.testId}|||remote`];
+    }
     const compoundKey = `${summary.testId}|||${source}`;
 
     allTestData[compoundKey] = {

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -25,6 +25,7 @@ let currentAgentFilter = 'all';
 let currentServingFilter = 'all';
 /** @type {string} */
 let currentModelFilter = 'all';
+let currentRunFilter = 'nightly';
 
 // Guides Pivot Table Sort State
 /** @type {GuideSortKey} */
@@ -44,12 +45,16 @@ const servingDisplayNames = {
 };
 document.addEventListener('DOMContentLoaded', async () => {
     try {
+        const params = new URLSearchParams(window.location.search);
+        const runFilterParam = params.get('runFilter') ?? params.get('runName');
+        if (runFilterParam !== null) {
+            currentRunFilter = runFilterParam;
+        }
+
         // Initialize UI
         setupTestFilters(); // New filter setup
         setupTableFilters();
         setupInsightsTimelineFilters();
-
-        const params = new URLSearchParams(window.location.search);
         
         // Wait for auth before loading if remote is needed. We load local immediately, remote when auth'd
         initGoogleAuth(async () => {
@@ -93,6 +98,12 @@ document.addEventListener('DOMContentLoaded', async () => {
 // Handle browser back/forward
 window.addEventListener('popstate', () => {
     const params = new URLSearchParams(window.location.search);
+    const runFilterParam = params.get('runFilter') ?? params.get('runName');
+    currentRunFilter = runFilterParam !== null ? runFilterParam : 'nightly';
+    const runFilterInput = /** @type {HTMLInputElement | null} */ (document.getElementById('insights-run-filter-input'));
+    if (runFilterInput) {
+        runFilterInput.value = currentRunFilter;
+    }
 
     selectedTestIds = new Set(Object.keys(allTestData)); // Default to all
     const testsParam = params.get('tests');
@@ -199,6 +210,16 @@ function setupTableFilters() {
 function setupInsightsTimelineFilters() {
     const limitInput = /** @type {HTMLInputElement} */ (document.getElementById('insights-limit-input'));
     const showAllCheck = /** @type {HTMLInputElement} */ (document.getElementById('insights-show-all-check'));
+    const runFilterInput = /** @type {HTMLInputElement} */ (document.getElementById('insights-run-filter-input'));
+
+    if (runFilterInput) {
+        runFilterInput.value = currentRunFilter;
+        runFilterInput.addEventListener('input', () => {
+            currentRunFilter = runFilterInput.value;
+            updateUrlParams();
+            renderPivotInsights();
+        });
+    }
 
     if (limitInput) {
         limitInput.addEventListener('change', () => {
@@ -303,6 +324,12 @@ function updateUrlParams() {
     } else {
         // Only list selected
         url.searchParams.set('tests', Array.from(selectedTestIds).join(','));
+    }
+
+    if (currentRunFilter === 'nightly') {
+        url.searchParams.delete('runFilter');
+    } else {
+        url.searchParams.set('runFilter', currentRunFilter);
     }
 
     window.history.replaceState({}, '', url);
@@ -814,6 +841,16 @@ function getSortedTestIds() {
 function renderPivotInsights() {
     let testIds = getSortedTestIds(); // Uses selected filters!
 
+    if (currentRunFilter && currentRunFilter.trim()) {
+        const query = currentRunFilter.trim().toLowerCase();
+        testIds = testIds.filter(id => {
+            const testInfo = allTestData[id];
+            if (!testInfo) return false;
+            const testId = (testInfo.testId || '').toLowerCase();
+            return testId.includes(query);
+        });
+    }
+
     const limitInput = /** @type {HTMLInputElement} */ (document.getElementById('insights-limit-input'));
     const showAllCheck = /** @type {HTMLInputElement} */ (document.getElementById('insights-show-all-check'));
     const showAll = showAllCheck ? showAllCheck.checked : false;
@@ -988,7 +1025,7 @@ function renderPivotInsights() {
             const gSD_width = Math.min(100, gRate + gSD) - gSD_left;
 
             const clickAttr = filterKey === 'guide'
-                ? `onclick="window.location.href='guide.html?guide=${encodeURIComponent(key)}'"`
+                ? `onclick="window.location.href='guide.html?guide=${encodeURIComponent(key)}${currentRunFilter ? `&runFilter=${encodeURIComponent(currentRunFilter)}` : ''}'"`
                 : `onclick="setInsightFilter('${filterKey}', '${key}')"`;
 
             const uBandHtml = uSD > 0 ? `<div class="variance-band unguided" style="left: ${uSD_left}%; width: ${uSD_width}%;"></div>` : '';

--- a/eval-view/server.js
+++ b/eval-view/server.js
@@ -717,11 +717,11 @@ const server = http.createServer(async (req, res) => {
             const runDir = path.dirname(filePath);
             if (fs.existsSync(runDir)) {
               try {
-                const { generateNormalizedTrajectory } = await import('../harness/lib/trajectory-parser.ts');
+                const { generateNormalizedTrajectory } = await import('../harness/lib/trajectory-normalizer.ts');
                 const { agentName, isKnown } = detectAgentFromPath(filePath);
                 const resolvedAgent = getAgentFromEvalsJson(runDir, agentName);
                 if (!isKnown && resolvedAgent === agentName) {
-                  console.warn(`[Server] Warning: Could not detect known agent in path "${filePath}". Supported identifiers: ${SUPPORTED_AGENTS.map(a => a.match).join(', ')}. To add a new agent, update SUPPORTED_AGENTS in eval-view/server.js and generateNormalizedTrajectory in harness/lib/trajectory-parser.ts.`);
+                  console.warn(`[Server] Warning: Could not detect known agent in path "${filePath}". Supported identifiers: ${SUPPORTED_AGENTS.map(a => a.match).join(', ')}. To add a new agent, update SUPPORTED_AGENTS in eval-view/server.js and generateNormalizedTrajectory in harness/lib/trajectory-normalizer.ts.`);
                 }
                 await generateNormalizedTrajectory(runDir, resolvedAgent, 'local');
               } catch (e) {
@@ -786,11 +786,11 @@ const server = http.createServer(async (req, res) => {
         if (path.basename(filePath) === 'trajectory_summary.json') {
           const runDir = path.dirname(filePath);
           if (fs.existsSync(runDir)) {
-            import('../harness/lib/trajectory-parser.ts').then(async ({ generateNormalizedTrajectory }) => {
+            import('../harness/lib/trajectory-normalizer.ts').then(async ({ generateNormalizedTrajectory }) => {
               const { agentName, isKnown } = detectAgentFromPath(filePath);
               const resolvedAgent = getAgentFromEvalsJson(runDir, agentName);
               if (!isKnown && resolvedAgent === agentName) {
-                console.warn(`[Server] Warning: Could not detect known agent in path "${filePath}". Supported identifiers: ${SUPPORTED_AGENTS.map(a => a.match).join(', ')}. To add a new agent, update SUPPORTED_AGENTS in eval-view/server.js and generateNormalizedTrajectory in harness/lib/trajectory-parser.ts.`);
+                console.warn(`[Server] Warning: Could not detect known agent in path "${filePath}". Supported identifiers: ${SUPPORTED_AGENTS.map(a => a.match).join(', ')}. To add a new agent, update SUPPORTED_AGENTS in eval-view/server.js and generateNormalizedTrajectory in harness/lib/trajectory-normalizer.ts.`);
               }
               await generateNormalizedTrajectory(runDir, resolvedAgent, 'local');
               if (fs.existsSync(filePath)) {
@@ -799,14 +799,14 @@ const server = http.createServer(async (req, res) => {
                 return;
               }
               const errMsg = !isKnown
-                ? `404 Not Found: Trajectory summary generation failed because an unknown agent was used for path "${filePath}". Supported identifiers: ${SUPPORTED_AGENTS.map(a => a.match).join(', ')}. To add another agent, update SUPPORTED_AGENTS in eval-view/server.js and generateNormalizedTrajectory in harness/lib/trajectory-parser.ts.`
+                ? `404 Not Found: Trajectory summary generation failed because an unknown agent was used for path "${filePath}". Supported identifiers: ${SUPPORTED_AGENTS.map(a => a.match).join(', ')}. To add another agent, update SUPPORTED_AGENTS in eval-view/server.js and generateNormalizedTrajectory in harness/lib/trajectory-normalizer.ts.`
                 : `404 Not Found: Trajectory summary generation failed for agent "${agentName}" in path "${filePath}".`;
               res.writeHead(404);
               res.end(errMsg);
             }).catch(e => {
               const { agentName, isKnown } = detectAgentFromPath(filePath);
               const errMsg = !isKnown
-                ? `Failed to auto-generate trajectory summary for unknown agent in path "${filePath}". Supported identifiers: ${SUPPORTED_AGENTS.map(a => a.match).join(', ')}. To add another agent, update SUPPORTED_AGENTS in eval-view/server.js and generateNormalizedTrajectory in harness/lib/trajectory-parser.ts.`
+                ? `Failed to auto-generate trajectory summary for unknown agent in path "${filePath}". Supported identifiers: ${SUPPORTED_AGENTS.map(a => a.match).join(', ')}. To add another agent, update SUPPORTED_AGENTS in eval-view/server.js and generateNormalizedTrajectory in harness/lib/trajectory-normalizer.ts.`
                 : `Failed to auto-generate trajectory summary for agent "${agentName}": ${e.message}`;
               console.error(errMsg, e);
               res.writeHead(404);

--- a/eval-view/server.js
+++ b/eval-view/server.js
@@ -59,6 +59,104 @@ function getAgentFromEvalsJson(startDir, fallbackAgent) {
   return fallbackAgent;
 }
 
+/**
+ * Generates and serves missing trajectory_summary.json on the fly.
+ * @param {string} filePath
+ * @param {http.ServerResponse} res
+ */
+async function handleMissingTrajectorySummary(filePath, res) {
+  const runDir = path.dirname(filePath);
+  if (!fs.existsSync(runDir)) {
+    res.writeHead(404);
+    res.end('404 Not Found: Run directory does not exist');
+    return;
+  }
+  const { agentName, isKnown } = detectAgentFromPath(filePath);
+  const resolvedAgent = getAgentFromEvalsJson(runDir, agentName);
+  if (!isKnown && resolvedAgent === agentName) {
+    console.warn(`[Server] Warning: Could not detect known agent in path "${filePath}". Supported identifiers: ${SUPPORTED_AGENTS.map(a => a.match).join(', ')}. To add a new agent, update SUPPORTED_AGENTS in eval-view/server.js and generateNormalizedTrajectory in harness/lib/trajectory-normalizer.ts.`);
+  }
+  try {
+    const { generateNormalizedTrajectory } = await import('../harness/lib/trajectory-normalizer.ts');
+    await generateNormalizedTrajectory(runDir, resolvedAgent, 'local');
+    if (fs.existsSync(filePath)) {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(fs.readFileSync(filePath), 'utf-8');
+      return;
+    }
+    res.writeHead(404);
+    res.end(`404 Not Found: Trajectory summary generation failed for agent "${resolvedAgent}" in path "${filePath}".`);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    console.error(`Failed to auto-generate trajectory summary for agent "${resolvedAgent}":`, message);
+    res.writeHead(500);
+    res.end(`500 Internal Error: ${message}`);
+  }
+}
+
+const STEP_AUTO_SCROLL_SCRIPT = `
+<script id="step-auto-scroll-injected">
+(function() {
+  function initStepAnchors() {
+    const logsContainer = document.getElementById("logs");
+    if (!logsContainer) return;
+
+    let toolStepCounter = 0;
+    const entries = Array.from(logsContainer.children);
+    entries.forEach((el, idx) => {
+      if (!el.id) el.id = "entry-" + (idx + 1);
+      const isToolCall = !!el.querySelector(".tool-use");
+      if (isToolCall) {
+        toolStepCounter++;
+        if (!el.id || el.id.startsWith("entry-")) el.id = "step-" + toolStepCounter;
+
+        const meta = el.querySelector(".meta");
+        if (meta && !meta.querySelector(".step-badge")) {
+          const badge = document.createElement("span");
+          badge.className = "step-badge";
+          badge.style.cssText = "background:#1f6feb22; color:#58a6ff; border:1px solid #1f6feb; border-radius:4px; padding:2px 8px; font-size:0.8em; font-weight:bold; margin-left:8px;";
+          badge.textContent = "STEP " + toolStepCounter;
+          const firstChild = meta.firstElementChild;
+          if (firstChild && firstChild.tagName === "SPAN") {
+            meta.insertBefore(badge, firstChild.nextSibling);
+          } else {
+            meta.appendChild(badge);
+          }
+        }
+      }
+    });
+
+    const hash = window.location.hash;
+    if (hash && hash.startsWith('#step-')) {
+      const target = document.querySelector(hash);
+      if (target) {
+        setTimeout(() => {
+          target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+          target.style.outline = '3px solid #58a6ff';
+          target.style.boxShadow = '0 0 25px rgba(88, 166, 255, 0.6)';
+        }, 150);
+      }
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => setTimeout(initStepAnchors, 100));
+  } else {
+    setTimeout(initStepAnchors, 100);
+  }
+
+  window.addEventListener('hashchange', () => {
+    const target = document.querySelector(window.location.hash);
+    if (target) {
+      target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      target.style.outline = '3px solid #58a6ff';
+      target.style.boxShadow = '0 0 25px rgba(88, 166, 255, 0.6)';
+    }
+  });
+})();
+</script>
+`;
+
 if (STATIC) {
   console.log('🌐 Running in STATIC mode via statikk. Dynamic APIs will be unavailable.');
   
@@ -559,7 +657,7 @@ const server = http.createServer(async (req, res) => {
     const authHeader = req.headers.authorization || '';
 
     const gdTsPath = path.join(ROOT_DIR, 'bin', 'gd.ts');
-    const p = spawn('npx', ['tsx', gdTsPath, 'compare', absDirA, absDirB], {
+    const p = spawn(process.execPath, [gdTsPath, 'compare', absDirA, absDirB], {
       cwd: ROOT_DIR,
       env: { ...process.env, GD_GCS_TOKEN: authHeader }
     });
@@ -702,35 +800,6 @@ const server = http.createServer(async (req, res) => {
 
         filePath = path.join(RESULTS_DIR, finalRelativePath);
 
-        // Auto-generate missing or outdated trajectory_summary.json on the fly
-        if (path.basename(filePath) === 'trajectory_summary.json') {
-          let needsGeneration = !fs.existsSync(filePath);
-          if (!needsGeneration) {
-            try {
-              const summaryJson = JSON.parse(fs.readFileSync(filePath, 'utf8'));
-              if (summaryJson.schemaVersion !== "2.0") needsGeneration = true;
-            } catch {
-              needsGeneration = true;
-            }
-          }
-          if (needsGeneration) {
-            const runDir = path.dirname(filePath);
-            if (fs.existsSync(runDir)) {
-              try {
-                const { generateNormalizedTrajectory } = await import('../harness/lib/trajectory-normalizer.ts');
-                const { agentName, isKnown } = detectAgentFromPath(filePath);
-                const resolvedAgent = getAgentFromEvalsJson(runDir, agentName);
-                if (!isKnown && resolvedAgent === agentName) {
-                  console.warn(`[Server] Warning: Could not detect known agent in path "${filePath}". Supported identifiers: ${SUPPORTED_AGENTS.map(a => a.match).join(', ')}. To add a new agent, update SUPPORTED_AGENTS in eval-view/server.js and generateNormalizedTrajectory in harness/lib/trajectory-normalizer.ts.`);
-                }
-                await generateNormalizedTrajectory(runDir, resolvedAgent, 'local');
-              } catch (e) {
-                console.error('Failed to auto-generate trajectory summary:', e);
-              }
-            }
-          }
-        }
-
         // If file does not exist locally and request is not local, return 400 for remote GCS streaming
         if (!fs.existsSync(filePath)) {
             const useLocal = reqUrl.includes('source=local');
@@ -765,7 +834,7 @@ const server = http.createServer(async (req, res) => {
   const extname = path.extname(filePath);
   const contentType = MIME_TYPES[extname] || 'application/octet-stream';
 
-  fs.readFile(filePath, (err, content) => {
+  fs.readFile(filePath, async (err, content) => {
     if (err) {
       if (err.code === 'EISDIR') {
         // It's a directory, try serving index.html
@@ -784,36 +853,8 @@ const server = http.createServer(async (req, res) => {
 
       if (err.code === 'ENOENT') {
         if (path.basename(filePath) === 'trajectory_summary.json') {
-          const runDir = path.dirname(filePath);
-          if (fs.existsSync(runDir)) {
-            import('../harness/lib/trajectory-normalizer.ts').then(async ({ generateNormalizedTrajectory }) => {
-              const { agentName, isKnown } = detectAgentFromPath(filePath);
-              const resolvedAgent = getAgentFromEvalsJson(runDir, agentName);
-              if (!isKnown && resolvedAgent === agentName) {
-                console.warn(`[Server] Warning: Could not detect known agent in path "${filePath}". Supported identifiers: ${SUPPORTED_AGENTS.map(a => a.match).join(', ')}. To add a new agent, update SUPPORTED_AGENTS in eval-view/server.js and generateNormalizedTrajectory in harness/lib/trajectory-normalizer.ts.`);
-              }
-              await generateNormalizedTrajectory(runDir, resolvedAgent, 'local');
-              if (fs.existsSync(filePath)) {
-                res.writeHead(200, { 'Content-Type': 'application/json' });
-                res.end(fs.readFileSync(filePath), 'utf-8');
-                return;
-              }
-              const errMsg = !isKnown
-                ? `404 Not Found: Trajectory summary generation failed because an unknown agent was used for path "${filePath}". Supported identifiers: ${SUPPORTED_AGENTS.map(a => a.match).join(', ')}. To add another agent, update SUPPORTED_AGENTS in eval-view/server.js and generateNormalizedTrajectory in harness/lib/trajectory-normalizer.ts.`
-                : `404 Not Found: Trajectory summary generation failed for agent "${agentName}" in path "${filePath}".`;
-              res.writeHead(404);
-              res.end(errMsg);
-            }).catch(e => {
-              const { agentName, isKnown } = detectAgentFromPath(filePath);
-              const errMsg = !isKnown
-                ? `Failed to auto-generate trajectory summary for unknown agent in path "${filePath}". Supported identifiers: ${SUPPORTED_AGENTS.map(a => a.match).join(', ')}. To add another agent, update SUPPORTED_AGENTS in eval-view/server.js and generateNormalizedTrajectory in harness/lib/trajectory-normalizer.ts.`
-                : `Failed to auto-generate trajectory summary for agent "${agentName}": ${e.message}`;
-              console.error(errMsg, e);
-              res.writeHead(404);
-              res.end(`404 Not Found (${errMsg})`);
-            });
-            return;
-          }
+          await handleMissingTrajectorySummary(filePath, res);
+          return;
         }
 
         // SPA Fallback: If it's a structural route (no extension or .html) that 404s,
@@ -840,144 +881,9 @@ const server = http.createServer(async (req, res) => {
     } else {
       if (contentType === 'text/html' && path.basename(filePath).startsWith('session-')) {
         let htmlStr = content.toString('utf-8');
-        
-        // If file contains logData and has an empty logs container, pre-render statically
-        if (htmlStr.includes('const logData = [') && (htmlStr.includes('<div id="logs"></div>') || htmlStr.includes('<div id="logs">\n</div>'))) {
-          try {
-            const startIdx = htmlStr.indexOf('const logData = [');
-            const endIdx = htmlStr.indexOf('];\n    const logsContainer');
-            if (startIdx !== -1 && endIdx !== -1) {
-              const rawLogData = htmlStr.slice(startIdx + 'const logData = '.length, endIdx + 1);
-              const logData = JSON.parse(rawLogData);
-
-              /** @param {any} s */
-              const escapeHtml = (s) => (s || '').toString().replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#039;');
-
-              let preRenderedLogsHtml = '';
-              let toolStepCounter = 0;
-
-              /**
-               * @param {any} entry
-               * @param {number} i
-               */
-              logData.forEach((/** @type {any} */ entry, /** @type {number} */ i) => {
-                let role = entry.role || entry.type || 'unknown';
-                let contentHtml = '';
-                const timestamp = entry.timestamp ? new Date(entry.timestamp).toLocaleTimeString() : '';
-
-                if (entry.type === 'turn_context') {
-                  role = 'system';
-                  contentHtml = '<div class="text-content" style="color:#8b949e;">[System Instructions Collapsed]</div>';
-                } else if (entry.type === 'event_msg') {
-                  const p = entry.payload || {};
-                  if (p.type === 'user_message') { role = 'user'; contentHtml = '<div class="text-content">' + escapeHtml(p.message) + '</div>'; }
-                  else if (p.type === 'agent_message') { role = 'assistant'; contentHtml = '<div class="text-content" style="color: #7ee787;">' + escapeHtml(p.message) + '</div>'; }
-                  else if (p.type === 'token_count') { role = 'system'; contentHtml = '<div class="text-content" style="font-size:0.8em; color:#8b949e;">Tokens: ' + (p.total_tokens || 'N/A') + '</div>'; }
-                } else if (entry.type === 'response_item') {
-                  const p = entry.payload || {};
-                  if (p.type === 'message') { role = p.role || 'assistant'; contentHtml = '<div class="text-content">' + escapeHtml(p.content?.[0]?.text || p.content?.[0]?.input_text || '') + '</div>'; }
-                  else if (p.type === 'reasoning') { role = 'assistant'; contentHtml = '<div class="thought"><b>Reasoning Process:</b><br/>' + escapeHtml(p.content || '[Reasoning]') + '</div>'; }
-                  else if (p.type === 'function_call' || p.type === 'custom_tool_call') {
-                    role = 'assistant';
-                    let argsStr = '';
-                    try {
-                      const parsed = typeof p.arguments === 'string' ? JSON.parse(p.arguments) : p.arguments;
-                      argsStr = Object.entries(parsed).map(([k, v]) => `<div style="margin-top:4px;"><strong>${escapeHtml(k)}:</strong> <span style="color:#79c0ff;">${escapeHtml(typeof v === 'object' ? JSON.stringify(v) : String(v))}</span></div>`).join('');
-                    } catch { argsStr = escapeHtml(String(p.arguments)); }
-                    contentHtml = `<div class="tool-use"><b>Tool: ${escapeHtml(p.name)} [${escapeHtml(p.call_id)}]</b><br/>${argsStr}</div>`;
-                  } else if (p.type === 'function_call_output' || p.type === 'custom_tool_call_output') {
-                    role = 'system';
-                    const errCls = p.is_error ? ' error' : '';
-                    contentHtml = `<div class="tool-result${errCls}"><b>Tool Result [${escapeHtml(p.call_id)}]:</b><br/>${escapeHtml(p.output || '')}</div>`;
-                  }
-                }
-
-                if (contentHtml) {
-                  let elId = 'entry-' + (i + 1);
-                  let badge = '';
-                  if (entry.type === 'response_item' && entry.payload && (entry.payload.type === 'function_call' || entry.payload.type === 'custom_tool_call')) {
-                    toolStepCounter++;
-                    elId = 'step-' + toolStepCounter;
-                    badge = '<span class="step-badge" style="background:#1f6feb22; color:#58a6ff; border:1px solid #1f6feb; border-radius:4px; padding:2px 8px; font-size:0.8em; font-weight:bold; margin-left:8px;">STEP ' + toolStepCounter + '</span>';
-                  }
-                  preRenderedLogsHtml += `<div class="log-entry role-${escapeHtml(role)}" id="${elId}"><div class="meta"><div><span>${escapeHtml(role).toUpperCase()}</span>${badge}</div><span class="timestamp">${timestamp}</span></div><div class="content-block">${contentHtml}</div><div class="toggle-raw" onclick="this.nextElementSibling.style.display = (this.nextElementSibling.style.display === 'block' ? 'none' : 'block')">Toggle Raw JSON</div><pre class="raw-json">${escapeHtml(JSON.stringify(entry, null, 2))}</pre></div>\n`;
-                }
-              });
-
-              htmlStr = htmlStr.replace('<div id="logs"></div>', '<div id="logs">\n' + preRenderedLogsHtml + '</div>')
-                               .replace('<div id="logs">\n</div>', '<div id="logs">\n' + preRenderedLogsHtml + '</div>');
-            }
-          } catch (e) {
-            console.error('Failed to pre-render session html:', e);
-          }
-        }
-
         if (!htmlStr.includes('id="step-auto-scroll-injected"')) {
-          const scriptToInject = `
-<script id="step-auto-scroll-injected">
-(function() {
-  function initStepAnchors() {
-    const logsContainer = document.getElementById("logs");
-    if (!logsContainer) return;
-
-    let toolStepCounter = 0;
-    const entries = Array.from(logsContainer.children);
-    entries.forEach((el, idx) => {
-      if (!el.id) el.id = "entry-" + (idx + 1);
-      const isToolCall = !!el.querySelector(".tool-use");
-      if (isToolCall) {
-        toolStepCounter++;
-        if (!el.id || el.id.startsWith("entry-")) el.id = "step-" + toolStepCounter;
-
-        const meta = el.querySelector(".meta");
-        if (meta && !meta.querySelector(".step-badge")) {
-          const badge = document.createElement("span");
-          badge.className = "step-badge";
-          badge.style.cssText = "background:#1f6feb22; color:#58a6ff; border:1px solid #1f6feb; border-radius:4px; padding:2px 8px; font-size:0.8em; font-weight:bold; margin-left:8px;";
-          badge.textContent = "STEP " + toolStepCounter;
-          const firstChild = meta.firstElementChild;
-          if (firstChild && firstChild.tagName === "SPAN") {
-            meta.insertBefore(badge, firstChild.nextSibling);
-          } else {
-            meta.appendChild(badge);
-          }
+          htmlStr = htmlStr.replace('</body>', STEP_AUTO_SCROLL_SCRIPT + '\n</body>');
         }
-      }
-    });
-
-    const hash = window.location.hash;
-    if (hash && hash.startsWith('#step-')) {
-      const target = document.querySelector(hash);
-      if (target) {
-        setTimeout(() => {
-          target.scrollIntoView({ behavior: 'smooth', block: 'center' });
-          target.style.outline = '3px solid #58a6ff';
-          target.style.boxShadow = '0 0 25px rgba(88, 166, 255, 0.6)';
-        }, 150);
-      }
-    }
-  }
-
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', () => setTimeout(initStepAnchors, 100));
-  } else {
-    setTimeout(initStepAnchors, 100);
-  }
-
-  window.addEventListener('hashchange', () => {
-    const target = document.querySelector(window.location.hash);
-    if (target) {
-      target.scrollIntoView({ behavior: 'smooth', block: 'center' });
-      target.style.outline = '3px solid #58a6ff';
-      target.style.boxShadow = '0 0 25px rgba(88, 166, 255, 0.6)';
-    }
-  });
-})();
-</script>
-`;
-          htmlStr = htmlStr.replace('</body>', scriptToInject + '\n</body>');
-        }
-
         res.writeHead(200, { 'Content-Type': contentType });
         res.end(htmlStr, 'utf-8');
         return;

--- a/eval-view/server.js
+++ b/eval-view/server.js
@@ -452,7 +452,7 @@ const server = http.createServer(async (req, res) => {
     });
 
     /** @param {any} str */
-    const stripAnsi = (str) => typeof str === 'string' ? str.replace(/\x1B\[\d+m/g, '') : String(str);
+    const stripAnsi = (str) => typeof str === 'string' ? str.replace(new RegExp(String.fromCharCode(27) + '\\[\\d+m', 'g'), '') : String(str);
 
     const origLog = console.log;
     const origWarn = console.warn;
@@ -848,7 +848,7 @@ const server = http.createServer(async (req, res) => {
             const endIdx = htmlStr.indexOf('];\n    const logsContainer');
             if (startIdx !== -1 && endIdx !== -1) {
               const rawLogData = htmlStr.slice(startIdx + 'const logData = '.length, endIdx + 1);
-              const logData = eval(rawLogData);
+              const logData = JSON.parse(rawLogData);
 
               /** @param {any} s */
               const escapeHtml = (s) => (s || '').toString().replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#039;');

--- a/eval-view/server.js
+++ b/eval-view/server.js
@@ -12,6 +12,53 @@ import { extractSuiteSummary } from './summary-extractor.js';
 const PORT = process.env.PORT || 8081;
 const STATIC = process.env.STATIC === 'true';
 
+// Registry of supported agent identifiers mapping path substrings to Agent display names.
+// To add a new agent in the future, simply append an entry here (e.g., { match: 'newagent', name: 'New Agent CLI' }).
+const SUPPORTED_AGENTS = [
+  { match: 'claude', name: 'claude_code' },
+  { match: 'gemini', name: 'gemini_cli' },
+  { match: 'jetski', name: 'jetski_cli' },
+  { match: 'codex', name: 'codex_cli' }
+];
+
+/**
+ * Detects the agent display name from a file path based on SUPPORTED_AGENTS.
+ * Returns { agentName: string, isKnown: boolean }.
+ */
+/**
+ * @param {string} filePath
+ */
+function detectAgentFromPath(filePath) {
+  const lowerPath = (filePath || '').toLowerCase();
+  for (const agent of SUPPORTED_AGENTS) {
+    if (lowerPath.includes(agent.match)) {
+      return { agentName: agent.name, isKnown: true };
+    }
+  }
+  return { agentName: 'Unknown Agent', isKnown: false };
+}
+
+/**
+ * Resolves the agent identifier from evals.json in parent directories, falling back to fallbackAgent.
+ * @param {string} startDir
+ * @param {string} fallbackAgent
+ * @returns {string}
+ */
+function getAgentFromEvalsJson(startDir, fallbackAgent) {
+  let curr = startDir;
+  while (curr && curr !== path.dirname(curr)) {
+    const evalsPath = path.join(curr, 'evals.json');
+    if (fs.existsSync(evalsPath)) {
+      try {
+        const data = JSON.parse(fs.readFileSync(evalsPath, 'utf8'));
+        if (data && data.agent) return data.agent;
+      } catch (e) {}
+    }
+    curr = path.dirname(curr);
+  }
+  return fallbackAgent;
+}
+
 if (STATIC) {
   console.log('🌐 Running in STATIC mode via statikk. Dynamic APIs will be unavailable.');
   
@@ -93,6 +140,14 @@ const MIME_TYPES = {
  *   timestamp?: string;
  * }} SuiteInfo
  */
+
+const EVAL_VIEW_ROOT = import.meta.dirname;
+const ROOT_DIR = path.resolve(EVAL_VIEW_ROOT, '..');
+const HARNESS_DIR = path.join(ROOT_DIR, 'harness');
+const RESULTS_DIR = process.env.USE_MOCK_RESULTS === 'true' ? path.join(EVAL_VIEW_ROOT, 'mock-results') : path.join(HARNESS_DIR, 'results');
+const BASE_APPS_DIR = path.join(HARNESS_DIR, 'base_apps');
+const TASKS_DIR = path.join(HARNESS_DIR, 'tasks');
+const GUIDES_DIR = path.join(ROOT_DIR, 'guides');
 
 /** @type {string | null} */
 let cachedGcsToken = null;
@@ -209,6 +264,7 @@ const server = http.createServer(async (req, res) => {
     return;
   }
 
+
   // Block directory traversal attempts
   if (decodedPath.includes('..')) {
     console.log(`403 Forbidden: Traversal attempt - ${req.method} ${reqUrl}`);
@@ -230,16 +286,14 @@ const server = http.createServer(async (req, res) => {
     /** @type {SuiteInfo[]} */
     let suitesList = [];
 
-    // Local
-    const resultsDir = process.env.USE_MOCK_RESULTS === 'true' ? './mock-results' : '../harness/results';
     try {
-      if (fs.existsSync(resultsDir)) {
-        const dirs = fs.readdirSync(resultsDir, { withFileTypes: true })
+      if (fs.existsSync(RESULTS_DIR)) {
+        const dirs = fs.readdirSync(RESULTS_DIR, { withFileTypes: true })
           .filter(dirent => dirent.isDirectory() && dirent.name !== 'single_task')
           .map(dirent => dirent.name);
         
         dirs.forEach(d => {
-          const suiteDir = path.join(resultsDir, d);
+          const suiteDir = path.join(RESULTS_DIR, d);
           const evalsJsonPath = path.join(suiteDir, 'evals.json');
           let timestamp = null;
           try {
@@ -301,15 +355,14 @@ const server = http.createServer(async (req, res) => {
   // --- /api/available-skills : lists folders with SKILL.md ---
   if (decodedPath === '/api/available-skills') {
     try {
-      const guidesDir = path.resolve('../guides');
       const skills = [];
-      if (fs.existsSync(guidesDir)) {
-        const candidates = fs.readdirSync(guidesDir, { withFileTypes: true })
+      if (fs.existsSync(GUIDES_DIR)) {
+        const candidates = fs.readdirSync(GUIDES_DIR, { withFileTypes: true })
           .filter(d => d.isDirectory() && !d.name.startsWith('.') && d.name !== 'node_modules')
           .map(d => d.name);
 
         for (const candidate of candidates) {
-          const skillSource = path.join(guidesDir, candidate, "SKILL.md");
+          const skillSource = path.join(GUIDES_DIR, candidate, "SKILL.md");
           if (fs.existsSync(skillSource)) {
             skills.push(candidate);
           }
@@ -331,7 +384,6 @@ const server = http.createServer(async (req, res) => {
     req.on('data', chunk => { body += chunk.toString(); });
     req.on('end', async () => {
       try {
-        // Return 200 immediately so UI can track the run
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ success: true }));
 
@@ -354,7 +406,7 @@ const server = http.createServer(async (req, res) => {
           ...options.tasks
         ], {
           stdio: 'inherit',
-          cwd: path.resolve('..'), // Run from root to resolve paths correctly
+          cwd: ROOT_DIR,
           detached: false
         });
 
@@ -367,10 +419,173 @@ const server = http.createServer(async (req, res) => {
           }
         });
 
-        p.unref(); // Avoid holding parent open if terminating event context
+        p.unref();
       } catch (e) {
         console.error('Launch failure:', e);
       }
+    });
+    return;
+  }
+
+  // --- /api/ensure-run : lazily downloads run directories from GCS if missing locally with live log streaming ---
+  if (decodedPath === '/api/ensure-run') {
+    const parsedUrl = new URL(reqUrl, `http://${req.headers.host}`);
+    const dirA = parsedUrl.searchParams.get('dirA');
+    const dirB = parsedUrl.searchParams.get('dirB');
+
+    if (!dirA && !dirB) {
+      res.writeHead(400, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.end('Missing dirA or dirB parameter');
+      return;
+    }
+
+    const authHeader = req.headers.authorization || '';
+    if (authHeader) {
+      process.env.GD_GCS_TOKEN = authHeader;
+    }
+
+    res.writeHead(200, {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+      'X-Content-Type-Options': 'nosniff'
+    });
+
+    /** @param {any} str */
+    const stripAnsi = (str) => typeof str === 'string' ? str.replace(/\x1B\[\d+m/g, '') : String(str);
+
+    const origLog = console.log;
+    const origWarn = console.warn;
+    const origErr = console.error;
+
+    /** @param {...any} args */
+    const streamLog = (...args) => {
+      const msg = args.map(stripAnsi).join(' ') + '\n';
+      res.write(msg);
+      origLog(...args);
+    };
+    /** @param {...any} args */
+    const streamWarn = (...args) => {
+      const msg = args.map(stripAnsi).join(' ') + '\n';
+      res.write(msg);
+      origWarn(...args);
+    };
+    /** @param {...any} args */
+    const streamErr = (...args) => {
+      const msg = args.map(stripAnsi).join(' ') + '\n';
+      res.write(msg);
+      origErr(...args);
+    };
+
+    console.log = streamLog;
+    console.warn = streamWarn;
+    console.error = streamErr;
+
+    try {
+      const authHeader = req.headers.authorization || '';
+      if (authHeader) {
+        process.env.GD_GCS_TOKEN = authHeader;
+      }
+      res.write(`[Server] Verifying local run files before loading comparison...\n`);
+      const { downloadRunFromGcsIfMissing } = await import('../harness/lib/gcs-downloader.ts');
+      const absoluteResultsDir = path.resolve(RESULTS_DIR);
+
+      if (dirA) {
+        const absA = path.resolve(RESULTS_DIR, dirA);
+        const relA = path.relative(absoluteResultsDir, absA);
+        if (!relA.startsWith('..') && !path.isAbsolute(relA)) {
+          res.write(`[Server] Checking run A: ${dirA}\n`);
+          await downloadRunFromGcsIfMissing(absA);
+        }
+      }
+      if (dirB && dirB !== dirA) {
+        const absB = path.resolve(RESULTS_DIR, dirB);
+        const relB = path.relative(absoluteResultsDir, absB);
+        if (!relB.startsWith('..') && !path.isAbsolute(relB)) {
+          res.write(`[Server] Checking run B: ${dirB}\n`);
+          await downloadRunFromGcsIfMissing(absB);
+        }
+      }
+      res.write(`[Server] Run files ready.\n`);
+    } catch (/** @type {any} */ e) {
+      const errMsg = `[Server Error] /api/ensure-run failed: ${e.message}\n`;
+      res.write(errMsg);
+      origErr(errMsg, e);
+    } finally {
+      console.log = origLog;
+      console.warn = origWarn;
+      console.error = origErr;
+      res.end();
+    }
+    return;
+  }
+
+  // --- /api/compare : runs comparison on the fly, streaming output ---
+  if (decodedPath === '/api/compare') {
+    const parsedUrl = new URL(reqUrl, `http://${req.headers.host}`);
+    const relativeDirA = parsedUrl.searchParams.get('runDirA');
+    const relativeDirB = parsedUrl.searchParams.get('runDirB');
+
+    if (!relativeDirA || !relativeDirB) {
+      res.writeHead(400, { 'Content-Type': 'text/plain' });
+      res.end('Missing runDirA or runDirB parameter');
+      return;
+    }
+
+    const absoluteResultsDir = path.resolve(RESULTS_DIR);
+    const absDirA = path.resolve(RESULTS_DIR, relativeDirA);
+    const absDirB = path.resolve(RESULTS_DIR, relativeDirB);
+
+    // Security check: ensure both paths are strictly within the results directory
+    const relA = path.relative(absoluteResultsDir, absDirA);
+    const relB = path.relative(absoluteResultsDir, absDirB);
+
+    if (relA.startsWith('..') || path.isAbsolute(relA) || relB.startsWith('..') || path.isAbsolute(relB)) {
+      res.writeHead(403, { 'Content-Type': 'text/plain' });
+      res.end('Forbidden: Paths must be within the results directory');
+      return;
+    }
+
+    // Set headers for chunked streaming
+    res.writeHead(200, {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+      'X-Content-Type-Options': 'nosniff'
+    });
+
+    res.write(`[Server] Starting on-the-fly comparison between:\n  A: ${absDirA}\n  B: ${absDirB}\n\n`);
+
+    const authHeader = req.headers.authorization || '';
+
+    const gdTsPath = path.join(ROOT_DIR, 'bin', 'gd.ts');
+    const p = spawn('npx', ['tsx', gdTsPath, 'compare', absDirA, absDirB], {
+      cwd: ROOT_DIR,
+      env: { ...process.env, GD_GCS_TOKEN: authHeader }
+    });
+
+    p.stdout.on('data', (data) => {
+      const str = data.toString();
+      res.write(str);
+      process.stdout.write(str);
+    });
+
+    p.stderr.on('data', (data) => {
+      const str = data.toString();
+      res.write(str);
+      process.stderr.write(str);
+    });
+
+    p.on('close', (code) => {
+      if (code !== 0) {
+        res.write(`\n[Server Error] Comparison command failed with code ${code}.\n`);
+      }
+      res.end();
+    });
+
+    p.on('error', (err) => {
+      res.write(`\n[Server Error] Failed to spawn comparison command: ${err.message}\n`);
+      res.end();
     });
     return;
   }
@@ -389,8 +604,7 @@ const server = http.createServer(async (req, res) => {
     /** @type {string[]} */
     let files = [];
     if (source === 'local') {
-      const resultsDir = process.env.USE_MOCK_RESULTS === 'true' ? './mock-results' : '../harness/results';
-      const targetDir = path.join(resultsDir, relativePath);
+      const targetDir = path.join(RESULTS_DIR, relativePath);
       try {
         if (fs.existsSync(targetDir)) {
           files = fs.readdirSync(targetDir, { withFileTypes: true })
@@ -417,7 +631,6 @@ const server = http.createServer(async (req, res) => {
   }
 
   // --- Silent File Probing API ---
-  // Avoids native browser 404 console errors by returning JSON { exists: boolean }
   if (decodedPath === '/api/exists') {
     const parsedUrl = new URL(reqUrl, `http://${req.headers.host}`);
     const checkPath = parsedUrl.searchParams.get('path');
@@ -429,19 +642,16 @@ const server = http.createServer(async (req, res) => {
 
     let filePath;
     if (checkPath.startsWith('base_apps/')) {
-      filePath = path.join('../harness/base_apps', checkPath.substring(10));
+      filePath = path.join(BASE_APPS_DIR, checkPath.substring(10));
     } else if (checkPath.startsWith('tasks/')) {
-      filePath = path.join('../harness/tasks', checkPath.substring(6));
+      filePath = path.join(TASKS_DIR, checkPath.substring(6));
     } else {
-      const resultsDir = process.env.USE_MOCK_RESULTS === 'true' ? './mock-results' : '../harness/results';
-      filePath = path.join(resultsDir, checkPath);
+      filePath = path.join(RESULTS_DIR, checkPath);
     }
 
     const absolutePath = path.resolve(filePath);
-    const evalViewRoot = path.resolve('.');
-    const harnessRoot = path.resolve('../harness');
-    const isInsideEvalView = absolutePath === evalViewRoot || absolutePath.startsWith(evalViewRoot + path.sep);
-    const isInsideHarness = absolutePath === harnessRoot || absolutePath.startsWith(harnessRoot + path.sep);
+    const isInsideEvalView = absolutePath === EVAL_VIEW_ROOT || absolutePath.startsWith(EVAL_VIEW_ROOT + path.sep);
+    const isInsideHarness = absolutePath === HARNESS_DIR || absolutePath.startsWith(HARNESS_DIR + path.sep);
 
     let exists = false;
     if (isInsideEvalView || isInsideHarness) {
@@ -456,47 +666,32 @@ const server = http.createServer(async (req, res) => {
   let filePath;
   // Map results and setup to the harness directory
   if (decodedPath.startsWith('/base_apps/')) {
-    filePath = path.join('../harness/base_apps', decodedPath.substring(11));
+    filePath = path.join(BASE_APPS_DIR, decodedPath.substring(11));
   } else if (decodedPath.startsWith('/tasks/')) {
-    filePath = path.join('../harness/tasks', decodedPath.substring(7));
+    filePath = path.join(TASKS_DIR, decodedPath.substring(7));
   } else if (decodedPath.startsWith('/guides/')) {
-    filePath = path.join('../guides', decodedPath.substring(8));
+    filePath = path.join(GUIDES_DIR, decodedPath.substring(8));
   } else {
     const relativePath = decodedPath.startsWith('/') ? decodedPath.substring(1) : decodedPath;
-    let localEvalViewPath = path.join('.', relativePath);
+    let localEvalViewPath = path.join(EVAL_VIEW_ROOT, relativePath);
     if (decodedPath === '/' || decodedPath === '') {
-      localEvalViewPath = './index.html';
+      localEvalViewPath = path.join(EVAL_VIEW_ROOT, 'index.html');
     }
 
     // If the file exists in eval-view, serve it.
-    // Otherwise, assume it's a test result file in ../harness/results
+    // Otherwise, assume it's a test result file in RESULTS_DIR
     if (fs.existsSync(localEvalViewPath)) {
         filePath = localEvalViewPath;
     } else {
-        const useLocal = reqUrl.includes('source=local');
-        const referer = req.headers.referer;
-        const refererLocal = referer && (referer.includes('source=local') || referer.includes('localhost'));
-        
-        if (!useLocal && !refererLocal && decodedPath.includes('/')) {
-            // Give a decent error if someone tries to stream a remote file directly
-            res.writeHead(400);
-            res.end('400 Bad Request: Remote GCS streaming must use client-side authenticated fetches directly to GCS.');
-            return;
-        }
-
-        // If this is an absolute navigation link (e.g. /menu) clicked from inside a test result,
-        // it will lack the <suite>/<run>/... prefix. We must restore it from the referer.
         let finalRelativePath = relativePath;
+        const referer = req.headers.referer;
         if (referer) {
             try {
                 const refererUrl = new URL(referer);
-                const refPath = refererUrl.pathname.substring(1); // remove leading slash
+                const refPath = refererUrl.pathname.substring(1);
                 
-                // If referer is a test result (e.g. suite/1/task/guided/index.html)
-                // and the requested path does NOT start with the suite name
                 const parts = refPath.split('/');
                 if (parts.length >= 4 && !finalRelativePath.startsWith(parts[0] + '/')) {
-                    // Reconstruct the base path up to the run type directory
                     const basePath = parts.slice(0, 4).join('/');
                     finalRelativePath = path.join(basePath, finalRelativePath);
                 }
@@ -505,21 +700,57 @@ const server = http.createServer(async (req, res) => {
             }
         }
 
-        const resultsDir = process.env.USE_MOCK_RESULTS === 'true' ? './mock-results' : '../harness/results';
-        filePath = path.join(resultsDir, finalRelativePath);
+        filePath = path.join(RESULTS_DIR, finalRelativePath);
+
+        // Auto-generate missing or outdated trajectory_summary.json on the fly
+        if (path.basename(filePath) === 'trajectory_summary.json') {
+          let needsGeneration = !fs.existsSync(filePath);
+          if (!needsGeneration) {
+            try {
+              const summaryJson = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+              if (summaryJson.schemaVersion !== "2.0") needsGeneration = true;
+            } catch {
+              needsGeneration = true;
+            }
+          }
+          if (needsGeneration) {
+            const runDir = path.dirname(filePath);
+            if (fs.existsSync(runDir)) {
+              try {
+                const { generateNormalizedTrajectory } = await import('../harness/lib/trajectory-parser.ts');
+                const { agentName, isKnown } = detectAgentFromPath(filePath);
+                const resolvedAgent = getAgentFromEvalsJson(runDir, agentName);
+                if (!isKnown && resolvedAgent === agentName) {
+                  console.warn(`[Server] Warning: Could not detect known agent in path "${filePath}". Supported identifiers: ${SUPPORTED_AGENTS.map(a => a.match).join(', ')}. To add a new agent, update SUPPORTED_AGENTS in eval-view/server.js and generateNormalizedTrajectory in harness/lib/trajectory-parser.ts.`);
+                }
+                await generateNormalizedTrajectory(runDir, resolvedAgent, 'local');
+              } catch (e) {
+                console.error('Failed to auto-generate trajectory summary:', e);
+              }
+            }
+          }
+        }
+
+        // If file does not exist locally and request is not local, return 400 for remote GCS streaming
+        if (!fs.existsSync(filePath)) {
+            const useLocal = reqUrl.includes('source=local');
+            const refererLocal = referer && (referer.includes('source=local') || referer.includes('localhost') || referer.includes('127.0.0.1') || referer.includes('compare.html') || referer.includes('dashboard.html') || referer.includes('guide.html'));
+            
+            if (!useLocal && !refererLocal && decodedPath.includes('/')) {
+                res.writeHead(400);
+                res.end('400 Bad Request: Remote GCS streaming must use client-side authenticated fetches directly to GCS.');
+                return;
+            }
+        }
     }
   }
 
   // Final check: Resolve the absolute path and ensure it's within allowed directories
   const absolutePath = path.resolve(filePath);
-  const evalViewRoot = path.resolve('.');
-  const harnessRoot = path.resolve('../harness');
-  const guidesRoot = path.resolve('../guides');
 
-  // Use path.sep to ensure we match whole directory names
-  const isInsideEvalView = absolutePath === evalViewRoot || absolutePath.startsWith(evalViewRoot + path.sep);
-  const isInsideHarness = absolutePath === harnessRoot || absolutePath.startsWith(harnessRoot + path.sep);
-  const isInsideGuides = absolutePath === guidesRoot || absolutePath.startsWith(guidesRoot + path.sep);
+  const isInsideEvalView = absolutePath === EVAL_VIEW_ROOT || absolutePath.startsWith(EVAL_VIEW_ROOT + path.sep);
+  const isInsideHarness = absolutePath === HARNESS_DIR || absolutePath.startsWith(HARNESS_DIR + path.sep);
+  const isInsideGuides = absolutePath === GUIDES_DIR || absolutePath.startsWith(GUIDES_DIR + path.sep);
 
   if (!isInsideEvalView && !isInsideHarness && !isInsideGuides) {
     console.log(`403 Forbidden: Access outside allowed directories - ${req.method} ${reqUrl} -> ${absolutePath}`);
@@ -552,6 +783,39 @@ const server = http.createServer(async (req, res) => {
       }
 
       if (err.code === 'ENOENT') {
+        if (path.basename(filePath) === 'trajectory_summary.json') {
+          const runDir = path.dirname(filePath);
+          if (fs.existsSync(runDir)) {
+            import('../harness/lib/trajectory-parser.ts').then(async ({ generateNormalizedTrajectory }) => {
+              const { agentName, isKnown } = detectAgentFromPath(filePath);
+              const resolvedAgent = getAgentFromEvalsJson(runDir, agentName);
+              if (!isKnown && resolvedAgent === agentName) {
+                console.warn(`[Server] Warning: Could not detect known agent in path "${filePath}". Supported identifiers: ${SUPPORTED_AGENTS.map(a => a.match).join(', ')}. To add a new agent, update SUPPORTED_AGENTS in eval-view/server.js and generateNormalizedTrajectory in harness/lib/trajectory-parser.ts.`);
+              }
+              await generateNormalizedTrajectory(runDir, resolvedAgent, 'local');
+              if (fs.existsSync(filePath)) {
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end(fs.readFileSync(filePath), 'utf-8');
+                return;
+              }
+              const errMsg = !isKnown
+                ? `404 Not Found: Trajectory summary generation failed because an unknown agent was used for path "${filePath}". Supported identifiers: ${SUPPORTED_AGENTS.map(a => a.match).join(', ')}. To add another agent, update SUPPORTED_AGENTS in eval-view/server.js and generateNormalizedTrajectory in harness/lib/trajectory-parser.ts.`
+                : `404 Not Found: Trajectory summary generation failed for agent "${agentName}" in path "${filePath}".`;
+              res.writeHead(404);
+              res.end(errMsg);
+            }).catch(e => {
+              const { agentName, isKnown } = detectAgentFromPath(filePath);
+              const errMsg = !isKnown
+                ? `Failed to auto-generate trajectory summary for unknown agent in path "${filePath}". Supported identifiers: ${SUPPORTED_AGENTS.map(a => a.match).join(', ')}. To add another agent, update SUPPORTED_AGENTS in eval-view/server.js and generateNormalizedTrajectory in harness/lib/trajectory-parser.ts.`
+                : `Failed to auto-generate trajectory summary for agent "${agentName}": ${e.message}`;
+              console.error(errMsg, e);
+              res.writeHead(404);
+              res.end(`404 Not Found (${errMsg})`);
+            });
+            return;
+          }
+        }
+
         // SPA Fallback: If it's a structural route (no extension or .html) that 404s,
         // try to serve the index.html from the same base run directory instead.
         if (!extname || extname === '.html') {
@@ -574,6 +838,150 @@ const server = http.createServer(async (req, res) => {
         res.end(`Server Error: ${err.code}`);
       }
     } else {
+      if (contentType === 'text/html' && path.basename(filePath).startsWith('session-')) {
+        let htmlStr = content.toString('utf-8');
+        
+        // If file contains logData and has an empty logs container, pre-render statically
+        if (htmlStr.includes('const logData = [') && (htmlStr.includes('<div id="logs"></div>') || htmlStr.includes('<div id="logs">\n</div>'))) {
+          try {
+            const startIdx = htmlStr.indexOf('const logData = [');
+            const endIdx = htmlStr.indexOf('];\n    const logsContainer');
+            if (startIdx !== -1 && endIdx !== -1) {
+              const rawLogData = htmlStr.slice(startIdx + 'const logData = '.length, endIdx + 1);
+              const logData = eval(rawLogData);
+
+              /** @param {any} s */
+              const escapeHtml = (s) => (s || '').toString().replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#039;');
+
+              let preRenderedLogsHtml = '';
+              let toolStepCounter = 0;
+
+              /**
+               * @param {any} entry
+               * @param {number} i
+               */
+              logData.forEach((/** @type {any} */ entry, /** @type {number} */ i) => {
+                let role = entry.role || entry.type || 'unknown';
+                let contentHtml = '';
+                const timestamp = entry.timestamp ? new Date(entry.timestamp).toLocaleTimeString() : '';
+
+                if (entry.type === 'turn_context') {
+                  role = 'system';
+                  contentHtml = '<div class="text-content" style="color:#8b949e;">[System Instructions Collapsed]</div>';
+                } else if (entry.type === 'event_msg') {
+                  const p = entry.payload || {};
+                  if (p.type === 'user_message') { role = 'user'; contentHtml = '<div class="text-content">' + escapeHtml(p.message) + '</div>'; }
+                  else if (p.type === 'agent_message') { role = 'assistant'; contentHtml = '<div class="text-content" style="color: #7ee787;">' + escapeHtml(p.message) + '</div>'; }
+                  else if (p.type === 'token_count') { role = 'system'; contentHtml = '<div class="text-content" style="font-size:0.8em; color:#8b949e;">Tokens: ' + (p.total_tokens || 'N/A') + '</div>'; }
+                } else if (entry.type === 'response_item') {
+                  const p = entry.payload || {};
+                  if (p.type === 'message') { role = p.role || 'assistant'; contentHtml = '<div class="text-content">' + escapeHtml(p.content?.[0]?.text || p.content?.[0]?.input_text || '') + '</div>'; }
+                  else if (p.type === 'reasoning') { role = 'assistant'; contentHtml = '<div class="thought"><b>Reasoning Process:</b><br/>' + escapeHtml(p.content || '[Reasoning]') + '</div>'; }
+                  else if (p.type === 'function_call' || p.type === 'custom_tool_call') {
+                    role = 'assistant';
+                    let argsStr = '';
+                    try {
+                      const parsed = typeof p.arguments === 'string' ? JSON.parse(p.arguments) : p.arguments;
+                      argsStr = Object.entries(parsed).map(([k, v]) => `<div style="margin-top:4px;"><strong>${escapeHtml(k)}:</strong> <span style="color:#79c0ff;">${escapeHtml(typeof v === 'object' ? JSON.stringify(v) : String(v))}</span></div>`).join('');
+                    } catch { argsStr = escapeHtml(String(p.arguments)); }
+                    contentHtml = `<div class="tool-use"><b>Tool: ${escapeHtml(p.name)} [${escapeHtml(p.call_id)}]</b><br/>${argsStr}</div>`;
+                  } else if (p.type === 'function_call_output' || p.type === 'custom_tool_call_output') {
+                    role = 'system';
+                    const errCls = p.is_error ? ' error' : '';
+                    contentHtml = `<div class="tool-result${errCls}"><b>Tool Result [${escapeHtml(p.call_id)}]:</b><br/>${escapeHtml(p.output || '')}</div>`;
+                  }
+                }
+
+                if (contentHtml) {
+                  let elId = 'entry-' + (i + 1);
+                  let badge = '';
+                  if (entry.type === 'response_item' && entry.payload && (entry.payload.type === 'function_call' || entry.payload.type === 'custom_tool_call')) {
+                    toolStepCounter++;
+                    elId = 'step-' + toolStepCounter;
+                    badge = '<span class="step-badge" style="background:#1f6feb22; color:#58a6ff; border:1px solid #1f6feb; border-radius:4px; padding:2px 8px; font-size:0.8em; font-weight:bold; margin-left:8px;">STEP ' + toolStepCounter + '</span>';
+                  }
+                  preRenderedLogsHtml += `<div class="log-entry role-${escapeHtml(role)}" id="${elId}"><div class="meta"><div><span>${escapeHtml(role).toUpperCase()}</span>${badge}</div><span class="timestamp">${timestamp}</span></div><div class="content-block">${contentHtml}</div><div class="toggle-raw" onclick="this.nextElementSibling.style.display = (this.nextElementSibling.style.display === 'block' ? 'none' : 'block')">Toggle Raw JSON</div><pre class="raw-json">${escapeHtml(JSON.stringify(entry, null, 2))}</pre></div>\n`;
+                }
+              });
+
+              htmlStr = htmlStr.replace('<div id="logs"></div>', '<div id="logs">\n' + preRenderedLogsHtml + '</div>')
+                               .replace('<div id="logs">\n</div>', '<div id="logs">\n' + preRenderedLogsHtml + '</div>');
+            }
+          } catch (e) {
+            console.error('Failed to pre-render session html:', e);
+          }
+        }
+
+        if (!htmlStr.includes('id="step-auto-scroll-injected"')) {
+          const scriptToInject = `
+<script id="step-auto-scroll-injected">
+(function() {
+  function initStepAnchors() {
+    const logsContainer = document.getElementById("logs");
+    if (!logsContainer) return;
+
+    let toolStepCounter = 0;
+    const entries = Array.from(logsContainer.children);
+    entries.forEach((el, idx) => {
+      if (!el.id) el.id = "entry-" + (idx + 1);
+      const isToolCall = !!el.querySelector(".tool-use");
+      if (isToolCall) {
+        toolStepCounter++;
+        if (!el.id || el.id.startsWith("entry-")) el.id = "step-" + toolStepCounter;
+
+        const meta = el.querySelector(".meta");
+        if (meta && !meta.querySelector(".step-badge")) {
+          const badge = document.createElement("span");
+          badge.className = "step-badge";
+          badge.style.cssText = "background:#1f6feb22; color:#58a6ff; border:1px solid #1f6feb; border-radius:4px; padding:2px 8px; font-size:0.8em; font-weight:bold; margin-left:8px;";
+          badge.textContent = "STEP " + toolStepCounter;
+          const firstChild = meta.firstElementChild;
+          if (firstChild && firstChild.tagName === "SPAN") {
+            meta.insertBefore(badge, firstChild.nextSibling);
+          } else {
+            meta.appendChild(badge);
+          }
+        }
+      }
+    });
+
+    const hash = window.location.hash;
+    if (hash && hash.startsWith('#step-')) {
+      const target = document.querySelector(hash);
+      if (target) {
+        setTimeout(() => {
+          target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+          target.style.outline = '3px solid #58a6ff';
+          target.style.boxShadow = '0 0 25px rgba(88, 166, 255, 0.6)';
+        }, 150);
+      }
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => setTimeout(initStepAnchors, 100));
+  } else {
+    setTimeout(initStepAnchors, 100);
+  }
+
+  window.addEventListener('hashchange', () => {
+    const target = document.querySelector(window.location.hash);
+    if (target) {
+      target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      target.style.outline = '3px solid #58a6ff';
+      target.style.boxShadow = '0 0 25px rgba(88, 166, 255, 0.6)';
+    }
+  });
+})();
+</script>
+`;
+          htmlStr = htmlStr.replace('</body>', scriptToInject + '\n</body>');
+        }
+
+        res.writeHead(200, { 'Content-Type': contentType });
+        res.end(htmlStr, 'utf-8');
+        return;
+      }
       res.writeHead(200, { 'Content-Type': contentType });
       res.end(content, 'utf-8');
     }

--- a/eval-view/utils.js
+++ b/eval-view/utils.js
@@ -404,3 +404,8 @@ export function normalizeTrajectoryClient(summary) {
   return summary;
 }
 
+export function hasNightlyRuns(testData) {
+  if (!testData || typeof testData !== 'object') return false;
+  return Object.values(testData).some(t => (t?.testId || '').toLowerCase().includes('nightly'));
+}
+

--- a/eval-view/utils.js
+++ b/eval-view/utils.js
@@ -366,3 +366,42 @@ export function $(query, context) {
   return /** @type {E} */ (result);
 }
 
+export function categorizeActionClient(name, params, thought) {
+  const actionName = (name || '').toLowerCase();
+  const actionParamsStr = JSON.stringify(params || {}).toLowerCase();
+  const thoughtStr = (thought || '').toLowerCase();
+
+  if (actionName === 'respond_to_user') return 'other';
+
+  if (actionName.includes('retrieve') || (actionName.includes('get_best_practices') && actionParamsStr.includes('retrieve')) || actionParamsStr.includes('retrieve')) {
+    return 'guide_retrieval';
+  }
+  if (actionName.includes('search') || actionName.includes('get_best_practices') || actionName.includes('query_guidance') || actionParamsStr.includes('search')) {
+    return 'skill_search';
+  }
+  if (
+    actionName.includes('write') || actionName.includes('replace') || actionName.includes('edit') || actionName.includes('touch') ||
+    actionParamsStr.includes('write_to_file') || actionParamsStr.includes('replace_file_content') ||
+    actionParamsStr.includes('index.html') || actionParamsStr.includes('app.jsx') || actionParamsStr.includes('style.css')
+  ) {
+    return 'code_mutation';
+  }
+  if (thoughtStr.includes('mandatory') || thoughtStr.includes('fallback') || thoughtStr.includes('css') || thoughtStr.includes('baseline') || thoughtStr.includes('guidance')) {
+    return 'mandatory_rule_thought';
+  }
+  return 'incidental_noise';
+}
+
+export function normalizeTrajectoryClient(summary) {
+  if (!summary) return summary;
+  summary.schemaVersion = "2.0";
+  if (Array.isArray(summary.steps)) {
+    for (const step of summary.steps) {
+      if (step.action && !step.action.canonicalCategory) {
+        step.action.canonicalCategory = categorizeActionClient(step.action.name, step.action.params, step.thought);
+      }
+    }
+  }
+  return summary;
+}
+

--- a/eval-view/utils.js
+++ b/eval-view/utils.js
@@ -54,8 +54,8 @@ export function escapeHtml(text) {
 }
 
 /**
- * @param {string} s
- * @returns {string}
+ * @param {string | null | undefined} s
+ * @returns {string | null | undefined}
  */
 export function capitalize(s) {
     if (typeof s !== 'string' || s.length === 0) return s;
@@ -366,6 +366,12 @@ export function $(query, context) {
   return /** @type {E} */ (result);
 }
 
+/**
+ * @param {string} [name]
+ * @param {Record<string, any>} [params]
+ * @param {string} [thought]
+ * @returns {string}
+ */
 export function categorizeActionClient(name, params, thought) {
   const actionName = (name || '').toLowerCase();
   const actionParamsStr = JSON.stringify(params || {}).toLowerCase();
@@ -392,6 +398,10 @@ export function categorizeActionClient(name, params, thought) {
   return 'incidental_noise';
 }
 
+/**
+ * @param {any} summary
+ * @returns {any}
+ */
 export function normalizeTrajectoryClient(summary) {
   if (!summary) return summary;
   if (Array.isArray(summary.steps)) {
@@ -404,6 +414,10 @@ export function normalizeTrajectoryClient(summary) {
   return summary;
 }
 
+/**
+ * @param {Record<string, any> | null | undefined} [testData]
+ * @returns {boolean}
+ */
 export function hasNightlyRuns(testData) {
   if (!testData || typeof testData !== 'object') return false;
   return Object.values(testData).some(t => (t?.testId || '').toLowerCase().includes('nightly'));

--- a/eval-view/utils.js
+++ b/eval-view/utils.js
@@ -394,7 +394,6 @@ export function categorizeActionClient(name, params, thought) {
 
 export function normalizeTrajectoryClient(summary) {
   if (!summary) return summary;
-  summary.schemaVersion = "2.0";
   if (Array.isArray(summary.steps)) {
     for (const step of summary.steps) {
       if (step.action && !step.action.canonicalCategory) {

--- a/eval-view/utils.test.ts
+++ b/eval-view/utils.test.ts
@@ -8,7 +8,8 @@ import {
   formatTokens,
   parseResultKey,
   categorizeActionClient,
-  normalizeTrajectoryClient
+  normalizeTrajectoryClient,
+  hasNightlyRuns
 } from "./utils.js";
 
 describe("eval-view utils", () => {
@@ -80,5 +81,13 @@ describe("eval-view utils", () => {
     const normalized = normalizeTrajectoryClient(rawSummary);
     assert.strictEqual(normalized.steps[0].action.canonicalCategory, "skill_search");
     assert.strictEqual(normalized.steps[1].action.canonicalCategory, "code_mutation");
+  });
+
+  test("hasNightlyRuns detects nightly in testId entries", () => {
+    assert.strictEqual(hasNightlyRuns(null), false);
+    assert.strictEqual(hasNightlyRuns({}), false);
+    assert.strictEqual(hasNightlyRuns({ a: { testId: "test-run-1" } }), false);
+    assert.strictEqual(hasNightlyRuns({ a: { testId: "nightly-2026-08-01" } }), true);
+    assert.strictEqual(hasNightlyRuns({ a: { testId: "run-A" }, b: { testId: "CLI-Nightly-eval" } }), true);
   });
 });

--- a/eval-view/utils.test.ts
+++ b/eval-view/utils.test.ts
@@ -1,0 +1,92 @@
+import { test, describe } from "node:test";
+import assert from "node:assert";
+import {
+  getRunStats,
+  isDisciplineSkillRun,
+  getColor,
+  escapeHtml,
+  capitalize,
+  formatTokens,
+  parseResultKey,
+  categorizeActionClient,
+  normalizeTrajectoryClient
+} from "./utils.js";
+
+describe("eval-view utils", () => {
+  test("getRunStats calculates passed checks rate accurately", () => {
+    assert.deepStrictEqual(getRunStats([]), { rate: 0, passed: 0, total: 0 });
+    assert.deepStrictEqual(getRunStats(null), { rate: 0, passed: 0, total: 0 });
+
+    const checks = [{ passed: true }, { passed: false }, { passed: true }, { passed: true }];
+    assert.deepStrictEqual(getRunStats(checks), { rate: 75, passed: 3, total: 4 });
+  });
+
+  test("isDisciplineSkillRun checks isDisciplineSkill or fallback isSkill", () => {
+    assert.strictEqual(isDisciplineSkillRun(null), false);
+    assert.strictEqual(isDisciplineSkillRun({ isDisciplineSkill: true }), true);
+    assert.strictEqual(isDisciplineSkillRun({ isDisciplineSkill: false }), false);
+    assert.strictEqual(isDisciplineSkillRun({ isSkill: true }), true);
+  });
+
+  test("getColor returns proper OKLCH color strings for thresholds", () => {
+    assert.ok(getColor(0).includes("oklch"));
+    assert.ok(getColor(50).includes("color-mix"));
+    assert.ok(getColor(100).includes("oklch"));
+  });
+
+  test("escapeHtml sanitizes special characters", () => {
+    assert.strictEqual(escapeHtml('<script>alert("x" & \'y\')</script>'), '&lt;script&gt;alert(&quot;x&quot; &amp; &#039;y&#039;)&lt;/script&gt;');
+    assert.strictEqual(escapeHtml(""), "");
+    assert.strictEqual(escapeHtml(null), null);
+  });
+
+  test("capitalize capitalizes the first character of strings", () => {
+    assert.strictEqual(capitalize("hello"), "Hello");
+    assert.strictEqual(capitalize(""), "");
+    assert.strictEqual(capitalize(null), null);
+  });
+
+  test("formatTokens formats compact token counts", () => {
+    assert.strictEqual(formatTokens(0), "0 tok");
+    assert.strictEqual(formatTokens(null), "0 tok");
+    assert.ok(formatTokens(1500).includes("1.5k tok") || formatTokens(1500).includes("1.5k"));
+  });
+
+  test("parseResultKey extracts task, guide, and runType", () => {
+    assert.strictEqual(parseResultKey("invalid"), null);
+
+    const parsed = parseResultKey("anchor-tooltip - anchor-positioning - guided");
+    assert.strictEqual(parsed.task, "anchor-tooltip");
+    assert.strictEqual(parsed.guide, "anchor-positioning");
+    assert.strictEqual(parsed.runType, "guided");
+  });
+
+  test("categorizeActionClient maps action names, parameters, and thoughts into categories", () => {
+    assert.strictEqual(categorizeActionClient("respond_to_user", {}, ""), "other");
+    assert.strictEqual(categorizeActionClient("retrieve", { id: "anchor-positioning" }, ""), "guide_retrieval");
+    assert.strictEqual(categorizeActionClient("search", { query: "popover" }, ""), "skill_search");
+    assert.strictEqual(categorizeActionClient("write_to_file", { TargetFile: "index.html" }, ""), "code_mutation");
+    assert.strictEqual(categorizeActionClient("other", {}, "I must follow the mandatory baseline rules"), "mandatory_rule_thought");
+    assert.strictEqual(categorizeActionClient("view_file", {}, "just reading"), "incidental_noise");
+  });
+
+  test("normalizeTrajectoryClient annotates missing canonicalCategories on steps", () => {
+    const rawSummary = {
+      agent: "gemini-cli",
+      steps: [
+        {
+          stepNumber: 1,
+          action: { name: "search", params: { query: "details" } }
+        },
+        {
+          stepNumber: 2,
+          action: { name: "write_to_file", params: { TargetFile: "app.jsx" } }
+        }
+      ]
+    };
+
+    const normalized = normalizeTrajectoryClient(rawSummary);
+    assert.strictEqual(normalized.steps[0].action.canonicalCategory, "skill_search");
+    assert.strictEqual(normalized.steps[1].action.canonicalCategory, "code_mutation");
+  });
+});

--- a/eval-view/utils.test.ts
+++ b/eval-view/utils.test.ts
@@ -1,5 +1,6 @@
 import { test, describe } from "node:test";
 import assert from "node:assert";
+import type { ScenarioCheck } from "../harness/lib/metrics.ts";
 import {
   getRunStats,
   getColor,
@@ -17,7 +18,12 @@ describe("eval-view utils", () => {
     assert.deepStrictEqual(getRunStats([]), { rate: 0, passed: 0, total: 0 });
     assert.deepStrictEqual(getRunStats(null), { rate: 0, passed: 0, total: 0 });
 
-    const checks = [{ passed: true }, { passed: false }, { passed: true }, { passed: true }];
+    const checks: ScenarioCheck[] = [
+      { id: "1", message: "", passed: true },
+      { id: "2", message: "", passed: false },
+      { id: "3", message: "", passed: true },
+      { id: "4", message: "", passed: true }
+    ];
     assert.deepStrictEqual(getRunStats(checks), { rate: 75, passed: 3, total: 4 });
   });
 
@@ -49,6 +55,7 @@ describe("eval-view utils", () => {
     assert.strictEqual(parseResultKey("invalid"), null);
 
     const parsed = parseResultKey("anchor-tooltip - anchor-positioning - guided");
+    assert.ok(parsed);
     assert.strictEqual(parsed.task, "anchor-tooltip");
     assert.strictEqual(parsed.guide, "anchor-positioning");
     assert.strictEqual(parsed.runType, "guided");

--- a/eval-view/utils.test.ts
+++ b/eval-view/utils.test.ts
@@ -2,7 +2,6 @@ import { test, describe } from "node:test";
 import assert from "node:assert";
 import {
   getRunStats,
-  isDisciplineSkillRun,
   getColor,
   escapeHtml,
   capitalize,
@@ -19,13 +18,6 @@ describe("eval-view utils", () => {
 
     const checks = [{ passed: true }, { passed: false }, { passed: true }, { passed: true }];
     assert.deepStrictEqual(getRunStats(checks), { rate: 75, passed: 3, total: 4 });
-  });
-
-  test("isDisciplineSkillRun checks isDisciplineSkill or fallback isSkill", () => {
-    assert.strictEqual(isDisciplineSkillRun(null), false);
-    assert.strictEqual(isDisciplineSkillRun({ isDisciplineSkill: true }), true);
-    assert.strictEqual(isDisciplineSkillRun({ isDisciplineSkill: false }), false);
-    assert.strictEqual(isDisciplineSkillRun({ isSkill: true }), true);
   });
 
   test("getColor returns proper OKLCH color strings for thresholds", () => {


### PR DESCRIPTION
## Summary
Part 3 of 3 (stacked on https://github.com/GoogleChrome/modern-web-guidance-src/pull/1187 ). 

Adds interactive web UI for side-by-side run comparisons in `eval-view`.

- **Compare UI**: Interactive side-by-side viewer (`/compare.html`) showing trajectory divergence, code diffs, Playwright outputs, and metric charts.
- **Guide View**: Multi-run selection badges and compare modal in `eval-view/guide.html`.
- **Server Endpoints**: `/api/compare`, `/api/download-run`, and on-demand `/api/trajectory-summary`.