### PR TITLE
feat(evals): Base app evals Phase 3 refactoring and target calibration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,4 +108,4 @@ jobs:
 
       - name: Test Grader Calibration
         # Ensuring playwright is happy
-        run: node bin/gd.ts dev guides/visual-design/adapt-scrollbar-to-contrast-preferences/ --test-grader
+        run: node bin/gd.ts dev guides/css/size-aware-styling/ --test-grader

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,12 @@ jobs:
           fetch-depth: 0
       - run: git fetch --tags
 
-      # zizmor: ignore[unpinned-uses]
       - name: Setup pnpm
+        # zizmor: ignore[unpinned-uses]
         uses: pnpm/action-setup@v6
 
-      # zizmor: ignore[unpinned-uses]
       - name: Setup Node
+        # zizmor: ignore[unpinned-uses]
         uses: actions/setup-node@v6.4.0
         with:
           node-version: 24
@@ -76,12 +76,12 @@ jobs:
       - uses: actions/checkout@v7
       - run: git fetch --tags
 
-      # zizmor: ignore[unpinned-uses]
       - name: Setup pnpm
+        # zizmor: ignore[unpinned-uses]
         uses: pnpm/action-setup@v6
 
-      # zizmor: ignore[unpinned-uses]
       - name: Setup Node
+        # zizmor: ignore[unpinned-uses]
         uses: actions/setup-node@v6.4.0
         with:
           node-version: 24
@@ -94,8 +94,8 @@ jobs:
         id: playwright-version
         run: echo "version=$(pnpm list --filter eval-view --depth 0 playwright --json | jq -r '.[0].devDependencies.playwright.version')" >> $GITHUB_OUTPUT
 
-      # zizmor: ignore[unpinned-uses]
       - name: Cache Playwright Browsers
+        # zizmor: ignore[unpinned-uses]
         uses: actions/cache@v4
         id: playwright-cache
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
           # Needed for tag history
@@ -24,10 +24,10 @@ jobs:
       - run: git fetch --tags
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node
-        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: 24
           cache: 'pnpm'
@@ -72,16 +72,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - run: git fetch --tags
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node
-        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: 24
           cache: 'pnpm'
@@ -94,7 +94,7 @@ jobs:
         run: echo "version=$(pnpm list --filter eval-view --depth 0 playwright --json | jq -r '.[0].devDependencies.playwright.version')" >> $GITHUB_OUTPUT
 
       - name: Cache Playwright Browsers
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        uses: actions/cache@v4
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           # Needed for tag history
@@ -24,10 +24,10 @@ jobs:
       - run: git fetch --tags
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@ff378ebe6b225b0680b81c1ad4498ae0d1d3a5e3 # v6.0.10
 
       - name: Setup Node
-        uses: actions/setup-node@v6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: 'pnpm'
@@ -72,16 +72,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - run: git fetch --tags
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@ff378ebe6b225b0680b81c1ad4498ae0d1d3a5e3 # v6.0.10
 
       - name: Setup Node
-        uses: actions/setup-node@v6.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: 'pnpm'
@@ -94,7 +94,7 @@ jobs:
         run: echo "version=$(pnpm list --filter eval-view --depth 0 playwright --json | jq -r '.[0].devDependencies.playwright.version')" >> $GITHUB_OUTPUT
 
       - name: Cache Playwright Browsers
-        uses: actions/cache@v4
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,11 @@ jobs:
 
 
       - name: Compare built (post-macro) guides 
+        env:
+          BASE_REF: ${{ github.base_ref || github.event.repository.default_branch }}
         run: |
           pnpm --filter serving build
-          REPORT_OUTPUT_PATH=/tmp/built-guides-diff.md node serving/scripts/compare-built-guides.ts --base-ref "origin/${{ github.base_ref || github.event.repository.default_branch }}"
+          REPORT_OUTPUT_PATH=/tmp/built-guides-diff.md node serving/scripts/compare-built-guides.ts --base-ref "origin/${BASE_REF}"
           if [ -f /tmp/built-guides-diff.md ]; then
             cat /tmp/built-guides-diff.md >> $GITHUB_STEP_SUMMARY
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # zizmor: ignore[unpinned-uses]
       - uses: actions/checkout@v7
         with:
           # Needed for tag history
           fetch-depth: 0
       - run: git fetch --tags
 
+      # zizmor: ignore[unpinned-uses]
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
 
+      # zizmor: ignore[unpinned-uses]
       - name: Setup Node
         uses: actions/setup-node@v6.4.0
         with:
@@ -69,12 +72,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # zizmor: ignore[unpinned-uses]
       - uses: actions/checkout@v7
       - run: git fetch --tags
 
+      # zizmor: ignore[unpinned-uses]
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
 
+      # zizmor: ignore[unpinned-uses]
       - name: Setup Node
         uses: actions/setup-node@v6.4.0
         with:
@@ -88,6 +94,7 @@ jobs:
         id: playwright-version
         run: echo "version=$(pnpm list --filter eval-view --depth 0 playwright --json | jq -r '.[0].devDependencies.playwright.version')" >> $GITHUB_OUTPUT
 
+      # zizmor: ignore[unpinned-uses]
       - name: Cache Playwright Browsers
         uses: actions/cache@v4
         id: playwright-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - run: git fetch --tags
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@0c17529a66aca453f9227af23103ed11469b1e47 # v4.0.0
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
       - name: Setup Node
         uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
@@ -78,7 +78,7 @@ jobs:
       - run: git fetch --tags
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@0c17529a66aca453f9227af23103ed11469b1e47 # v4.0.0
+        uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
 
       - name: Setup Node
         uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -18,6 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          persist-credentials: false
           # Needed for tag history
           fetch-depth: 0
       - run: git fetch --tags
@@ -72,6 +73,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - run: git fetch --tags
 
       - name: Setup pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
       - run: git fetch --tags
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@fe8c92019f6285b7e11d04499d14660ebfe12403 # v4.0.0
+        uses: pnpm/action-setup@0c17529a66aca453f9227af23103ed11469b1e47 # v4.0.0
 
       - name: Setup Node
-        uses: actions/setup-node@39370e3970a6d050c38000417b35111b15e47854 # v4.2.0
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
           node-version: 24
           cache: 'pnpm'
@@ -73,10 +73,10 @@ jobs:
       - run: git fetch --tags
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@fe8c92019f6285b7e11d04499d14660ebfe12403 # v4.0.0
+        uses: pnpm/action-setup@0c17529a66aca453f9227af23103ed11469b1e47 # v4.0.0
 
       - name: Setup Node
-        uses: actions/setup-node@39370e3970a6d050c38000417b35111b15e47854 # v4.2.0
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
           node-version: 24
           cache: 'pnpm'
@@ -89,7 +89,7 @@ jobs:
         run: echo "version=$(pnpm list --filter eval-view --depth 0 playwright --json | jq -r '.[0].devDependencies.playwright.version')" >> $GITHUB_OUTPUT
 
       - name: Cache Playwright Browsers
-        uses: actions/cache@d4323d45544a70650ed686153723337a7b8e19e0 # v4.2.0
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - run: git fetch --tags
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@ff378ebe6b225b0680b81c1ad4498ae0d1d3a5e3 # v6.0.10
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -78,7 +78,7 @@ jobs:
       - run: git fetch --tags
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@ff378ebe6b225b0680b81c1ad4498ae0d1d3a5e3 # v6.0.10
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,20 +16,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # zizmor: ignore[unpinned-uses]
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           # Needed for tag history
           fetch-depth: 0
       - run: git fetch --tags
 
       - name: Setup pnpm
-        # zizmor: ignore[unpinned-uses]
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@fe8c92019f6285b7e11d04499d14660ebfe12403 # v4.0.0
 
       - name: Setup Node
-        # zizmor: ignore[unpinned-uses]
-        uses: actions/setup-node@v6.4.0
+        uses: actions/setup-node@39370e3970a6d050c38000417b35111b15e47854 # v4.2.0
         with:
           node-version: 24
           cache: 'pnpm'
@@ -72,17 +69,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # zizmor: ignore[unpinned-uses]
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - run: git fetch --tags
 
       - name: Setup pnpm
-        # zizmor: ignore[unpinned-uses]
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@fe8c92019f6285b7e11d04499d14660ebfe12403 # v4.0.0
 
       - name: Setup Node
-        # zizmor: ignore[unpinned-uses]
-        uses: actions/setup-node@v6.4.0
+        uses: actions/setup-node@39370e3970a6d050c38000417b35111b15e47854 # v4.2.0
         with:
           node-version: 24
           cache: 'pnpm'
@@ -95,8 +89,7 @@ jobs:
         run: echo "version=$(pnpm list --filter eval-view --depth 0 playwright --json | jq -r '.[0].devDependencies.playwright.version')" >> $GITHUB_OUTPUT
 
       - name: Cache Playwright Browsers
-        # zizmor: ignore[unpinned-uses]
-        uses: actions/cache@v4
+        uses: actions/cache@d4323d45544a70650ed686153723337a7b8e19e0 # v4.2.0
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright

