### PR TITLE
feat: add `draft` frontmatter flag to withhold guides from publishing

### DIFF
--- a/.agents/skills/project-guides/SKILL.md
+++ b/.agents/skills/project-guides/SKILL.md
@@ -44,6 +44,7 @@ web-feature-ids:
 ```
 * **web-features**: Must be a list of accurate IDs found via webstatus.dev. Include ALL features referenced in the guide body, not just the primary one. If an ID is missing, inform the USER.
   * **Pending Features (`tmp-` prefix)**: If a feature ID is pending upstream in `@web-platform-dx/web-features` (e.g. an open issue), use `tmp-<candidate-slug>` (e.g. `tmp-streaming-api`) AND register it in `lib/pending-web-features.json` along with its upstream issue link. This connects the guide to its GitHub issue and project board cards while pending, while ensuring centralized approval and no speculative ID sprawl. When the feature ID is officially released upstream in `web-features`, validator checks will automatically fail in CI to prompt updating the frontmatter to the official ID.
+* **draft** (optional): Set `draft: true` (or any truthy value, e.g. `draft: future`) to withhold the guide from all distribution (search index, README, megaskill) without deleting it. Omit for normal publishing.
 
 ### 2. Tone and Formatting
 

--- a/guides/sync-use-cases.test.ts
+++ b/guides/sync-use-cases.test.ts
@@ -451,6 +451,8 @@ describe('buildRequiredFilesChecklist', () => {
       hasGrader: false,
       hasTask: false,
       featureIds: [],
+      draft: false,
+      isPublished: false,
       isDisciplineSkill: false,
       ...overrides,
     };
@@ -525,6 +527,8 @@ describe('buildIssueContent', () => {
       hasGrader: false,
       hasTask: false,
       featureIds: [],
+      draft: false,
+      isPublished: false,
       isDisciplineSkill: false,
     };
   }
@@ -786,6 +790,8 @@ describe('processGuideInventory', () => {
       hasGrader: false,
       hasTask: false,
       featureIds: [],
+      draft: false,
+      isPublished: false,
       isDisciplineSkill: false,
       ...overrides,
     };

--- a/lib/guide-validation.test.ts
+++ b/lib/guide-validation.test.ts
@@ -532,6 +532,37 @@ describe('inventoryGuide and classifyGuide target discovery', () => {
   });
 });
 
+describe('guide draft flag (publish control)', () => {
+  // Inventory a guide.md with the given body in a throwaway dir.
+  const inventory = (md: string) => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'guide-draft-'));
+    const guideDir = path.join(tmpDir, 'g');
+    fs.mkdirSync(guideDir, { recursive: true });
+    fs.writeFileSync(path.join(guideDir, 'guide.md'), md);
+    try {
+      return inventoryGuide(guideDir);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  };
+
+  test('published when it has content and no draft flag', () => {
+    const inv = inventory('---\nname: g\n---\n# G\nBody');
+    assert.strictEqual(inv.draft, false);
+    assert.strictEqual(inv.isPublished, true);
+  });
+
+  test('any truthy draft withholds it', () => {
+    assert.strictEqual(inventory('---\ndraft: true\n---\n# G\nBody').isPublished, false);
+    assert.strictEqual(inventory('---\ndraft: future\n---\n# G\nBody').draft, 'future');
+    assert.strictEqual(inventory('---\ndraft: future\n---\n# G\nBody').isPublished, false);
+  });
+
+  test('a stub (frontmatter, no body) is never published', () => {
+    assert.strictEqual(inventory('---\nname: g\n---\n').isPublished, false);
+  });
+});
+
 describe('getSupportedBaseApps', () => {
   test('returns the exact list of supported base applications', () => {
     const apps = getSupportedBaseApps();

--- a/lib/guide-validation.test.ts
+++ b/lib/guide-validation.test.ts
@@ -550,6 +550,7 @@ describe('guide draft flag (publish control)', () => {
     const inv = inventory('---\nname: g\n---\n# G\nBody');
     assert.strictEqual(inv.draft, false);
     assert.strictEqual(inv.isPublished, true);
+    assert.strictEqual(inv.isStub, false); // has content -> not a stub
   });
 
   test('any truthy draft withholds it', () => {
@@ -558,8 +559,18 @@ describe('guide draft flag (publish control)', () => {
     assert.strictEqual(inventory('---\ndraft: future\n---\n# G\nBody').isPublished, false);
   });
 
+  test('falsy-looking string draft values still publish', () => {
+    // Quoting a boolean (draft: "false") or writing draft: no must not silently unpublish.
+    for (const val of ['"false"', 'no', 'off', '0', "''"]) {
+      const inv = inventory(`---\ndraft: ${val}\n---\n# G\nBody`);
+      assert.strictEqual(inv.isPublished, true, `draft: ${val}`);
+    }
+  });
+
   test('a stub (frontmatter, no body) is never published', () => {
-    assert.strictEqual(inventory('---\nname: g\n---\n').isPublished, false);
+    const inv = inventory('---\nname: g\n---\n');
+    assert.strictEqual(inv.isPublished, false);
+    assert.strictEqual(inv.isStub, true);
   });
 });
 

