### PR TITLE
feat: add Kimi Code plugin manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,14 @@ grok plugin install https://github.com/GoogleChrome/modern-web-guidance --trust
 ```
 </details>
 
+<details>
+<summary><b>Kimi Code</b></summary>
+
+```shell
+/plugins install https://github.com/GoogleChrome/modern-web-guidance
+```
+</details>
+
 ## <img src="https://github.com/GoogleChrome/modern-web-guidance/raw/main/.github/img/refresh-cw.svg" width="24" height="24" style="vertical-align: middle; margin-right: 4px;"> Updating
 
 If you installed the skill using `npx modern-web-guidance@latest install`, you can update with: `npx modern-web-guidance@latest update`.

--- a/serving/skills-cli/RELEASING.md
+++ b/serving/skills-cli/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing Modern Web Guidance Skills
 
-To release updates for our AI skills (Claude Code, Gemini CLI, and VS Code Extensions), we use an automated pipeline that bundles our source files into a lightweight distribution pack (`dist/`) and pushes it to `GoogleChrome/modern-web-guidance`.
+To release updates for our AI skills (Claude Code, Gemini CLI, VS Code, Cursor, GitHub Copilot CLI, and Kimi Code), we use an automated pipeline that bundles our source files into a lightweight distribution pack (`dist/`) and pushes it to `GoogleChrome/modern-web-guidance`.
 
 ## The Publishing Pipeline
 
@@ -11,7 +11,7 @@ pnpm --filter serving run publish-skills
 ```
 
 **What this script does under the hood:**
-1. Increments the patch version (`v0.0.x`) across all extension manifests (Gemini, Claude, and VS Code).
+1. Increments the patch version (`v0.0.x`) across all extension manifests (Gemini, Claude, VS Code, Cursor, Copilot, and Kimi).
 2. Executes the build process to bundle all tools, local databases, and metadata, alongside injecting dynamic markdown into the README.
 3. Runs integration tests to ensure the `dist/` directory was compiled correctly.
 4. Pushes the compiled `dist/` folder to the `main` branch of `git@github.com:GoogleChrome/modern-web-guidance.git`.

