### PR TITLE
feat: add frontmatter field to withhold guides from publishing

### DIFF
--- a/.agents/skills/project-guides/SKILL.md
+++ b/.agents/skills/project-guides/SKILL.md
@@ -43,6 +43,7 @@ web-feature-ids:
 ---
 ```
 * **web-features**: Must be a list of accurate IDs found via webstatus.dev. Include ALL features referenced in the guide body, not just the primary one. If an ID is missing, inform the USER.
+* **status** (optional): Set to `draft`, `retracted`, or `future` to withhold the guide from all distribution (search index, README, megaskill) without deleting it. Omit for normal publishing. Any other value is a validation error.
 
 ### 2. Tone and Formatting
 

--- a/lib/guide-validation.test.ts
+++ b/lib/guide-validation.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { parseExpectations, validateHtmlTags, inventoryGuide, classifyGuide, getSupportedBaseApps } from './guide-validation.ts';
+import { parseExpectations, validateHtmlTags, inventoryGuide, classifyGuide, getSupportedBaseApps, isPublished, validateGuide, type GuideInventory } from './guide-validation.ts';
 
 describe('parseExpectations', () => {
   test('legacy flat format: all bullets treated as mustPass', () => {
@@ -136,6 +136,47 @@ describe('inventoryGuide and classifyGuide target discovery', () => {
       
       const status = classifyGuide(inv);
       assert.strictEqual(status, 'eval-ready');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('guide status (publish control)', () => {
+  const inv = (over: Partial<GuideInventory>): GuideInventory => ({ hasGuide: true, ...over } as GuideInventory);
+
+  test('isPublished excludes stubs and withheld statuses', () => {
+    assert.strictEqual(isPublished(inv({})), true, 'content, no status');
+    assert.strictEqual(isPublished(inv({ hasGuide: false })), false, 'empty stub');
+    assert.strictEqual(isPublished(inv({ hasGuide: false, status: 'draft' })), false, 'stub + status');
+    for (const status of ['draft', 'retracted', 'future'] as const) {
+      assert.strictEqual(isPublished(inv({ status })), false, status);
+    }
+  });
+
+  test('inventoryGuide reads the frontmatter status', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'guide-status-'));
+    const guideDir = path.join(tmpDir, 'draft-guide');
+    fs.mkdirSync(guideDir, { recursive: true });
+    fs.writeFileSync(path.join(guideDir, 'guide.md'), '---\nstatus: draft\n---\n# Draft\nBody');
+    try {
+      assert.strictEqual(inventoryGuide(guideDir).status, 'draft');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test('validateGuide errors on an unknown status value', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'guide-status-'));
+    const guideDir = path.join(tmpDir, 'bad-status');
+    fs.mkdirSync(guideDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(guideDir, 'guide.md'),
+      '---\nname: bad-status\ndescription: d\nweb-feature-ids:\n  - has\nstatus: draftt\n---\n# X\nBody',
+    );
+    try {
+      const errors = validateGuide(path.join(guideDir, 'guide.md')).errors;
+      assert.ok(errors.some(e => e.includes('Invalid "status" value "draftt"')), errors.join('\n'));
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/lib/guide-validation.ts
+++ b/lib/guide-validation.ts
@@ -36,10 +36,25 @@ export interface GuideInventoryResult {
   incompleteSubdirs: string[];
 }
 
+/**
+ * Frontmatter `status` values that withhold a guide from distribution
+ * (search index, README, megaskill) without deleting it. Absent = published.
+ */
+export const UNPUBLISH_STATUSES = ['draft', 'retracted', 'future'] as const;
+export type GuideLifecycle = (typeof UNPUBLISH_STATUSES)[number];
+
+/**
+ * True when a guide should be published to dist
+ */
+export function isPublished(inv: GuideInventory): boolean {
+  return inv.hasGuide && !(inv.status !== undefined && UNPUBLISH_STATUSES.includes(inv.status));
+}
+
 interface GuideData {
   name?: string;
   description?: string;
   'web-feature-ids'?: string[];
+  status?: GuideLifecycle;
   [key: string]: any;
 }
 
@@ -115,6 +130,10 @@ export function validateGuide(filePath: string): ValidationResult {
     }
   }
 
+  if (data.status !== undefined && !UNPUBLISH_STATUSES.includes(data.status)) {
+    errors.push(`Invalid "status" value "${data.status}" in ${relativePath}. Must be one of: ${UNPUBLISH_STATUSES.join(', ')}.`);
+  }
+
   errors.push(...validateMacros(body, relativePath));
   errors.push(...validateHtmlTags(body, relativePath));
 
@@ -184,7 +203,7 @@ export function processGuideInventory(guides: GuideInventory[]): GuideInventoryR
     const relativeSubdir = path.relative(REPO_ROOT, subdir);
     const guideExists = hasGuide || inv.isStub;
     const isDisciplineGuide = inv.name === inv.category || ['css-layout', 'passkeys'].includes(inv.name);
-    
+
     // Discipline skills don't need demo.html; a frontmatter-only stub
     // (a proposed use case) doesn't need one either
     if (!isDisciplineSkill && !isDisciplineGuide && ((hasGuide && !hasDemo) || (hasDemo && !guideExists))) {
@@ -316,6 +335,7 @@ export interface GuideInventory {
   hasGrader: boolean;
   hasTask: boolean;
   featureIds: string[];
+  status?: GuideLifecycle;
   isDisciplineSkill: boolean;
   targets?: TargetInventory[];
 }
@@ -483,7 +503,9 @@ export function inventoryGuide(dir: string): GuideInventory {
     }
   }
 
-  const featureIds = guideContent ? (matter(guideContent).data['web-feature-ids'] || []) : [];
+  const frontmatter = guideContent ? matter(guideContent).data : {};
+  const featureIds = frontmatter['web-feature-ids'] || [];
+  const status = frontmatter.status as GuideLifecycle | undefined;
 
   const targetsDir = path.join(dir, TARGETS_DIR);
   const hasTargets = fs.existsSync(targetsDir) && fs.statSync(targetsDir).isDirectory();
@@ -534,6 +556,7 @@ export function inventoryGuide(dir: string): GuideInventory {
     hasGrader,
     hasTask,
     featureIds,
+    status,
     isDisciplineSkill,
     targets,
   };
@@ -598,7 +621,7 @@ export function scanDisciplineSkills(scanDir = guidesDir): GuideInventory[] {
 
   for (const category of categories) {
     const categoryDir = path.join(scanDir, category);
-    
+
     // If the category directory itself contains a SKILL.md, it's a discipline skill
     if (fs.existsSync(path.join(categoryDir, SKILL_FILE))) {
       skills.push(inventoryGuide(categoryDir));

--- a/serving/scripts/build-guides.ts
+++ b/serving/scripts/build-guides.ts
@@ -17,7 +17,7 @@ export interface StoreUseCase {
 }
 import { replaceMacros, type BuildTarget } from "../lib/macros.ts";
 
-import { scanAllGuides, type GuideInventory, getGuideMarkdownPath } from "../../lib/guide-validation.ts";
+import { scanAllGuides, isPublished, type GuideInventory, getGuideMarkdownPath } from "../../lib/guide-validation.ts";
 import { config } from "../../lib/skills-config.ts";
 import { getFeatureName } from "../lib/baseline.ts";
 
@@ -157,7 +157,7 @@ export async function processGuides(opts: BuildOptions): Promise<boolean> {
   // 2. Scan & Hash
   let readyGuides = scanAllGuides().filter(inv => {
     const excluded = config.monoskill.excludeFromBundling || [];
-    return inv.hasGuide && !excluded.includes(inv.category) && !excluded.includes(inv.name);
+    return isPublished(inv) && !excluded.includes(inv.category) && !excluded.includes(inv.name);
   });
   const currentHash = await computePipelineHash(readyGuides, TARGET, IS_NO_CHUNKING);
 

--- a/serving/scripts/build-megaskill.ts
+++ b/serving/scripts/build-megaskill.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import matter from 'gray-matter';
+import { inventoryGuide, isPublished } from '../../lib/guide-validation.ts';
 
 function toTitleCase(kebabString: string): string {
   return kebabString
@@ -46,15 +46,14 @@ function buildTaxonomyMarkdown(guidesDir: string, distRefsDir: string): string {
     fs.mkdirSync(distCategoryDir, {recursive: true});
 
     for (const usecase of usecases) {
-      const guidePath = path.join(categoryPath, usecase, 'guide.md');
+      const dir = path.join(categoryPath, usecase);
+      const guidePath = path.join(dir, 'guide.md');
       if (!fs.existsSync(guidePath)) continue;
 
-      const guideContent = fs.readFileSync(guidePath, 'utf-8');
-      const { content: parsedContent } = matter(guideContent);
+      // Skip stubs (no body) and guides withheld from distribution via `status`
+      if (!isPublished(inventoryGuide(dir))) continue;
 
-      // Skip if there's no content beyond frontmatter
-      const contentWithoutFrontmatter = parsedContent.trim();
-      if (contentWithoutFrontmatter.length === 0) continue;
+      const guideContent = fs.readFileSync(guidePath, 'utf-8');
 
       // Extract title from first H1 or fall back
       let title: string;

--- a/serving/skills-cli/build-readme.ts
+++ b/serving/skills-cli/build-readme.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import path from "path";
 import matter from "gray-matter";
 import { features, groups } from "web-features";
-import { scanAllGuides } from "../../lib/guide-validation.ts";
+import { scanAllGuides, isPublished } from "../../lib/guide-validation.ts";
 import { getFeatureName } from "../lib/baseline.ts";
 import { rootDir } from "../../lib/paths.ts";
 
@@ -73,7 +73,7 @@ function listToMarkdownTable(items: string[], colCount = 3): string {
 }
 
 export function updateReadmeWithFeaturesAndUseCases(publishRoot: string) {
-  const readyGuides = scanAllGuides().filter(inv => inv.hasGuide && inv.featureIds.length > 0);
+  const readyGuides = scanAllGuides().filter(inv => isPublished(inv) && inv.featureIds.length > 0);
 
   const allFeatureIds = new Set<string>();
   const categoryMap = new Map<string, { id: string; category: string; description: string }[]>();


### PR DESCRIPTION
> [!NOTE] 
> I drafted this last night before seeing @paulirish’s comment https://github.com/GoogleChrome/modern-web-guidance-src/issues/1017#issuecomment-5023911612 . Putting it up here as I think it's still useful for gauging scope, but I’ll mark it as draft while we're still discussing the API shape.

The design in this PR was a `status: draft | retracted | future` in frontmatter to be excluded from all distribution (search index, README, megaskill) without deleting them. Present but unknown status values fail validation. Absent value = publish.
I know I said in #1017 to just go with a single `draft` value, but these three felt distinct enough and useful in the short-term. 

Introduces `isPublished(inv)` as the single publish predicate (real content + no withholding status), replacing the per-surface stub checks across the three build paths.

I debated having a symmetrical empty `PUBLISH_STATUSES` as well for any future values, but chose YAGNI instead. Happy to change it if we feel that would be useful.


Closes #1017