--- a/lib/guide-validation.ts
+++ b/lib/guide-validation.ts
@@ -45,6 +45,9 @@ interface GuideData {
   [key: string]: any;
 }
 
+/** String `draft` values interpreted as not-a-draft (a quoted/typed-out boolean). */
+const FALSY_DRAFT = new Set(['', 'false', 'no', 'off', '0']);
+
 interface ValidationResult {
   errors: string[];
   data: GuideData;
@@ -223,7 +226,7 @@ export function processGuideInventory(guides: GuideInventory[]): GuideInventoryR
       guideData = validation.data;
       guideBody = validation.body;
 
-      if (isDisciplineSkill || isDisciplineGuide || !hasGuide) {
+      if (isDisciplineSkill || isDisciplineGuide || inv.isStub) {
         // Discipline skills/guides and stubs don't require the same frontmatter as use cases
         guideErrors = guideErrors.filter(e => !e.includes('Missing "web-feature-ids"') && !e.includes('Missing "description"'));
       }
@@ -465,9 +468,14 @@ export function inventoryGuide(dir: string, options?: { useTargetEvals?: boolean
   const { data = {}, content = '' } = guideContent ? matter(guideContent) : {};
   const hasFrontmatter = Object.keys(data).length > 0 || guideContent.startsWith('---');
   const hasContent = content.replace(/<!--[\s\S]*?-->/g, '').trim().length > 0;
-  const isStub = hasFrontmatter;
+  const isStub = hasFrontmatter && !hasContent;
   const hasGuide = hasContent;
-  const draft = data.draft ?? false;
+  // Any truthy `draft` withholds the guide, but treat explicitly falsy-looking
+  // strings (e.g. `draft: "false"`, `draft: no`) as not-draft — quoting a
+  // boolean shouldn't silently unpublish a guide.
+  const draft = typeof data.draft === 'string' && FALSY_DRAFT.has(data.draft.trim().toLowerCase())
+    ? false
+    : data.draft ?? false;
   const isPublished = hasGuide && !draft;
 
   const targetsDir = path.join(dir, TARGETS_DIR);
@@ -545,8 +553,8 @@ export function inventoryGuide(dir: string, options?: { useTargetEvals?: boolean
 export type GuideStatus = 'eval-ready' | 'needs-test' | 'needs-calibration' | 'needs-expectations' | 'stub' | 'incomplete';
 
 export function classifyGuide(inv: GuideInventory): GuideStatus {
-  if (!inv.hasGuide && !inv.isStub) return 'incomplete';
-  if (inv.isStub && !inv.hasGuide) return 'stub';
+  if (inv.isStub) return 'stub';
+  if (!inv.hasGuide) return 'incomplete';
   if (!inv.hasExpectations || inv.expectationsEmpty) return 'needs-expectations';
 
   if (inv.targets && inv.targets.length > 0) {

--- a/lib/guide-validation.ts
+++ b/lib/guide-validation.ts
@@ -40,6 +40,8 @@ interface GuideData {
   name?: string;
   description?: string;
   'web-feature-ids'?: string[];
+  /** Any truthy value withholds the guide from distribution; `draft: true` recommended. */
+  draft?: boolean | string;
   [key: string]: any;
 }
 
@@ -187,7 +189,7 @@ export function processGuideInventory(guides: GuideInventory[]): GuideInventoryR
     const relativeSubdir = path.relative(REPO_ROOT, subdir);
     const guideExists = hasGuide || inv.isStub;
     const isDisciplineGuide = inv.name === inv.category || ['css-layout', 'passkeys'].includes(inv.name);
-    
+
     // Discipline skills don't need demo.html; a frontmatter-only stub
     // (a proposed use case) doesn't need one either
     // Guides with multi-app targets don't need a top-level demo.html
@@ -337,6 +339,10 @@ export interface GuideInventory {
   hasGrader: boolean;
   hasTask: boolean;
   featureIds: string[];
+  /** Frontmatter `draft` flag; any truthy value withholds the guide from distribution. */
+  draft: boolean | string;
+  /** Whether the guide belongs in dist: has content and no truthy `draft`. */
+  isPublished: boolean;
   isDisciplineSkill: boolean;
   targets?: TargetInventory[];
 }
@@ -455,25 +461,14 @@ export function inventoryGuide(dir: string, options?: { useTargetEvals?: boolean
 
   const guideFilePath = path.join(dir, isDisciplineSkill ? SKILL_FILE : GUIDE_FILE);
   const guideContent = readFileSafe(guideFilePath);
-  let hasGuide = false;
-  let isStub = false;
 
-  if (guideContent) {
-    const parsed = matter(guideContent);
-    const hasFrontmatter = Object.keys(parsed.data).length > 0 || guideContent.startsWith('---');
-    const hasContent = parsed.content.replace(/<!--[\s\S]*?-->/g, '').trim().length > 0;
-
-    if (hasFrontmatter) {
-      isStub = true;
-      if (hasContent) {
-        hasGuide = true;
-      }
-    } else if (hasContent) {
-      hasGuide = true;
-    }
-  }
-
-  const featureIds = guideContent ? (matter(guideContent).data['web-feature-ids'] || []) : [];
+  const { data = {}, content = '' } = guideContent ? matter(guideContent) : {};
+  const hasFrontmatter = Object.keys(data).length > 0 || guideContent.startsWith('---');
+  const hasContent = content.replace(/<!--[\s\S]*?-->/g, '').trim().length > 0;
+  const isStub = hasFrontmatter;
+  const hasGuide = hasContent;
+  const draft = data.draft ?? false;
+  const isPublished = hasGuide && !draft;
 
   const targetsDir = path.join(dir, TARGETS_DIR);
   const hasTargets = fs.existsSync(targetsDir) && fs.statSync(targetsDir).isDirectory();
@@ -539,7 +534,9 @@ export function inventoryGuide(dir: string, options?: { useTargetEvals?: boolean
     hasNegativeDemo,
     hasGrader,
     hasTask,
-    featureIds,
+    featureIds: data['web-feature-ids'] || [],
+    draft,
+    isPublished,
     isDisciplineSkill,
     targets: useTargets ? targets : undefined,
   };
@@ -604,7 +601,7 @@ export function scanDisciplineSkills(scanDir = guidesDir): GuideInventory[] {
 
   for (const category of categories) {
     const categoryDir = path.join(scanDir, category);
-    
+
     // If the category directory itself contains a SKILL.md, it's a discipline skill
     if (fs.existsSync(path.join(categoryDir, SKILL_FILE))) {
       skills.push(inventoryGuide(categoryDir));

--- a/serving/scripts/build-guides.ts
+++ b/serving/scripts/build-guides.ts
@@ -161,7 +161,7 @@ export async function processGuides(opts: BuildOptions): Promise<boolean> {
   // 2. Scan & Hash
   let readyGuides = scanAllGuides().filter(inv => {
     const excluded = config.monoskill.excludeFromBundling || [];
-    return inv.hasGuide && !excluded.includes(inv.category) && !excluded.includes(inv.name);
+    return inv.isPublished && !excluded.includes(inv.category) && !excluded.includes(inv.name);
   });
   const currentHash = await computePipelineHash(readyGuides, TARGET, IS_NO_CHUNKING);
 

--- a/serving/scripts/build-megaskill.ts
+++ b/serving/scripts/build-megaskill.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import matter from 'gray-matter';
+import { inventoryGuide } from '../../lib/guide-validation.ts';
 
 function toTitleCase(kebabString: string): string {
   return kebabString
@@ -46,15 +46,13 @@ function buildTaxonomyMarkdown(guidesDir: string, distRefsDir: string): string {
     fs.mkdirSync(distCategoryDir, {recursive: true});
 
     for (const usecase of usecases) {
-      const guidePath = path.join(categoryPath, usecase, 'guide.md');
+      const dir = path.join(categoryPath, usecase);
+      const guidePath = path.join(dir, 'guide.md');
       if (!fs.existsSync(guidePath)) continue;
 
-      const guideContent = fs.readFileSync(guidePath, 'utf-8');
-      const { content: parsedContent } = matter(guideContent);
+      if (!inventoryGuide(dir).isPublished) continue;
 
-      // Skip if there's no content beyond frontmatter
-      const contentWithoutFrontmatter = parsedContent.trim();
-      if (contentWithoutFrontmatter.length === 0) continue;
+      const guideContent = fs.readFileSync(guidePath, 'utf-8');
 
       // Extract title from first H1 or fall back
       let title: string;

--- a/serving/skills-cli/build-readme.ts
+++ b/serving/skills-cli/build-readme.ts
@@ -73,7 +73,7 @@ function listToMarkdownTable(items: string[], colCount = 3): string {
 }
 
 export function getFeaturesAndUseCases() {
-  const readyGuides = scanAllGuides().filter(inv => inv.hasGuide && inv.featureIds.length > 0);
+  const readyGuides = scanAllGuides().filter(inv => inv.isPublished && inv.featureIds.length > 0);
   const allFeatureIds = new Set<string>();
   const categoryMap = new Map<string, { id: string; category: string; description: string }[]>();
 


### PR DESCRIPTION
Closes #1017 

Adds:
- `draft` frontmatter option. Guides can set `draft: true` (or any truthy value, e.g. `draft: future`) in frontmatter to be excluded from all distribution (search index, README, megaskill) without deleting them. Evals are unaffected — a draft guide with eval artifacts still runs.
The value is intentionally not validated (per https://github.com/GoogleChrome/modern-web-guidance-src/issues/1017#issuecomment-5023911612 )
- `draft` and `isPublished` properties in `GuideInventory`. `isPublished` (real content + not draft) is computed once as a guide-inventory property, consumed by all three build paths.

I also did a little minor refactoring to make the logic and dependencies in `inventoryGuide()` easier to follow, but I can revert it if needed.

Note: I kept the logic as-is to avoid regressions, but it's a little confusing that `isStub` is true even for a fully fleshed out guide…