### PR TITLE
feat(harness): embed subagent trajectories inline & support multi-session tool collection

### DIFF
--- a/harness/agents/claude-code-agent.ts
+++ b/harness/agents/claude-code-agent.ts
@@ -9,7 +9,7 @@ import { generateClaudeTrajectoryHtml } from '../lib/claude-trajectory-viewer.ts
 // NOTE: Native Claude Code logs in ~/.claude/projects are stored without a prefix.
 // However, exportClaudeCodeTrajectories() explicitly prepends 'session-' when copying them
 // into the test output directory to ensure uniform matching across the dashboard and metrics engine.
-const TRAJECTORY_GLOB = 'session-*.jsonl';
+const TRAJECTORY_GLOB = '*.jsonl';
 
 function getSessionFiles(dir: string, recursive = false): string[] {
   return fs.globSync(recursive ? `**/${TRAJECTORY_GLOB}` : TRAJECTORY_GLOB, { cwd: dir });
@@ -64,19 +64,19 @@ function exportClaudeCodeTrajectories(workDir: string, targetDir: string): void 
 
   // Find all jsonl files in the Claude projects directory
   const files = fs.globSync('**/*.jsonl', { cwd: claudeLogDir });
-  
+  const parsedSessions: { relativePath: string; baseName: string; logData: any[] }[] = [];
+  const subagentsMap: Record<string, any[]> = {};
+
+  // Step 1: Read all JSONL files and populate subagentsMap
   for (const relativePath of files as string[]) {
     const src = path.join(claudeLogDir, relativePath);
-    
-    // 1. Determine base name and copy original JSONL file to targetDir
     const baseName = relativePath.replace(/[\\/]/g, '-').replace(/\.jsonl$/, '');
-    const rawDestName = `session-${baseName}.jsonl`;
+    const isSubagent = relativePath.includes('subagents/');
+    const rawDestName = isSubagent ? `subagent-${baseName}.jsonl` : `session-${baseName}.jsonl`;
     fs.copyFileSync(src, path.join(targetDir, rawDestName));
 
-    // 2. Read and parse JSONL
     const logContent = fs.readFileSync(src, 'utf8');
     const jsonLines = logContent.split(/\r?\n/).filter(Boolean);
-    
     const logData = jsonLines.map(line => {
       try {
         return JSON.parse(line);
@@ -86,13 +86,23 @@ function exportClaudeCodeTrajectories(workDir: string, targetDir: string): void 
       }
     });
 
-    // 3. Generate and save the HTML viewer
-    const htmlContent = generateClaudeTrajectoryHtml(logData);
+    parsedSessions.push({ relativePath, baseName, logData });
 
-    // 4. Save HTML viewer to target directory
-    const destName = `session-${baseName}.html`;
-    const dest = path.join(targetDir, destName);
-    fs.writeFileSync(dest, htmlContent, 'utf8');
+    // Match subagent ID if this is a subagent file
+    const match = relativePath.match(/subagents[/\\]agent-([a-zA-Z0-9_-]+)\.jsonl$/);
+    if (match && match[1]) {
+      subagentsMap[match[1]] = logData;
+    }
+  }
+
+  // Step 2: Generate HTML viewers embedding subagent trajectories where referenced (main sessions only)
+  for (const session of parsedSessions) {
+    if (!session.relativePath.includes('subagents/')) {
+      const htmlContent = generateClaudeTrajectoryHtml(session.logData, subagentsMap);
+      const destName = `session-${session.baseName}.html`;
+      const dest = path.join(targetDir, destName);
+      fs.writeFileSync(dest, htmlContent, 'utf8');
+    }
   }
 }
 
