### PR TITLE
Use exponential w/ jitter when retrying

### DIFF
--- a/harness/run_suite.ts
+++ b/harness/run_suite.ts
@@ -456,15 +456,30 @@ env.PATH = \`${targetDir}:\${env.PATH}\`;
 const start = Date.now();
 let result;
 let attempts = 0;
-const maxAttempts = 3; // 1 initial attempt + 2 retries
+const maxAttempts = 5; // 1 initial attempt + 4 retries with exponential backoff
+const baseDelay = 15000; // 15 seconds base delay
 
 while (attempts < maxAttempts) {
   attempts++;
   result = spawnSync(process.execPath, args, { stdio: 'inherit', cwd: ${JSON.stringify(process.cwd())}, timeout: 600000, env });
   if (result.status === 0) break;
+
+  // Check if this is a rate limit error (429)
+  const isRateLimit = result.status === 1 || (result.stderr && result.stderr.toString().includes('429'));
+
   if (attempts < maxAttempts) {
-    console.warn('⚠️ Attempt ' + attempts + ' failed with status ' + result.status + '. Waiting 20 seconds before retrying...');
-    spawnSync(process.execPath, ['-e', 'setTimeout(()=>{}, 20000)']);
+    // Exponential backoff: 15s, 30s, 60s, 120s (with some jitter)
+    // For rate limits, use longer delays
+    const base = isRateLimit ? 30000 : baseDelay;
+    const delay = base * Math.pow(2, attempts - 1) + Math.random() * 5000;
+    const delaySec = Math.round(delay / 1000);
+
+    if (isRateLimit) {
+      console.warn('⚠️ Rate limit hit (429). Attempt ' + attempts + ' failed. Waiting ' + delaySec + 's before retry...');
+    } else {
+      console.warn('⚠️ Attempt ' + attempts + ' failed with status ' + result.status + '. Waiting ' + delaySec + 's (exponential backoff)...');
+    }
+    spawnSync(process.execPath, ['-e', 'setTimeout(()=>{}, ' + delay + ')']);
   }
 }
 const runtime = Date.now() - start;

--- a/harness/tests/runner-retry.test.ts
+++ b/harness/tests/runner-retry.test.ts
@@ -14,11 +14,11 @@ function removeTempDir(dir: string) {
   fs.rmSync(dir, { recursive: true, force: true });
 }
 
-// Helper to patch the 20-second delay in the generated run.mjs to 1ms
+// Helper to patch the delay in the generated run.mjs to 1ms
 function patchRunnerDelay(targetDir: string) {
   const runMjsPath = path.join(targetDir, 'run.mjs');
   let content = fs.readFileSync(runMjsPath, 'utf8');
-  content = content.replace("setTimeout(()=>{}, 20000)", "setTimeout(()=>{}, 1)");
+  content = content.replace(/setTimeout\(\(\)=>{}, ' \+ delay \+ '\)/g, "setTimeout(()=>{}, 1)");
   fs.writeFileSync(runMjsPath, content, 'utf8');
 }
 
@@ -199,7 +199,7 @@ test('run.mjs: fails permanently after maximum attempts', () => {
     // Check state
     const state = getMockAgentState(tempDir);
     assert.ok(state, 'State file should exist');
-    assert.strictEqual(state.attempts, 3, 'Should have attempted exactly 3 times (1 initial + 2 retries)');
+    assert.strictEqual(state.attempts, 5, 'Should have attempted exactly 5 times (1 initial + 4 retries)');
 
     // Check generation_failed.json exists and has correct info
     const failureFile = path.join(tempDir, 'generation_failed.json');


### PR DESCRIPTION
I got unlucky running evals w/ many workers and hit an OpenRouter limit enough times to get no results for a couple guides. Retrying w/ an exponential backoff + random jitter would have prevented that.