### PR TITLE
fix: navigation-drawer guide link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ We cover the past several years of the web platform's new features, all the way 
   </tr>
 </table>
 
-_View an example:_ [the `navigation-drawer` guide](https://github.com/GoogleChrome/modern-web-guidance/blob/main/skills/modern-web-guidance/guides/overlays/navigation-drawer.md).
+_View an example:_ [the `navigation-drawer` guide](https://github.com/GoogleChrome/modern-web-guidance/blob/main/skills/modern-web-guidance/guides/ui-components/navigation-drawer.md).
 
 <!-- INJECT_SKILL_COVERAGE_START -->
 #### The full list


### PR DESCRIPTION
Fixes a 404 error when trying to access the navigation drawer guide