### PR TITLE
chrome-extensions skill: fix permissions.request() user-gesture pitfall

### DIFF
--- a/skills-src/chrome-extensions/SKILL.md
+++ b/skills-src/chrome-extensions/SKILL.md
@@ -81,14 +81,8 @@ See `references/extensions/csp-sandbox.md` for full details.
 
 #### 4. `tab.url` requires the `tabs` permission
 
-Without it, `tab.url` silently returns `undefined` — no error thrown.
-
-```js
-// manifest.json — REQUIRED if you read tab.url or tab.title anywhere:
-{ "permissions": ["tabs"] }
-```
-
-See `references/extensions/tab-management.md`.
+Without it, `tab.url` silently returns `undefined` — no error thrown. See
+`references/extensions/permissions.md`.
 
 #### 5. Always use async/await — never `.then()` chains
 
@@ -196,27 +190,10 @@ await chrome.action.setBadgeText({ text: '5' });
 
 #### 12. `activeTab` only works on direct user gestures — not from side panels
 
-`activeTab` grants temporary access to the current tab ONLY when triggered by:
-- Clicking the extension action icon
-- A context menu item (including the `"tab"` context)
-- A keyboard shortcut from the `commands` API
-- Accepting an omnibox suggestion
-
-It does **NOT** grant access when clicking a button in a side panel, popup button that opens later,
-or any programmatic trigger.
-
-```js
-// ❌ BROKEN — activeTab does NOT work from a side panel button click
-document.getElementById('summarize').addEventListener('click', async () => {
-  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-  await chrome.scripting.executeScript({ target: { tabId: tab.id }, func: () => document.body.innerText });
-});
-
-// ✅ FIX — use "tabs" permission + specific host_permissions instead
-// manifest.json: { "permissions": ["tabs", "scripting"], "host_permissions": ["<all_urls>"] }
-```
-
-See `references/extensions/side-panel.md`.
+`activeTab` grants temporary access to the current tab ONLY on a direct user gesture (action
+icon click, context menu item, keyboard shortcut, omnibox suggestion) — NOT from a button click
+inside a side panel or popup. Use `tabs` + `host_permissions` instead. See
+`references/extensions/permissions.md` and `references/extensions/side-panel.md`.
 
 #### 13. DevTools panel URLs are relative to the extension root
 
@@ -379,6 +356,14 @@ const all     = await chrome.windows.getAll({ populate: true });
 
 **`chrome.windows` methods:** `getAll`, `getLastFocused`, `getCurrent`, `get(windowId)`, `create`, `update`, `remove`. See `references/extensions/tab-management.md`.
 
+#### 20. `chrome.permissions.request()` requires a user gesture — call it directly in the click handler, not via message passing
+
+`chrome.permissions.request()` only works when called synchronously within a user gesture. If a
+UI context (side panel, popup) sends a message to the service worker and the service worker
+calls it in response, the gesture context is lost crossing the message-passing boundary and the
+call fails silently. Call it directly in the click handler of the UI context instead — see
+`references/extensions/permissions.md`.
+
 ### Always Manifest V3
 
 Never generate Manifest V2 code.
@@ -485,6 +470,7 @@ For detailed API patterns and publishing guidance, read the relevant file BEFORE
 
 | Topic | Reference |
 |-------|-----------|
+| Permissions | `references/extensions/permissions.md` |
 | Side panels | `references/extensions/side-panel.md` |
 | Content scripts & DOM | `references/extensions/content-scripts.md` |
 | Popups | `references/extensions/popup-ui.md` |
