### PR TITLE
Decouple `feature-to-groups.generated.json` from guide content

### DIFF
--- a/guides/feature-to-groups.generated.json
+++ b/guides/feature-to-groups.generated.json
@@ -1,209 +1,47 @@
 {
-  "aborting": [],
-  "accent-color": [
-    "css"
-  ],
   "active-view-transition": [
-    "selectors",
     "view-transitions"
   ],
-  "anchor-positioning": [],
-  "autofill": [
-    "forms"
+  "animation-composition": [
+    "animation"
   ],
-  "backdrop": [
-    "selectors"
+  "animations-css": [
+    "animation"
   ],
-  "blocking-render": [
-    "html"
-  ],
-  "calc-size": [
-    "css"
-  ],
-  "canvas-html": [
-    "canvas",
-    "html-elements",
-    "webgl",
-    "webgpu"
-  ],
-  "color-scheme": [
-    "css"
-  ],
-  "contain-intrinsic-size": [
-    "containment"
-  ],
-  "container-anchor-position-queries": [],
-  "container-queries": [
-    "container-queries"
-  ],
-  "container-scroll-state-queries": [
-    "container-queries"
-  ],
-  "container-style-queries": [
-    "container-queries"
-  ],
-  "content-visibility": [
-    "css"
-  ],
-  "contrast-color": [
-    "color-types"
+  "column-pseudo": [
+    "scrolling"
   ],
   "cross-document-view-transitions": [
     "view-transitions"
   ],
-  "customizable-select": [
-    "forms",
-    "html-elements"
-  ],
-  "declarative-webmcp": [
-    "webmcp"
-  ],
-  "details": [
-    "html-elements"
-  ],
-  "details-name": [
-    "html-elements"
-  ],
-  "dialog": [
-    "html-elements"
-  ],
-  "dialog-closedby": [
-    "html-elements"
-  ],
-  "document-modelcontext": [
-    "webmcp"
-  ],
-  "enterkeyhint": [],
-  "event-timing": [
-    "performance"
-  ],
-  "fedcm": [
-    "credential-management"
-  ],
-  "fetch": [
-    "fetch"
-  ],
-  "fetch-priority": [
-    "fetch",
-    "resource-hints"
-  ],
-  "fetchlater": [
-    "fetch"
-  ],
-  "field-sizing": [
-    "css"
-  ],
-  "font-size-adjust": [
-    "fonts"
-  ],
-  "function": [
-    "css"
-  ],
-  "has": [
-    "selectors"
-  ],
-  "hidden-until-found": [
-    "html"
-  ],
-  "highlight": [],
-  "image-set": [
-    "css"
-  ],
-  "individual-transforms": [
-    "transforms"
-  ],
-  "inert": [
-    "html"
-  ],
-  "input-email-tel-url": [
-    "forms",
-    "html-elements"
-  ],
-  "inputmode": [],
-  "interest-invokers": [
-    "html"
+  "cubic-bezier-easing": [
+    "animation",
+    "transitions"
   ],
   "interpolate-size": [
     "animation",
     "transitions"
   ],
-  "intersection-observer": [],
-  "intl-duration-format": [
-    "intl"
-  ],
-  "invoker-commands": [],
-  "languagedetector": [],
-  "languagemodel": [],
-  "light-dark": [
-    "css"
-  ],
-  "linear-easing": [
-    "css"
-  ],
-  "link-rel-expect": [],
-  "link-rel-preload": [
-    "resource-hints"
-  ],
-  "long-animation-frames": [
-    "performance"
-  ],
-  "masks": [
-    "clipping-shapes-masking"
-  ],
-  "move-before": [
-    "dom"
-  ],
-  "mutationobserver": [
-    "dom"
-  ],
-  "navigation": [],
-  "not": [
-    "selectors"
-  ],
-  "overflow-clip": [
-    "css"
-  ],
-  "overflow-clip-margin": [
-    "css"
-  ],
-  "overlay": [
-    "css"
+  "overflow-anchor": [
+    "scrolling"
   ],
   "overscroll-behavior": [
     "scrolling"
   ],
-  "page-visibility": [],
-  "page-visibility-state": [
-    "performance"
+  "scroll-behavior": [
+    "scrolling"
   ],
-  "partitioned-cookies": [
-    "cookies"
+  "scroll-buttons": [
+    "scrolling"
   ],
-  "permissions-policy": [],
-  "popover": [
-    "html"
-  ],
-  "popover-hint": [
-    "html"
-  ],
-  "prefers-color-scheme": [
-    "media-queries"
-  ],
-  "prefers-contrast": [
-    "media-queries"
-  ],
-  "prefers-reduced-motion": [
-    "media-queries"
-  ],
-  "registered-custom-properties": [],
-  "resize-observer": [],
-  "scheduler": [],
   "scroll-driven-animations": [
     "animation",
     "scrolling"
   ],
-  "scroll-initial-target": [],
   "scroll-into-view": [
+    "scrolling"
+  ],
+  "scroll-into-view-container": [
     "scrolling"
   ],
   "scroll-snap": [
@@ -212,7 +50,13 @@
   "scroll-snap-events": [
     "scrolling"
   ],
+  "scroll-to-text-fragment": [
+    "scrolling"
+  ],
   "scrollbar-color": [
+    "scrolling"
+  ],
+  "scrollbar-gutter": [
     "scrolling"
   ],
   "scrollbar-width": [
@@ -221,46 +65,21 @@
   "scrollend": [
     "scrolling"
   ],
-  "sibling-count": [
-    "css"
+  "smil-svg-animations": [
+    "animation"
   ],
-  "speculation-rules": [],
-  "starting-style": [
-    "css"
+  "steps-easing": [
+    "animation",
+    "transitions"
   ],
-  "summarizer": [],
-  "svg": [
-    "image-formats",
-    "svg"
-  ],
-  "temporal": [
-    "javascript"
-  ],
-  "text-box": [
-    "text"
-  ],
-  "text-wrap": [
-    "text-wrap"
-  ],
-  "text-wrap-balance": [
-    "text-wrap"
-  ],
-  "text-wrap-pretty": [
-    "text-wrap"
-  ],
-  "top-level-await": [
-    "javascript"
+  "text-decoration-line-blink": [
+    "animation"
   ],
   "transition-behavior": [
     "transitions"
   ],
-  "translator": [],
-  "trig-functions": [
-    "css"
-  ],
-  "ua-client-hints": [],
-  "user-pseudos": [
-    "selectors"
+  "transitions": [
+    "transitions"
   ],
   "view-transition-class": [
     "view-transitions"
@@ -268,10 +87,16 @@
   "view-transitions": [
     "view-transitions"
   ],
+  "view-transitions-element-scoped": [
+    "view-transitions"
+  ],
   "web-animations": [
     "animation"
   ],
   "webauthn": [
+    "webauthn"
+  ],
+  "webauthn-public-key-easy": [
     "webauthn"
   ],
   "webauthn-signals": [

--- a/guides/feature-to-groups.generated.json
+++ b/guides/feature-to-groups.generated.json
@@ -44,10 +44,19 @@
   "scroll-into-view-container": [
     "scrolling"
   ],
+  "scroll-marker-targets": [
+    "scrolling"
+  ],
+  "scroll-markers": [
+    "scrolling"
+  ],
   "scroll-snap": [
     "scrolling"
   ],
   "scroll-snap-events": [
+    "scrolling"
+  ],
+  "scroll-target-group": [
     "scrolling"
   ],
   "scroll-to-text-fragment": [

--- a/guides/generate-codeowners.ts
+++ b/guides/generate-codeowners.ts
@@ -10,7 +10,7 @@ const ATL_CONFIG_PATH = path.join(__dirname, 'atls.json');
 const CODEOWNERS_PATH = path.join(REPO_ROOT, 'CODEOWNERS');
 
 import { scanAllGuides } from '../lib/guide-validation.ts';
-import { getFeatureGroups } from '../serving/lib/baseline.ts';
+import { getFeatureGroups, getOwnedFeatureToGroups } from '../serving/lib/baseline.ts';
 
 interface AtlConfig {
   default: Record<string, string | string[]>;
@@ -140,29 +140,12 @@ export function generateAtlBlock(config: AtlConfig): string {
   return lines.join('\n');
 }
 
-function getExpectedFeatureToGroups(): Record<string, string[]> {
-  const allGuides = scanAllGuides();
-  const featureToGroups: Record<string, string[]> = {};
-  for (const g of allGuides) {
-    if (g.featureIds) {
-      for (const fid of g.featureIds) {
-        featureToGroups[fid] = getFeatureGroups(fid);
-      }
-    }
-  }
-  // Sort keys and values for deterministic JSON output
-  const sorted: Record<string, string[]> = {};
-  for (const key of Object.keys(featureToGroups).sort()) {
-    sorted[key] = featureToGroups[key].sort();
-  }
-  return sorted;
-}
-
 export function updateCodeowners(checkOnly = false): boolean {
   const config = loadAtlConfig();
   const generatedBlock = generateAtlBlock(config);
 
-  const expectedFeatureToGroups = getExpectedFeatureToGroups();
+  const ownedGroups = new Set(Object.keys(config.web_features_groups));
+  const expectedFeatureToGroups = getOwnedFeatureToGroups(ownedGroups);
   const featureToGroupsPath = path.join(__dirname, 'feature-to-groups.generated.json');
   let currentFeatureToGroupsContent = '';
   try {

--- a/serving/lib/baseline.ts
+++ b/serving/lib/baseline.ts
@@ -1,4 +1,4 @@
-import { features } from 'web-features';
+import { features, groups } from 'web-features';
 import bcd from '@mdn/browser-compat-data' with { type: 'json' };
 import type { Browsers, BrowserName } from '@mdn/browser-compat-data';
 
@@ -187,15 +187,28 @@ export function getFeatureName(featureId: string): string {
   return feature.name;
 }
 
+/** A group plus its ancestors, most-specific first (`scroll-markers` → `["scroll-markers", "scrolling"]`). */
+export function getAncestorGroups(group: string): string[] {
+  const chain: string[] = [];
+  // Walk up the parent chain; the seen-check guards cycles.
+  for (let g: string | undefined = group; g && !chain.includes(g); g = (groups as any)[g]?.parent) {
+    chain.push(g);
+  }
+  return chain;
+}
+
 /**
- * Gets the group tags associated with a feature ID.
+ * A feature's group tags, flattened to include ancestors so owning a parent
+ * group covers its subtree (a `scroll-markers` feature also counts as `scrolling`).
+ * TEMP: child-vs-parent precedence unresolved (first-match, not most-specific).
  */
 export function getFeatureGroups(featureId: string): string[] {
   const feature = features[featureId] as any;
-  if (feature && feature.group) {
-    return Array.isArray(feature.group) ? feature.group : [feature.group];
+  if (!feature || !feature.group) {
+    return [];
   }
-  return [];
+  const immediate: string[] = Array.isArray(feature.group) ? feature.group : [feature.group];
+  return [...new Set(immediate.flatMap(getAncestorGroups))];
 }
 
 /**

--- a/serving/lib/baseline.ts
+++ b/serving/lib/baseline.ts
@@ -199,6 +199,19 @@ export function getFeatureGroups(featureId: string): string[] {
 }
 
 /**
+ * Maps each feature belonging to one of `ownedGroups` to the subset of those
+ * groups it belongs to (sorted). Features in none of the groups are omitted.
+ * @param ownedGroups - The group tags to index features by
+ */
+export function getOwnedFeatureToGroups(ownedGroups: Set<string>): Record<string, string[]> {
+  return Object.fromEntries(
+    Object.keys(features).sort()
+      .map(fid => [fid, getFeatureGroups(fid).filter(group => ownedGroups.has(group)).sort()])
+      .filter(([, featureGroups]) => featureGroups.length > 0)
+  ) as Record<string, string[]>;
+}
+
+/**
  * Validates a feature ID.
  */
 export function validateFeature(id: string): FeatureValidationResult {


### PR DESCRIPTION
Closes #1022.

Implements the fix detailed in #1022 as well as a temp workaround for #1029 which considers all groups. These live in separate commits.

### Notes

- No new package imports in `generate-codeowners.ts`; the `web-features` lookup lives in `serving/lib/baseline.ts` (the access layer) as `getOwnedFeatureToGroups()` + `getAncestorGroups()`.
- Cache output is deterministic (keys + values sorted) and independent of `web-features`' emit order.

### Size

Code: **+22 / −22** (net ~0), excluding the regenerated `feature-to-groups.generated.json` (data: +47 / −213) and comments.