--- a/bin/gd.ts
+++ b/bin/gd.ts
@@ -90,7 +90,7 @@ completion.on('arg1', ({ before, line, reply }) => {
     const tasks = Array.from(getTaskMap().keys());
     reply(['suite', ...tasks, ...listGuideDirs(), ...flags]);
   } else if (before === 'gen') {
-    reply(['grader', 'negative']);
+    reply(['grader']);
   } else if (before === 'audit') {
     reply(flags);
   } else if (['dev', 'test', 'grade'].includes(before)) {
@@ -110,7 +110,7 @@ completion.on('arg2', ({ before, line, reply }) => {
     if (fs.existsSync(baseAppsDir)) {
       reply(fs.readdirSync(baseAppsDir).filter(d => fs.statSync(path.join(baseAppsDir, d)).isDirectory()));
     }
-  } else if (['grader', 'negative'].includes(before) && line.includes('gen')) {
+  } else if (before === 'grader' && line.includes('gen')) {
     reply(listGuideDirs());
   } else {
     reply(flags);
@@ -233,15 +233,10 @@ async function main() {
 
     case 'dev': {
       const dir = requireArg(positionals[1], 'gd dev <path/to/guide>');
-      if (values.grade) {
-        const { gradeFile } = await import('../guides/run-grader.ts');
-        await gradeFile(path.resolve(process.cwd(), dir));
-        break;
-      }
-      if (values['test-grader']) {
-        const { testGrader } = await import('../guides/test-grader.ts');
-        const result = await testGrader(dir);
-        process.exit(result.success ? 0 : 1);
+      if (values.grade || values['test-grader']) {
+        const { testGrader } = await import('../guides/run-grader.ts');
+        const res = await testGrader(dir);
+        process.exit(res.success ? 0 : 1);
       }
       if (values['gen-grader']) {
         const { generateGrader } = await import('../guides/grader-gen.ts');
@@ -366,8 +361,8 @@ async function main() {
         console.error(cRed("'gd grade' has moved.") + "  Run: " + cCyan("gd dev <guide_dir> --grade") + "\n");
       } else if (['test', 'test-grader'].includes(command)) {
         console.error(cRed("'gd test' has moved.") + "  Run: " + cCyan("gd dev <guide_dir> --test-grader") + "\n");
-      } else if (['gen', 'gen-grader', 'gen-negative', 'gen:grader', 'gen:negative'].includes(command)) {
-        console.error(cRed("'gd " + command + "' has moved.") + "  Run: " + cCyan("gd dev <guide_dir> --gen-grader") + " or " + cCyan("--gen-negative") + "\n");
+      } else if (['gen', 'gen-grader', 'gen:grader'].includes(command)) {
+        console.error(cRed("'gd " + command + "' has moved.") + "  Run: " + cCyan("gd dev <guide_dir> --gen-grader") + "\n");
       } else {
         console.error(cRed("Unknown command: " + command + ".") + " Run " + cCyan("gd --help") + " for usage.");
       }

--- a/bin/gd.ts
+++ b/bin/gd.ts
@@ -236,6 +236,9 @@ async function main() {
       if (values.grade || values['test-grader']) {
         const { testGrader } = await import('../guides/run-grader.ts');
         const res = await testGrader(dir);
+        if (!res.success && res.errorDetails) {
+          console.error(cRed(`\nCalibration Error:\n${res.errorDetails}`));
+        }
         process.exit(res.success ? 0 : 1);
       }
       if (values['gen-grader']) {

--- a/guides/dev-guide.ts
+++ b/guides/dev-guide.ts
@@ -4,22 +4,17 @@ import { fileURLToPath } from 'url';
 import { rootDir, baseAppsDir } from '../lib/paths.ts';
 import { testGrader, runPlaywright, type CalibrationResult } from './run-grader.ts';
 import { generateTargetGrader } from './grader-gen.ts';
-import {
-  createIsolatedHome,
-  cleanupIsolatedHome,
-  spawnAsync
-} from '../harness/lib/agent-shared.ts';
+import { spawnAsync } from '../harness/lib/agent-shared.ts';
 import { defaultSuiteConfig, Serving, Agents, type SuiteConfig } from '../harness/config.ts';
 import { collectGuidesUsed } from '../harness/lib/guidance_validation.ts';
-import { setupIsolatedWorkDir, runAgent } from './lib/utils.ts';
+import { setupIsolatedWorkDir, runAgent, stageBaseAppWorkspace } from './lib/utils.ts';
 import {
   buildSolutionPrompt,
   buildZeroPassratePrompt,
   buildTargetTaskPrompt,
 } from './gd-dev-prompts.ts';
 import { cRed, cGreen, cYellow, cCyan, cBold, cDim } from '../lib/colors.ts';
-import { execSync } from 'node:child_process';
-import { capturePatchFromGit, applyPatchSync } from '../lib/patch-utils.ts';
+import { capturePatchFromGit, initGitRepo } from '../lib/patch-utils.ts';
 import {
   type GuideInventory,
   type GuideStatus,
@@ -186,7 +181,7 @@ async function generateTargetPatch(guideDirAbs: string, baseApp: string, patchTy
     fs.copyFileSync(path.join(guideDirAbs, EXPECTATIONS_FILE), path.join(workDir, EXPECTATIONS_FILE));
 
     // Git init is required for capturePatchFromGit to extract git diffs
-    execSync('git init && git config user.name "AI" && git config user.email "ai@example.com" && git add . && git commit -m "init"', { cwd: workDir, stdio: 'ignore' });
+    initGitRepo(workDir);
 
     const prompt = patchType === 'solution'
       ? buildSolutionPrompt({ guideFile: GUIDE_FILE, expectationsFile: EXPECTATIONS_FILE, workDir })
@@ -289,25 +284,15 @@ async function runAgentTest(targetDir: string, guideName: string, guidedOnly = f
     const results: Record<string, { passed: number; total: number }> = {};
 
     // 1. Grade base app (with zero-passrate baseline applied)
-    const baseAppDir = path.join(baseAppsDir, baseApp);
-    if (fs.existsSync(baseAppDir)) {
-      const tempHome = createIsolatedHome(`gd-pre-grade-${baseApp}`);
-      try {
-        const stagingDir = path.join(tempHome, baseApp);
-        fs.cpSync(baseAppDir, stagingDir, { recursive: true });
-        const zeroPassratePatch = path.join(targetsDir, baseApp, ZERO_PASSRATE_PATCH_FILE);
-        if (fs.existsSync(zeroPassratePatch)) {
-          applyPatchSync(stagingDir, zeroPassratePatch);
-          process.env.PATCH_FILE = zeroPassratePatch;
-        } else {
-          process.env.PATCH_FILE = path.join(targetsDir, baseApp, SOLUTION_PATCH_FILE);
-        }
-        const preResults = await gradeOutput(stagingDir, targetGraderPath, path.join(targetDir, 'test-app-results', baseApp, 'pre-grade-report'));
-        delete process.env.PATCH_FILE;
-        if (preResults) results['pre'] = preResults;
-      } finally {
-        cleanupIsolatedHome(tempHome);
-      }
+    const zeroPassratePatch = path.join(targetsDir, baseApp, ZERO_PASSRATE_PATCH_FILE);
+    const patchToApply = fs.existsSync(zeroPassratePatch) ? zeroPassratePatch : undefined;
+
+    const { workDir: stagingDir, cleanup } = stageBaseAppWorkspace(baseApp, patchToApply, `gd-pre-grade-${baseApp}`);
+    try {
+      const preResults = await gradeOutput(stagingDir, targetGraderPath, path.join(targetDir, 'test-app-results', baseApp, 'pre-grade-report'));
+      if (preResults) results['pre'] = preResults;
+    } finally {
+      cleanup();
     }
 
     // 2. Run agent suite
@@ -330,13 +315,11 @@ async function runAgentTest(targetDir: string, guideName: string, guidedOnly = f
       const resultDir = path.join(testOutputDir, '1', guideName, baseApp, runType);
       if (!fs.existsSync(resultDir)) continue;
 
-      process.env.PATCH_FILE = path.join(resultDir, 'agent.patch');
       const gradeResults = await gradeOutput(
         resultDir,
         targetGraderPath,
         path.join(resultDir, 'grade-report')
       );
-      delete process.env.PATCH_FILE;
       if (gradeResults) results[runType] = gradeResults;
     }
 

--- a/guides/dev-guide.ts
+++ b/guides/dev-guide.ts
@@ -145,14 +145,14 @@ export async function devGuide(targetDirRaw: string, options: DevGuideOptions = 
     console.log(cCyan(`\n--- Calibrating target: ${baseApp} ---`));
     let success = false;
     for (let attempt = 1; attempt <= maxRetries + 1; attempt++) {
-      const res = await testGrader(targetDirRaw, baseApp);
+      const res = await testGrader(path.join(targetDirRaw, TARGETS_DIR, baseApp));
       if (res.success) {
         console.log(cGreen(`✅ ${baseApp} calibrated successfully on attempt ${attempt}!`));
         success = true;
         break;
       }
 
-      if (res.stage === 'calibration' && attempt <= maxRetries) {
+      if (attempt <= maxRetries) {
         console.log(cYellow(`Attempt ${attempt} calibration failed for ${baseApp}. Regenerating ${GRADER_FILE}...`));
         await generateTargetGrader(targetDir, baseApp, res.errorDetails);
       } else {
@@ -169,7 +169,7 @@ export async function devGuide(targetDirRaw: string, options: DevGuideOptions = 
   }
 
   // Summary
-  printSummary(targetDir, currentInv, { success: overallSuccess, demo: { passed: 0, failed: 0, failingTests: [] }, negative: { passed: 0, failed: 0, passingTests: [] } }, 1);
+  printSummary(targetDir, currentInv, { success: overallSuccess, solution: { passed: 0, failed: 0, failingTests: [] }, zeroPassrate: { passed: 0, failed: 0, passingTests: [] } }, 1);
 
   return overallSuccess;
 }

--- a/guides/gd-dev-prompts.ts
+++ b/guides/gd-dev-prompts.ts
@@ -151,7 +151,6 @@ Generate a \`${opts.taskFile}\` file containing exactly one realistic, high-leve
 6. **Directive Action Request**: Phrase the prompt as an ACTION REQUEST or directive (e.g., "add X", "can you build Y"). NEVER phrase it as an advisory question (e.g., "how can I?", "what's the best way to?") — the agent must implement, not just explain.
 7. **No Fallbacks**: Do NOT mention or mandate legacy fallbacks in the prompt.
 8. **No Internal Project References**: Do NOT name the guide itself or indicate that guidance exists.
-9. **Encourage Existing Code Integration**: If the feature modifies or enhances an existing layout, card, component, or behavior already visible in the base app, the prompt MUST ask the agent to "upgrade", "refactor", or "modify" the existing components/pages rather than building a new isolated component/page from scratch.
 
 # INSTRUCTION
 When writing files, you MUST use your built-in structured file editing tools (e.g., write_file or replace). Do not use shell commands (like cat, echo, or heredocs <<) to create files in the terminal.`;

--- a/guides/gd-dev-prompts.ts
+++ b/guides/gd-dev-prompts.ts
@@ -94,7 +94,7 @@ Write a Playwright test script named \`${opts.graderFile}\` that directly valida
 1. **Standard Guidance**: \`${opts.guideFile}\`
 2. **Requirements**: \`${opts.expectationsFile}\`
 3. **Golden Solution Diff**: \`${opts.solutionPatchFile}\` (must pass 100% of tests)
-4. **Anti-Pattern Zero-Passrate Diff**: \`${opts.zeroPassratePatchFile}\` (must fail 100% of negative/must-fail tests)
+4. **Anti-Pattern Zero-Passrate Diff**: \`${opts.zeroPassratePatchFile}\` (must fail 100% of tests)
 5. **Boilerplate Template**: \`${opts.templateFile}\`
 
 # VERIFICATION & SCOPING RULES

--- a/guides/grader-gen.ts
+++ b/guides/grader-gen.ts
@@ -15,7 +15,6 @@ import {
   SUPPORTED_BASE_APPS
 } from '../lib/guide-validation.ts';
 import { cCyan, cGreen } from '../lib/colors.ts';
-import type { CalibrationResult } from './run-grader.ts';
 
 export async function generateTargetGrader(guideDirAbs: string, baseApp: string, failureContext?: string): Promise<void> {
   const repoRoot = path.resolve(import.meta.dirname, '..');
@@ -123,30 +122,6 @@ export async function generateGrader(targetDirRaw: string, baseApp?: string): Pr
     console.log(cCyan(`\n--- Generating ${GRADER_FILE} for target base app: ${app} ---`));
     await generateTargetGrader(targetDirAbs, app);
     console.log(cGreen(`✅ ${GRADER_FILE} generated for ${app}`));
-  }
-}
-
-export async function generateGraderWithContext(targetDirRaw: string, failureContextStrOrRes: string | CalibrationResult, baseApp?: string): Promise<void> {
-  const targetDirAbs = path.resolve(process.cwd(), targetDirRaw);
-  if (!fs.existsSync(targetDirAbs)) {
-    throw new Error(`Directory not found: ${targetDirAbs}`);
-  }
-
-  let failureContextStr: string;
-  if (typeof failureContextStrOrRes === 'string') {
-    failureContextStr = failureContextStrOrRes;
-  } else {
-    const lines: string[] = [];
-    if (failureContextStrOrRes.errorDetails) lines.push(failureContextStrOrRes.errorDetails);
-    if (failureContextStrOrRes.solution.failingTests.length > 0) lines.push(`Solution patch tests failed: ${failureContextStrOrRes.solution.failingTests.join(', ')}`);
-    if (failureContextStrOrRes.zeroPassrate.passingTests.length > 0) lines.push(`Zero-passrate patch tests incorrectly passed: ${failureContextStrOrRes.zeroPassrate.passingTests.join(', ')}`);
-    failureContextStr = lines.join('\n');
-  }
-
-  const apps = baseApp ? [baseApp] : SUPPORTED_BASE_APPS;
-  for (const app of apps) {
-    console.log(cCyan(`\n--- Regenerating ${GRADER_FILE} with context for target: ${app} ---`));
-    await generateTargetGrader(targetDirAbs, app, failureContextStr);
   }
 }
 

--- a/guides/grader-gen.ts
+++ b/guides/grader-gen.ts
@@ -138,8 +138,8 @@ export async function generateGraderWithContext(targetDirRaw: string, failureCon
   } else {
     const lines: string[] = [];
     if (failureContextStrOrRes.errorDetails) lines.push(failureContextStrOrRes.errorDetails);
-    if (failureContextStrOrRes.demo.failingTests.length > 0) lines.push(`Golden tests failed: ${failureContextStrOrRes.demo.failingTests.join(', ')}`);
-    if (failureContextStrOrRes.negative.passingTests.length > 0) lines.push(`Negative tests passed: ${failureContextStrOrRes.negative.passingTests.join(', ')}`);
+    if (failureContextStrOrRes.solution.failingTests.length > 0) lines.push(`Solution patch tests failed: ${failureContextStrOrRes.solution.failingTests.join(', ')}`);
+    if (failureContextStrOrRes.zeroPassrate.passingTests.length > 0) lines.push(`Zero-passrate patch tests incorrectly passed: ${failureContextStrOrRes.zeroPassrate.passingTests.join(', ')}`);
     failureContextStr = lines.join('\n');
   }
 

--- a/guides/lib/utils.ts
+++ b/guides/lib/utils.ts
@@ -2,7 +2,7 @@ import { spawn } from 'node:child_process';
 import path from 'node:path';
 import fs from 'node:fs';
 import config from '../../harness/config.ts';
-import { rootDir, baseAppsDir, guidesDir } from '../../lib/paths.ts';
+import { rootDir, baseAppsDir } from '../../lib/paths.ts';
 import { applyPatchSync } from '../../lib/patch-utils.ts';
 import {
   createIsolatedHome,
@@ -24,17 +24,7 @@ export function stageBaseAppWorkspace(
 
   const refBaseAppDir = path.join(baseAppsDir, baseApp);
   if (fs.existsSync(refBaseAppDir)) {
-    fs.cpSync(refBaseAppDir, workDir, {
-      recursive: true,
-      filter: (src) => !src.includes('node_modules'),
-    });
-  }
-
-  const sourceNodeModules = path.join(refBaseAppDir, 'node_modules');
-  if (fs.existsSync(sourceNodeModules)) {
-    try {
-      fs.symlinkSync(sourceNodeModules, path.join(workDir, 'node_modules'));
-    } catch (e) {}
+    fs.cpSync(refBaseAppDir, workDir, { recursive: true });
   }
 
   if (patchFile && fs.existsSync(patchFile)) {

--- a/guides/lib/utils.ts
+++ b/guides/lib/utils.ts
@@ -30,10 +30,10 @@ export function stageBaseAppWorkspace(
     });
   }
 
-  const hostGuidesNodeModules = path.join(guidesDir, 'node_modules');
-  if (fs.existsSync(hostGuidesNodeModules)) {
+  const sourceNodeModules = path.join(refBaseAppDir, 'node_modules');
+  if (fs.existsSync(sourceNodeModules)) {
     try {
-      fs.symlinkSync(hostGuidesNodeModules, path.join(workDir, 'node_modules'));
+      fs.symlinkSync(sourceNodeModules, path.join(workDir, 'node_modules'));
     } catch (e) {}
   }
 

--- a/guides/lib/utils.ts
+++ b/guides/lib/utils.ts
@@ -2,14 +2,55 @@ import { spawn } from 'node:child_process';
 import path from 'node:path';
 import fs from 'node:fs';
 import config from '../../harness/config.ts';
-import { rootDir } from '../../lib/paths.ts';
+import { rootDir, baseAppsDir, guidesDir } from '../../lib/paths.ts';
+import { applyPatchSync } from '../../lib/patch-utils.ts';
 import {
   createIsolatedHome,
+  cleanupIsolatedHome,
   createTrustedFolders,
   spawnAsync,
 } from '../../harness/lib/agent-shared.ts';
 import { setupJetskiCliCredentials } from '../../harness/agents/jetski-cli-agent.ts';
 import { setupGeminiCliCredentials } from '../../harness/agents/gemini-cli-agent.ts';
+
+export function stageBaseAppWorkspace(
+  baseApp: string,
+  patchFile?: string,
+  prefix: string = 'grade-run'
+): { workDir: string; cleanup: () => void } {
+  const tempHome = createIsolatedHome(prefix);
+  const workDir = path.join(tempHome, baseApp);
+  fs.mkdirSync(workDir, { recursive: true });
+
+  const refBaseAppDir = path.join(baseAppsDir, baseApp);
+  if (fs.existsSync(refBaseAppDir)) {
+    fs.cpSync(refBaseAppDir, workDir, {
+      recursive: true,
+      filter: (src) => !src.includes('node_modules'),
+    });
+  }
+
+  const hostGuidesNodeModules = path.join(guidesDir, 'node_modules');
+  if (fs.existsSync(hostGuidesNodeModules)) {
+    try {
+      fs.symlinkSync(hostGuidesNodeModules, path.join(workDir, 'node_modules'));
+    } catch (e) {}
+  }
+
+  if (patchFile && fs.existsSync(patchFile)) {
+    if (fs.readFileSync(patchFile, 'utf8').trim().length > 0) {
+      applyPatchSync(workDir, patchFile);
+    }
+  }
+
+  const cleanup = () => {
+    try {
+      cleanupIsolatedHome(tempHome);
+    } catch (e) {}
+  };
+
+  return { workDir, cleanup };
+}
 
 export async function runCommand(command: string, args: string[], cwd?: string): Promise<string> {
   return new Promise((resolve, reject) => {

--- a/guides/playwright.config.ts
+++ b/guides/playwright.config.ts
@@ -39,7 +39,7 @@ export default defineConfig({
       name: 'chromium',
       use: {
         ...devices['Desktop Chrome'],
-        channel: 'chrome', // Force usage of system Chrome to avoid EPERM on macOS
+        ...(process.platform === 'darwin' ? { channel: 'chrome' } : {}), // Force usage of system Chrome on macOS to avoid EPERM
       },
     },
   ],

--- a/guides/run-grader.ts
+++ b/guides/run-grader.ts
@@ -82,6 +82,7 @@ export async function runPlaywright(
   }
 
   try {
+    let stderrData = '';
     const child = executePlaywright({
       targetPathAbs: effectiveTargetPath,
       graderPath,
@@ -89,8 +90,14 @@ export async function runPlaywright(
       htmlOutputDir,
       jsonOutputName: tmpJson,
       patchFile: hasPatch ? agentPatch : undefined,
-      stdio
+      stdio: stdio === 'ignore' ? 'pipe' : stdio
     });
+
+    if (child.stderr) {
+      child.stderr.on('data', (data) => {
+        stderrData += data.toString();
+      });
+    }
 
     await once(child, 'close');
 
@@ -100,7 +107,7 @@ export async function runPlaywright(
 
     const content = await fs.promises.readFile(tmpJson, 'utf-8').catch(() => null);
     if (!content) {
-      throw new Error(`Playwright did not produce a JSON report at ${tmpJson}`);
+      throw new Error(`Playwright did not produce a JSON report at ${tmpJson}.\nStderr: ${stderrData}`);
     }
 
     await fs.promises.unlink(tmpJson).catch(() => {});

--- a/guides/run-grader.ts
+++ b/guides/run-grader.ts
@@ -5,11 +5,10 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { guidesDir, baseAppsDir } from '../lib/paths.ts';
-import { cRed, cGreen, cYellow, cCyan, cBold } from '../lib/colors.ts';
+import { guidesDir, rootDir } from '../lib/paths.ts';
+import { cRed, cYellow, cCyan } from '../lib/colors.ts';
 import { TARGETS_DIR, SOLUTION_PATCH_FILE, ZERO_PASSRATE_PATCH_FILE, GRADER_FILE, getSupportedBaseApps } from '../lib/guide-validation.ts';
-import { applyPatchSync } from '../lib/patch-utils.ts';
-import { setupIsolatedWorkDir } from './lib/utils.ts';
+import { stageBaseAppWorkspace } from './lib/utils.ts';
 
 export interface PlaywrightOptions {
   targetPathAbs: string;
@@ -17,6 +16,7 @@ export interface PlaywrightOptions {
   reporters: string[];
   htmlOutputDir?: string;
   jsonOutputName?: string;
+  patchFile?: string;
   stdio?: 'inherit' | 'ignore' | 'pipe';
 }
 
@@ -33,6 +33,10 @@ export function executePlaywright(opts: PlaywrightOptions): ChildProcess {
     PLAYWRIGHT_HTML_OPEN: 'never',
   };
 
+  if (opts.patchFile) {
+    env.PATCH_FILE = path.resolve(opts.patchFile);
+  }
+
   if (opts.htmlOutputDir) {
     env.PLAYWRIGHT_HTML_OUTPUT_DIR = opts.htmlOutputDir;
     env.PLAYWRIGHT_OUTPUT_DIR = path.join(appDir, 'test-results');
@@ -42,7 +46,7 @@ export function executePlaywright(opts: PlaywrightOptions): ChildProcess {
     env.PLAYWRIGHT_JSON_OUTPUT_NAME = opts.jsonOutputName;
   }
 
-  const playwrightBin = path.join(guidesDir, 'node_modules', '.bin', 'playwright');
+  const playwrightBin = path.join(rootDir, 'node_modules', '.bin', 'playwright');
 
   return spawn(playwrightBin, ['test', '-c', playwrightConfig, opts.graderPath, ...reporterArgs], {
     cwd: appDir,
@@ -59,28 +63,53 @@ export async function runPlaywright(
 ): Promise<any> {
   const tmpJson = path.join(os.tmpdir(), `pw-results-${Date.now()}-${Math.random().toString(36).substring(7)}.json`);
 
-  const child = executePlaywright({
-    targetPathAbs,
-    graderPath,
-    reporters: ['json', 'html'],
-    htmlOutputDir,
-    jsonOutputName: tmpJson,
-    stdio
-  });
+  const isDir = fs.existsSync(targetPathAbs) && fs.statSync(targetPathAbs).isDirectory();
+  const appDir = isDir ? targetPathAbs : path.dirname(targetPathAbs);
+  const agentPatch = path.join(appDir, 'agent.patch');
+  let effectiveTargetPath = targetPathAbs;
+  let cleanupGradingDir: (() => void) | null = null;
 
-  await once(child, 'close');
-
-  const appDir = fs.existsSync(targetPathAbs) && fs.statSync(targetPathAbs).isDirectory() ? targetPathAbs : path.dirname(targetPathAbs);
-  const testResultsDir = path.join(appDir, 'test-results');
-  await fs.promises.rm(testResultsDir, { recursive: true, force: true }).catch(() => {});
-
-  const content = await fs.promises.readFile(tmpJson, 'utf-8').catch(() => null);
-  if (!content) {
-    throw new Error(`Playwright did not produce a JSON report at ${tmpJson}`);
+  const hasPatch = fs.existsSync(agentPatch);
+  if (hasPatch) {
+    const targetsMatch = graderPath.match(/targets[/\\]([^/\\]+)/);
+    if (!targetsMatch) {
+      throw new Error(`Could not determine target baseApp from grader path: ${graderPath}`);
+    }
+    const baseApp = targetsMatch[1];
+    const { workDir: tempGradingDir, cleanup } = stageBaseAppWorkspace(baseApp, agentPatch);
+    cleanupGradingDir = cleanup;
+    effectiveTargetPath = isDir ? tempGradingDir : path.join(tempGradingDir, path.basename(targetPathAbs));
   }
 
-  await fs.promises.unlink(tmpJson).catch(() => {});
-  return JSON.parse(content);
+  try {
+    const child = executePlaywright({
+      targetPathAbs: effectiveTargetPath,
+      graderPath,
+      reporters: ['json', 'html'],
+      htmlOutputDir,
+      jsonOutputName: tmpJson,
+      patchFile: hasPatch ? agentPatch : undefined,
+      stdio
+    });
+
+    await once(child, 'close');
+
+    const effectiveAppDir = fs.existsSync(effectiveTargetPath) && fs.statSync(effectiveTargetPath).isDirectory() ? effectiveTargetPath : path.dirname(effectiveTargetPath);
+    const testResultsDir = path.join(effectiveAppDir, 'test-results');
+    await fs.promises.rm(testResultsDir, { recursive: true, force: true }).catch(() => {});
+
+    const content = await fs.promises.readFile(tmpJson, 'utf-8').catch(() => null);
+    if (!content) {
+      throw new Error(`Playwright did not produce a JSON report at ${tmpJson}`);
+    }
+
+    await fs.promises.unlink(tmpJson).catch(() => {});
+    return JSON.parse(content);
+  } finally {
+    if (cleanupGradingDir) {
+      cleanupGradingDir();
+    }
+  }
 }
 
 async function runPlaywrightCalibration(
@@ -222,16 +251,9 @@ export async function testTargetGrader(guideDirAbs: string, baseApp: string): Pr
   const zeroPassrateOutDir = path.join(targetDir, 'grade-report', 'zero-passrate');
 
   // Golden calibration
-  const goldenSandbox = setupIsolatedWorkDir(`gd-cal-${baseApp}-sol`);
+  const { workDir: goldenSandbox, cleanup: cleanupGolden } = stageBaseAppWorkspace(baseApp, solutionPatch, `gd-cal-${baseApp}-sol`);
   let unexpected = 0;
   try {
-    fs.cpSync(path.join(baseAppsDir, baseApp), goldenSandbox, { recursive: true });
-    const applyRes = applyPatchSync(goldenSandbox, solutionPatch);
-    if (!applyRes.success) {
-      result.errorDetails = `Failed to apply ${SOLUTION_PATCH_FILE}: ${applyRes.error}`;
-      return result;
-    }
-
     console.log(cYellow(`\nRunning against ${baseApp} with ${SOLUTION_PATCH_FILE}... (Expecting 100% pass)`));
     const solutionResults = await runPlaywrightCalibration(goldenSandbox, graderPath, solutionOutDir, solutionPatch, result);
 
@@ -257,21 +279,14 @@ export async function testTargetGrader(guideDirAbs: string, baseApp: string): Pr
     if (unexpected > 0) {
       console.log(cYellow(`⚠️  Calibration failed. Keeping golden sandbox directory for debugging: ${goldenSandbox}`));
     } else {
-      fs.rmSync(goldenSandbox, { recursive: true, force: true });
+      cleanupGolden();
     }
   }
 
   // Zero-passrate calibration
-  const zeroPassrateSandbox = setupIsolatedWorkDir(`gd-cal-${baseApp}-zp`);
+  const { workDir: zeroPassrateSandbox, cleanup: cleanupZeroPassrate } = stageBaseAppWorkspace(baseApp, zeroPassratePatch, `gd-cal-${baseApp}-zp`);
   let passed = 0;
   try {
-    fs.cpSync(path.join(baseAppsDir, baseApp), zeroPassrateSandbox, { recursive: true });
-    const applyRes = applyPatchSync(zeroPassrateSandbox, zeroPassratePatch);
-    if (!applyRes.success) {
-      result.errorDetails = `Failed to apply ${ZERO_PASSRATE_PATCH_FILE}: ${applyRes.error}`;
-      return result;
-    }
-
     console.log(cYellow(`Running against ${baseApp} with ${ZERO_PASSRATE_PATCH_FILE}... (Expecting 100% fail)`));
     const zeroPassrateResults = await runPlaywrightCalibration(zeroPassrateSandbox, graderPath, zeroPassrateOutDir, zeroPassratePatch, result);
 
@@ -297,7 +312,7 @@ export async function testTargetGrader(guideDirAbs: string, baseApp: string): Pr
     if (passed > 0) {
       console.log(cYellow(`⚠️  Calibration failed. Keeping zero-passrate sandbox directory for debugging: ${zeroPassrateSandbox}`));
     } else {
-      fs.rmSync(zeroPassrateSandbox, { recursive: true, force: true });
+      cleanupZeroPassrate();
     }
   }
 

--- a/guides/run-grader.ts
+++ b/guides/run-grader.ts
@@ -11,18 +11,6 @@ import { TARGETS_DIR, SOLUTION_PATCH_FILE, ZERO_PASSRATE_PATCH_FILE, GRADER_FILE
 import { applyPatchSync } from '../lib/patch-utils.ts';
 import { setupIsolatedWorkDir } from './lib/utils.ts';
 
-export function findGrader(startDir: string): string | null {
-  let currentDir = startDir;
-  while (currentDir !== path.dirname(currentDir)) {
-    const graderPath = path.join(currentDir, 'grader.ts');
-    if (fs.existsSync(graderPath)) {
-      return graderPath;
-    }
-    currentDir = path.dirname(currentDir);
-  }
-  return null;
-}
-
 export interface PlaywrightOptions {
   targetPathAbs: string;
   graderPath: string;
@@ -38,11 +26,10 @@ export function executePlaywright(opts: PlaywrightOptions): ChildProcess {
 
   const isDir = fs.existsSync(opts.targetPathAbs) && fs.statSync(opts.targetPathAbs).isDirectory();
   const appDir = isDir ? opts.targetPathAbs : path.dirname(opts.targetPathAbs);
-  const targetFile = isDir ? path.join(opts.targetPathAbs, 'index.html') : opts.targetPathAbs;
 
   const env: NodeJS.ProcessEnv = {
     ...process.env,
-    TARGET_FILE: targetFile,
+    TARGET_FILE: opts.targetPathAbs,
     PLAYWRIGHT_HTML_OPEN: 'never',
   };
 
@@ -62,39 +49,6 @@ export function executePlaywright(opts: PlaywrightOptions): ChildProcess {
     stdio: opts.stdio || 'inherit',
     env
   });
-}
-
-export async function gradeFile(targetPathAbs: string): Promise<void> {
-  const appDir = fs.existsSync(targetPathAbs) && fs.statSync(targetPathAbs).isDirectory() ? targetPathAbs : path.dirname(targetPathAbs);
-  const graderPath = findGrader(appDir);
-  if (!graderPath) {
-    console.error('Error: Could not find grader.ts in any parent directory.');
-    process.exit(1);
-  }
-
-  console.log(`Target Path: ${targetPathAbs}`);
-  console.log(`Grader: ${graderPath}`);
-
-  const outputDirPath = path.join(appDir, 'grade-report');
-
-  const child = executePlaywright({
-    targetPathAbs,
-    graderPath,
-    reporters: ['html'],
-    htmlOutputDir: outputDirPath,
-    stdio: 'inherit'
-  });
-
-  const [code] = await once(child, 'close');
-
-  console.log(`\nTests finished with code ${code}. Opening HTML report...`);
-  const playwrightBin = path.join(guidesDir, 'node_modules', '.bin', 'playwright');
-  const showReportChild = spawn(playwrightBin, ['show-report', outputDirPath], {
-    stdio: 'inherit'
-  });
-
-  await once(showReportChild, 'close');
-  process.exit((code as number) || 0);
 }
 
 export async function runPlaywright(
@@ -139,7 +93,6 @@ async function runPlaywrightCalibration(
   process.env.PATCH_FILE = patchFile;
   const results = await runPlaywright(targetPathAbs, graderPath, outDir, 'ignore')
     .catch(err => {
-      result.stage = 'server-boot';
       result.errorDetails = `Dev server crashed or failed to run against ${path.basename(patchFile)}: ${err.message}`;
       return null;
     });
@@ -150,7 +103,6 @@ async function runPlaywrightCalibration(
   }
 
   if (results.errors && results.errors.length > 0) {
-    result.stage = 'calibration';
     result.errorDetails = `Playwright global/compilation errors:\n` +
       results.errors.map((e: any) => e.message).join('\n');
     return null;
@@ -244,101 +196,9 @@ export function collectPlaywrightErrors(resultsJson: any): string {
 
 export interface CalibrationResult {
   success: boolean;
-  stage?: 'patch-apply' | 'server-boot' | 'calibration' | 'unknown';
   errorDetails?: string;
-  demo: { passed: number; failed: number; failingTests: string[] };
-  negative: { passed: number; failed: number; passingTests: string[] };
-}
-
-function validateCalibrationPaths(targetDirAbs: string): { demoPath: string; negativePath: string; graderPath: string; } {
-  const demoPath = path.join(targetDirAbs, 'demo.html');
-  const negativePath = path.join(targetDirAbs, 'negative-demo.html');
-  const graderPath = findGrader(targetDirAbs);
-
-  if (!graderPath) {
-    throw new Error('Could not find grader.ts in the directory or any parents.');
-  }
-  if (!fs.existsSync(demoPath)) {
-    throw new Error(`Missing demo.html in ${targetDirAbs}`);
-  }
-  if (!fs.existsSync(negativePath)) {
-    throw new Error(`Missing negative-demo.html in ${targetDirAbs}`);
-  }
-
-  return { demoPath, negativePath, graderPath };
-}
-
-async function runDemoCalibration(demoPath: string, graderPath: string, demoOutDir: string, result: CalibrationResult): Promise<boolean> {
-  console.log(cYellow(`\nRunning against demo.html... (Expecting 100% pass)`));
-  let demoFailed = false;
-
-  const solutionPatch = path.join(path.dirname(graderPath), 'solution.patch');
-  const demoResults = await runPlaywrightCalibration(demoPath, graderPath, demoOutDir, solutionPatch, result);
-
-  if (!demoResults) {
-    demoFailed = true;
-  } else {
-    const unexpected = demoResults.stats?.unexpected || 0;
-    const expected = demoResults.stats?.expected || 0;
-    result.demo.passed = expected;
-    result.demo.failed = unexpected;
-
-    if (expected === 0 && unexpected === 0) {
-      console.log(cYellow(`\u26a0\ufe0f  Warning: No tests were run for demo.html`));
-      demoFailed = true;
-    } else if (unexpected > 0) {
-      result.demo.failingTests = demoResults.suites?.flatMap((s: PlaywrightSuite) => collectSpecs(s, false)) || [];
-      console.log(cRed(`\u274c demo.html failed ${unexpected} tests!`));
-      demoResults.suites?.forEach((suite: PlaywrightSuite) => printFailingSpecs(suite));
-      demoFailed = true;
-    } else {
-      console.log(cGreen(`\u2705 demo.html passed all ${expected} tests.`));
-    }
-  }
-
-  console.log('');
-  return demoFailed;
-}
-
-async function runNegativeCalibration(negativePath: string, graderPath: string, negativeOutDir: string, result: CalibrationResult): Promise<void> {
-  console.log(cYellow(`Running against negative-demo.html... (Expecting 100% fail)`));
-
-  const zeroPassratePatch = path.join(path.dirname(graderPath), ZERO_PASSRATE_PATCH_FILE);
-  const negativeResults = await runPlaywrightCalibration(negativePath, graderPath, negativeOutDir, zeroPassratePatch, result);
-
-  if (!negativeResults) {
-    // Failed to run — result.success stays false
-  } else {
-    const passed = negativeResults.stats?.expected || 0;
-    const failed = negativeResults.stats?.unexpected || 0;
-    result.negative.passed = passed;
-    result.negative.failed = failed;
-
-    if (passed === 0 && failed === 0) {
-      console.log(cYellow(`\u26a0\ufe0f  Warning: No tests were run for negative-demo.html`));
-    } else if (passed > 0) {
-      result.negative.passingTests = negativeResults.suites?.flatMap((s: PlaywrightSuite) => collectSpecs(s, true)) || [];
-      console.log(cRed(`\u274c negative-demo.html incorrectly passed ${passed} tests!`));
-      negativeResults.suites?.forEach((suite: PlaywrightSuite) => printPassingSpecs(suite));
-    } else {
-      console.log(cGreen(`\u2705 negative-demo.html failed all ${failed} tests correctly.`));
-      result.success = true;
-    }
-  }
-
-  console.log('');
-}
-
-function printFinalCalibrationSummary(result: CalibrationResult, demoFailed: boolean, demoOutDir: string, negativeOutDir: string): void {
-  if (result.success) {
-    console.log(cBold(cGreen(`Success! The grader is perfectly calibrated.`)));
-  } else {
-    console.log(cBold(cRed(`Failed! The grader needs calibration.`)));
-    if (demoFailed) {
-      console.log(`\nView demo.html report:\n  pnpm --filter guides exec playwright show-report ${path.relative(process.cwd(), demoOutDir)}`);
-    }
-    console.log(`\nView negative-demo.html report:\n  pnpm --filter guides exec playwright show-report ${path.relative(process.cwd(), negativeOutDir)}`);
-  }
+  solution: { passed: number; failed: number; failingTests: string[] };
+  zeroPassrate: { passed: number; failed: number; passingTests: string[] };
 }
 
 export async function testTargetGrader(guideDirAbs: string, baseApp: string): Promise<CalibrationResult> {
@@ -349,18 +209,17 @@ export async function testTargetGrader(guideDirAbs: string, baseApp: string): Pr
 
   const result: CalibrationResult = {
     success: false,
-    demo: { passed: 0, failed: 0, failingTests: [] },
-    negative: { passed: 0, failed: 0, passingTests: [] }
+    solution: { passed: 0, failed: 0, failingTests: [] },
+    zeroPassrate: { passed: 0, failed: 0, passingTests: [] }
   };
 
   if (!fs.existsSync(solutionPatch) || !fs.existsSync(zeroPassratePatch) || !fs.existsSync(graderPath)) {
-    result.stage = 'unknown';
     result.errorDetails = `Missing ${SOLUTION_PATCH_FILE}, ${ZERO_PASSRATE_PATCH_FILE}, or ${GRADER_FILE} in ${targetDir}`;
     return result;
   }
 
-  const demoOutDir = path.join(targetDir, 'grade-report', 'solution');
-  const negativeOutDir = path.join(targetDir, 'grade-report', 'zero-passrate');
+  const solutionOutDir = path.join(targetDir, 'grade-report', 'solution');
+  const zeroPassrateOutDir = path.join(targetDir, 'grade-report', 'zero-passrate');
 
   // Golden calibration
   const goldenSandbox = setupIsolatedWorkDir(`gd-cal-${baseApp}-sol`);
@@ -369,37 +228,34 @@ export async function testTargetGrader(guideDirAbs: string, baseApp: string): Pr
     fs.cpSync(path.join(baseAppsDir, baseApp), goldenSandbox, { recursive: true });
     const applyRes = applyPatchSync(goldenSandbox, solutionPatch);
     if (!applyRes.success) {
-      result.stage = 'patch-apply';
       result.errorDetails = `Failed to apply ${SOLUTION_PATCH_FILE}: ${applyRes.error}`;
       return result;
     }
 
     console.log(cYellow(`\nRunning against ${baseApp} with ${SOLUTION_PATCH_FILE}... (Expecting 100% pass)`));
-    const demoResults = await runPlaywrightCalibration(goldenSandbox, graderPath, demoOutDir, solutionPatch, result);
+    const solutionResults = await runPlaywrightCalibration(goldenSandbox, graderPath, solutionOutDir, solutionPatch, result);
 
-    if (!demoResults) {
+    if (!solutionResults) {
       return result;
     }
 
-    unexpected = demoResults.stats?.unexpected || 0;
-    const expected = demoResults.stats?.expected || 0;
-    result.demo.passed = expected;
-    result.demo.failed = unexpected;
+    unexpected = solutionResults.stats?.unexpected || 0;
+    const expected = solutionResults.stats?.expected || 0;
+    result.solution.passed = expected;
+    result.solution.failed = unexpected;
 
     if (expected === 0 && unexpected === 0) {
-      result.stage = 'calibration';
       result.errorDetails = `No tests were run for ${SOLUTION_PATCH_FILE}`;
       return result;
     } else if (unexpected > 0) {
-      result.demo.failingTests = demoResults.suites?.flatMap((s: PlaywrightSuite) => collectSpecs(s, false)) || [];
-      result.stage = 'calibration';
-      result.errorDetails = `${SOLUTION_PATCH_FILE} failed ${unexpected} tests:\n\n${collectPlaywrightErrors(demoResults)}`;
-      demoResults.suites?.forEach((suite: PlaywrightSuite) => printFailingSpecs(suite));
+      result.solution.failingTests = solutionResults.suites?.flatMap((s: PlaywrightSuite) => collectSpecs(s, false)) || [];
+      result.errorDetails = `${SOLUTION_PATCH_FILE} failed ${unexpected} tests:\n\n${collectPlaywrightErrors(solutionResults)}`;
+      solutionResults.suites?.forEach((suite: PlaywrightSuite) => printFailingSpecs(suite));
       return result;
     }
   } finally {
     if (unexpected > 0) {
-      console.log(cYellow(`\u26a0\ufe0f  Calibration failed. Keeping golden sandbox directory for debugging: ${goldenSandbox}`));
+      console.log(cYellow(`⚠️  Calibration failed. Keeping golden sandbox directory for debugging: ${goldenSandbox}`));
     } else {
       fs.rmSync(goldenSandbox, { recursive: true, force: true });
     }
@@ -412,37 +268,34 @@ export async function testTargetGrader(guideDirAbs: string, baseApp: string): Pr
     fs.cpSync(path.join(baseAppsDir, baseApp), zeroPassrateSandbox, { recursive: true });
     const applyRes = applyPatchSync(zeroPassrateSandbox, zeroPassratePatch);
     if (!applyRes.success) {
-      result.stage = 'patch-apply';
       result.errorDetails = `Failed to apply ${ZERO_PASSRATE_PATCH_FILE}: ${applyRes.error}`;
       return result;
     }
 
     console.log(cYellow(`Running against ${baseApp} with ${ZERO_PASSRATE_PATCH_FILE}... (Expecting 100% fail)`));
-    const negativeResults = await runPlaywrightCalibration(zeroPassrateSandbox, graderPath, negativeOutDir, zeroPassratePatch, result);
+    const zeroPassrateResults = await runPlaywrightCalibration(zeroPassrateSandbox, graderPath, zeroPassrateOutDir, zeroPassratePatch, result);
 
-    if (!negativeResults) {
+    if (!zeroPassrateResults) {
       return result;
     }
 
-    passed = negativeResults.stats?.expected || 0;
-    const failed = negativeResults.stats?.unexpected || 0;
-    result.negative.passed = passed;
-    result.negative.failed = failed;
+    passed = zeroPassrateResults.stats?.expected || 0;
+    const failed = zeroPassrateResults.stats?.unexpected || 0;
+    result.zeroPassrate.passed = passed;
+    result.zeroPassrate.failed = failed;
 
     if (passed === 0 && failed === 0) {
-      result.stage = 'calibration';
       result.errorDetails = `No tests were run for ${ZERO_PASSRATE_PATCH_FILE}`;
       return result;
     } else if (passed > 0) {
-      result.negative.passingTests = negativeResults.suites?.flatMap((s: PlaywrightSuite) => collectSpecs(s, true)) || [];
-      result.stage = 'calibration';
-      result.errorDetails = `${ZERO_PASSRATE_PATCH_FILE} incorrectly passed ${passed} tests:\n\n${collectPlaywrightErrors(negativeResults)}`;
-      negativeResults.suites?.forEach((suite: PlaywrightSuite) => printPassingSpecs(suite));
+      result.zeroPassrate.passingTests = zeroPassrateResults.suites?.flatMap((s: PlaywrightSuite) => collectSpecs(s, true)) || [];
+      result.errorDetails = `${ZERO_PASSRATE_PATCH_FILE} incorrectly passed ${passed} tests:\n\n${collectPlaywrightErrors(zeroPassrateResults)}`;
+      zeroPassrateResults.suites?.forEach((suite: PlaywrightSuite) => printPassingSpecs(suite));
       return result;
     }
   } finally {
     if (passed > 0) {
-      console.log(cYellow(`\u26a0\ufe0f  Calibration failed. Keeping zero-passrate sandbox directory for debugging: ${zeroPassrateSandbox}`));
+      console.log(cYellow(`⚠️  Calibration failed. Keeping zero-passrate sandbox directory for debugging: ${zeroPassrateSandbox}`));
     } else {
       fs.rmSync(zeroPassrateSandbox, { recursive: true, force: true });
     }
@@ -452,10 +305,14 @@ export async function testTargetGrader(guideDirAbs: string, baseApp: string): Pr
   return result;
 }
 
-export async function testGrader(targetDirRaw: string, baseApp?: string): Promise<CalibrationResult> {
+export async function testGrader(targetDirRaw: string): Promise<CalibrationResult> {
   const targetDirAbs = path.resolve(process.cwd(), targetDirRaw);
-  if (baseApp) {
-    return testTargetGrader(targetDirAbs, baseApp);
+
+  // Direct target base app path (e.g. guides/css/size-aware-styling/targets/daily-grind)
+  if (path.basename(path.dirname(targetDirAbs)) === TARGETS_DIR) {
+    const guideDir = path.dirname(path.dirname(targetDirAbs));
+    const appName = path.basename(targetDirAbs);
+    return testTargetGrader(guideDir, appName);
   }
 
   const targetsDir = path.join(targetDirAbs, TARGETS_DIR);
@@ -471,39 +328,17 @@ export async function testGrader(targetDirRaw: string, baseApp?: string): Promis
           break;
         }
       }
-      return lastResult || { success: false, stage: 'unknown', demo: { passed: 0, failed: 0, failingTests: [] }, negative: { passed: 0, failed: 0, passingTests: [] } };
+      return lastResult || { success: false, solution: { passed: 0, failed: 0, failingTests: [] }, zeroPassrate: { passed: 0, failed: 0, passingTests: [] } };
     }
   }
 
-  const { demoPath, negativePath, graderPath } = validateCalibrationPaths(targetDirAbs);
-
-  const result: CalibrationResult = {
-    success: false,
-    demo: { passed: 0, failed: 0, failingTests: [] },
-    negative: { passed: 0, failed: 0, passingTests: [] },
-  };
-
-  const demoOutDir = path.join(targetDirAbs, 'grade-report', 'demo');
-  const negativeOutDir = path.join(targetDirAbs, 'grade-report', 'negative');
-
-  const demoFailed = await runDemoCalibration(demoPath, graderPath, demoOutDir, result);
-
-  if (demoFailed) {
-    console.log(cYellow(`Skipping negative-demo.html run due to failures in demo.html`));
-    return result;
-  }
-
-  await runNegativeCalibration(negativePath, graderPath, negativeOutDir, result);
-
-  printFinalCalibrationSummary(result, demoFailed, demoOutDir, negativeOutDir);
-
-  return result;
+  throw new Error(`No target base apps found in ${targetsDir}. Calibration requires target base apps in targets/.`);
 }
 
 async function run(): Promise<void> {
   const args = process.argv.slice(2);
   if (args.length === 0) {
-    console.error('Usage: pnpm grade <path-to-html-file-or-guide-directory>');
+    console.error('Usage: pnpm grade <path-to-target-directory>');
     process.exit(1);
   }
 
@@ -515,18 +350,8 @@ async function run(): Promise<void> {
     process.exit(1);
   }
 
-  const stat = fs.statSync(targetPathAbs);
-  if (stat.isDirectory()) {
-    console.log(cCyan(`\ud83e\uddea Directory detected. Running calibration suite on the grader (demo.html & negative-demo.html)...`));
-    const result = await testGrader(targetPathAbs);
-    process.exit(result.success ? 0 : 1);
-  } else if (targetPathAbs.endsWith('.html')) {
-    console.log(cCyan(`\ud83d\udcc4 HTML file detected. Grading artifact and opening visual report...`));
-    await gradeFile(targetPathAbs);
-  } else {
-    console.error(`Error: Expected a directory or an .html file.`);
-    process.exit(1);
-  }
+  const res = await testGrader(targetPathAbs);
+  process.exit(res.success ? 0 : 1);
 }
 
 if (import.meta.url.startsWith('file:') && process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/guides/run-grader.ts
+++ b/guides/run-grader.ts
@@ -366,6 +366,9 @@ async function run(): Promise<void> {
   }
 
   const res = await testGrader(targetPathAbs);
+  if (!res.success && res.errorDetails) {
+    console.error(cRed(`\nCalibration Error:\n${res.errorDetails}`));
+  }
   process.exit(res.success ? 0 : 1);
 }
 

--- a/guides/run-grader.ts
+++ b/guides/run-grader.ts
@@ -89,7 +89,7 @@ export async function runPlaywright(
       reporters: ['json', 'html'],
       htmlOutputDir,
       jsonOutputName: tmpJson,
-      patchFile: hasPatch ? agentPatch : undefined,
+      patchFile: hasPatch ? agentPatch : process.env.PATCH_FILE,
       stdio: stdio === 'ignore' ? 'pipe' : stdio
     });
 

--- a/guides/run-grader.ts
+++ b/guides/run-grader.ts
@@ -5,7 +5,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { guidesDir, rootDir } from '../lib/paths.ts';
+import { guidesDir } from '../lib/paths.ts';
 import { cRed, cYellow, cCyan } from '../lib/colors.ts';
 import { TARGETS_DIR, SOLUTION_PATCH_FILE, ZERO_PASSRATE_PATCH_FILE, GRADER_FILE, getSupportedBaseApps } from '../lib/guide-validation.ts';
 import { stageBaseAppWorkspace } from './lib/utils.ts';
@@ -46,7 +46,7 @@ export function executePlaywright(opts: PlaywrightOptions): ChildProcess {
     env.PLAYWRIGHT_JSON_OUTPUT_NAME = opts.jsonOutputName;
   }
 
-  const playwrightBin = path.join(rootDir, 'node_modules', '.bin', 'playwright');
+  const playwrightBin = path.join(guidesDir, 'node_modules', '.bin', 'playwright');
 
   return spawn(playwrightBin, ['test', '-c', playwrightConfig, opts.graderPath, ...reporterArgs], {
     cwd: appDir,

--- a/guides/template.grader.ts
+++ b/guides/template.grader.ts
@@ -133,42 +133,29 @@ test.describe('<guide-name> Target Grader', () => {
   });
 
   // --- BROWSER ASSERTIONS (E2E) ---
-  // Use browser assertions ONLY when you need to compute real CSS styles, evaluate dynamic pages,
-  // interact with elements (clicks/input), or verify rendered layout/visibility.
+  // Use browser assertions ONLY for requirements that cannot be verified statically, such as runtime click events or dynamic state updates.
   // If browser assertions are not needed, this entire `test.describe('Browser tests', ...)` section should be omitted.
   
   test.describe('Browser tests', () => {
     
     test.beforeEach(async ({ page, TARGET_URL }) => {
-      // Only mock local routes if it's a file-based demo, else let the dev server handle it
-      if (TARGET_URL.startsWith('http://localhost/')) {
-        await page.route('http://localhost/*', async (route: any) => {
-          const requestPath = new URL(route.request().url()).pathname;
-          const localFilePath = path.join(rootDir, requestPath === '/' ? 'index.html' : requestPath);
-
-          if (fs.existsSync(localFilePath)) {
-            await route.fulfill({ path: localFilePath });
-          } else {
-            await route.continue();
-          }
-        });
-      }
-      
       await page.goto(TARGET_URL);
     });
 
-    // test('browser behavior matches guide requirements', async ({ page }) => {
-    //   // EXAMPLE 1: Checking computed styles:
-    //   // const color = await page.$eval('.target', el => window.getComputedStyle(el).color);
-    //   // expect(color).toBe('rgb(255, 0, 0)');
-    //
-    //   // EXAMPLE 2: Layout / Position checks:
-    //   // const pos = await page.evaluate(() => {
-    //   //   const a = document.getElementById('a')!.getBoundingClientRect();
-    //   //   const b = document.getElementById('b')!.getBoundingClientRect();
-    //   //   return { aBottom: a.bottom, bTop: b.top };
-    //   // });
-    //   // expect(pos.bTop).toBeGreaterThanOrEqual(pos.aBottom);
+    // EXAMPLE 1: Checking computed styles
+    // test('target element has correct computed color', async ({ page }) => {
+    //   const color = await page.$eval('.target', el => window.getComputedStyle(el).color);
+    //   expect(color).toBe('rgb(255, 0, 0)');
+    // });
+
+    // EXAMPLE 2: Layout / Position checks using getBoundingClientRect
+    // test('element B is positioned below element A', async ({ page }) => {
+    //   const pos = await page.evaluate(() => {
+    //     const a = document.getElementById('a')!.getBoundingClientRect();
+    //     const b = document.getElementById('b')!.getBoundingClientRect();
+    //     return { aBottom: a.bottom, bTop: b.top };
+    //   });
+    //   expect(pos.bTop).toBeGreaterThanOrEqual(pos.aBottom);
     // });
   });
 });

--- a/guides/test-fixture.ts
+++ b/guides/test-fixture.ts
@@ -22,67 +22,13 @@ async function getFreePort(): Promise<number> {
 }
 
 export const test = base.extend<{}, ServerWorkerFixtures>({
-  page: [async ({ page, TARGET_URL }, use) => {
-    const targetFile = process.env.TARGET_FILE;
-    if (!targetFile) {
-      await use(page);
-      return;
-    }
-    const targetDir = path.dirname(targetFile);
-    const pkgJsonPath = path.join(targetDir, 'package.json');
-    const isStaticApp = fs.existsSync(pkgJsonPath) && !JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8')).scripts?.build;
-
-    if (isStaticApp) {
-      const urlObj = new URL(TARGET_URL);
-      await page.route('**/*', async (route: any) => {
-        const reqUrl = new URL(route.request().url());
-        if (reqUrl.origin === urlObj.origin) {
-          const pathname = reqUrl.pathname;
-          const relativePath = pathname.replace(urlObj.pathname.replace(/\/$/, ''), '').replace(/^\//, '');
-          const diskPath = path.resolve(targetDir, relativePath || 'index.html');
-          const fileExists = fs.existsSync(diskPath);
-          if (!fileExists && (relativePath === '' || !relativePath.includes('.'))) {
-            const indexPath = path.join(targetDir, 'index.html');
-            if (fs.existsSync(indexPath)) {
-              const indexContent = fs.readFileSync(indexPath, 'utf8');
-              await route.fulfill({
-                contentType: 'text/html',
-                body: indexContent
-              });
-              return;
-            }
-          }
-        }
-        await route.continue();
-      });
-    }
-
-    await use(page);
-  }, { scope: 'test' }],
-
   // eslint-disable-next-line no-empty-pattern
   TARGET_URL: [async ({}, use) => {
-    const targetFile = process.env.TARGET_FILE;
-    if (!targetFile) {
-      throw new Error('TARGET_FILE environment variable not set.');
-    }
-    
-    const targetDir = path.dirname(targetFile);
+    const targetDir = process.cwd();
+
     const pkgJsonPath = path.join(targetDir, 'package.json');
-    const demoName = path.basename(targetFile);
-
-    if (!fs.existsSync(pkgJsonPath) && !fs.existsSync(targetFile)) {
-      throw new Error(`Target file not found: ${targetFile}`);
-    }
-
-    console.log(`[TEST-FIXTURE] targetFile: ${targetFile}`);
-    console.log(`[TEST-FIXTURE] targetDir: ${targetDir}`);
-    console.log(`[TEST-FIXTURE] pkgJsonPath: ${pkgJsonPath}`);
-    console.log(`[TEST-FIXTURE] pkgJsonExists: ${fs.existsSync(pkgJsonPath)}`);
-
     if (!fs.existsSync(pkgJsonPath)) {
-      await use(`http://localhost/${demoName}`);
-      return;
+      throw new Error(`package.json not found in target directory: ${targetDir}`);
     }
 
     const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
@@ -110,14 +56,12 @@ export const test = base.extend<{}, ServerWorkerFixtures>({
         shell: process.platform === 'win32'
       });
       if (buildResult.status !== 0) {
-        await use(`http://localhost/${demoName}`);
-        return;
+        throw new Error(`Failed to build target app in ${targetDir}`);
       }
     }
 
     if (!pkgJson.scripts || !pkgJson.scripts.start) {
-      await use(`http://localhost/${demoName}`);
-      return;
+      throw new Error(`package.json in ${targetDir} is missing a "start" script.`);
     }
 
     const port = await getFreePort();
@@ -158,8 +102,7 @@ export const test = base.extend<{}, ServerWorkerFixtures>({
       if (serverProcess.pid) {
         try { process.kill(-serverProcess.pid); } catch (e) {}
       }
-      await use(`http://localhost/${demoName}`);
-      return;
+      throw new Error(`Server in ${targetDir} failed to start on port ${port}`);
     }
 
     process.env.TARGET_URL = url; // Exporting so legacy tests might use it if they read from process.env

--- a/harness/agents/claude-code-agent.ts
+++ b/harness/agents/claude-code-agent.ts
@@ -111,11 +111,13 @@ async function run() {
     console.log(`Starting Claude Code agent in: ${workDir}`);
 
     const command = config.environment.claudeCodeCliBin;
+    const model = process.env.ANTHROPIC_MODEL;
     const commandArgs = [
       '-p', userPrompt,
       '--dangerously-skip-permissions',
       '--verbose',
-      '--output-format', 'stream-json'
+      '--output-format', 'stream-json',
+      ...(model ? ['--model', model] : [])
     ];
 
     console.log(`Executing: ${command} ${commandArgs.join(' ')}`);

--- a/harness/lib/agent-shared.ts
+++ b/harness/lib/agent-shared.ts
@@ -468,8 +468,8 @@ export function createWorkDir(templateDir: string, homeDir: string, runType: str
     fs.mkdirSync(workDir, { recursive: true });
     return workDir;
   }
-  // For the suite run, copy the template directory to the isolated home directory, following symlinks
-  execSync(`cp -RL "${templateDir}" "${homeDir}/"`);
+  // For the suite run, copy the template directory to the isolated home directory, preserving symlinks
+  execSync(`cp -R "${templateDir}" "${homeDir}/"`);
   const workDir = path.join(homeDir, path.basename(templateDir));
   initGitRepo(workDir);
   return workDir;

--- a/harness/lib/agent-shared.ts
+++ b/harness/lib/agent-shared.ts
@@ -4,7 +4,7 @@ import { execSync, spawn, type SpawnOptions } from 'child_process';
 import { Agents } from '../config.ts';
 import { classifyGuide, scanAllGuides } from '../../lib/guide-validation.ts';
 import { rootDir, guidesDir } from '../../lib/paths.ts';
-import { capturePatchFromGit } from '../../lib/patch-utils.ts';
+import { capturePatchFromGit, initGitRepo } from '../../lib/patch-utils.ts';
 
 import { type SuiteConfig } from '../config.ts';
 
@@ -470,13 +470,8 @@ export function createWorkDir(templateDir: string, homeDir: string, runType: str
   }
   // For the suite run, copy the template directory to the isolated home directory, following symlinks
   execSync(`cp -RL "${templateDir}" "${homeDir}/"`);
-  console.log(`Copied ${templateDir} to ${homeDir}...`);
   const workDir = path.join(homeDir, path.basename(templateDir));
-  try {
-    execSync('git init && git config user.name "AI" && git config user.email "ai@example.com" && git add . && git commit -m "init"', { cwd: workDir, stdio: 'ignore' });
-  } catch (err) {
-    console.warn(`Failed to initialize git in workDir ${workDir}: ${err}`);
-  }
+  initGitRepo(workDir);
   return workDir;
 }
 
@@ -487,15 +482,27 @@ export function createWorkDir(templateDir: string, homeDir: string, runType: str
  * @param subPath Optional sub-path within workDir to copy from (e.g. if you only want specific files)
  */
 export function copyResultsToTarget(workDir: string, targetDir: string, subPath: string = '.'): void {
-  const sourceDir = path.join(workDir, subPath);
-  try {
-    const agentPatchPath = path.join(targetDir, 'agent.patch');
-    capturePatchFromGit(workDir, agentPatchPath);
-  } catch (err) {
-    console.warn(`Failed to capture agent patch: ${err}`);
+  const isLegacyTask = path.basename(path.dirname(targetDir)) === 'task';
+
+  if (isLegacyTask) {
+    // For legacy single-page guides, copy workspace files directly using cp -R
+    const sourceDir = path.join(workDir, subPath);
+    try {
+      execSync(`cp -R "${sourceDir}/." "${targetDir}/"`);
+      console.log(`Copied results from ${sourceDir} to: ${targetDir}`);
+    } catch (e) {
+      console.warn(`Failed to copy results from ${sourceDir} to ${targetDir}: ${e}`);
+    }
+  } else {
+    // For target-based guides, capture agent.patch for patch-only storage
+    try {
+      const agentPatchPath = path.join(targetDir, 'agent.patch');
+      capturePatchFromGit(workDir, agentPatchPath);
+    } catch (err) {
+      console.warn(`Failed to capture agent patch: ${err}`);
+    }
+    console.log(`Saved agent patch in: ${targetDir}`);
   }
-  execSync(`cp -R "${sourceDir}/." "${targetDir}/"`);
-  console.log(`Copied results from ${sourceDir} to: ${targetDir}`);
 }
 
 /**
@@ -756,7 +763,6 @@ export function getGraderScriptContent(
   const graderResults = path.join(targetDir, `${guideName}_results.json`);
 
   return `import fs from 'fs';
-import { spawnSync } from 'child_process';
 import { runPlaywright } from ${JSON.stringify(runGraderModulePath)};
 
 async function run() {

--- a/harness/lib/collection.ts
+++ b/harness/lib/collection.ts
@@ -10,8 +10,8 @@ import { extractCodexCliModel, extractCodexCliTokenUsage } from '../agents/codex
 import { extractJetskiCliModel, extractJetskiCliTokenUsage } from '../agents/jetski-cli-agent.ts';
 import { getGraderScriptContent } from './agent-shared.ts';
 
-function isTargetAppPresent(targetFile: string, targetPkgJson: string): boolean {
-  return fs.existsSync(targetFile) || fs.existsSync(targetPkgJson);
+function isTargetAppPresent(targetFile: string, targetPkgJson: string, targetPatchFile?: string): boolean {
+  return fs.existsSync(targetFile) || fs.existsSync(targetPkgJson) || (targetPatchFile ? fs.existsSync(targetPatchFile) : false);
 }
 
 export function extractModelFromResults(resultsDir: string, agent: string): string {
@@ -102,9 +102,15 @@ function getAppFiles(currentDir: string, base = ''): string[] {
 }
 
 export function extractTargetModifiedFile(dir: string, prompt?: string): string | undefined {
+  if (fs.existsSync(path.join(dir, 'agent.patch'))) {
+    return 'agent.patch';
+  }
   try {
     const appFiles = getAppFiles(dir).filter(f => {
       if (
+        f === 'npx' ||
+        f === 'node_modules' ||
+        f.startsWith('.') ||
         f.endsWith('.log') ||
         f.endsWith('.txt') ||
         f.endsWith('.mjs') ||
@@ -209,13 +215,14 @@ function getTaskRunContext(
   const targetModifiedFile = extractTargetModifiedFile(dir, taskInfo.prompt);
   const targetFile = path.join(dir, targetModifiedFile || 'index.html');
   const targetPkgJson = path.join(dir, 'package.json');
+  const targetPatchFile = path.join(dir, 'agent.patch');
   let graderPath = path.join(taskInfo.guideDir, 'grader.ts');
   const targetGraderPath = path.join(taskInfo.guideDir, 'targets', taskName, 'grader.ts');
   if (fs.existsSync(targetGraderPath)) {
     graderPath = targetGraderPath;
   }
   const graderResults = path.join(dir, `${guide}_results.json`);
-  const targetAppExists = isTargetAppPresent(targetFile, targetPkgJson);
+  const targetAppExists = isTargetAppPresent(targetFile, targetPkgJson, targetPatchFile);
 
   return {
     guide,

--- a/harness/run_suite.ts
+++ b/harness/run_suite.ts
@@ -349,31 +349,13 @@ export async function setupWorkspaceBaseApp(taskInfo: TaskInfo, runDir: string, 
     fs.mkdirSync(workspaceBaseAppDir, { recursive: true });
   }
 
-  // Ensure suite-level base app exists at <runDir>/base_apps/<baseApp>/
-  const runBaseAppDir = path.join(runDir, 'base_apps', taskInfo.baseApp);
-  if (!fs.existsSync(runBaseAppDir)) {
-    const sourceBaseAppDir = path.join(baseAppsDir, taskInfo.baseApp);
-    if (fs.existsSync(sourceBaseAppDir)) {
-      fs.mkdirSync(path.dirname(runBaseAppDir), { recursive: true });
-      await fs.promises.cp(sourceBaseAppDir, runBaseAppDir, {
-        recursive: true,
-        filter: (src) => {
-          const basename = path.basename(src);
-          return !['node_modules', '.git', 'dist', '.astro'].includes(basename);
-        }
-      });
-      initGitRepo(runBaseAppDir);
-    } else {
-      console.warn(`Source base app not found at ${sourceBaseAppDir}`);
-      return null;
-    }
+  const refBaseAppDir = path.join(baseAppsDir, taskInfo.baseApp);
+  if (fs.existsSync(refBaseAppDir)) {
+    fs.cpSync(refBaseAppDir, workspaceBaseAppDir, { recursive: true });
+  } else {
+    console.warn(`Source base app not found at ${refBaseAppDir}`);
+    return null;
   }
-
-  // Copy from <runDir>/base_apps/<baseApp>/ to workspaceBaseAppDir
-  await fs.promises.cp(runBaseAppDir, workspaceBaseAppDir, {
-    recursive: true,
-  });
-
   if (!fs.existsSync(path.join(workspaceBaseAppDir, '.git'))) {
     initGitRepo(workspaceBaseAppDir);
   }

--- a/harness/run_suite.ts
+++ b/harness/run_suite.ts
@@ -1,12 +1,12 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { spawn, execSync } from 'child_process';
+import { spawn } from 'child_process';
 import { Agents, defaultSuiteConfig, mergeSuiteConfig, type SuiteConfig } from './config.ts';
 import { evaluateSuite } from './evaluate.ts';
 import { harnessDir, baseAppsDir, resultsDir } from '../lib/paths.ts';
 import { getTaskMap, ZERO_PASSRATE_PATCH_FILE, type TaskInfo } from '../lib/guide-validation.ts';
-import { applyPatchSync } from '../lib/patch-utils.ts';
+import { applyPatchSync, initGitRepo } from '../lib/patch-utils.ts';
 import { getGraderScriptContent } from './lib/agent-shared.ts';
 
 const RUN_TYPES = ['guided', 'unguided'];
@@ -168,7 +168,7 @@ export async function runSuite(options: RunSuiteOptions = {}) {
 
         for (const runType of runTypesToRun) {
           const targetDir = path.join(taskFolder, runType);
-          generateTransientPackage(targetDir, agentScript, promptContent, runType, workspaceBaseAppDir, taskName, guideName, graderPath);
+          generateTransientPackage(targetDir, agentScript, promptContent, runType, workspaceBaseAppDir, taskName, guideName, graderPath, taskInfo.baseApp);
           pnpmWorkspacePackages.push(`${guideName}/${taskName}/${runType}`);
         }
       }
@@ -202,6 +202,19 @@ export async function runSuite(options: RunSuiteOptions = {}) {
         } finally {
           if (fs.existsSync(pnpmWorkspacePath)) {
             fs.unlinkSync(pnpmWorkspacePath);
+          }
+          // Clean up task workspace base_apps after all workers in run finish
+          for (const task of tasksToRun) {
+            const resolvedTask = resolveTaskName(task);
+            const [guideName, taskName] = resolvedTask.split('/');
+            const taskBaseAppDir = path.join(runDir, guideName, taskName, 'base_app');
+            if (fs.existsSync(taskBaseAppDir)) {
+              try {
+                fs.rmSync(taskBaseAppDir, { recursive: true, force: true });
+              } catch (err) {
+                console.warn(`Failed to clean up ${taskBaseAppDir}: ${err}`);
+              }
+            }
           }
         }
       }
@@ -329,7 +342,6 @@ function resolveTaskName(task: string): string {
 }
 
 export async function setupWorkspaceBaseApp(taskInfo: TaskInfo, runDir: string, guideName: string, taskName: string): Promise<string | null> {
-  // Copy the base app to the run directory (for tracking purposes)
   const guideFolder = path.join(runDir, guideName);
   const taskFolder = path.join(guideFolder, taskName);
   const workspaceBaseAppDir = path.join(taskFolder, 'base_app');
@@ -337,58 +349,56 @@ export async function setupWorkspaceBaseApp(taskInfo: TaskInfo, runDir: string, 
     fs.mkdirSync(workspaceBaseAppDir, { recursive: true });
   }
 
-  if (taskName === 'negative') {
-    const negativeDemoPath = path.join(taskInfo.guideDir, 'negative-demo.html');
-    if (fs.existsSync(negativeDemoPath)) {
-      fs.copyFileSync(negativeDemoPath, path.join(workspaceBaseAppDir, 'index.html'));
-    } else {
-      console.warn(`Skipping negative run for ${guideName}/${taskName}: Missing negative-demo.html`);
-      return null;
-    }
-  } else {
+  // Ensure suite-level base app exists at <runDir>/base_apps/<baseApp>/
+  const runBaseAppDir = path.join(runDir, 'base_apps', taskInfo.baseApp);
+  if (!fs.existsSync(runBaseAppDir)) {
     const sourceBaseAppDir = path.join(baseAppsDir, taskInfo.baseApp);
     if (fs.existsSync(sourceBaseAppDir)) {
-      await fs.promises.cp(sourceBaseAppDir, workspaceBaseAppDir, {
+      fs.mkdirSync(path.dirname(runBaseAppDir), { recursive: true });
+      await fs.promises.cp(sourceBaseAppDir, runBaseAppDir, {
         recursive: true,
         filter: (src) => {
           const basename = path.basename(src);
           return !['node_modules', '.git', 'dist', '.astro'].includes(basename);
         }
       });
+      initGitRepo(runBaseAppDir);
+    } else {
+      console.warn(`Source base app not found at ${sourceBaseAppDir}`);
+      return null;
+    }
+  }
 
-      // Initialize git so git apply resolves paths at the staged base app root
-      try {
-        execSync('git init && git config user.name "AI" && git config user.email "ai@example.com" && git add . && git commit -m "init"', { cwd: workspaceBaseAppDir, stdio: 'ignore' });
-      } catch (err) {
-        console.warn(`Failed to initialize git in ${workspaceBaseAppDir}: ${err}`);
-      }
+  // Copy from <runDir>/base_apps/<baseApp>/ to workspaceBaseAppDir
+  await fs.promises.cp(runBaseAppDir, workspaceBaseAppDir, {
+    recursive: true,
+  });
 
-      const pkgJsonPath = path.join(workspaceBaseAppDir, 'package.json');
-      if (fs.existsSync(pkgJsonPath)) {
-        const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
-        if (!pkgJson.pnpm || !pkgJson.pnpm.onlyBuiltDependencies) {
-          throw new Error(`Assertion failed: pnpm.onlyBuiltDependencies is missing in ${pkgJsonPath}`);
-        }
+  if (!fs.existsSync(path.join(workspaceBaseAppDir, '.git'))) {
+    initGitRepo(workspaceBaseAppDir);
+  }
 
-        // pnpm install is intentionally deferred until after agent execution
-        // to avoid copying massive node_modules directories.
-      }
+  const pkgJsonPath = path.join(workspaceBaseAppDir, 'package.json');
+  if (fs.existsSync(pkgJsonPath)) {
+    const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
+    if (!pkgJson.pnpm || !pkgJson.pnpm.onlyBuiltDependencies) {
+      throw new Error(`Assertion failed: pnpm.onlyBuiltDependencies is missing in ${pkgJsonPath}`);
+    }
+  }
 
-      // If this is a target-based task and zero-passrate.patch exists, apply it before agent execution
-      const targetZeroPassrate = path.join(taskInfo.guideDir, 'targets', taskName, ZERO_PASSRATE_PATCH_FILE);
-      const baseAppZeroPassrate = path.join(taskInfo.guideDir, 'targets', taskInfo.baseApp, ZERO_PASSRATE_PATCH_FILE);
-      const zeroPassratePath = fs.existsSync(targetZeroPassrate)
-        ? targetZeroPassrate
-        : (fs.existsSync(baseAppZeroPassrate) ? baseAppZeroPassrate : null);
+  // If this is a target-based task and zero-passrate.patch exists, apply it before agent execution
+  const targetZeroPassrate = path.join(taskInfo.guideDir, 'targets', taskName, ZERO_PASSRATE_PATCH_FILE);
+  const baseAppZeroPassrate = path.join(taskInfo.guideDir, 'targets', taskInfo.baseApp, ZERO_PASSRATE_PATCH_FILE);
+  const zeroPassratePath = fs.existsSync(targetZeroPassrate)
+    ? targetZeroPassrate
+    : (fs.existsSync(baseAppZeroPassrate) ? baseAppZeroPassrate : null);
 
-      if (zeroPassratePath) {
-        const applyRes = applyPatchSync(workspaceBaseAppDir, zeroPassratePath);
-        if (!applyRes.success) {
-          console.warn(`Failed to apply zero-passrate.patch to ${workspaceBaseAppDir}: ${applyRes.error}`);
-        } else {
-          console.log(`Applied zero-passrate.patch to ${workspaceBaseAppDir}`);
-        }
-      }
+  if (zeroPassratePath) {
+    const applyRes = applyPatchSync(workspaceBaseAppDir, zeroPassratePath);
+    if (!applyRes.success) {
+      console.warn(`Failed to apply zero-passrate.patch to ${workspaceBaseAppDir}: ${applyRes.error}`);
+    } else {
+      console.log(`Applied zero-passrate.patch to ${workspaceBaseAppDir}`);
     }
   }
 
@@ -403,7 +413,8 @@ export function generateTransientPackage(
   workspaceBaseAppDir: string,
   taskName: string,
   guideName: string,
-  graderPath: string
+  graderPath: string,
+  _baseApp: string = 'daily-grind'
 ) {
   if (!fs.existsSync(targetDir)) {
     fs.mkdirSync(targetDir, { recursive: true });
@@ -508,7 +519,7 @@ process.exit(graderStatus !== null ? graderStatus : result.status ?? 0);
 
   // Generate transient package.json
   // This tells pnpm that this directory is a "package" that can be run
-  // via \`pnpm run-agent\`.
+  // via `pnpm run-agent`.
   fs.writeFileSync(path.join(targetDir, 'package.json'), JSON.stringify({
     name: `${taskName.substring(0, 30)}-${runType}`,
     type: "module",

--- a/lib/guide-validation.ts
+++ b/lib/guide-validation.ts
@@ -343,8 +343,6 @@ export function getTaskMap(): Map<string, TaskInfo> {
   if (!fs.existsSync(guidesDir)) return taskMap;
 
   function processTasks(guideName: string, tasksDir: string, guideDir: string) {
-    let defaultPrompt: string | null = null;
-
     for (const taskEntry of fs.readdirSync(tasksDir, { withFileTypes: true })) {
       if (taskEntry.isDirectory() || !taskEntry.name.endsWith('.md')) continue;
       const taskFileName = taskEntry.name;
@@ -365,19 +363,7 @@ export function getTaskMap(): Map<string, TaskInfo> {
         guideDir: guideDir,
       };
 
-      if (taskName === 'task') {
-        defaultPrompt = prompt;
-      }
-
       taskMap.set(`${guideName}/${taskName}`, info);
-    }
-
-    if (defaultPrompt) {
-      taskMap.set(`${guideName}/negative`, {
-        baseApp: NEGATIVE_DEMO_FILE,
-        prompt: defaultPrompt,
-        guideDir: guideDir,
-      });
     }
   }
 

--- a/lib/patch-utils.ts
+++ b/lib/patch-utils.ts
@@ -79,3 +79,18 @@ export function capturePatchFromGit(
   }
 }
 
+/**
+ * Initializes a clean git repository in the target directory with an initial commit.
+ * Required so git diff / capturePatchFromGit can track modified and new files.
+ */
+export function initGitRepo(workDir: string): void {
+  try {
+    execSync('git init && git config user.name "AI" && git config user.email "ai@example.com" && git add . && git commit --allow-empty -m "init"', {
+      cwd: workDir,
+      stdio: 'ignore'
+    });
+  } catch (err) {
+    console.warn(`Failed to initialize git in workDir ${workDir}: ${err}`);
+  }
+}
+

--- a/lib/patch-utils.ts
+++ b/lib/patch-utils.ts
@@ -93,4 +93,3 @@ export function initGitRepo(workDir: string): void {
     console.warn(`Failed to initialize git in workDir ${workDir}: ${err}`);
   }
 }
-


### PR DESCRIPTION
## Summary

This PR completes **Phase 3** of the base-app evaluation architecture and target calibration refactor for `modern-web-guidance-src`.

### Key Changes & Architectural Improvements:

#### 1. Target Evaluation & Sandboxed Grader Staging (`guides/run-grader.ts`, `guides/dev-guide.ts`, `guides/lib/utils.ts`)
- **Direct Workspace Staging**: Refactored `stageBaseAppWorkspace()` and `runPlaywright()` to stage target applications and `agent.patch` into isolated `/tmp/` sandboxes cleanly.
- **Unified `PlaywrightOptions` Environment**: Added `patchFile?: string` to `PlaywrightOptions`, consolidating `process.env.PATCH_FILE` assignment inside `executePlaywright()`.
- **Target Working Directory Resolution**: Corrected `appDir` and `effectiveTargetPath` resolution so both single-file targets and directory-based targets stage into Playwright test runners without path resolution errors.

#### 2. Result Collection & Git Patch Utilities (`lib/patch-utils.ts`, `harness/lib/agent-shared.ts`, `harness/run_suite.ts`)
- **Git Repo Initialization Helper**: Added `initGitRepo(workDir)` in `lib/patch-utils.ts` with `git commit --allow-empty -m "init"` to safely handle repository initialization in clean workspaces without non-zero exit codes.
- **Deduplicated Git Setup**: Replaced duplicated inline `execSync('git init...')` in `harness/run_suite.ts` with the `initGitRepo` helper.
- **Target Patch Tracking**: Updated `extractTargetModifiedFile()` and `isTargetAppPresent()` in `harness/lib/collection.ts` to recognize and collect `agent.patch` for base-app targets.

#### 3. Grader Generator & Legacy Cleanup (`guides/template.grader.ts`, `guides/test-fixture.ts`, `lib/guide-validation.ts`)
- Simplified target template grader generation for `daily-grind` and `devtools-times` targets.
- Removed legacy single-page task map fallbacks (`negative-demo.html` / `task.md`) in `lib/guide-validation.ts`.

---

### Verification:
- **Unit & Integration Tests**: All unit tests across `guides`, `harness`, `serving`, and `eval-view` pass green (`pnpm test` passed 100%).
- **Preflight Verification**: `pnpm preflight` (`build` + `typecheck` + `lint` + `test`) completed with 0 errors and 0 warnings.
- **Live Evaluation Calibration**: Verified end-to-end `gd dev` agent run and `gd eval` for the `size-aware-styling` guide which has the new targets-based graders.