@@ -530,6 +516,7 @@ Verify EVERY item before delivering:
 - [ ] Tab/desktop capture uses state locking to prevent double-start errors
 - [ ] `chrome.desktopCapture.chooseDesktopMedia` passes `targetTab` with `tabs` permission
 - [ ] `chrome.windows` calls use `getAll`/`getLastFocused`/`getCurrent` — NOT `.query()` (it doesn't exist)
+- [ ] `chrome.permissions.request()` is called directly in a UI click handler — never forwarded through the service worker via `sendMessage`
 - [ ] `chrome.userScripts` availability checked before use (API throws if user hasn't enabled it)
 - [ ] User script configs persisted in `chrome.storage` and restored on `runtime.onInstalled` `"update"` reason
 - [ ] `configureWorld({ messaging: true })` called before user scripts send messages; listening on `onUserScriptMessage` not `onMessage`

--- a/skills-src/chrome-extensions/SKILL.md
+++ b/skills-src/chrome-extensions/SKILL.md
@@ -356,12 +356,13 @@ const all     = await chrome.windows.getAll({ populate: true });
 
 **`chrome.windows` methods:** `getAll`, `getLastFocused`, `getCurrent`, `get(windowId)`, `create`, `update`, `remove`. See `references/extensions/tab-management.md`.
 
-#### 20. `chrome.permissions.request()` requires a user gesture — call it directly in the click handler, not via message passing
+#### 20. `chrome.permissions.request()` in the service worker must be called with no `await` before it in the message listener
 
-`chrome.permissions.request()` only works when called synchronously within a user gesture. If a
-UI context (side panel, popup) sends a message to the service worker and the service worker
-calls it in response, the gesture context is lost crossing the message-passing boundary and the
-call fails silently. Call it directly in the click handler of the UI context instead — see
+A user gesture from a UI context (side panel, popup) does propagate across `chrome.runtime.sendMessage`
+to the service worker's `onMessage` listener — but only for that one synchronous turn. If the
+listener does an `await` (even a short delay) before calling `chrome.permissions.request()`, the
+gesture is gone and the call throws `"This function must be called during a user gesture"`. Call
+it as the first thing in the listener, with nothing awaited before it — see
 `references/extensions/permissions.md`.
 
 ### Always Manifest V3
@@ -516,7 +517,7 @@ Verify EVERY item before delivering:
 - [ ] Tab/desktop capture uses state locking to prevent double-start errors
 - [ ] `chrome.desktopCapture.chooseDesktopMedia` passes `targetTab` with `tabs` permission
 - [ ] `chrome.windows` calls use `getAll`/`getLastFocused`/`getCurrent` — NOT `.query()` (it doesn't exist)
-- [ ] `chrome.permissions.request()` is called directly in a UI click handler — never forwarded through the service worker via `sendMessage`
+- [ ] `chrome.permissions.request()` in a service worker `onMessage` listener is called with no `await` before it (gesture is lost after the first async gap)
 - [ ] `chrome.userScripts` availability checked before use (API throws if user hasn't enabled it)
 - [ ] User script configs persisted in `chrome.storage` and restored on `runtime.onInstalled` `"update"` reason
 - [ ] `configureWorld({ messaging: true })` called before user scripts send messages; listening on `onUserScriptMessage` not `onMessage`

--- a/skills-src/chrome-extensions/references/extensions/permissions.md
+++ b/skills-src/chrome-extensions/references/extensions/permissions.md
@@ -1,0 +1,107 @@
+# Permissions
+
+## `permissions` vs `host_permissions`
+
+These are separate manifest keys — don't conflate them:
+
+```json
+{
+  "permissions": ["tabs", "scripting", "storage"],
+  "host_permissions": ["https://api.example.com/*"]
+}
+```
+
+- `permissions` grants access to chrome.* APIs (`tabs`, `storage`, `scripting`, `desktopCapture`, etc.)
+- `host_permissions` grants access to specific origins for `fetch`, `chrome.scripting.executeScript`, and reading tab URLs cross-origin
+
+Scope `host_permissions` to specific domains rather than `<all_urls>` unless the extension genuinely needs to run on every site — broad host permissions draw extra Chrome Web Store review scrutiny.
+
+## `tab.url` requires the `tabs` permission
+
+Without it, `tab.url` and `tab.title` silently return `undefined` — no error thrown.
+
+```js
+// manifest.json — REQUIRED if you read tab.url or tab.title anywhere:
+{ "permissions": ["tabs"] }
+```
+
+See `references/extensions/tab-management.md` for the full tabs/windows API.
+
+## `activeTab` only works on direct user gestures — not from side panels
+
+`activeTab` grants temporary access to the current tab ONLY when triggered by:
+- Clicking the extension action icon
+- A context menu item (including the `"tab"` context)
+- A keyboard shortcut from the `commands` API
+- Accepting an omnibox suggestion
+
+It does **NOT** grant access when clicking a button in a side panel, a popup button that opens
+later, or any programmatic trigger.
+
+```js
+// ❌ BROKEN — activeTab does NOT work from a side panel button click
+document.getElementById('summarize').addEventListener('click', async () => {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  await chrome.scripting.executeScript({ target: { tabId: tab.id }, func: () => document.body.innerText });
+});
+
+// ✅ FIX — use "tabs" permission + specific host_permissions instead
+// manifest.json: { "permissions": ["tabs", "scripting"], "host_permissions": ["<all_urls>"] }
+```
+
+See `references/extensions/side-panel.md` for the side-panel-specific writeup.
+
+## `chrome.permissions.request()` requires a user gesture — call it directly in the click handler
+
+`chrome.permissions.request()` (for optional/dynamic permissions) only works when called
+synchronously within a user gesture (a click, keypress, etc.). If a UI context (side panel,
+popup) sends a message to the service worker and the service worker calls
+`chrome.permissions.request()` in response, Chrome no longer sees a user gesture — the call
+fails silently or rejects, because the gesture context is lost crossing the message-passing
+boundary.
+
+```js
+// ❌ BROKEN — side panel forwards the request through the service worker,
+// losing the user-gesture context
+// side-panel.js
+button.addEventListener('click', () => {
+  chrome.runtime.sendMessage({ type: 'REQUEST_PERMISSION' });
+});
+// service-worker.js
+chrome.runtime.onMessage.addListener((msg) => {
+  if (msg.type === 'REQUEST_PERMISSION') {
+    chrome.permissions.request({ permissions: ['downloads'] }); // no user-gesture context here
+  }
+});
+
+// ✅ CORRECT — call chrome.permissions.request() directly inside the click handler
+// side-panel.js
+button.addEventListener('click', async () => {
+  const granted = await chrome.permissions.request({ permissions: ['downloads'] });
+  if (granted) {
+    chrome.runtime.sendMessage({ type: 'PERMISSION_GRANTED' });
+  }
+});
+```
+
+**Rule of thumb:** any API that requires a user gesture (`chrome.permissions.request`,
+`activeTab`) must be called directly in the event handler of the UI context that received the
+click. Do not route it through the service worker first. If the service worker needs to know
+the outcome, have the UI context call the API itself and then message the result (not the
+request) to the service worker.
+
+## Checking and removing permissions
+
+```js
+// Check whether an optional permission is currently granted
+const hasIt = await chrome.permissions.contains({ permissions: ['downloads'] });
+
+// Remove a previously granted optional permission
+await chrome.permissions.remove({ permissions: ['downloads'] });
+```
+
+Declare optional permissions in the manifest so they're eligible to be requested at runtime:
+
+```json
+{ "optional_permissions": ["downloads"] }
+```

--- a/skills-src/chrome-extensions/references/extensions/permissions.md
+++ b/skills-src/chrome-extensions/references/extensions/permissions.md
@@ -51,44 +51,50 @@ document.getElementById('summarize').addEventListener('click', async () => {
 
 See `references/extensions/side-panel.md` for the side-panel-specific writeup.
 
-## `chrome.permissions.request()` requires a user gesture — call it directly in the click handler
+## `chrome.permissions.request()` needs a user gesture — the gesture survives one `sendMessage` hop, but not an `await` after that
 
-`chrome.permissions.request()` (for optional/dynamic permissions) only works when called
-synchronously within a user gesture (a click, keypress, etc.). If a UI context (side panel,
-popup) sends a message to the service worker and the service worker calls
-`chrome.permissions.request()` in response, Chrome no longer sees a user gesture — the call
-fails silently or rejects, because the gesture context is lost crossing the message-passing
-boundary.
+`chrome.permissions.request()` (for optional/dynamic permissions) only works within a user
+gesture (a click, keypress, etc.). A gesture from a UI context (side panel, popup) **does**
+propagate across `chrome.runtime.sendMessage` to the service worker's `onMessage` listener — but
+it's only good for that one synchronous turn. If the listener `await`s anything (a timer, a
+storage read, another message round-trip) before calling `chrome.permissions.request()`, the
+gesture is gone and the call throws `"This function must be called during a user gesture, such
+as an onclick handler"`.
 
 ```js
-// ❌ BROKEN — side panel forwards the request through the service worker,
-// losing the user-gesture context
 // side-panel.js
 button.addEventListener('click', () => {
-  chrome.runtime.sendMessage({ type: 'REQUEST_PERMISSION' });
+  chrome.runtime.sendMessage({ type: 'REQUEST_PERMISSION' }, (granted) => { ... });
 });
+
 // service-worker.js
-chrome.runtime.onMessage.addListener((msg) => {
+
+// ❌ BROKEN — an await before chrome.permissions.request() burns the gesture window
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   if (msg.type === 'REQUEST_PERMISSION') {
-    chrome.permissions.request({ permissions: ['downloads'] }); // no user-gesture context here
+    (async () => {
+      await chrome.storage.local.get('someSetting'); // gesture is gone after this
+      const granted = await chrome.permissions.request({ permissions: ['downloads'] });
+      sendResponse(granted);
+    })();
+    return true;
   }
 });
 
-// ✅ CORRECT — call chrome.permissions.request() directly inside the click handler
-// side-panel.js
-button.addEventListener('click', async () => {
-  const granted = await chrome.permissions.request({ permissions: ['downloads'] });
-  if (granted) {
-    chrome.runtime.sendMessage({ type: 'PERMISSION_GRANTED' });
+// ✅ CORRECT — call chrome.permissions.request() as the first thing in the listener,
+// nothing awaited before it
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.type === 'REQUEST_PERMISSION') {
+    chrome.permissions.request({ permissions: ['downloads'] }).then(sendResponse);
+    return true; // fine to await the *result* — the call itself already happened synchronously
   }
 });
 ```
 
-**Rule of thumb:** any API that requires a user gesture (`chrome.permissions.request`,
-`activeTab`) must be called directly in the event handler of the UI context that received the
-click. Do not route it through the service worker first. If the service worker needs to know
-the outcome, have the UI context call the API itself and then message the result (not the
-request) to the service worker.
+**Rule of thumb:** call `chrome.permissions.request()` (or anything else gated on a user
+gesture, like `activeTab`) as the very first statement of the message listener that receives the
+click-triggered message — before any other `await`. Awaiting the *returned* promise afterward is
+fine; awaiting anything *before* the call is what breaks it.
 
 ## Checking and removing permissions
 


### PR DESCRIPTION
## Summary
- Document that `chrome.permissions.request()` must be called synchronously in the UI click handler (or in a message handler)
- Extract permission-related pitfalls (`tabs` permission for `tab.url`, `activeTab` user-gesture restriction, `chrome.permissions.request()`) into a new `references/extensions/permissions.md`, condensing the corresponding SKILL.md sections to short pointers
- Add matching Output Checklist item and Reference Files table entry