@@ -222,15 +232,17 @@ export function collectClaudeToolsFromTrajectory(dir: string): string[] {
   const sessionFiles = getSessionFiles(dir);
   if (sessionFiles.length === 0) return toolsUsed;
 
-  const items = parseJsonlFile(path.join(dir, sessionFiles[0]));
-  for (const obj of items) {
-    const content = obj.message?.content;
-    for (const item of Array.isArray(content) ? content : []) {
-      if (item.type === 'tool_use') {
-        if (item.name === 'Skill' && item.input?.skill) {
-          toolsUsed.push(item.input.skill);
-        } else if (item.name === 'activate_skill' && item.input?.name) {
-          toolsUsed.push(item.input.name);
+  for (const file of sessionFiles) {
+    const items = parseJsonlFile(path.join(dir, file));
+    for (const obj of items) {
+      const content = obj.message?.content;
+      for (const item of Array.isArray(content) ? content : []) {
+        if (item.type === 'tool_use') {
+          if (item.name === 'Skill' && item.input?.skill) {
+            toolsUsed.push(item.input.skill);
+          } else if (item.name === 'activate_skill' && item.input?.name) {
+            toolsUsed.push(item.input.name);
+          }
         }
       }
     }

--- a/harness/agents/codex-cli-agent.ts
+++ b/harness/agents/codex-cli-agent.ts
@@ -225,21 +225,23 @@ export function collectCodexToolsFromTrajectory(dir: string): string[] {
   const sessionFiles = getSessionFiles(dir);
   if (sessionFiles.length === 0) return toolsUsed;
 
-  const items = parseJsonlFile(path.join(dir, sessionFiles[0]));
-  for (const obj of items) {
-    const functionCall = obj.type === 'function_call' ? obj : (obj.payload?.type === 'function_call' ? obj.payload : null);
-    if (functionCall?.name === 'exec_command' && functionCall.arguments) {
-      try {
-        const args = typeof functionCall.arguments === 'string' ? JSON.parse(functionCall.arguments) : functionCall.arguments;
-        const command = args.cmd || '';
-        if (command.includes('/skills/') && command.includes('SKILL.md')) {
-          const match = command.match(/\.agents\/skills\/([^/]+)\/SKILL\.md/);
-          if (match) {
-            toolsUsed.push(match[1]);
+  for (const file of sessionFiles) {
+    const items = parseJsonlFile(path.join(dir, file));
+    for (const obj of items) {
+      const functionCall = obj.type === 'function_call' ? obj : (obj.payload?.type === 'function_call' ? obj.payload : null);
+      if (functionCall?.name === 'exec_command' && functionCall.arguments) {
+        try {
+          const args = typeof functionCall.arguments === 'string' ? JSON.parse(functionCall.arguments) : functionCall.arguments;
+          const command = args.cmd || '';
+          if (command.includes('/skills/') && command.includes('SKILL.md')) {
+            const match = command.match(/\.agents\/skills\/([^/]+)\/SKILL\.md/);
+            if (match) {
+              toolsUsed.push(match[1]);
+            }
           }
+        } catch {
+          // Ignore
         }
-      } catch {
-        // Ignore
       }
     }
   }

--- a/harness/agents/gemini-cli-agent.ts
+++ b/harness/agents/gemini-cli-agent.ts
@@ -242,27 +242,28 @@ export function extractGeminiCliTokenUsage(dir: string): { total: number; cached
 export function collectGeminiToolsFromTrajectory(dir: string): string[] {
   const toolsUsed: string[] = [];
   const sessionFiles = getSessionFiles(dir);
-  const firstSession = sessionFiles[0];
-  if (!firstSession) return toolsUsed;
+  if (sessionFiles.length === 0) return toolsUsed;
 
-  try {
-    const sessionPath = path.join(dir, firstSession);
-    const session = readTrajectory(sessionPath);
-    if (Array.isArray(session.messages)) {
-      for (const msg of session.messages) {
-        if (msg.type === 'gemini' && Array.isArray(msg.toolCalls)) {
-          for (const tc of msg.toolCalls) {
-            if (tc.name.includes('get_best_practices')) {
-              toolsUsed.push('modern-web-guidance');
-            } else if (tc.name === 'activate_skill' && tc.args && tc.args.name) {
-              toolsUsed.push(tc.args.name as string);
+  for (const sessionFile of sessionFiles) {
+    try {
+      const sessionPath = path.join(dir, sessionFile);
+      const session = readTrajectory(sessionPath);
+      if (Array.isArray(session.messages)) {
+        for (const msg of session.messages) {
+          if (msg.type === 'gemini' && Array.isArray(msg.toolCalls)) {
+            for (const tc of msg.toolCalls) {
+              if (tc.name.includes('get_best_practices')) {
+                toolsUsed.push('modern-web-guidance');
+              } else if (tc.name === 'activate_skill' && tc.args && tc.args.name) {
+                toolsUsed.push(tc.args.name as string);
+              }
             }
           }
         }
       }
+    } catch (e) {
+      console.error(`Failed to collect guidance tools used for Gemini CLI in ${sessionFile}:`, e);
     }
-  } catch (e) {
-    console.error(`Failed to collect guidance tools used for Gemini CLI:`, e);
   }
 
   return Array.from(new Set(toolsUsed));

--- a/harness/lib/claude-trajectory-viewer.ts
+++ b/harness/lib/claude-trajectory-viewer.ts
@@ -1,6 +1,6 @@
-export function generateClaudeTrajectoryHtml(logData: any[]): string {
+export function generateClaudeTrajectoryHtml(logData: any[], subagentsMap: Record<string, any[]> = {}): string {
   // Escape '<' in the JSON representation to prevent XSS or broken script tags
-  const safeJsonData = JSON.stringify(logData).replace(/</g, '\\u003c');
+  const safeData = JSON.stringify({ logData, subagentsMap }).replace(/</g, '\\u003c');
 
   return `<!DOCTYPE html>
 <html>
@@ -23,14 +23,23 @@ export function generateClaudeTrajectoryHtml(logData: any[]): string {
     .code-change { background-color: #dcfce7; padding: 10px; border-radius: 4px; border-left: 4px solid #22c55e; margin: 10px 0; font-family: monospace; white-space: pre-wrap; }
     .raw-json { display: none; background: #f8f9fa; padding: 10px; border-radius: 4px; font-size: 0.8em; overflow-x: auto; margin-top: 10px; border: 1px solid #e5e7eb; white-space: pre-wrap; }
     .toggle-raw { cursor: pointer; color: #3b82f6; text-decoration: underline; font-size: 0.85em; margin-top: 10px; display: inline-block; }
+    .subagent-block { margin: 15px 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; white-space: normal; }
+    .subagent-details { background: #faf5ff; border: 2px solid #a855f7; border-radius: 8px; padding: 12px; box-shadow: 0 4px 6px -1px rgba(168, 85, 247, 0.1); }
+    .subagent-summary { cursor: pointer; font-weight: bold; color: #6b21a8; font-size: 0.95em; display: flex; align-items: center; justify-content: space-between; }
+    .subagent-summary:hover { color: #581c87; }
+    .subagent-badge { background: #8b5cf6; color: #fff; padding: 3px 8px; border-radius: 12px; font-size: 0.75em; font-weight: bold; margin-left: 8px; }
   </style>
 </head>
 <body>
   <h2>Claude Code Trajectory Viewer</h2>
   <div id="logs"></div>
   <script>
-    const logData = ${safeJsonData};
+    const payload = ${safeData};
+    const logData = payload.logData || [];
+    const subagentsMap = payload.subagentsMap || {};
     const logsContainer = document.getElementById('logs');
+    const thinkingRegex = new RegExp('&lt;thinking&gt;([\\\\s\\\\S]*?)&lt;/thinking&gt;', 'g');
+    const agentIdRegex = new RegExp('agentId:\\\\s*([a-zA-Z0-9_-]+)');
     
     function escapeHtml(str) {
       return (str || '').toString()
@@ -45,7 +54,7 @@ export function generateClaudeTrajectoryHtml(logData: any[]): string {
       if (!content) return '';
       if (typeof content === 'string') {
         let html = escapeHtml(content);
-        html = html.replace(/&lt;thinking&gt;([\\s\\S]*?)&lt;\\/thinking&gt;/g, '<div class="thought"><b>Thought:</b>\\n$1</div>');
+        html = html.replace(thinkingRegex, '<div class="thought"><b>Thought:</b><br/>$1</div>');
         return '<div class="text-content">' + html + '</div>';
       }
       
@@ -53,7 +62,7 @@ export function generateClaudeTrajectoryHtml(logData: any[]): string {
         return content.map(block => {
           if (block.type === 'text') {
              let html = escapeHtml(block.text);
-             html = html.replace(/&lt;thinking&gt;([\\s\\S]*?)&lt;\\/thinking&gt;/g, '<div class="thought"><b>Thought:</b>\\n$1</div>');
+             html = html.replace(thinkingRegex, '<div class="thought"><b>Thought:</b><br/>$1</div>');
              return '<div class="text-content">' + html + '</div>';
           }
           if (block.type === 'thinking') {
@@ -87,15 +96,67 @@ export function generateClaudeTrajectoryHtml(logData: any[]): string {
              return \`<div class="tool-use"><b>Tool: \${safeName} [\${safeId}]</b><br/>\${safeInput}</div>\`;
           }
           if (block.type === 'tool_result') {
-             const out = typeof block.content === 'string' ? escapeHtml(block.content) : formatContent(block.content);
+             let out = typeof block.content === 'string' ? escapeHtml(block.content) : formatContent(block.content);
              const errorClass = block.is_error ? ' error' : '';
              const errorText = block.is_error ? ' [ERROR]' : '';
-             return \`<div class="tool-result\${errorClass}"><b>Tool Result [\${escapeHtml(block.tool_use_id)}]\${errorText}:</b><br/>\${out}</div>\`;
+
+             // Check for subagent output and embed subagent trajectory if available
+             let subagentHtml = '';
+             let matchedSubagentId = null;
+             if (typeof block.content === 'string') {
+               const match = block.content.match(agentIdRegex);
+               if (match && match[1]) matchedSubagentId = match[1];
+             } else if (Array.isArray(block.content)) {
+               for (const item of block.content) {
+                 if (item?.type === 'text' && typeof item.text === 'string') {
+                   const match = item.text.match(agentIdRegex);
+                   if (match && match[1]) { matchedSubagentId = match[1]; break; }
+                 }
+               }
+             }
+
+             if (matchedSubagentId && subagentsMap[matchedSubagentId]) {
+               const subLogs = subagentsMap[matchedSubagentId];
+               const renderedSubagent = renderSubagentLogEntries(subLogs);
+               subagentHtml = \`
+                 <div class="subagent-block">
+                   <details class="subagent-details">
+                     <summary class="subagent-summary">
+                       <span>🤖 <strong>Subagent Trajectory</strong> (ID: agent-\${escapeHtml(matchedSubagentId)}) <span class="subagent-badge">\${subLogs.length} steps</span></span>
+                       <span style="font-size:0.85em; text-decoration:underline;">Click to Expand/Collapse</span>
+                     </summary>
+                     <div style="margin-top:12px; padding-left:12px; border-left:3px solid #8b5cf6;">
+                       \${renderedSubagent}
+                     </div>
+                   </details>
+                 </div>
+               \`;
+             }
+
+             return \`<div class="tool-result\${errorClass}"><b>Tool Result [\${escapeHtml(block.tool_use_id)}]\${errorText}:</b><br/>\${out}</div>\${subagentHtml}\`;
           }
           return \`<div class="raw-json" style="display:block;">\${escapeHtml(JSON.stringify(block, null, 2))}</div>\`;
         }).join('');
       }
       return '<div class="text-content">' + escapeHtml(JSON.stringify(content, null, 2)) + '</div>';
+    }
+
+    function renderSubagentLogEntries(entries) {
+      if (!Array.isArray(entries)) return '';
+      return entries.map((entry, idx) => {
+        let role = entry.role || entry.type || 'unknown';
+        let mainContent = entry.message || entry.content || entry;
+        if (entry.message && entry.message.content) {
+          mainContent = entry.message.content;
+          role = entry.message.role || role;
+        }
+        return \`
+          <div class="log-entry role-\${escapeHtml(role)}" style="margin-bottom:12px; padding:10px;">
+            <div class="meta" style="font-size:0.8em; color:#7e22ce;">SUBAGENT \${escapeHtml(role).toUpperCase()} (Step \${idx + 1})</div>
+            <div class="content-block">\${formatContent(mainContent)}</div>
+          </div>
+        \`;
+      }).join('');
     }
 
     logData.forEach((entry, i) => {


### PR DESCRIPTION
## Summary of Problems & Solutions

### 1. Multi-Session Tool & Metric Collection Gap
* **Problem**: Agent harnesses (`claude-code-agent`, `codex-cli-agent`, `gemini-cli-agent`) were only collecting tool usage and metrics from `sessionFiles[0]`. When an agent spawned subagents or created secondary session files, tools executed within subagent sessions were omitted from summary metrics.
Led to issues with missing MWG tool call:
<img width="433" height="92" alt="Screenshot 2026-07-30 at 2 48 10 PM" src="https://github.com/user-attachments/assets/82cdad16-a168-4604-953e-1f1b1d5efee3" />

* **Solution**: Updated `collectClaudeToolsFromTrajectory`, `collectCodexToolsFromTrajectory`, and `collectGeminiToolsFromTrajectory` to iterate over all `sessionFiles` in the run directory.

### 2. Trajectory Viewer Resolution & Subagent Visibility
* **Problem**: Claude Code creates separate session logs for subagents under `subagents/agent-*.jsonl`. Exporting standalone `session-*-subagents-*.html` files caused dashboard trajectory resolution to pick subagent files over main session files, hiding the primary trajectory.
* **Solution**:
  * Modified `claude-trajectory-viewer.ts` to support `subagentsMap` and render subagent trajectories inline inside an expandable purple `<details>` card directly below the subagent's `Tool Result`.
  * Updated `claude-code-agent.ts` to name raw subagent logs `subagent-*.jsonl` and generate HTML viewers exclusively for main session files (`session-*.html`).

Subagent Trajectory is now viewable: <img width="1667" height="660" alt="Screenshot 2026-07-30 at 2 43 28 PM" src="https://github.com/user-attachments/assets/21cbec2e-dc94-42be-ab88-640dee2dc3eb" />