--- a/serving/skills-cli/build-dist.ts
+++ b/serving/skills-cli/build-dist.ts
@@ -73,6 +73,11 @@ function updateVersionsInDir(publishCliDir: string, newVersion: string) {
   copilotPluginData.version = newVersion;
   fs.writeFileSync(copilotPluginPath, JSON.stringify(copilotPluginData, null, 2) + '\n');
 
+  // Kimi plugin
+  const kimiPluginPath = path.join(publishCliDir, "kimi.plugin.json");
+  const kimiPluginData = JSON.parse(fs.readFileSync(kimiPluginPath, 'utf8'));
+  kimiPluginData.version = newVersion;
+  fs.writeFileSync(kimiPluginPath, JSON.stringify(kimiPluginData, null, 2) + '\n');
 }
 
 export function processSkills(publishRoot: string) {

--- a/serving/skills-cli/template/README.md
+++ b/serving/skills-cli/template/README.md
@@ -155,6 +155,14 @@ grok plugin install https://github.com/GoogleChrome/modern-web-guidance --trust
 ```
 </details>
 
+<details>
+<summary><b>Kimi Code</b></summary>
+
+```shell
+/plugins install https://github.com/GoogleChrome/modern-web-guidance
+```
+</details>
+
 ## <img src="https://github.com/GoogleChrome/modern-web-guidance/raw/main/.github/img/refresh-cw.svg" width="24" height="24" style="vertical-align: middle; margin-right: 4px;"> Updating
 
 If you installed the skill using `npx modern-web-guidance@latest install`, you can update with: `npx modern-web-guidance@latest update`.

--- a/serving/skills-cli/template/kimi.plugin.json
+++ b/serving/skills-cli/template/kimi.plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "modern-web-guidance",
-  "description": "Keep your coding agent up to date with the latest web best practices",
+  "description": "Modern Web Guidance is an agent skill and CLI tool designed to help AI coding agents build web applications using modern, secure, and high-performance APIs rather than outdated workarounds. Supported by the Google Chrome team, it injects expert-curated web platform best practices directly into an agent's context window to prevent the generation of bloated, legacy code.",
   "version": "0.0.26",
   "author": {
     "name": "Google Chrome"

--- a/serving/skills-cli/template/kimi.plugin.json
+++ b/serving/skills-cli/template/kimi.plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "modern-web-guidance",
+  "description": "Keep your coding agent up to date with the latest web best practices",
+  "version": "0.0.26",
+  "author": {
+    "name": "Google Chrome"
+  },
+  "license": "Apache-2.0",
+  "skills": [
+    "./skills/modern-web-guidance/",
+    "./skills/chrome-extensions/"
+  ]
+}

--- a/serving/skills-cli/test-dist.test.ts
+++ b/serving/skills-cli/test-dist.test.ts
@@ -54,6 +54,24 @@ test('Gemini and VS Code manifests', async () => {
   assert.strictEqual(pkgJson.contributes.chatSkills[0].path, './skills/modern-web-guidance/SKILL.md');
 });
 
+test('Kimi plugin manifest', async () => {
+  const kimiJson = JSON.parse(await fs.readFile(path.join(STAGING_DIR, 'kimi.plugin.json'), 'utf8'));
+  assert.strictEqual(kimiJson.name, 'modern-web-guidance');
+  assert.strictEqual(kimiJson.author.name, 'Google Chrome');
+
+  // updateVersionsInDir must keep the manifest version in sync with the rest of the distribution
+  const pkgJson = JSON.parse(await fs.readFile(path.join(STAGING_DIR, 'package.json'), 'utf8'));
+  assert.strictEqual(kimiJson.version, pkgJson.version, 'kimi.plugin.json version should match package.json version');
+
+  // Kimi resolves each `skills` entry relative to the plugin root (the dist dir)
+  assert.deepStrictEqual(kimiJson.skills, ['./skills/modern-web-guidance/', './skills/chrome-extensions/']);
+  for (const skillDir of kimiJson.skills) {
+    assert.ok(skillDir.startsWith('./'), `Kimi skills path ${skillDir} must start with './'`);
+    const resolvedSkillMd = path.join(STAGING_DIR, skillDir, 'SKILL.md');
+    await assert.doesNotReject(fs.access(resolvedSkillMd), `Kimi skills path ${skillDir} must resolve to a directory containing SKILL.md`);
+  }
+});
+
 test('SKILL.md validations', async () => {
   const skillPath = path.join(STAGING_DIR, 'skills/modern-web-guidance/SKILL.md');
   await assert.doesNotReject(fs.access(skillPath), `Missing SKILL.md in modern-web-guidance`);


### PR DESCRIPTION
## What

Adds a [Kimi Code](https://github.com/MoonshotAI/kimi-code) plugin manifest so Kimi Code users can install Modern Web Guidance directly:

```shell
/plugins install https://github.com/GoogleChrome/modern-web-guidance
```

Kimi Code resolves plugin manifests at the plugin root (`kimi.plugin.json` or `.kimi-plugin/plugin.json`). Unlike Claude Code / Cursor, it does not auto-discover a plugin's `skills/` directory — the manifest must declare each skills directory explicitly (its fallback only covers a root-level `SKILL.md`), so this file is required for both skills to load.

## Changes

- **`serving/skills-cli/template/kimi.plugin.json`** (new): declares `skills: ["./skills/modern-web-guidance/", "./skills/chrome-extensions/"]`. Field set and style follow `.claude-plugin/plugin.json`.
- **`build-dist.ts`**: bump `kimi.plugin.json` in `updateVersionsInDir()`, same pattern as the other platform manifests.
- **`test-dist.test.ts`**: new `Kimi plugin manifest` test asserting name/author, version in sync with `package.json`, and that each declared skills path starts with `./` and resolves to a directory containing `SKILL.md`.
- **README (root + template), RELEASING.md**: document the Kimi Code install method; bring the platform lists up to date (they previously also missed Cursor and Copilot).

## Testing

- `node serving/skills-cli/build-dist.ts` — dist now contains `kimi.plugin.json` with the version bumped to the latest tag.
- `node --test serving/skills-cli/test-dist.test.ts` — all tests pass (1 pre-existing skip).
- Verified the built manifest against Kimi Code's actual plugin loader (`parseManifest` + skill discovery in agent-core v2): zero diagnostics, both skills discovered.
- `oxlint` clean; no typecheck errors in the touched files.
- End-to-end manual smoke test in Kimi Code: installed the built artifact from a GitHub URL, reloaded the session, and verified that both `modern-web-guidance` and `chrome-extensions` were registered and usable. The former successfully ran its `search` / `retrieve` flow, and the latter loaded its extension-specific reference guidance.

Happy to adjust naming, file placement, or the README wording — and to open a tracking issue first if you'd like one for the proposal.
