### PR TITLE
feat(cli): `gd compare` and AI variance diagnosis (2/3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,3 @@ serving/lib/tfjs_model_minilm/saved_model*/
 # Agent skills artifacts
 .agents/skills/nightly-eval-investigation/artifacts/
 
-# AI Variance Diagnosis outputs
-harness/results/
-variance_diagnosis.md

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,7 @@ serving/lib/tfjs_model_minilm/saved_model*/
 
 # Agent skills artifacts
 .agents/skills/nightly-eval-investigation/artifacts/
+
+# AI Variance Diagnosis outputs
+harness/results/
+variance_diagnosis.md

--- a/bin/gd.ts
+++ b/bin/gd.ts
@@ -47,6 +47,7 @@ const COMMAND_METADATA = {
   backfill: { desc: 'Backfill metrics for historical suites', flags: [] },
   baselinestatus: { desc: 'Check browser support and Baseline status', flags: [] },
   pr: { desc: 'Push branch and create or update GitHub PR from dev report', flags: [] },
+  compare: { desc: 'Compare two evaluation runs to diagnose performance variance', flags: [] },
 
   'setup-completion': { desc: 'Install shell auto-completion', flags: [] },
 } satisfies Record<string, { desc: string; flags: OptionName[] }>;
@@ -171,7 +172,7 @@ function showHelp() {
 
     {
       title: 'Evaluation & Dashboard',
-      commands: ['eval', 'run', 'dashboard', 'deploy', 'upload', 'backfill'],
+      commands: ['eval', 'run', 'dashboard', 'deploy', 'upload', 'backfill', 'compare'],
     },
     {
       title: 'Utilities & Setup',
@@ -225,6 +226,19 @@ async function main() {
   }
 
   switch (command) {
+    case 'compare': {
+      const runDirA = requireArg(positionals[1], 'gd compare <runDirA> <runDirB>');
+      const runDirB = requireArg(positionals[2], 'gd compare <runDirA> <runDirB>');
+      const { runComparison } = await import('../harness/lib/compare-evals.ts');
+      try {
+        await runComparison(runDirA, runDirB);
+      } catch (err: any) {
+        console.error(`Comparison failed: ${err.message}`);
+        process.exit(1);
+      }
+      break;
+    }
+
     case 'setup-completion': {
       completion.setupShellInitFile();
       console.log('Auto-completion installed. Restart your terminal to apply.');

--- a/bin/gd.ts
+++ b/bin/gd.ts
@@ -197,7 +197,7 @@ function showHelp() {
       const meta = COMMAND_METADATA[cmd as CommandName];
       if (!meta) continue;
 
-      const args = (cmd === 'dev' || cmd === 'pr') ? ' <dir>' : cmd === 'run' ? ' <tmpl> <prompt>' : cmd === 'eval' ? ' [suite|tasks...]' : cmd === 'baselinestatus' ? ' <query>' : '';
+      const args = (cmd === 'dev' || cmd === 'pr') ? ' <dir>' : cmd === 'run' ? ' <tmpl> <prompt>' : cmd === 'eval' ? ' [suite|tasks...]' : cmd === 'baselinestatus' ? ' <query>' : cmd === 'compare' ? ' <runDirA> <runDirB>' : '';
       console.log(`  ${cCyan((cmd + args).padEnd(28))} ${meta.desc}`);
 
       if (meta.flags.length > 0) {

--- a/bin/gd.ts
+++ b/bin/gd.ts
@@ -7,7 +7,7 @@ import { spawn } from 'child_process';
 import omelette from 'omelette';
 import { cRed, cCyan, cBold, cDim } from '../lib/colors.ts';
 import { Serving, resolveSuiteConfig } from '../harness/config.ts';
-import { rootDir, guidesDir, baseAppsDir, evalViewDir } from '../lib/paths.ts';
+import { rootDir, guidesDir, baseAppsDir, evalViewDir, resultsDir } from '../lib/paths.ts';
 import { getTaskMap } from '../lib/guide-validation.ts';
 
 // Load environment variables (Node 20.12+)
@@ -90,6 +90,14 @@ completion.on('arg1', ({ before, line, reply }) => {
   if (before === 'eval') {
     const tasks = Array.from(getTaskMap().keys());
     reply(['suite', ...tasks, ...listGuideDirs(), ...flags]);
+  } else if (before === 'compare') {
+    let recentRuns: string[] = [];
+    if (fs.existsSync(resultsDir)) {
+      try {
+        recentRuns = fs.readdirSync(resultsDir).filter(d => fs.statSync(path.join(resultsDir, d)).isDirectory());
+      } catch {}
+    }
+    reply([...recentRuns, ...flags]);
   } else if (before === 'gen') {
     reply(['grader']);
   } else if (before === 'audit') {
@@ -105,6 +113,14 @@ completion.on('arg2', ({ before, line, reply }) => {
   const flags = getFlagsForLine(line);
   if (line.includes('gd eval')) {
     reply(flags);
+  } else if (line.includes('gd compare')) {
+    let recentRuns: string[] = [];
+    if (fs.existsSync(resultsDir)) {
+      try {
+        recentRuns = fs.readdirSync(resultsDir).filter(d => fs.statSync(path.join(resultsDir, d)).isDirectory());
+      } catch {}
+    }
+    reply([...recentRuns, ...flags]);
   } else if (line.includes('gd dev') && before.startsWith('guides/')) {
     reply(flags);
   } else if (before === 'run') {

--- a/harness/README.md
+++ b/harness/README.md
@@ -727,3 +727,30 @@ The `--config` flag accepts either:
 - A JSON string via `GD_SUITE_CONFIG` environment variable (less convenient)
 
 See `harness/config-pi.ts` for an example configuration.
+
+## Diagnosing Performance Variance with `gd compare`
+
+The `gd compare` command compares two evaluation run directories to diagnose behavioral differences and performance variance between agent runs:
+
+```bash
+# Compare two local run directories
+gd compare harness/results/<suite-a>/<run-1>/<guide>/<task>/<run-type> harness/results/<suite-b>/<run-2>/<guide>/<task>/<run-type>
+
+# Example: Compare guided vs unguided runs
+gd compare harness/results/nightly-2026-08-10_17-00-02-jetski_cli/1/details-styling/task/guided harness/results/nightly-2026-08-10_17-00-02-jetski_cli/1/details-styling/task/unguided
+
+# Compare runs from remote GCS suites (automatically downloaded and cached locally)
+gd compare nightly-2026-08-10_17-00-02-jetski_cli/1/details-styling/task/guided nightly-2026-08-11_17-00-02-jetski_cli/1/details-styling/task/guided
+```
+
+### Path Formats
+Run directory paths can be:
+- **Local repository paths**: Paths relative to repo root (e.g. `harness/results/<suite-name>/<run-number>/<guide-name>/<task-name>/<run-type>`).
+- **Results-relative or remote suite paths**: Paths relative to `harness/results/` (e.g. `<suite-name>/<run-number>/<guide-name>/<task-name>/<run-type>`).
+- **Remote GCS buckets**: If the specified run directory is not found locally, `gd compare` automatically downloads the run artifacts from Google Cloud Storage (`gs://guidance-evals/<suite-path>`) before launching analysis.
+
+### Analysis Pipeline
+The comparison executes a three-phase pipeline:
+1. **Pre-processes trajectories** into chronological milestone steps (filtering noise and retrying error loops).
+2. **Dispatches parallel sub-agents** using the configured solution agent CLI (Jetski or Gemini CLI) to analyze guide compliance, code mutations, and friction.
+3. **Synthesizes a structured markdown diagnosis** written to `harness/results/<suite-name>/variance_diagnoses/<guide>-<task>-<runType>.md`.

--- a/harness/agents/claude-code-agent.ts
+++ b/harness/agents/claude-code-agent.ts
@@ -14,7 +14,8 @@ import {
   truncateMessage,
   finalizeTrajectorySummary,
   generateNormalizedTrajectory,
-  readTrajectorySummary
+  readTrajectorySummary,
+  standardizeAction
 } from '../lib/trajectory-normalizer.ts';
 import type { ClaudeLogEntry } from './claude.d.ts';
 
@@ -204,11 +205,7 @@ function parseClaudeLogEntries(
             timestamp,
             subagentId,
             thought,
-            action: {
-              type: mapToolType(tool.name || ''),
-              name: tool.name || 'unknown',
-              params: tool.input
-            }
+            action: standardizeAction(mapToolType(tool.name || ''), tool.name || 'unknown', tool.input)
           }) - 1;
 
           if (tool.id) {

--- a/harness/agents/codex-cli-agent.ts
+++ b/harness/agents/codex-cli-agent.ts
@@ -189,6 +189,8 @@ export function extractCommandsFromCodexItem(obj: any): string[] {
   if (typeof raw === 'object') {
     if (typeof raw.cmd === 'string') commands.push(raw.cmd);
     else if (typeof raw.command === 'string') commands.push(raw.command);
+    else if (Array.isArray(raw.command)) commands.push(raw.command.join(' '));
+    else if (Array.isArray(raw.cmd)) commands.push(raw.cmd.join(' '));
     return commands;
   }
 
@@ -198,6 +200,8 @@ export function extractCommandsFromCodexItem(obj: any): string[] {
       if (parsed && typeof parsed === 'object') {
         if (typeof parsed.cmd === 'string') return [parsed.cmd];
         if (typeof parsed.command === 'string') return [parsed.command];
+        if (Array.isArray(parsed.command)) return [parsed.command.join(' ')];
+        if (Array.isArray(parsed.cmd)) return [parsed.cmd.join(' ')];
       }
     } catch {
       // Not direct JSON

--- a/harness/agents/codex-cli-agent.ts
+++ b/harness/agents/codex-cli-agent.ts
@@ -25,7 +25,8 @@ import {
   finalizeTrajectorySummary,
   generateNormalizedTrajectory,
   readTrajectorySummary,
-  getSessionFiles
+  getSessionFiles,
+  standardizeAction
 } from '../lib/trajectory-normalizer.ts';
 import type { CodexRolloutLine } from './codex.d.ts';
 
@@ -289,11 +290,7 @@ export function parseCodexTrajectory(logData: CodexRolloutLine[] | any[], subage
           timestamp,
           subagentId,
           thought: currentThought || `Executing ${cmdName}`,
-          action: {
-            type: actionType,
-            name: actionName,
-            params
-          }
+          action: standardizeAction(actionType, actionName, params)
         };
         steps.push(step);
         if (subagentId) {

--- a/harness/agents/codex-cli-agent.ts
+++ b/harness/agents/codex-cli-agent.ts
@@ -326,7 +326,6 @@ export function parseCodexTrajectory(logData: CodexRolloutLine[] | any[], subage
         } else if (rawOut) {
           outStr = typeof rawOut === 'object' ? (rawOut.text || rawOut.content || JSON.stringify(rawOut)) : String(rawOut);
         }
-        }
         const step = callId ? callMap.get(callId) : undefined;
         if (step) {
           const isError = p.is_error === true || outStr.toLowerCase().includes('error:');
@@ -334,7 +333,6 @@ export function parseCodexTrajectory(logData: CodexRolloutLine[] | any[], subage
             status: isError ? 'error' : 'success',
             message: truncateMessage(outStr)
           };
-        }
         }
       }
 

--- a/harness/agents/codex-cli-agent.ts
+++ b/harness/agents/codex-cli-agent.ts
@@ -310,11 +310,14 @@ export function parseCodexTrajectory(logData: CodexRolloutLine[] | any[], subage
         const p = entry.payload;
         const callId = p.call_id;
         const rawOut = p.output ?? '';
-        const outStr = typeof rawOut === 'string'
-          ? rawOut
-          : Array.isArray(rawOut)
-            ? rawOut.map((item: any) => (typeof item === 'string' ? item : item?.text || JSON.stringify(item))).join('\n')
-            : JSON.stringify(rawOut);
+        let outStr = '';
+        if (typeof rawOut === 'string') {
+          outStr = rawOut;
+        } else if (Array.isArray(rawOut)) {
+          outStr = rawOut.map((c: any) => typeof c === 'string' ? c : c?.text || JSON.stringify(c)).join('\n');
+        } else if (rawOut) {
+          outStr = typeof rawOut === 'object' ? (rawOut.text || rawOut.content || JSON.stringify(rawOut)) : String(rawOut);
+        }
         const step = callId ? callMap.get(callId) : undefined;
         if (step) {
           const isError = p.is_error === true || outStr.toLowerCase().includes('error:');
@@ -322,6 +325,7 @@ export function parseCodexTrajectory(logData: CodexRolloutLine[] | any[], subage
             status: isError ? 'error' : 'success',
             message: truncateMessage(outStr)
           };
+        }
         }
       }
 

--- a/harness/agents/codex-cli-agent.ts
+++ b/harness/agents/codex-cli-agent.ts
@@ -28,7 +28,7 @@ import {
   getSessionFiles,
   standardizeAction
 } from '../lib/trajectory-normalizer.ts';
-import type { CodexRolloutLine } from './codex.d.ts';
+import type { CodexRolloutLine, CodexOutputContentBlock } from './codex.d.ts';
 
 const MAX_RESPONSE_PREVIEW_LENGTH = 150;
 
@@ -314,9 +314,18 @@ export function parseCodexTrajectory(logData: CodexRolloutLine[] | any[], subage
         if (typeof rawOut === 'string') {
           outStr = rawOut;
         } else if (Array.isArray(rawOut)) {
-          outStr = rawOut.map((c: any) => typeof c === 'string' ? c : c?.text || JSON.stringify(c)).join('\n');
+          outStr = rawOut
+            .map((c: CodexOutputContentBlock | unknown) =>
+              typeof c === 'string'
+                ? c
+                : c && typeof c === 'object' && 'text' in c && typeof (c as { text: unknown }).text === 'string'
+                  ? (c as { text: string }).text
+                  : JSON.stringify(c)
+            )
+            .join('\n');
         } else if (rawOut) {
           outStr = typeof rawOut === 'object' ? (rawOut.text || rawOut.content || JSON.stringify(rawOut)) : String(rawOut);
+        }
         }
         const step = callId ? callMap.get(callId) : undefined;
         if (step) {

--- a/harness/agents/codex.d.ts
+++ b/harness/agents/codex.d.ts
@@ -118,18 +118,24 @@ export interface CodexResponseFunctionCallItem {
 
 /**
  * Content block inside a Codex tool output item (Responses API format).
+ * Grounded in codex-rs (CodexFunctionCallOutputContentItem).
  * In OpenAI Responses API rollouts, output is typically an array of content blocks,
- * primarily input_text, text, or image.
+ * such as input_text, input_image, input_audio, or encrypted_content.
  */
-export type CodexOutputContentBlock =
+export type CodexFunctionCallOutputContentItem =
   | { type: "input_text"; text: string }
+  | { type: "input_image"; image_url: string; detail?: string }
+  | { type: "input_audio"; audio_url: string }
+  | { type: "encrypted_content"; encrypted_content: string }
   | { type: "text"; text: string }
   | { type: "image"; image_url?: string; [key: string]: unknown }
   | { type: string; text?: string; [key: string]: unknown };
 
+export type CodexOutputContentBlock = CodexFunctionCallOutputContentItem;
+
 export type CodexToolCallOutput =
   | string
-  | CodexOutputContentBlock[]
+  | CodexFunctionCallOutputContentItem[]
   | Record<string, unknown>;
 
 export interface CodexResponseFunctionCallOutputItem {

--- a/harness/agents/codex.d.ts
+++ b/harness/agents/codex.d.ts
@@ -116,11 +116,27 @@ export interface CodexResponseFunctionCallItem {
   status?: string;
 }
 
+/**
+ * Content block inside a Codex tool output item (Responses API format).
+ * In OpenAI Responses API rollouts, output is typically an array of content blocks,
+ * primarily input_text, text, or image.
+ */
+export type CodexOutputContentBlock =
+  | { type: "input_text"; text: string }
+  | { type: "text"; text: string }
+  | { type: "image"; image_url?: string; [key: string]: unknown }
+  | { type: string; text?: string; [key: string]: unknown };
+
+export type CodexToolCallOutput =
+  | string
+  | CodexOutputContentBlock[]
+  | Record<string, unknown>;
+
 export interface CodexResponseFunctionCallOutputItem {
   type: "function_call_output";
   id?: string;
   call_id: string;
-  output: string | Record<string, unknown> | Array<{ type: string; text?: string; [key: string]: unknown }>;
+  output: CodexToolCallOutput;
   is_error?: boolean;
 }
 
@@ -137,7 +153,7 @@ export interface CodexResponseCustomToolCallOutputItem {
   type: "custom_tool_call_output";
   id?: string;
   call_id: string;
-  output: string | Record<string, unknown> | Array<{ type: string; text?: string; [key: string]: unknown }>;
+  output: CodexToolCallOutput;
   is_error?: boolean;
 }
 

--- a/harness/agents/codex.d.ts
+++ b/harness/agents/codex.d.ts
@@ -120,7 +120,7 @@ export interface CodexResponseFunctionCallOutputItem {
   type: "function_call_output";
   id?: string;
   call_id: string;
-  output: string | Record<string, unknown> | Array<unknown>;
+  output: string | Record<string, unknown> | Array<{ type: string; text?: string; [key: string]: unknown }>;
   is_error?: boolean;
 }
 
@@ -137,7 +137,7 @@ export interface CodexResponseCustomToolCallOutputItem {
   type: "custom_tool_call_output";
   id?: string;
   call_id: string;
-  output: string | Record<string, unknown> | Array<unknown>;
+  output: string | Record<string, unknown> | Array<{ type: string; text?: string; [key: string]: unknown }>;
   is_error?: boolean;
 }
 

--- a/harness/agents/gemini-cli-agent.ts
+++ b/harness/agents/gemini-cli-agent.ts
@@ -14,7 +14,8 @@ import {
   truncateMessage,
   finalizeTrajectorySummary,
   generateNormalizedTrajectory,
-  readTrajectorySummary
+  readTrajectorySummary,
+  standardizeAction
 } from '../lib/trajectory-normalizer.ts';
 
 export function setupGeminiCliCredentials(tempHome: string): string {
@@ -143,11 +144,7 @@ export function parseGeminiTrajectory(session: any, subagentsMap: Record<string,
               timestamp,
               subagentId,
               thought,
-              action: {
-                type: mapToolType(tc.name || ''),
-                name: tc.name || 'unknown',
-                params: tc.args
-              }
+              action: standardizeAction(mapToolType(tc.name || ''), tc.name || 'unknown', tc.args)
             }) - 1;
             lastAssistantStepIndices.push(stepIdx);
           }

--- a/harness/agents/jetski-cli-agent.ts
+++ b/harness/agents/jetski-cli-agent.ts
@@ -298,8 +298,8 @@ export function parseJetskiCliSession(dirPath: string): TrajectorySummary {
           const objs = findJsonObjectsInString(payloadStr);
           const isErr = row.status !== undefined && JETSKI_ERROR_STATUS_CODES.has(row.status);
           for (const obj of objs) {
-            if (!obj.toolAction && !obj.toolSummary && !obj.CommandLine && !obj.AbsolutePath && !obj.DirectoryPath && !obj.TargetFile) continue;
-            const key = JSON.stringify({ cmd: obj.CommandLine, file: obj.AbsolutePath || obj.TargetFile || obj.DirectoryPath, act: obj.toolAction || obj.toolSummary });
+            if (!obj.toolAction && !obj.toolSummary && !obj.CommandLine && !obj.AbsolutePath && !obj.DirectoryPath && !obj.TargetFile && !obj.Query && !obj.query) continue;
+            const key = JSON.stringify({ cmd: obj.CommandLine, file: obj.AbsolutePath || obj.TargetFile || obj.DirectoryPath, query: obj.Query || obj.query, act: obj.toolAction || obj.toolSummary });
             if (seenJsonHashes.has(key)) continue;
             seenJsonHashes.add(key);
 
@@ -315,6 +315,7 @@ export function parseJetskiCliSession(dirPath: string): TrajectorySummary {
                 subagentId,
                 thought: obj.toolSummary || obj.toolAction || 'Modifying target file',
                 action: standardizeAction('write_file', toolName, {
+                  ...obj,
                   path: targetFile,
                   targetFile,
                   content: truncateMessage(obj.CodeContent || obj.ReplacementChunks || '', MAX_PAYLOAD_PREVIEW_LENGTH)
@@ -324,7 +325,7 @@ export function parseJetskiCliSession(dirPath: string): TrajectorySummary {
             } else if (obj.CommandLine || (obj.toolAction && obj.toolAction.includes('Running command'))) {
               const actType = 'run_command' as const;
               const actName = obj.CommandLine ? obj.CommandLine.split(' ')[0] : 'terminal_command';
-              const params = { command: obj.CommandLine || obj.toolAction || '' };
+              const params = { ...obj, command: obj.CommandLine || obj.toolAction || '' };
 
               steps.push({
                 stepNumber: 0,
@@ -340,16 +341,26 @@ export function parseJetskiCliSession(dirPath: string): TrajectorySummary {
                 timestamp,
                 subagentId,
                 thought: obj.toolSummary || obj.toolAction || 'Exploring workspace structure',
-                action: standardizeAction('read_file', 'view_file', { path: obj.AbsolutePath || obj.toolSummary || '' }),
+                action: standardizeAction('read_file', 'view_file', { ...obj, path: obj.AbsolutePath || obj.toolSummary || '' }),
                 outcome: { status: isErr ? 'error' : 'success' }
               });
-            } else if (obj.DirectoryPath || obj.SearchDirectory || (obj.toolAction && obj.toolAction.includes('Listing'))) {
+            } else if (obj.Query || obj.query) {
+              const query = obj.Query || obj.query;
+              steps.push({
+                stepNumber: 0,
+                timestamp,
+                subagentId,
+                thought: obj.toolSummary || obj.toolAction || 'Searching workspace',
+                action: standardizeAction('web_search', 'code_search', { ...obj, query }),
+                outcome: { status: isErr ? 'error' : 'success' }
+              });
+            } else if (obj.DirectoryPath || obj.SearchDirectory) {
               steps.push({
                 stepNumber: 0,
                 timestamp,
                 subagentId,
                 thought: obj.toolSummary || obj.toolAction || 'Exploring workspace structure',
-                action: standardizeAction('read_file', 'list_dir', { path: obj.DirectoryPath || obj.SearchDirectory || '' }),
+                action: standardizeAction('read_file', 'list_dir', { ...obj, path: obj.DirectoryPath || obj.SearchDirectory || '' }),
                 outcome: { status: isErr ? 'error' : 'success' }
               });
             }

--- a/harness/agents/jetski-cli-agent.ts
+++ b/harness/agents/jetski-cli-agent.ts
@@ -343,13 +343,13 @@ export function parseJetskiCliSession(dirPath: string): TrajectorySummary {
                 action: standardizeAction('read_file', 'view_file', { path: obj.AbsolutePath || obj.toolSummary || '' }),
                 outcome: { status: isErr ? 'error' : 'success' }
               });
-            } else if (obj.DirectoryPath || (obj.toolAction && obj.toolAction.includes('Listing'))) {
+            } else if (obj.DirectoryPath || obj.SearchDirectory || (obj.toolAction && obj.toolAction.includes('Listing'))) {
               steps.push({
                 stepNumber: 0,
                 timestamp,
                 subagentId,
                 thought: obj.toolSummary || obj.toolAction || 'Exploring workspace structure',
-                action: standardizeAction('read_file', 'list_dir', { path: obj.DirectoryPath || '' }),
+                action: standardizeAction('read_file', 'list_dir', { path: obj.DirectoryPath || obj.SearchDirectory || '' }),
                 outcome: { status: isErr ? 'error' : 'success' }
               });
             }

--- a/harness/agents/jetski-cli-agent.ts
+++ b/harness/agents/jetski-cli-agent.ts
@@ -23,7 +23,8 @@ import {
   truncateMessage,
   finalizeTrajectorySummary,
   generateNormalizedTrajectory,
-  readTrajectorySummary
+  readTrajectorySummary,
+  standardizeAction
 } from '../lib/trajectory-normalizer.ts';
 
 const JETSKI_ERROR_STATUS_CODES = new Set([2, 4, 5]);
@@ -313,31 +314,24 @@ export function parseJetskiCliSession(dirPath: string): TrajectorySummary {
                 timestamp,
                 subagentId,
                 thought: obj.toolSummary || obj.toolAction || 'Modifying target file',
-                action: {
-                  type: 'write_file',
-                  name: toolName,
-                  params: {
-                    targetFile,
-                    content: truncateMessage(obj.CodeContent || obj.ReplacementChunks || '', MAX_PAYLOAD_PREVIEW_LENGTH)
-                  }
-                },
+                action: standardizeAction('write_file', toolName, {
+                  path: targetFile,
+                  targetFile,
+                  content: truncateMessage(obj.CodeContent || obj.ReplacementChunks || '', MAX_PAYLOAD_PREVIEW_LENGTH)
+                }),
                 outcome: { status: isErr ? 'error' : 'success' }
               });
             } else if (obj.CommandLine || (obj.toolAction && obj.toolAction.includes('Running command'))) {
-              const actType: NonNullable<StandardizedStep['action']>['type'] = 'run_command';
+              const actType = 'run_command' as const;
               const actName = obj.CommandLine ? obj.CommandLine.split(' ')[0] : 'terminal_command';
-              const params: Record<string, any> = { command: obj.CommandLine || obj.toolAction };
+              const params = { command: obj.CommandLine || obj.toolAction || '' };
 
               steps.push({
                 stepNumber: 0,
                 timestamp,
                 subagentId,
                 thought: obj.toolSummary || obj.toolAction || 'Running terminal command',
-                action: {
-                  type: actType,
-                  name: actName,
-                  params
-                },
+                action: standardizeAction(actType, actName, params),
                 outcome: { status: isErr ? 'error' : 'success' }
               });
             } else if (obj.AbsolutePath || (obj.toolAction && (obj.toolAction.includes('Viewing') || obj.toolAction.includes('Reading')))) {
@@ -346,11 +340,7 @@ export function parseJetskiCliSession(dirPath: string): TrajectorySummary {
                 timestamp,
                 subagentId,
                 thought: obj.toolSummary || obj.toolAction || 'Exploring workspace structure',
-                action: {
-                  type: 'read_file',
-                  name: 'view_file',
-                  params: { path: obj.AbsolutePath || obj.toolSummary }
-                },
+                action: standardizeAction('read_file', 'view_file', { path: obj.AbsolutePath || obj.toolSummary || '' }),
                 outcome: { status: isErr ? 'error' : 'success' }
               });
             } else if (obj.DirectoryPath || (obj.toolAction && obj.toolAction.includes('Listing'))) {
@@ -359,11 +349,7 @@ export function parseJetskiCliSession(dirPath: string): TrajectorySummary {
                 timestamp,
                 subagentId,
                 thought: obj.toolSummary || obj.toolAction || 'Exploring workspace structure',
-                action: {
-                  type: 'read_file',
-                  name: 'list_dir',
-                  params: { path: obj.DirectoryPath }
-                },
+                action: standardizeAction('read_file', 'list_dir', { path: obj.DirectoryPath || '' }),
                 outcome: { status: isErr ? 'error' : 'success' }
               });
             }

--- a/harness/agents/jetski-cli-agent.ts
+++ b/harness/agents/jetski-cli-agent.ts
@@ -298,8 +298,8 @@ export function parseJetskiCliSession(dirPath: string): TrajectorySummary {
           const objs = findJsonObjectsInString(payloadStr);
           const isErr = row.status !== undefined && JETSKI_ERROR_STATUS_CODES.has(row.status);
           for (const obj of objs) {
-            if (!obj.toolAction && !obj.toolSummary && !obj.CommandLine && !obj.AbsolutePath && !obj.DirectoryPath && !obj.TargetFile && !obj.Query && !obj.query) continue;
-            const key = JSON.stringify({ cmd: obj.CommandLine, file: obj.AbsolutePath || obj.TargetFile || obj.DirectoryPath, query: obj.Query || obj.query, act: obj.toolAction || obj.toolSummary });
+            if (!obj.toolAction && !obj.toolSummary && !obj.CommandLine && !obj.AbsolutePath && !obj.DirectoryPath && !obj.TargetFile) continue;
+            const key = JSON.stringify({ cmd: obj.CommandLine, file: obj.AbsolutePath || obj.TargetFile || obj.DirectoryPath, act: obj.toolAction || obj.toolSummary });
             if (seenJsonHashes.has(key)) continue;
             seenJsonHashes.add(key);
 
@@ -342,16 +342,6 @@ export function parseJetskiCliSession(dirPath: string): TrajectorySummary {
                 subagentId,
                 thought: obj.toolSummary || obj.toolAction || 'Exploring workspace structure',
                 action: standardizeAction('read_file', 'view_file', { ...obj, path: obj.AbsolutePath || obj.toolSummary || '' }),
-                outcome: { status: isErr ? 'error' : 'success' }
-              });
-            } else if (obj.Query || obj.query) {
-              const query = obj.Query || obj.query;
-              steps.push({
-                stepNumber: 0,
-                timestamp,
-                subagentId,
-                thought: obj.toolSummary || obj.toolAction || 'Searching workspace',
-                action: standardizeAction('web_search', 'code_search', { ...obj, query }),
                 outcome: { status: isErr ? 'error' : 'success' }
               });
             } else if (obj.DirectoryPath || obj.SearchDirectory) {

--- a/harness/agents/pi-agent.ts
+++ b/harness/agents/pi-agent.ts
@@ -26,7 +26,8 @@ import {
   finalizeTrajectorySummary,
   generateNormalizedTrajectory,
   readTrajectorySummary,
-  getSessionFiles
+  getSessionFiles,
+  standardizeAction
 } from '../lib/trajectory-normalizer.ts';
 
 const MAX_RESPONSE_PREVIEW_LENGTH = 150;
@@ -231,11 +232,7 @@ export function parsePiTrajectory(logData: any[], subagentsMap: Record<string, a
               timestamp,
               subagentId,
               thought,
-              action: {
-                type: mapToolType(toolName),
-                name: toolName,
-                params
-              }
+              action: standardizeAction(mapToolType(toolName), toolName, params)
             }) - 1;
 
             if (subagentId) {

--- a/harness/agents/pi-agent.ts
+++ b/harness/agents/pi-agent.ts
@@ -249,14 +249,23 @@ export function parsePiTrajectory(logData: any[], subagentsMap: Record<string, a
             }
           }
         }
-      } else if (entry.role === 'user' || entry.type === 'tool_result') {
-        const content = entry.content || entry.output || '';
-        const toolUseId = entry.tool_use_id || entry.call_id;
+      } else if (
+        entry.role === 'user' ||
+        entry.type === 'tool_result' ||
+        (entry.type === 'message' && entry.message?.role === 'toolResult')
+      ) {
+        const msg = entry.message || entry;
+        const toolUseId = msg.toolCallId || entry.tool_use_id || entry.call_id;
+        let content = msg.content || entry.output || '';
+        if (Array.isArray(content)) {
+          content = content.map((c: any) => (typeof c === 'string' ? c : c?.text || JSON.stringify(c))).join('\n');
+        }
+        const isError = msg.isError !== undefined ? msg.isError : Boolean(entry.is_error);
         if (toolUseId) {
           const stepIdx = toolUseToStepMap.get(toolUseId);
           if (stepIdx !== undefined && steps[stepIdx]) {
             steps[stepIdx].outcome = {
-              status: entry.is_error ? 'error' : 'success',
+              status: isError ? 'error' : 'success',
               message: truncateMessage(content)
             };
           }

--- a/harness/agents/pi-agent.ts
+++ b/harness/agents/pi-agent.ts
@@ -197,7 +197,12 @@ export function parsePiTrajectory(logData: any[], subagentsMap: Record<string, a
         } else {
           for (const tc of toolCalls) {
             const toolName = tc.function?.name || tc.name || 'unknown';
-            const params = tc.arguments || tc.function?.arguments || tc.input || {};
+            let params = tc.arguments || tc.function?.arguments || tc.input || {};
+            if (typeof params === 'string') {
+              try {
+                params = JSON.parse(params);
+              } catch {}
+            }
 
             if (toolName === 'modern-web-guidance' || toolName.includes('get_best_practices')) {
               toolsUsed.add('modern-web-guidance');

--- a/harness/lib/collection.ts
+++ b/harness/lib/collection.ts
@@ -62,7 +62,7 @@ function extractErrorMessage(dir: string, targetFile: string): string {
 }
 
 export function parseResultPath(relPath: string): { guide: string, taskName: string, runType: string } | null {
-  const parts = relPath.split(path.sep);
+  const parts = relPath.split(/[/\\]/).filter(Boolean);
   let guide: string, taskName: string, runType: string;
   
   if (parts.length === 2) {
@@ -71,7 +71,7 @@ export function parseResultPath(relPath: string): { guide: string, taskName: str
     runType = parts[1];
     guide = parts[0].replace(/-task(-negative)?$/, '');
   } else if (parts.length >= 3) {
-    [guide, taskName, runType] = parts;
+    [guide, taskName, runType] = parts.slice(-3);
   } else {
     return null;
   }

--- a/harness/lib/compare-evals.ts
+++ b/harness/lib/compare-evals.ts
@@ -1,8 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { spawn } from 'node:child_process';
 
-import config from '../config.ts';
+import { Agents } from '../config.ts';
 import { cGreen, cRed, cCyan, cBold } from '../../lib/colors.ts';
 import { downloadRunFromGcsIfMissing } from './gcs-downloader.ts';
 import { baseAppsDir, guidesDir, resultsDir } from '../../lib/paths.ts';
@@ -10,19 +9,13 @@ import { getCompliancePrompts, getCodeAndFrictionPrompts, getSynthesizerPrompts 
 import { generateUnifiedDiff } from '../../lib/patch-utils.ts';
 import { categorizeAction, type StandardizedStep, type TrajectorySummary } from './trajectory-normalizer.ts';
 import { parseResultPath } from './collection.ts';
-import { GUIDE_FILE, EXPECTATIONS_FILE, GRADER_FILE } from '../../lib/guide-validation.ts';
+import { isEnoent } from './agent-shared.ts';
+import { getDefaultSolutionAgent, getGuidesMap, getTaskMap, GUIDE_FILE, EXPECTATIONS_FILE, GRADER_FILE, TASK_FILE } from '../../lib/guide-validation.ts';
+import { runAgent } from '../../guides/lib/utils.ts';
 
 const ERROR_LOOP_THRESHOLD = 2;
 const MAX_THOUGHT_SNIPPET_LEN = 120;
 const MAX_ACTION_PARAMS_SNIPPET_LEN = 200;
-
-function isNodeError(err: unknown): err is NodeJS.ErrnoException {
-  return err instanceof Error && 'code' in err;
-}
-
-function isEnoent(err: unknown): boolean {
-  return isNodeError(err) && err.code === 'ENOENT';
-}
 
 function tryReadFile(filePath: string): string | null {
   try {
@@ -45,68 +38,29 @@ function tryReadJson<T = any>(filePath: string): T | null {
 }
 
 /**
- * Calls the local agent CLI (Jetski or Gemini CLI based on GD_DEV_USE_JETSKI) to generate diagnostic text.
+ * Calls the local agent CLI (Jetski or Gemini CLI based on repository config) to generate diagnostic text.
  */
 async function callAgentCli(systemInstruction: string, prompt: string, label = 'Compare Agent'): Promise<string> {
-  const useJetski = process.env.GD_DEV_USE_JETSKI === '1';
-  const command = useJetski ? config.environment.jetskiCliBin : config.environment.geminiCliBin;
   const combinedPrompt = systemInstruction ? `${systemInstruction}\n\n${prompt}` : prompt;
-  const commandArgs = ['-p', combinedPrompt];
+  const agent = (getDefaultSolutionAgent() as Agents) || Agents.JETSKI;
 
-  if (useJetski) {
-    const model = process.env.JETSKI_MODEL;
-    if (model) commandArgs.push('--model', model);
-    commandArgs.push('--dangerously-skip-permissions');
-  } else {
-    const model = process.env.GEMINI_MODEL;
-    if (model) commandArgs.push('--model', model);
+  console.log(`[${label}] Executing via ${agent}...`);
+
+  const cleanOutput = await runAgent(agent, combinedPrompt, undefined, { captureOutput: true });
+  if (!cleanOutput) {
+    throw new Error(`[${label}] Empty response received from ${agent}`);
   }
 
-  console.log(`[${label}] Executing via ${useJetski ? 'Jetski CLI' : 'Gemini CLI'}...`);
+  try {
+    const debugDir = path.join(resultsDir, 'compare_work');
+    fs.mkdirSync(debugDir, { recursive: true });
+    const slug = label.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+    fs.writeFileSync(path.join(debugDir, `response_debug_${slug}.txt`), cleanOutput, 'utf8');
+  } catch (e) {
+    console.warn(`[${label}] Failed to save debug response:`, e);
+  }
 
-  return new Promise((resolve, reject) => {
-    const child = spawn(command, commandArgs, {
-      env: { ...process.env },
-      stdio: ['ignore', 'pipe', 'pipe']
-    });
-
-    let stdoutData = '';
-    let stderrData = '';
-
-    child.stdout.on('data', (chunk) => {
-      stdoutData += chunk.toString();
-    });
-
-    child.stderr.on('data', (chunk) => {
-      stderrData += chunk.toString();
-    });
-
-    child.on('error', (err) => {
-      reject(new Error(`[${label}] Failed to start ${useJetski ? 'Jetski' : 'Gemini'} CLI (${command}): ${err.message}`));
-    });
-
-    child.on('close', (exitCode) => {
-      if (exitCode !== 0) {
-        reject(new Error(`[${label}] ${useJetski ? 'Jetski' : 'Gemini'} CLI failed with exit code ${exitCode}:\n${stderrData || stdoutData}`));
-      } else {
-        const cleanOutput = stdoutData.trim();
-        if (!cleanOutput) {
-          reject(new Error(`[${label}] Empty response received from ${useJetski ? 'Jetski' : 'Gemini'} CLI`));
-        } else {
-          try {
-            const debugDir = path.join(resultsDir, 'compare_work');
-            fs.mkdirSync(debugDir, { recursive: true });
-            const slug = label.toLowerCase().replace(/[^a-z0-9]+/g, '_');
-            fs.writeFileSync(path.join(debugDir, `response_debug_${slug}.txt`), cleanOutput, 'utf8');
-          } catch (e) {
-            console.warn(`[${label}] Failed to save debug response:`, e);
-          }
-
-          resolve(cleanOutput);
-        }
-      }
-    });
-  });
+  return cleanOutput;
 }
 
 export interface TaggedStep {
@@ -162,62 +116,49 @@ export interface RunContext {
  * Finds guide.md, expectations.md, task.md, grader.ts, and base app content for a given guide/task name.
  */
 function findGuideContext(guideName: string, taskName: string): GuideContext {
+  const guideInfo = getGuidesMap().get(guideName);
+  const taskKey = `${guideName}/${taskName}`;
+  const taskInfo = getTaskMap().get(taskKey);
+
+  const guideDir = taskInfo?.guideDir || guideInfo?.dir || (fs.existsSync(path.join(guidesDir, guideName)) ? path.join(guidesDir, guideName) : '');
+
   let guideContent = '';
   let expectationsContent = '';
-  let taskPrompt = '';
   let graderContent = '';
+  let taskPrompt = taskInfo?.prompt || '';
   let baseAppContent = '';
-  let guideDir = '';
-
-  // Direct check first
-  const directPath = path.join(guidesDir, guideName);
-  if (tryReadFile(path.join(directPath, GUIDE_FILE))) {
-    guideDir = directPath;
-  } else {
-    try {
-      const items = fs.readdirSync(guidesDir, { withFileTypes: true });
-      for (const item of items) {
-        if (item.isDirectory()) {
-          const nested = path.join(guidesDir, item.name, guideName);
-          if (tryReadFile(path.join(nested, GUIDE_FILE))) {
-            guideDir = nested;
-            break;
-          }
-        }
-      }
-    } catch {
-      // guides directory not readable
-    }
-  }
 
   if (guideDir) {
     guideContent = tryReadFile(path.join(guideDir, GUIDE_FILE)) || '';
     expectationsContent = tryReadFile(path.join(guideDir, EXPECTATIONS_FILE)) || '';
-    graderContent = tryReadFile(path.join(guideDir, GRADER_FILE)) || '';
 
-    // Task prompt lookup
-    const taskCandidates = [
-      path.join(guideDir, 'tasks', `${taskName}.md`),
-      path.join(guideDir, 'tasks', 'task.md'),
-      path.join(guideDir, 'task.md')
-    ];
+    // Check target-specific grader first (targets/<taskName>/grader.ts), then root grader.ts
+    const targetGrader = path.join(guideDir, 'targets', taskName, GRADER_FILE);
+    graderContent = tryReadFile(targetGrader) || tryReadFile(path.join(guideDir, GRADER_FILE)) || '';
 
-    for (const candidate of taskCandidates) {
-      const content = tryReadFile(candidate);
-      if (content) {
-        taskPrompt = content;
-        break;
+    // If prompt wasn't populated from task map, check candidate file locations
+    if (!taskPrompt) {
+      const taskCandidates = [
+        path.join(guideDir, 'targets', taskName, TASK_FILE),
+        path.join(guideDir, 'tasks', `${taskName}.md`),
+        path.join(guideDir, 'tasks', TASK_FILE),
+        path.join(guideDir, TASK_FILE)
+      ];
+
+      for (const candidate of taskCandidates) {
+        const content = tryReadFile(candidate);
+        if (content) {
+          taskPrompt = content;
+          break;
+        }
       }
     }
 
-    if (taskPrompt) {
-      const baseAppMatch = taskPrompt.match(/base_app:\s*([^\s\r\n]+)/i);
-      if (baseAppMatch) {
-        const baseAppName = baseAppMatch[1].trim();
-        const baseAppDir = path.join(baseAppsDir, baseAppName);
-        const baseCode = findCodeOutput(baseAppDir);
-        baseAppContent = baseCode.content;
-      }
+    const baseAppName = taskInfo?.baseApp || taskPrompt.match(/base_app:\s*([^\s\r\n]+)/i)?.[1]?.trim();
+    if (baseAppName) {
+      const baseAppDir = path.join(baseAppsDir, baseAppName);
+      const baseCode = findCodeOutput(baseAppDir);
+      baseAppContent = baseCode.content;
     }
   }
 

--- a/harness/lib/compare-evals.ts
+++ b/harness/lib/compare-evals.ts
@@ -1,7 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-
-import { Agents } from '../config.ts';
 import { cGreen, cRed, cCyan, cBold } from '../../lib/colors.ts';
 import { downloadRunFromGcsIfMissing } from './gcs-downloader.ts';
 import { baseAppsDir, guidesDir, resultsDir } from '../../lib/paths.ts';
@@ -41,7 +39,7 @@ function tryReadJson<T = any>(filePath: string): T | null {
  */
 async function callAgentCli(systemInstruction: string, prompt: string, label = 'Compare Agent'): Promise<string> {
   const combinedPrompt = systemInstruction ? `${systemInstruction}\n\n${prompt}` : prompt;
-  const agent = (getDefaultSolutionAgent() as Agents) || Agents.JETSKI;
+  const agent = getDefaultSolutionAgent();
 
   console.log(`[${label}] Executing via ${agent}...`);
 

--- a/harness/lib/compare-evals.ts
+++ b/harness/lib/compare-evals.ts
@@ -6,8 +6,6 @@ import config from '../config.ts';
 import { cGreen, cRed, cCyan, cBold } from '../../lib/colors.ts';
 import { downloadRunFromGcsIfMissing } from './gcs-downloader.ts';
 import { rootDir, baseAppsDir } from '../../lib/paths.ts';
-import { parseJsonlFile } from './agent-shared.ts';
-import { extractInitialPromptFromLogs } from './trajectory-parser.ts';
 import { getCompliancePrompts, getCodeAndFrictionPrompts, getSynthesizerPrompts } from './compare-prompts.ts';
 
 /**
@@ -241,6 +239,11 @@ function findCodeOutput(dir: string, targetFileFromEvals?: string): { path: stri
   return { path: 'unknown', content: '' };
 }
 
+function stripAnsi(text: string): string {
+  // eslint-disable-next-line no-control-regex
+  return text.replace(/\u001b\[[0-9;]*m/g, '');
+}
+
 /**
  * Recursively parses Playwright's JSON report and extracts assertions with detailed error traces and locations.
  */
@@ -262,13 +265,13 @@ function parsePlaywrightResults(report: any): { message: string; passed: boolean
             if (Array.isArray(test.results)) {
               for (const res of test.results) {
                 if (res.error?.message) {
-                  const cleanMsg = res.error.message.replace(/\u001b\[[0-9;]*m/g, '');
+                  const cleanMsg = stripAnsi(res.error.message);
                   if (!errors.includes(cleanMsg)) errors.push(cleanMsg);
                 }
                 if (Array.isArray(res.errors)) {
                   for (const err of res.errors) {
                     if (err.message) {
-                      const cleanMsg = err.message.replace(/\u001b\[[0-9;]*m/g, '');
+                      const cleanMsg = stripAnsi(err.message);
                       if (!errors.includes(cleanMsg)) errors.push(cleanMsg);
                     }
                     if (err.location && !location) {
@@ -505,22 +508,7 @@ function loadRunContext(runDir: string): RunContext {
   const code = findCodeOutput(absoluteDir, targetFileFromEvals);
   const preprocessed = preprocessTrajectory(trajectorySummary, chatLog, targetFileFromEvals);
 
-  const allSessionFiles = fs.existsSync(absoluteDir) ? fs.readdirSync(absoluteDir).filter(f => f.startsWith('session-') && (f.endsWith('.json') || f.endsWith('.jsonl'))) : [];
-  const sessionFiles = allSessionFiles.sort((a, b) => {
-    const aSub = a.includes('-subagents-');
-    const bSub = b.includes('-subagents-');
-    if (aSub && !bSub) return 1;
-    if (!aSub && bSub) return -1;
-    return a.localeCompare(b);
-  });
-  const sessionPath = sessionFiles[0] ? path.join(absoluteDir, sessionFiles[0]) : '';
-  let logData: any[] = [];
-  if (sessionPath && fs.existsSync(sessionPath)) {
-    try {
-      logData = sessionPath.endsWith('.jsonl') ? parseJsonlFile(sessionPath) : JSON.parse(fs.readFileSync(sessionPath, 'utf8'));
-    } catch {}
-  }
-  const initialPrompt = trajectorySummary?.initialPrompt || extractInitialPromptFromLogs(logData, chatLog) || 'Initial prompt not found in logs.';
+  const initialPrompt = trajectorySummary?.initialPrompt || 'Initial prompt not found in trajectory summary.';
 
   return {
     dir: absoluteDir,

--- a/harness/lib/compare-evals.ts
+++ b/harness/lib/compare-evals.ts
@@ -4,7 +4,7 @@ import path from 'node:path';
 import { Agents } from '../config.ts';
 import { cGreen, cRed, cCyan, cBold } from '../../lib/colors.ts';
 import { downloadRunFromGcsIfMissing } from './gcs-downloader.ts';
-import { baseAppsDir, guidesDir } from '../../lib/paths.ts';
+import { baseAppsDir, guidesDir, resultsDir } from '../../lib/paths.ts';
 import { getCompliancePrompts, getCodeAndFrictionPrompts, getSynthesizerPrompts } from './compare-prompts.ts';
 import { generateUnifiedDiff } from '../../lib/patch-utils.ts';
 import { categorizeAction, type TrajectorySummary } from './trajectory-normalizer.ts';
@@ -354,7 +354,15 @@ function extractTargetFileFromEvalsJson(runDir: string): string | undefined {
  * Loads all relevant context for a single run including preprocessed trajectory.
  */
 function loadRunContext(runDir: string): RunContext {
-  const absoluteDir = path.resolve(runDir);
+  let absoluteDir = path.resolve(runDir);
+  if (!fs.existsSync(absoluteDir)) {
+    const stripped = runDir.replace(/^(\.\/)?(harness\/)?results\/?/, '');
+    const candidate = path.resolve(resultsDir, stripped);
+    if (fs.existsSync(candidate)) {
+      absoluteDir = candidate;
+    }
+  }
+
   try {
     fs.statSync(absoluteDir);
   } catch (err: unknown) {

--- a/harness/lib/compare-evals.ts
+++ b/harness/lib/compare-evals.ts
@@ -1,0 +1,783 @@
+import fs from 'fs';
+import path from 'path';
+import { spawn } from 'node:child_process';
+
+import config from '../config.ts';
+import { cGreen, cRed, cCyan, cBold } from '../../lib/colors.ts';
+import { downloadRunFromGcsIfMissing } from './gcs-downloader.ts';
+import { rootDir, baseAppsDir } from '../../lib/paths.ts';
+import { parseJsonlFile } from './agent-shared.ts';
+import { extractInitialPromptFromLogs } from './trajectory-parser.ts';
+import { getCompliancePrompts, getCodeAndFrictionPrompts, getSynthesizerPrompts } from './compare-prompts.ts';
+
+/**
+ * Calls the local agent CLI (Jetski or Gemini CLI based on GD_DEV_USE_JETSKI) to generate diagnostic text.
+ */
+async function callAgentCli(systemInstruction: string, prompt: string, label: string = 'Compare Agent'): Promise<string> {
+  const useJetski = process.env.GD_DEV_USE_JETSKI === '1';
+  const command = useJetski ? config.environment.jetskiCliBin : config.environment.geminiCliBin;
+  const combinedPrompt = systemInstruction ? `${systemInstruction}\n\n${prompt}` : prompt;
+  const commandArgs = ['-p', combinedPrompt];
+
+  if (useJetski) {
+    const model = process.env.JETSKI_MODEL;
+    if (model) commandArgs.push('--model', model);
+    commandArgs.push('--dangerously-skip-permissions');
+  } else {
+    const model = process.env.GEMINI_MODEL;
+    if (model) commandArgs.push('--model', model);
+  }
+
+  console.log(`[${label}] Executing via ${useJetski ? 'Jetski CLI' : 'Gemini CLI'}...`);
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, commandArgs, {
+      env: { ...process.env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdoutData = '';
+    let stderrData = '';
+
+    child.stdout.on('data', (chunk) => {
+      stdoutData += chunk.toString();
+    });
+
+    child.stderr.on('data', (chunk) => {
+      stderrData += chunk.toString();
+    });
+
+    child.on('error', (err) => {
+      reject(new Error(`[${label}] Failed to start ${useJetski ? 'Jetski' : 'Gemini'} CLI (${command}): ${err.message}`));
+    });
+
+    child.on('close', (exitCode) => {
+      if (exitCode !== 0) {
+        reject(new Error(`[${label}] ${useJetski ? 'Jetski' : 'Gemini'} CLI failed with exit code ${exitCode}:\n${stderrData || stdoutData}`));
+      } else {
+        const cleanOutput = stdoutData.trim();
+        if (!cleanOutput) {
+          reject(new Error(`[${label}] Empty response received from ${useJetski ? 'Jetski' : 'Gemini'} CLI`));
+        } else {
+          try {
+            const debugDir = path.resolve('./harness/results/compare_work');
+            if (!fs.existsSync(debugDir)) {
+              fs.mkdirSync(debugDir, { recursive: true });
+            }
+            const slug = label.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+            fs.writeFileSync(path.join(debugDir, `response_debug_${slug}.txt`), cleanOutput, 'utf8');
+          } catch {}
+
+          resolve(cleanOutput);
+        }
+      }
+    });
+  });
+}
+
+export interface TaggedStep {
+  stepNumber: number;
+  category: 'skill_search' | 'guide_retrieval' | 'mandatory_rule_thought' | 'code_mutation' | 'incidental_noise';
+  thought?: string;
+  actionName?: string;
+  actionDetails?: string;
+  isError?: boolean;
+  raw: any;
+}
+
+export interface PreprocessedTrajectory {
+  taggedSteps: TaggedStep[];
+  searchQueries: string[];
+  retrievedGuideIds: string[];
+  mandatoryRulesAdopted: string[];
+  codeMutationCount: number;
+  noiseCount: number;
+  errorLoopCount: number;
+}
+
+export interface GuideContext {
+  guideName: string;
+  taskName: string;
+  guideContent: string;
+  expectationsContent: string;
+  taskPrompt: string;
+  graderContent: string;
+  baseAppContent: string;
+}
+
+export interface RunContext {
+  dir: string;
+  runNumber: number;
+  score: number;
+  resultsJson: any;
+  trajectorySummary: any;
+  chatLog: string;
+  codeOutput: string;
+  codePath: string;
+  preprocessed: PreprocessedTrajectory;
+  initialPrompt: string;
+}
+
+/**
+ * Helper to find guide.md, expectations.md, task.md, grader.ts, and base app content for a given guide/task name.
+ */
+function findGuideContext(guideName: string, taskName: string): GuideContext {
+  const guidesBaseDir = path.join(rootDir, 'guides');
+  let guideContent = '';
+  let expectationsContent = '';
+  let taskPrompt = '';
+  let graderContent = '';
+  let baseAppContent = '';
+  let guideDir = '';
+
+  if (fs.existsSync(guidesBaseDir)) {
+    // 1. Search for guide directory
+    const items = fs.readdirSync(guidesBaseDir, { withFileTypes: true });
+    for (const item of items) {
+      if (item.isDirectory()) {
+        const direct = path.join(guidesBaseDir, guideName);
+        if (fs.existsSync(direct)) {
+          guideDir = direct;
+          break;
+        }
+        const nested = path.join(guidesBaseDir, item.name, guideName);
+        if (fs.existsSync(nested)) {
+          guideDir = nested;
+          break;
+        }
+      }
+    }
+
+    if (guideDir) {
+      const guidePath = path.join(guideDir, 'guide.md');
+      if (fs.existsSync(guidePath)) {
+        guideContent = fs.readFileSync(guidePath, 'utf8');
+      }
+
+      // Expectations
+      const expPath = path.join(guideDir, 'expectations.md');
+      if (fs.existsSync(expPath)) {
+        expectationsContent = fs.readFileSync(expPath, 'utf8');
+      }
+
+      // Grader
+      const graderPath = path.join(guideDir, 'grader.ts');
+      if (fs.existsSync(graderPath)) {
+        graderContent = fs.readFileSync(graderPath, 'utf8');
+      }
+
+      // Task prompt
+      const taskPath1 = path.join(guideDir, 'tasks', `${taskName}.md`);
+      const taskPath2 = path.join(guideDir, 'tasks', 'task.md');
+      const taskPath3 = path.join(guideDir, 'task.md');
+      let foundTaskPath = '';
+      if (fs.existsSync(taskPath1)) {
+        foundTaskPath = taskPath1;
+      } else if (fs.existsSync(taskPath2)) {
+        foundTaskPath = taskPath2;
+      } else if (fs.existsSync(taskPath3)) {
+        foundTaskPath = taskPath3;
+      }
+
+      if (foundTaskPath) {
+        taskPrompt = fs.readFileSync(foundTaskPath, 'utf8');
+        const baseAppMatch = taskPrompt.match(/base_app:\s*([^\s\r\n]+)/i);
+        if (baseAppMatch) {
+          const baseAppName = baseAppMatch[1].trim();
+          const baseAppDir = path.join(baseAppsDir, baseAppName);
+          if (fs.existsSync(baseAppDir)) {
+            const baseCode = findCodeOutput(baseAppDir);
+            baseAppContent = baseCode.content;
+          }
+        }
+      }
+    }
+  }
+
+  return {
+    guideName,
+    taskName,
+    guideContent: guideContent || 'No guide.md content found.',
+    expectationsContent: expectationsContent || 'No expectations.md content found.',
+    taskPrompt: taskPrompt || 'No task.md prompt found.',
+    graderContent: graderContent || 'No grader.ts content found.',
+    baseAppContent: baseAppContent || 'No base app content found.'
+  };
+}
+
+/**
+ * Helper to find the main generated code file in a run directory.
+ */
+function findCodeOutput(dir: string, targetFileFromEvals?: string): { path: string; content: string } {
+  if (targetFileFromEvals) {
+    const fullPath = path.join(dir, targetFileFromEvals);
+    if (fs.existsSync(fullPath)) {
+      return {
+        path: targetFileFromEvals,
+        content: fs.readFileSync(fullPath, 'utf8')
+      };
+    }
+  }
+  const candidates = [
+    'dist/index.html',
+    'src/App.jsx',
+    'src/App.js',
+    'src/main.jsx',
+    'src/main.js',
+    'src/index.jsx',
+    'src/index.js',
+    'index.html'
+  ];
+
+  for (const c of candidates) {
+    const fullPath = path.join(dir, c);
+    if (fs.existsSync(fullPath)) {
+      return {
+        path: c,
+        content: fs.readFileSync(fullPath, 'utf8')
+      };
+    }
+  }
+  return { path: 'unknown', content: '' };
+}
+
+/**
+ * Recursively parses Playwright's JSON report and extracts assertions with detailed error traces and locations.
+ */
+function parsePlaywrightResults(report: any): { message: string; passed: boolean; errors?: string[]; location?: { file?: string; line?: number; column?: number } }[] {
+  const assertions: { message: string; passed: boolean; errors?: string[]; location?: { file?: string; line?: number; column?: number } }[] = [];
+  if (!report || !Array.isArray(report.suites)) {
+    return assertions;
+  }
+  
+  function collectSpecs(suite: any) {
+    if (Array.isArray(suite.specs)) {
+      suite.specs.forEach((spec: any) => {
+        const passed = !!spec.ok;
+        const errors: string[] = [];
+        let location: { file?: string; line?: number; column?: number } | undefined;
+
+        if (!passed && Array.isArray(spec.tests)) {
+          for (const test of spec.tests) {
+            if (Array.isArray(test.results)) {
+              for (const res of test.results) {
+                if (res.error?.message) {
+                  const cleanMsg = res.error.message.replace(/\u001b\[[0-9;]*m/g, '');
+                  if (!errors.includes(cleanMsg)) errors.push(cleanMsg);
+                }
+                if (Array.isArray(res.errors)) {
+                  for (const err of res.errors) {
+                    if (err.message) {
+                      const cleanMsg = err.message.replace(/\u001b\[[0-9;]*m/g, '');
+                      if (!errors.includes(cleanMsg)) errors.push(cleanMsg);
+                    }
+                    if (err.location && !location) {
+                      location = err.location;
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+
+        assertions.push({
+          message: spec.title,
+          passed,
+          errors: errors.length > 0 ? errors : undefined,
+          location
+        });
+      });
+    }
+    if (Array.isArray(suite.suites)) {
+      suite.suites.forEach(collectSpecs);
+    }
+  }
+
+  report.suites.forEach(collectSpecs);
+  return assertions;
+}
+
+/**
+ * Phase 1 Pre-Processor: Categorizes trajectory steps into 5 milestone/noise types and computes metrics.
+ */
+function preprocessTrajectory(trajectorySummary: any, _chatLog: string, targetFileFromEvals?: string): PreprocessedTrajectory {
+  const steps = trajectorySummary?.steps || [];
+  const taggedSteps: TaggedStep[] = [];
+  const searchQueries: string[] = [];
+  const retrievedGuideIds: string[] = [];
+  const mandatoryRulesAdopted: string[] = [];
+  let codeMutationCount = 0;
+  let noiseCount = 0;
+  let errorLoopCount = 0;
+  let consecutiveErrors = 0;
+
+  for (let i = 0; i < steps.length; i++) {
+    const rawStep = steps[i];
+    const stepNumber = rawStep.stepNumber || i + 1;
+    const thought = rawStep.thought || '';
+    const actionName = (rawStep.action?.name || rawStep.action?.type || '').toLowerCase();
+    const actionParamsStr = JSON.stringify(rawStep.action?.params || rawStep.action || {}).toLowerCase();
+    const isErr = rawStep.outcome?.status === 'error';
+
+    if (isErr) {
+      consecutiveErrors++;
+      if (consecutiveErrors >= 2) {
+        errorLoopCount++;
+      }
+    } else {
+      consecutiveErrors = 0;
+    }
+
+    let category: TaggedStep['category'] = 'incidental_noise';
+    if (rawStep.action?.canonicalCategory && rawStep.action.canonicalCategory !== 'other') {
+      category = rawStep.action.canonicalCategory as TaggedStep['category'];
+    }
+
+    // 1. Guide Retrieval
+    if (category === 'guide_retrieval' || actionName.includes('retrieve') || (actionName.includes('get_best_practices') && actionParamsStr.includes('retrieve')) || actionParamsStr.includes('retrieve')) {
+      category = 'guide_retrieval';
+      const paramsObj = rawStep.action?.params || rawStep.action || {};
+      let guideId = paramsObj.id || paramsObj.guideId;
+      if (!guideId && typeof paramsObj.command === 'string' && paramsObj.command.includes('retrieve')) {
+        guideId = paramsObj.query;
+      }
+      if (!guideId && typeof paramsObj.query === 'string' && actionParamsStr.includes('retrieve')) {
+        guideId = paramsObj.query;
+      }
+      if (!guideId && typeof paramsObj.command === 'string') {
+        const match = paramsObj.command.match(/retrieve\s+\\?["']([^"'\\]+)/i) || paramsObj.command.match(/retrieve\s+([^"'\s]+)/i);
+        if (match) guideId = match[1];
+      }
+      if (!guideId) {
+        const match = actionParamsStr.match(/id["\s:]+\\?["']?([^"'\\}]+)/i) || actionParamsStr.match(/retrieve\s+\\?["']([^"'\\]+)/i) || actionParamsStr.match(/retrieve\s+([^"'\s}]+)/i);
+        if (match) guideId = match[1];
+      }
+      if (guideId) {
+        retrievedGuideIds.push(String(guideId).trim());
+      }
+    }
+    // 2. Skill Search
+    else if (category === 'skill_search' || actionName.includes('search') || actionParamsStr.includes('search')) {
+      category = 'skill_search';
+      const paramsObj = rawStep.action?.params || rawStep.action || {};
+      let query = paramsObj.query;
+      if (!query && typeof paramsObj.command === 'string') {
+        const match = paramsObj.command.match(/search\s+\\?["']([^"'\\]+)/i) || paramsObj.command.match(/search\s+([^"'\s]+)/i);
+        if (match) query = match[1];
+      }
+      if (!query) {
+        const match = actionParamsStr.match(/query["\s:]+\\?["']?([^"'\\}]+)/i) || actionParamsStr.match(/search\s+\\?["']([^"'\\]+)/i);
+        if (match) query = match[1];
+      }
+      if (query) {
+        searchQueries.push(String(query).trim());
+      }
+    }
+    // 3. Code Mutation
+    else if (
+      category === 'code_mutation' ||
+      actionName.includes('write') || actionName.includes('replace') || actionName.includes('touch') ||
+      actionParamsStr.includes('write_to_file') || actionParamsStr.includes('replace_file_content') ||
+      (targetFileFromEvals ? actionParamsStr.includes(path.basename(targetFileFromEvals).toLowerCase()) : (actionParamsStr.includes('index.html') || actionParamsStr.includes('app.jsx') || actionParamsStr.includes('style.css')))
+    ) {
+      category = 'code_mutation';
+      codeMutationCount++;
+    }
+    // 4. Mandatory Rule Thought / Adoption
+    else if (
+      category === 'mandatory_rule_thought' ||
+      thought.toLowerCase().includes('mandatory') || thought.toLowerCase().includes('fallback') ||
+      thought.toLowerCase().includes('css') || thought.toLowerCase().includes('baseline') ||
+      thought.toLowerCase().includes('guidance')
+    ) {
+      category = 'mandatory_rule_thought';
+      mandatoryRulesAdopted.push(thought.slice(0, 120));
+    }
+    // 5. Incidental Noise (view_file, ls, list_dir, grep)
+    else {
+      category = 'incidental_noise';
+      noiseCount++;
+    }
+
+    taggedSteps.push({
+      stepNumber,
+      category,
+      thought,
+      actionName: rawStep.action?.name,
+      actionDetails: actionParamsStr.slice(0, 200),
+      isError: isErr,
+      raw: rawStep
+    });
+  }
+
+  return {
+    taggedSteps,
+    searchQueries: Array.from(new Set(searchQueries)),
+    retrievedGuideIds: Array.from(new Set(retrievedGuideIds)),
+    mandatoryRulesAdopted,
+    codeMutationCount,
+    noiseCount,
+    errorLoopCount
+  };
+}
+
+function extractTargetFileFromEvalsJson(runDir: string): string | undefined {
+  let curr = runDir;
+  while (curr && curr !== path.dirname(curr)) {
+    const evalsPath = path.join(curr, 'evals.json');
+    if (fs.existsSync(evalsPath)) {
+      try {
+        const data = JSON.parse(fs.readFileSync(evalsPath, 'utf8'));
+        if (data && data.results) {
+          const pathSegments = runDir.split(/[/\\]/);
+          const taskName = pathSegments[pathSegments.length - 2];
+          for (const testName in data.results) {
+            const runs = data.results[testName];
+            if (Array.isArray(runs)) {
+              for (const run of runs) {
+                if (run.targetFile && (run.taskName === taskName || testName.includes(taskName || ''))) {
+                  return run.targetFile;
+                }
+              }
+            }
+          }
+        }
+      } catch (e) {}
+    }
+    curr = path.dirname(curr);
+  }
+  return undefined;
+}
+
+/**
+ * Loads all relevant context for a single run including preprocessed trajectory.
+ */
+function loadRunContext(runDir: string): RunContext {
+  const absoluteDir = path.resolve(runDir);
+  if (!fs.existsSync(absoluteDir)) {
+    throw new Error(`Run directory not found: ${absoluteDir}`);
+  }
+
+  const pathSegments = absoluteDir.split(/[/\\]/);
+  const runNumberMatch = absoluteDir.match(/[/\\](\d+)[/\\]/);
+  const runNumber = runNumberMatch ? parseInt(runNumberMatch[1]) : 0;
+  const guideName = pathSegments[pathSegments.length - 3] || '';
+
+  let resultsPath = path.join(absoluteDir, `${guideName}_results.json`);
+  if (!fs.existsSync(resultsPath) && fs.existsSync(absoluteDir)) {
+    const fallbackResultsFile = fs.readdirSync(absoluteDir).find(f => f.endsWith('_results.json'));
+    if (fallbackResultsFile) {
+      resultsPath = path.join(absoluteDir, fallbackResultsFile);
+    }
+  }
+
+  let resultsJson: any = null;
+  let score = 0;
+  if (fs.existsSync(resultsPath)) {
+    try {
+      const rawReport = JSON.parse(fs.readFileSync(resultsPath, 'utf8'));
+      resultsJson = parsePlaywrightResults(rawReport);
+      const passed = resultsJson.filter((c: any) => c.passed).length;
+      score = resultsJson.length > 0 ? Math.round((passed / resultsJson.length) * 100) : 0;
+    } catch (e) {
+      console.warn(`Warning: Failed to parse results JSON in ${absoluteDir}`);
+    }
+  }
+
+  let trajectorySummary: any = null;
+  const trajPath = path.join(absoluteDir, 'trajectory_summary.json');
+  if (fs.existsSync(trajPath)) {
+    try {
+      trajectorySummary = JSON.parse(fs.readFileSync(trajPath, 'utf8'));
+    } catch (e) {
+      console.warn(`Warning: Failed to parse trajectory summary in ${absoluteDir}`);
+    }
+  }
+
+  let chatLog = '';
+  const chatLogPath = path.join(absoluteDir, 'chat_log.txt');
+  if (fs.existsSync(chatLogPath)) {
+    chatLog = fs.readFileSync(chatLogPath, 'utf8');
+  }
+
+  const targetFileFromEvals = extractTargetFileFromEvalsJson(absoluteDir);
+  const code = findCodeOutput(absoluteDir, targetFileFromEvals);
+  const preprocessed = preprocessTrajectory(trajectorySummary, chatLog, targetFileFromEvals);
+
+  const allSessionFiles = fs.existsSync(absoluteDir) ? fs.readdirSync(absoluteDir).filter(f => f.startsWith('session-') && (f.endsWith('.json') || f.endsWith('.jsonl'))) : [];
+  const sessionFiles = allSessionFiles.sort((a, b) => {
+    const aSub = a.includes('-subagents-');
+    const bSub = b.includes('-subagents-');
+    if (aSub && !bSub) return 1;
+    if (!aSub && bSub) return -1;
+    return a.localeCompare(b);
+  });
+  const sessionPath = sessionFiles[0] ? path.join(absoluteDir, sessionFiles[0]) : '';
+  let logData: any[] = [];
+  if (sessionPath && fs.existsSync(sessionPath)) {
+    try {
+      logData = sessionPath.endsWith('.jsonl') ? parseJsonlFile(sessionPath) : JSON.parse(fs.readFileSync(sessionPath, 'utf8'));
+    } catch {}
+  }
+  const initialPrompt = trajectorySummary?.initialPrompt || extractInitialPromptFromLogs(logData, chatLog) || 'Initial prompt not found in logs.';
+
+  return {
+    dir: absoluteDir,
+    runNumber,
+    score,
+    resultsJson,
+    trajectorySummary,
+    chatLog,
+    codeOutput: code.content,
+    codePath: code.path,
+    preprocessed,
+    initialPrompt
+  };
+}
+
+/**
+ * Generates an aligned LCS unified diff of two strings for accurate LLM context.
+ */
+function generateUnifiedDiff(oldText: string, newText: string, oldLabel = 'Old', newLabel = 'New', contextLines = 3): string {
+  const oldLines = oldText.split(/\r?\n/);
+  const newLines = newText.split(/\r?\n/);
+
+  const m = oldLines.length;
+  const n = newLines.length;
+  
+  const dp: number[][] = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0));
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      if (oldLines[i - 1] === newLines[j - 1]) {
+        dp[i][j] = dp[i - 1][j - 1] + 1;
+      } else {
+        dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+      }
+    }
+  }
+
+  interface EditOp {
+    type: 'equal' | 'add' | 'remove';
+    oldIndex?: number;
+    newIndex?: number;
+    line: string;
+  }
+  const ops: EditOp[] = [];
+  let i = m, j = n;
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && oldLines[i - 1] === newLines[j - 1]) {
+      ops.push({ type: 'equal', oldIndex: i, newIndex: j, line: oldLines[i - 1] });
+      i--;
+      j--;
+    } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+      ops.push({ type: 'add', newIndex: j, line: newLines[j - 1] });
+      j--;
+    } else if (i > 0 && (j === 0 || dp[i][j - 1] < dp[i - 1][j])) {
+      ops.push({ type: 'remove', oldIndex: i, line: oldLines[i - 1] });
+      i--;
+    }
+  }
+  ops.reverse();
+
+  if (ops.every(op => op.type === 'equal')) {
+    return 'No differences detected.';
+  }
+
+  const hunks: {
+    oldStart: number;
+    oldLinesCount: number;
+    newStart: number;
+    newLinesCount: number;
+    lines: string[];
+  }[] = [];
+
+  let opIndex = 0;
+  while (opIndex < ops.length) {
+    while (opIndex < ops.length && ops[opIndex].type === 'equal') {
+      opIndex++;
+    }
+    if (opIndex >= ops.length) break;
+
+    const hunkStart = Math.max(0, opIndex - contextLines);
+    let hunkEnd = opIndex;
+
+    while (hunkEnd < ops.length) {
+      if (ops[hunkEnd].type !== 'equal') {
+        hunkEnd++;
+      } else {
+        let nextChange = hunkEnd;
+        while (nextChange < ops.length && ops[nextChange].type === 'equal' && (nextChange - hunkEnd) < 2 * contextLines) {
+          nextChange++;
+        }
+        if (nextChange < ops.length && ops[nextChange].type !== 'equal') {
+          hunkEnd = nextChange;
+        } else {
+          break;
+        }
+      }
+    }
+
+    const actualEnd = Math.min(ops.length - 1, hunkEnd + contextLines - 1);
+    const hunkOps = ops.slice(hunkStart, actualEnd + 1);
+    const oldStarts = hunkOps.filter(op => op.oldIndex !== undefined).map(op => op.oldIndex!);
+    const newStarts = hunkOps.filter(op => op.newIndex !== undefined).map(op => op.newIndex!);
+    
+    const oldStart = oldStarts.length > 0 ? oldStarts[0] : (hunkStart > 0 && ops[hunkStart - 1].oldIndex ? ops[hunkStart - 1].oldIndex! + 1 : 1);
+    const newStart = newStarts.length > 0 ? newStarts[0] : (hunkStart > 0 && ops[hunkStart - 1].newIndex ? ops[hunkStart - 1].newIndex! + 1 : 1);
+    const oldLinesCount = hunkOps.filter(op => op.type === 'equal' || op.type === 'remove').length;
+    const newLinesCount = hunkOps.filter(op => op.type === 'equal' || op.type === 'add').length;
+
+    const lines = hunkOps.map(op => {
+      if (op.type === 'equal') return `  ${op.line}`;
+      if (op.type === 'remove') return `- ${op.line}`;
+      return `+ ${op.line}`;
+    });
+
+    hunks.push({ oldStart, oldLinesCount, newStart, newLinesCount, lines });
+    opIndex = actualEnd + 1;
+  }
+
+  let result = `--- ${oldLabel}\n+++ ${newLabel}\n`;
+  for (const hunk of hunks) {
+    result += `@@ -${hunk.oldStart},${hunk.oldLinesCount} +${hunk.newStart},${hunk.newLinesCount} @@\n`;
+    result += hunk.lines.join('\n') + '\n';
+  }
+  return result.trim();
+}
+
+/**
+ * Phase 2: Sub-agent 1 - Guide Compliance & Requirement Auditor.
+ */
+async function runSubAgent1_GuideCompliance(
+  guideCtx: GuideContext,
+  ctxA: RunContext,
+  ctxB: RunContext,
+  statusA: string,
+  statusB: string
+): Promise<string> {
+  const { systemInstruction, prompt } = getCompliancePrompts(guideCtx, ctxA, ctxB, statusA, statusB);
+  return callAgentCli(systemInstruction, prompt, 'Sub-Agent 1 (Guide Compliance)');
+}
+
+/**
+ * Phase 2: Sub-agent 2 - Code-to-Trajectory Backtracking & Friction Diagnostic.
+ */
+async function runSubAgent2_CodeAndFriction(
+  guideCtx: GuideContext,
+  ctxA: RunContext,
+  ctxB: RunContext,
+  diffBaseVsA: string,
+  diffBaseVsB: string,
+  diffAvsB: string,
+  statusA: string,
+  statusB: string
+): Promise<string> {
+  const { systemInstruction, prompt } = getCodeAndFrictionPrompts(guideCtx, ctxA, ctxB, diffBaseVsA, diffBaseVsB, diffAvsB, statusA, statusB);
+  return callAgentCli(systemInstruction, prompt, 'Sub-Agent 2 (Code & Friction)');
+}
+
+/**
+ * Phase 3: Synthesizer - Combines sub-agent outputs into the 4-section diagnostic report.
+ */
+async function synthesizeDiagnosis(
+  guideCtx: GuideContext,
+  ctxA: RunContext,
+  ctxB: RunContext,
+  complianceAnalysis: string,
+  codeAndFrictionAnalysis: string,
+  statusA: string,
+  statusB: string
+): Promise<string> {
+  const { systemInstruction, prompt } = getSynthesizerPrompts(guideCtx, ctxA, ctxB, complianceAnalysis, codeAndFrictionAnalysis, statusA, statusB);
+  return callAgentCli(systemInstruction, prompt, 'Synthesizer Sub-Agent');
+}
+
+/**
+ * Runs the diagnostic agent comparison using local CLI sub-agents.
+ */
+export async function runComparison(runDirA: string, runDirB: string): Promise<string> {
+  console.log(cCyan(`\n=== Starting Run Comparison (Guide-Grounded 3-Phase Pipeline) ===`));
+  console.log(`Run A: ${runDirA}`);
+  console.log(`Run B: ${runDirB}\n`);
+
+  await downloadRunFromGcsIfMissing(runDirA);
+  await downloadRunFromGcsIfMissing(runDirB);
+
+  const ctxA = loadRunContext(runDirA);
+  const ctxB = loadRunContext(runDirB);
+
+  const isAProblem = ctxA.score < ctxB.score;
+  const successCtx = isAProblem ? ctxB : ctxA;
+
+  console.log(`Comparing Run A (Score: ${ctxA.score}%) vs Run B (Score: ${ctxB.score}%)...`);
+
+  const pathSegments = successCtx.dir.split(/[/\\]/);
+  const runType = pathSegments.pop() || 'guided';
+  const taskName = pathSegments.pop() || 'task';
+  const guideName = pathSegments.pop() || 'guide';
+
+  const guideCtx = findGuideContext(guideName, taskName);
+  const diffBaseVsA = generateUnifiedDiff(guideCtx.baseAppContent || '', ctxA.codeOutput || '', 'Base App', 'Run A Output');
+  const diffBaseVsB = generateUnifiedDiff(guideCtx.baseAppContent || '', ctxB.codeOutput || '', 'Base App', 'Run B Output');
+  const diffAvsB = generateUnifiedDiff(ctxA.codeOutput || '', ctxB.codeOutput || '', 'Run A Output', 'Run B Output');
+
+  const statusA = ctxA.score > ctxB.score ? 'SUCCESSFUL' : ctxA.score < ctxB.score ? 'FAILED/POORER' : 'COMPARED RUN';
+  const statusB = ctxB.score > ctxA.score ? 'SUCCESSFUL' : ctxB.score < ctxA.score ? 'FAILED/POORER' : 'COMPARED RUN';
+
+  const suiteMatch = successCtx.dir.match(/(.*[/\\]results[/\\][^/\\]+)/);
+  const suiteDir = suiteMatch ? suiteMatch[1] : successCtx.dir;
+  const workDir = path.join(suiteDir, 'compare_work');
+  if (!fs.existsSync(workDir)) {
+    fs.mkdirSync(workDir, { recursive: true });
+  }
+
+  try {
+    console.log(cBold(`[Compare Agent] Phase 1: Pre-processed trajectories into tagged milestones.`));
+    console.log(`  Run A: ${ctxA.preprocessed.taggedSteps.length} steps (${ctxA.preprocessed.noiseCount} noise, ${ctxA.preprocessed.errorLoopCount} retries)`);
+    console.log(`  Run B: ${ctxB.preprocessed.taggedSteps.length} steps (${ctxB.preprocessed.noiseCount} noise, ${ctxB.preprocessed.errorLoopCount} retries)`);
+
+    console.log(cBold(`[Compare Agent] Phase 2: Dispatching parallel sub-agents (Guide Compliance & Code/Friction)...`));
+    const [complianceAnalysis, codeAndFrictionAnalysis] = await Promise.all([
+      runSubAgent1_GuideCompliance(guideCtx, ctxA, ctxB, statusA, statusB),
+      runSubAgent2_CodeAndFriction(guideCtx, ctxA, ctxB, diffBaseVsA, diffBaseVsB, diffAvsB, statusA, statusB)
+    ]);
+
+    console.log(cBold(`[Compare Agent] Phase 3: Synthesizing final 4-section diagnostic report...`));
+    const markdownReport = await synthesizeDiagnosis(
+      guideCtx,
+      ctxA,
+      ctxB,
+      complianceAnalysis,
+      codeAndFrictionAnalysis,
+      statusA,
+      statusB
+    );
+
+    let savedPath = '';
+    if (suiteMatch) {
+      const diagnosesDir = path.join(suiteDir, 'variance_diagnoses');
+      if (!fs.existsSync(diagnosesDir)) {
+        fs.mkdirSync(diagnosesDir, { recursive: true });
+      }
+      
+      const fileName = `${guideName}-${taskName}-${runType}.md`;
+      savedPath = path.join(diagnosesDir, fileName);
+      fs.writeFileSync(savedPath, markdownReport, 'utf8');
+      console.log(cGreen(`\n✅ Saved diagnostic report to: ${savedPath}`));
+    }
+
+    const localSavedPath = path.resolve('./variance_diagnosis.md');
+    fs.writeFileSync(localSavedPath, markdownReport, 'utf8');
+    console.log(cGreen(`✅ Saved local copy to: ${localSavedPath}\n`));
+
+    console.log(cBold(cCyan('--- DIAGNOSTIC REPORT ---')));
+    console.log(markdownReport);
+    console.log(cCyan('-------------------------'));
+
+    return markdownReport;
+  } catch (err: any) {
+    console.error(cRed(`❌ Diagnosis failed: ${err.message}`));
+    throw err;
+  }
+}

--- a/harness/lib/compare-evals.ts
+++ b/harness/lib/compare-evals.ts
@@ -4,10 +4,10 @@ import path from 'node:path';
 import { Agents } from '../config.ts';
 import { cGreen, cRed, cCyan, cBold } from '../../lib/colors.ts';
 import { downloadRunFromGcsIfMissing } from './gcs-downloader.ts';
-import { baseAppsDir, guidesDir, resultsDir } from '../../lib/paths.ts';
+import { baseAppsDir, guidesDir } from '../../lib/paths.ts';
 import { getCompliancePrompts, getCodeAndFrictionPrompts, getSynthesizerPrompts } from './compare-prompts.ts';
 import { generateUnifiedDiff } from '../../lib/patch-utils.ts';
-import { categorizeAction, type StandardizedStep, type TrajectorySummary } from './trajectory-normalizer.ts';
+import { categorizeAction, type TrajectorySummary } from './trajectory-normalizer.ts';
 import { parseResultPath } from './collection.ts';
 import { isEnoent } from './agent-shared.ts';
 import { getDefaultSolutionAgent, getGuidesMap, getTaskMap, GUIDE_FILE, EXPECTATIONS_FILE, GRADER_FILE, TASK_FILE } from '../../lib/guide-validation.ts';
@@ -15,7 +15,6 @@ import { runAgent } from '../../guides/lib/utils.ts';
 
 const ERROR_LOOP_THRESHOLD = 2;
 const MAX_THOUGHT_SNIPPET_LEN = 120;
-const MAX_ACTION_PARAMS_SNIPPET_LEN = 200;
 
 function tryReadFile(filePath: string): string | null {
   try {
@@ -51,15 +50,6 @@ async function callAgentCli(systemInstruction: string, prompt: string, label = '
     throw new Error(`[${label}] Empty response received from ${agent}`);
   }
 
-  try {
-    const debugDir = path.join(resultsDir, 'compare_work');
-    fs.mkdirSync(debugDir, { recursive: true });
-    const slug = label.toLowerCase().replace(/[^a-z0-9]+/g, '_');
-    fs.writeFileSync(path.join(debugDir, `response_debug_${slug}.txt`), cleanOutput, 'utf8');
-  } catch (e) {
-    console.warn(`[${label}] Failed to save debug response:`, e);
-  }
-
   return cleanOutput;
 }
 
@@ -68,9 +58,6 @@ export interface TaggedStep {
   category: 'skill_search' | 'guide_retrieval' | 'mandatory_rule_thought' | 'code_mutation' | 'incidental_noise';
   thought?: string;
   actionName?: string;
-  actionDetails?: string;
-  isError?: boolean;
-  raw: StandardizedStep;
 }
 
 export interface PreprocessedTrajectory {
@@ -102,12 +89,9 @@ export interface PlaywrightAssertion {
 
 export interface RunContext {
   dir: string;
-  runNumber: number;
   score: number;
   resultsJson: PlaywrightAssertion[];
-  trajectorySummary: TrajectorySummary | null;
   codeOutput: string;
-  codePath: string;
   preprocessed: PreprocessedTrajectory;
   initialPrompt: string;
 }
@@ -287,7 +271,6 @@ function preprocessTrajectory(trajectorySummary: TrajectorySummary | null): Prep
     const thought = rawStep.thought || '';
     const actionName = rawStep.action?.name || '';
     const actionParams = rawStep.action?.params;
-    const actionParamsStr = JSON.stringify(actionParams || {}).toLowerCase();
     const isErr = rawStep.outcome?.status === 'error';
 
     if (isErr) {
@@ -320,10 +303,7 @@ function preprocessTrajectory(trajectorySummary: TrajectorySummary | null): Prep
       stepNumber,
       category,
       thought,
-      actionName,
-      actionDetails: actionParamsStr.slice(0, MAX_ACTION_PARAMS_SNIPPET_LEN),
-      isError: isErr,
-      raw: rawStep
+      actionName
     });
   }
 
@@ -345,16 +325,20 @@ function preprocessTrajectory(trajectorySummary: TrajectorySummary | null): Prep
 
 function extractTargetFileFromEvalsJson(runDir: string): string | undefined {
   let curr = runDir;
+  const parsed = parseResultPath(runDir);
+  const guideName = parsed?.guide;
+  const taskName = parsed?.taskName;
+
   while (curr && curr !== path.dirname(curr)) {
     const data = tryReadJson(path.join(curr, 'evals.json'));
     if (data && data.results) {
-      const pathSegments = runDir.split(/[/\\]/);
-      const taskName = pathSegments[pathSegments.length - 2];
       for (const testName in data.results) {
         const runs = data.results[testName];
         if (Array.isArray(runs)) {
           for (const run of runs) {
-            if (run.targetFile && (run.taskName === taskName || testName.includes(taskName || ''))) {
+            const matchesGuide = !guideName || run.guideName === guideName || run.taskPath?.includes(guideName);
+            const matchesTask = !taskName || run.taskName === taskName;
+            if (matchesGuide && matchesTask && run.targetFile) {
               return run.targetFile;
             }
           }
@@ -380,10 +364,8 @@ function loadRunContext(runDir: string): RunContext {
     throw err;
   }
 
-  const pathSegments = absoluteDir.split(/[/\\]/);
-  const runNumberMatch = absoluteDir.match(/[/\\](\d+)[/\\]/);
-  const runNumber = runNumberMatch ? parseInt(runNumberMatch[1], 10) : 0;
-  const guideName = pathSegments[pathSegments.length - 3] || '';
+  const parsed = parseResultPath(absoluteDir);
+  const guideName = parsed?.guide || '';
 
   let resultsJson: PlaywrightAssertion[] = [];
   let score = 0;
@@ -414,12 +396,9 @@ function loadRunContext(runDir: string): RunContext {
 
   return {
     dir: absoluteDir,
-    runNumber,
     score,
     resultsJson,
-    trajectorySummary,
     codeOutput: code.content,
-    codePath: code.path,
     preprocessed,
     initialPrompt
   };
@@ -433,10 +412,11 @@ async function runSubAgent1_GuideCompliance(
   ctxA: RunContext,
   ctxB: RunContext,
   statusA: string,
-  statusB: string
+  statusB: string,
+  agentCaller = callAgentCli
 ): Promise<string> {
   const { systemInstruction, prompt } = getCompliancePrompts(guideCtx, ctxA, ctxB, statusA, statusB);
-  return callAgentCli(systemInstruction, prompt, 'Sub-Agent 1 (Guide Compliance)');
+  return agentCaller(systemInstruction, prompt, 'Sub-Agent 1 (Guide Compliance)');
 }
 
 /**
@@ -450,7 +430,8 @@ async function runSubAgent2_CodeAndFriction(
   diffBaseVsB: string,
   diffAvsB: string,
   statusA: string,
-  statusB: string
+  statusB: string,
+  agentCaller = callAgentCli
 ): Promise<string> {
   const { systemInstruction, prompt } = getCodeAndFrictionPrompts(
     guideCtx,
@@ -462,7 +443,7 @@ async function runSubAgent2_CodeAndFriction(
     statusA,
     statusB
   );
-  return callAgentCli(systemInstruction, prompt, 'Sub-Agent 2 (Code & Friction)');
+  return agentCaller(systemInstruction, prompt, 'Sub-Agent 2 (Code & Friction)');
 }
 
 /**
@@ -475,7 +456,8 @@ async function synthesizeDiagnosis(
   complianceAnalysis: string,
   codeAndFrictionAnalysis: string,
   statusA: string,
-  statusB: string
+  statusB: string,
+  agentCaller = callAgentCli
 ): Promise<string> {
   const { systemInstruction, prompt } = getSynthesizerPrompts(
     guideCtx,
@@ -486,13 +468,17 @@ async function synthesizeDiagnosis(
     statusA,
     statusB
   );
-  return callAgentCli(systemInstruction, prompt, 'Synthesizer Sub-Agent');
+  return agentCaller(systemInstruction, prompt, 'Synthesizer Sub-Agent');
 }
 
 /**
  * Runs the diagnostic agent comparison using local CLI sub-agents.
  */
-export async function runComparison(runDirA: string, runDirB: string): Promise<string> {
+export async function runComparison(
+  runDirA: string,
+  runDirB: string,
+  agentCaller: (sys: string, prompt: string, label?: string) => Promise<string> = callAgentCli
+): Promise<string> {
   console.log(cCyan(`\n=== Starting Run Comparison (Guide-Grounded 3-Phase Pipeline) ===`));
   console.log(`Run A: ${runDirA}`);
   console.log(`Run B: ${runDirB}\n`);
@@ -510,10 +496,10 @@ export async function runComparison(runDirA: string, runDirB: string): Promise<s
   const isAProblem = ctxA.score < ctxB.score;
   const successCtx = isAProblem ? ctxB : ctxA;
 
-  const parsedPath = parseResultPath(path.relative(resultsDir, successCtx.dir));
-  const guideName = parsedPath?.guide || successCtx.dir.split(/[/\\]/).slice(-3, -2)[0] || 'guide';
-  const taskName = parsedPath?.taskName || successCtx.dir.split(/[/\\]/).slice(-2, -1)[0] || 'task';
-  const runType = parsedPath?.runType || successCtx.dir.split(/[/\\]/).slice(-1)[0] || 'guided';
+  const parsedPath = parseResultPath(successCtx.dir);
+  const guideName = parsedPath?.guide || 'guide';
+  const taskName = parsedPath?.taskName || 'task';
+  const runType = parsedPath?.runType || 'guided';
 
   const guideCtx = findGuideContext(guideName, taskName);
   const diffBaseVsA = generateUnifiedDiff(guideCtx.baseAppContent || '', ctxA.codeOutput || '', 'Base App', 'Run A Output');
@@ -525,8 +511,6 @@ export async function runComparison(runDirA: string, runDirB: string): Promise<s
 
   const suiteMatch = successCtx.dir.match(/(.*[/\\]results[/\\][^/\\]+)/);
   const suiteDir = suiteMatch ? suiteMatch[1] : successCtx.dir;
-  const workDir = path.join(suiteDir, 'compare_work');
-  fs.mkdirSync(workDir, { recursive: true });
 
   try {
     console.log(cBold(`[Compare Agent] Phase 1: Pre-processed trajectories into tagged milestones.`));
@@ -535,8 +519,8 @@ export async function runComparison(runDirA: string, runDirB: string): Promise<s
 
     console.log(cBold(`[Compare Agent] Phase 2: Dispatching parallel sub-agents (Guide Compliance & Code/Friction)...`));
     const [complianceAnalysis, codeAndFrictionAnalysis] = await Promise.all([
-      runSubAgent1_GuideCompliance(guideCtx, ctxA, ctxB, statusA, statusB),
-      runSubAgent2_CodeAndFriction(guideCtx, ctxA, ctxB, diffBaseVsA, diffBaseVsB, diffAvsB, statusA, statusB)
+      runSubAgent1_GuideCompliance(guideCtx, ctxA, ctxB, statusA, statusB, agentCaller),
+      runSubAgent2_CodeAndFriction(guideCtx, ctxA, ctxB, diffBaseVsA, diffBaseVsB, diffAvsB, statusA, statusB, agentCaller)
     ]);
 
     console.log(cBold(`[Compare Agent] Phase 3: Synthesizing final 4-section diagnostic report...`));
@@ -547,7 +531,8 @@ export async function runComparison(runDirA: string, runDirB: string): Promise<s
       complianceAnalysis,
       codeAndFrictionAnalysis,
       statusA,
-      statusB
+      statusB,
+      agentCaller
     );
 
     if (suiteMatch) {
@@ -558,10 +543,6 @@ export async function runComparison(runDirA: string, runDirB: string): Promise<s
       fs.writeFileSync(savedPath, markdownReport, 'utf8');
       console.log(cGreen(`\n✅ Saved diagnostic report to: ${savedPath}`));
     }
-
-    const localSavedPath = path.resolve('./variance_diagnosis.md');
-    fs.writeFileSync(localSavedPath, markdownReport, 'utf8');
-    console.log(cGreen(`✅ Saved local copy to: ${localSavedPath}\n`));
 
     console.log(cBold(cCyan('--- DIAGNOSTIC REPORT ---')));
     console.log(markdownReport);

--- a/harness/lib/compare-evals.ts
+++ b/harness/lib/compare-evals.ts
@@ -8,7 +8,7 @@ import { downloadRunFromGcsIfMissing } from './gcs-downloader.ts';
 import { baseAppsDir, guidesDir, resultsDir } from '../../lib/paths.ts';
 import { getCompliancePrompts, getCodeAndFrictionPrompts, getSynthesizerPrompts } from './compare-prompts.ts';
 import { generateUnifiedDiff } from '../../lib/patch-utils.ts';
-import { categorizeAction, type StandardizedStep, type TrajectorySummary } from './trajectory-parser.ts';
+import { categorizeAction, type StandardizedStep, type TrajectorySummary } from './trajectory-normalizer.ts';
 import { parseResultPath } from './collection.ts';
 import { GUIDE_FILE, EXPECTATIONS_FILE, GRADER_FILE } from '../../lib/guide-validation.ts';
 

--- a/harness/lib/compare-evals.ts
+++ b/harness/lib/compare-evals.ts
@@ -1,17 +1,53 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 import { spawn } from 'node:child_process';
 
 import config from '../config.ts';
 import { cGreen, cRed, cCyan, cBold } from '../../lib/colors.ts';
 import { downloadRunFromGcsIfMissing } from './gcs-downloader.ts';
-import { rootDir, baseAppsDir } from '../../lib/paths.ts';
+import { baseAppsDir, guidesDir, resultsDir } from '../../lib/paths.ts';
 import { getCompliancePrompts, getCodeAndFrictionPrompts, getSynthesizerPrompts } from './compare-prompts.ts';
+import { generateUnifiedDiff } from '../../lib/patch-utils.ts';
+import { categorizeAction, type StandardizedStep, type TrajectorySummary } from './trajectory-parser.ts';
+import { parseResultPath } from './collection.ts';
+import { GUIDE_FILE, EXPECTATIONS_FILE, GRADER_FILE } from '../../lib/guide-validation.ts';
+
+const ERROR_LOOP_THRESHOLD = 2;
+const MAX_THOUGHT_SNIPPET_LEN = 120;
+const MAX_ACTION_PARAMS_SNIPPET_LEN = 200;
+
+function isNodeError(err: unknown): err is NodeJS.ErrnoException {
+  return err instanceof Error && 'code' in err;
+}
+
+function isEnoent(err: unknown): boolean {
+  return isNodeError(err) && err.code === 'ENOENT';
+}
+
+function tryReadFile(filePath: string): string | null {
+  try {
+    return fs.readFileSync(filePath, 'utf8');
+  } catch (err: unknown) {
+    if (isEnoent(err)) return null;
+    throw err;
+  }
+}
+
+function tryReadJson<T = any>(filePath: string): T | null {
+  const content = tryReadFile(filePath);
+  if (!content) return null;
+  try {
+    return JSON.parse(content) as T;
+  } catch {
+    console.warn(`Warning: Failed to parse JSON from ${filePath}`);
+    return null;
+  }
+}
 
 /**
  * Calls the local agent CLI (Jetski or Gemini CLI based on GD_DEV_USE_JETSKI) to generate diagnostic text.
  */
-async function callAgentCli(systemInstruction: string, prompt: string, label: string = 'Compare Agent'): Promise<string> {
+async function callAgentCli(systemInstruction: string, prompt: string, label = 'Compare Agent'): Promise<string> {
   const useJetski = process.env.GD_DEV_USE_JETSKI === '1';
   const command = useJetski ? config.environment.jetskiCliBin : config.environment.geminiCliBin;
   const combinedPrompt = systemInstruction ? `${systemInstruction}\n\n${prompt}` : prompt;
@@ -31,7 +67,7 @@ async function callAgentCli(systemInstruction: string, prompt: string, label: st
   return new Promise((resolve, reject) => {
     const child = spawn(command, commandArgs, {
       env: { ...process.env },
-      stdio: ['ignore', 'pipe', 'pipe'],
+      stdio: ['ignore', 'pipe', 'pipe']
     });
 
     let stdoutData = '';
@@ -58,13 +94,13 @@ async function callAgentCli(systemInstruction: string, prompt: string, label: st
           reject(new Error(`[${label}] Empty response received from ${useJetski ? 'Jetski' : 'Gemini'} CLI`));
         } else {
           try {
-            const debugDir = path.resolve('./harness/results/compare_work');
-            if (!fs.existsSync(debugDir)) {
-              fs.mkdirSync(debugDir, { recursive: true });
-            }
+            const debugDir = path.join(resultsDir, 'compare_work');
+            fs.mkdirSync(debugDir, { recursive: true });
             const slug = label.toLowerCase().replace(/[^a-z0-9]+/g, '_');
             fs.writeFileSync(path.join(debugDir, `response_debug_${slug}.txt`), cleanOutput, 'utf8');
-          } catch {}
+          } catch (e) {
+            console.warn(`[${label}] Failed to save debug response:`, e);
+          }
 
           resolve(cleanOutput);
         }
@@ -80,7 +116,7 @@ export interface TaggedStep {
   actionName?: string;
   actionDetails?: string;
   isError?: boolean;
-  raw: any;
+  raw: StandardizedStep;
 }
 
 export interface PreprocessedTrajectory {
@@ -103,13 +139,19 @@ export interface GuideContext {
   baseAppContent: string;
 }
 
+export interface PlaywrightAssertion {
+  message: string;
+  passed: boolean;
+  errors?: string[];
+  location?: { file?: string; line?: number; column?: number };
+}
+
 export interface RunContext {
   dir: string;
   runNumber: number;
   score: number;
-  resultsJson: any;
-  trajectorySummary: any;
-  chatLog: string;
+  resultsJson: PlaywrightAssertion[];
+  trajectorySummary: TrajectorySummary | null;
   codeOutput: string;
   codePath: string;
   preprocessed: PreprocessedTrajectory;
@@ -117,10 +159,9 @@ export interface RunContext {
 }
 
 /**
- * Helper to find guide.md, expectations.md, task.md, grader.ts, and base app content for a given guide/task name.
+ * Finds guide.md, expectations.md, task.md, grader.ts, and base app content for a given guide/task name.
  */
 function findGuideContext(guideName: string, taskName: string): GuideContext {
-  const guidesBaseDir = path.join(rootDir, 'guides');
   let guideContent = '';
   let expectationsContent = '';
   let taskPrompt = '';
@@ -128,66 +169,54 @@ function findGuideContext(guideName: string, taskName: string): GuideContext {
   let baseAppContent = '';
   let guideDir = '';
 
-  if (fs.existsSync(guidesBaseDir)) {
-    // 1. Search for guide directory
-    const items = fs.readdirSync(guidesBaseDir, { withFileTypes: true });
-    for (const item of items) {
-      if (item.isDirectory()) {
-        const direct = path.join(guidesBaseDir, guideName);
-        if (fs.existsSync(direct)) {
-          guideDir = direct;
-          break;
+  // Direct check first
+  const directPath = path.join(guidesDir, guideName);
+  if (tryReadFile(path.join(directPath, GUIDE_FILE))) {
+    guideDir = directPath;
+  } else {
+    try {
+      const items = fs.readdirSync(guidesDir, { withFileTypes: true });
+      for (const item of items) {
+        if (item.isDirectory()) {
+          const nested = path.join(guidesDir, item.name, guideName);
+          if (tryReadFile(path.join(nested, GUIDE_FILE))) {
+            guideDir = nested;
+            break;
+          }
         }
-        const nested = path.join(guidesBaseDir, item.name, guideName);
-        if (fs.existsSync(nested)) {
-          guideDir = nested;
-          break;
-        }
+      }
+    } catch {
+      // guides directory not readable
+    }
+  }
+
+  if (guideDir) {
+    guideContent = tryReadFile(path.join(guideDir, GUIDE_FILE)) || '';
+    expectationsContent = tryReadFile(path.join(guideDir, EXPECTATIONS_FILE)) || '';
+    graderContent = tryReadFile(path.join(guideDir, GRADER_FILE)) || '';
+
+    // Task prompt lookup
+    const taskCandidates = [
+      path.join(guideDir, 'tasks', `${taskName}.md`),
+      path.join(guideDir, 'tasks', 'task.md'),
+      path.join(guideDir, 'task.md')
+    ];
+
+    for (const candidate of taskCandidates) {
+      const content = tryReadFile(candidate);
+      if (content) {
+        taskPrompt = content;
+        break;
       }
     }
 
-    if (guideDir) {
-      const guidePath = path.join(guideDir, 'guide.md');
-      if (fs.existsSync(guidePath)) {
-        guideContent = fs.readFileSync(guidePath, 'utf8');
-      }
-
-      // Expectations
-      const expPath = path.join(guideDir, 'expectations.md');
-      if (fs.existsSync(expPath)) {
-        expectationsContent = fs.readFileSync(expPath, 'utf8');
-      }
-
-      // Grader
-      const graderPath = path.join(guideDir, 'grader.ts');
-      if (fs.existsSync(graderPath)) {
-        graderContent = fs.readFileSync(graderPath, 'utf8');
-      }
-
-      // Task prompt
-      const taskPath1 = path.join(guideDir, 'tasks', `${taskName}.md`);
-      const taskPath2 = path.join(guideDir, 'tasks', 'task.md');
-      const taskPath3 = path.join(guideDir, 'task.md');
-      let foundTaskPath = '';
-      if (fs.existsSync(taskPath1)) {
-        foundTaskPath = taskPath1;
-      } else if (fs.existsSync(taskPath2)) {
-        foundTaskPath = taskPath2;
-      } else if (fs.existsSync(taskPath3)) {
-        foundTaskPath = taskPath3;
-      }
-
-      if (foundTaskPath) {
-        taskPrompt = fs.readFileSync(foundTaskPath, 'utf8');
-        const baseAppMatch = taskPrompt.match(/base_app:\s*([^\s\r\n]+)/i);
-        if (baseAppMatch) {
-          const baseAppName = baseAppMatch[1].trim();
-          const baseAppDir = path.join(baseAppsDir, baseAppName);
-          if (fs.existsSync(baseAppDir)) {
-            const baseCode = findCodeOutput(baseAppDir);
-            baseAppContent = baseCode.content;
-          }
-        }
+    if (taskPrompt) {
+      const baseAppMatch = taskPrompt.match(/base_app:\s*([^\s\r\n]+)/i);
+      if (baseAppMatch) {
+        const baseAppName = baseAppMatch[1].trim();
+        const baseAppDir = path.join(baseAppsDir, baseAppName);
+        const baseCode = findCodeOutput(baseAppDir);
+        baseAppContent = baseCode.content;
       }
     }
   }
@@ -204,18 +233,16 @@ function findGuideContext(guideName: string, taskName: string): GuideContext {
 }
 
 /**
- * Helper to find the main generated code file in a run directory.
+ * Finds the main generated code file in a run directory.
  */
 function findCodeOutput(dir: string, targetFileFromEvals?: string): { path: string; content: string } {
   if (targetFileFromEvals) {
-    const fullPath = path.join(dir, targetFileFromEvals);
-    if (fs.existsSync(fullPath)) {
-      return {
-        path: targetFileFromEvals,
-        content: fs.readFileSync(fullPath, 'utf8')
-      };
+    const content = tryReadFile(path.join(dir, targetFileFromEvals));
+    if (content !== null) {
+      return { path: targetFileFromEvals, content };
     }
   }
+
   const candidates = [
     'dist/index.html',
     'src/App.jsx',
@@ -227,15 +254,13 @@ function findCodeOutput(dir: string, targetFileFromEvals?: string): { path: stri
     'index.html'
   ];
 
-  for (const c of candidates) {
-    const fullPath = path.join(dir, c);
-    if (fs.existsSync(fullPath)) {
-      return {
-        path: c,
-        content: fs.readFileSync(fullPath, 'utf8')
-      };
+  for (const candidate of candidates) {
+    const content = tryReadFile(path.join(dir, candidate));
+    if (content !== null) {
+      return { path: candidate, content };
     }
   }
+
   return { path: 'unknown', content: '' };
 }
 
@@ -247,12 +272,12 @@ function stripAnsi(text: string): string {
 /**
  * Recursively parses Playwright's JSON report and extracts assertions with detailed error traces and locations.
  */
-function parsePlaywrightResults(report: any): { message: string; passed: boolean; errors?: string[]; location?: { file?: string; line?: number; column?: number } }[] {
-  const assertions: { message: string; passed: boolean; errors?: string[]; location?: { file?: string; line?: number; column?: number } }[] = [];
+function parsePlaywrightResults(report: any): PlaywrightAssertion[] {
+  const assertions: PlaywrightAssertion[] = [];
   if (!report || !Array.isArray(report.suites)) {
     return assertions;
   }
-  
+
   function collectSpecs(suite: any) {
     if (Array.isArray(suite.specs)) {
       suite.specs.forEach((spec: any) => {
@@ -302,9 +327,9 @@ function parsePlaywrightResults(report: any): { message: string; passed: boolean
 }
 
 /**
- * Phase 1 Pre-Processor: Categorizes trajectory steps into 5 milestone/noise types and computes metrics.
+ * Categorizes trajectory steps into milestone/noise types and computes metrics.
  */
-function preprocessTrajectory(trajectorySummary: any, _chatLog: string, targetFileFromEvals?: string): PreprocessedTrajectory {
+function preprocessTrajectory(trajectorySummary: TrajectorySummary | null): PreprocessedTrajectory {
   const steps = trajectorySummary?.steps || [];
   const taggedSteps: TaggedStep[] = [];
   const searchQueries: string[] = [];
@@ -319,87 +344,34 @@ function preprocessTrajectory(trajectorySummary: any, _chatLog: string, targetFi
     const rawStep = steps[i];
     const stepNumber = rawStep.stepNumber || i + 1;
     const thought = rawStep.thought || '';
-    const actionName = (rawStep.action?.name || rawStep.action?.type || '').toLowerCase();
-    const actionParamsStr = JSON.stringify(rawStep.action?.params || rawStep.action || {}).toLowerCase();
+    const actionName = rawStep.action?.name || '';
+    const actionParams = rawStep.action?.params;
+    const actionParamsStr = JSON.stringify(actionParams || {}).toLowerCase();
     const isErr = rawStep.outcome?.status === 'error';
 
     if (isErr) {
       consecutiveErrors++;
-      if (consecutiveErrors >= 2) {
+      if (consecutiveErrors >= ERROR_LOOP_THRESHOLD) {
         errorLoopCount++;
       }
     } else {
       consecutiveErrors = 0;
     }
 
-    let category: TaggedStep['category'] = 'incidental_noise';
-    if (rawStep.action?.canonicalCategory && rawStep.action.canonicalCategory !== 'other') {
-      category = rawStep.action.canonicalCategory as TaggedStep['category'];
-    }
+    const rawCat = rawStep.action?.canonicalCategory || categorizeAction(actionName, actionParams, thought);
+    const category: TaggedStep['category'] = rawCat && rawCat !== 'other' ? rawCat : 'incidental_noise';
 
-    // 1. Guide Retrieval
-    if (category === 'guide_retrieval' || actionName.includes('retrieve') || (actionName.includes('get_best_practices') && actionParamsStr.includes('retrieve')) || actionParamsStr.includes('retrieve')) {
-      category = 'guide_retrieval';
-      const paramsObj = rawStep.action?.params || rawStep.action || {};
-      let guideId = paramsObj.id || paramsObj.guideId;
-      if (!guideId && typeof paramsObj.command === 'string' && paramsObj.command.includes('retrieve')) {
-        guideId = paramsObj.query;
-      }
-      if (!guideId && typeof paramsObj.query === 'string' && actionParamsStr.includes('retrieve')) {
-        guideId = paramsObj.query;
-      }
-      if (!guideId && typeof paramsObj.command === 'string') {
-        const match = paramsObj.command.match(/retrieve\s+\\?["']([^"'\\]+)/i) || paramsObj.command.match(/retrieve\s+([^"'\s]+)/i);
-        if (match) guideId = match[1];
-      }
-      if (!guideId) {
-        const match = actionParamsStr.match(/id["\s:]+\\?["']?([^"'\\}]+)/i) || actionParamsStr.match(/retrieve\s+\\?["']([^"'\\]+)/i) || actionParamsStr.match(/retrieve\s+([^"'\s}]+)/i);
-        if (match) guideId = match[1];
-      }
-      if (guideId) {
-        retrievedGuideIds.push(String(guideId).trim());
-      }
-    }
-    // 2. Skill Search
-    else if (category === 'skill_search' || actionName.includes('search') || actionParamsStr.includes('search')) {
-      category = 'skill_search';
-      const paramsObj = rawStep.action?.params || rawStep.action || {};
-      let query = paramsObj.query;
-      if (!query && typeof paramsObj.command === 'string') {
-        const match = paramsObj.command.match(/search\s+\\?["']([^"'\\]+)/i) || paramsObj.command.match(/search\s+([^"'\s]+)/i);
-        if (match) query = match[1];
-      }
-      if (!query) {
-        const match = actionParamsStr.match(/query["\s:]+\\?["']?([^"'\\}]+)/i) || actionParamsStr.match(/search\s+\\?["']([^"'\\]+)/i);
-        if (match) query = match[1];
-      }
-      if (query) {
-        searchQueries.push(String(query).trim());
-      }
-    }
-    // 3. Code Mutation
-    else if (
-      category === 'code_mutation' ||
-      actionName.includes('write') || actionName.includes('replace') || actionName.includes('touch') ||
-      actionParamsStr.includes('write_to_file') || actionParamsStr.includes('replace_file_content') ||
-      (targetFileFromEvals ? actionParamsStr.includes(path.basename(targetFileFromEvals).toLowerCase()) : (actionParamsStr.includes('index.html') || actionParamsStr.includes('app.jsx') || actionParamsStr.includes('style.css')))
-    ) {
-      category = 'code_mutation';
+    if (category === 'guide_retrieval') {
+      const guideId = actionParams?.id || actionParams?.guideId || actionParams?.query || actionParams?.command;
+      if (guideId) retrievedGuideIds.push(String(guideId).trim());
+    } else if (category === 'skill_search') {
+      const query = actionParams?.query || actionParams?.command || actionParams?.search;
+      if (query) searchQueries.push(String(query).trim());
+    } else if (category === 'code_mutation') {
       codeMutationCount++;
-    }
-    // 4. Mandatory Rule Thought / Adoption
-    else if (
-      category === 'mandatory_rule_thought' ||
-      thought.toLowerCase().includes('mandatory') || thought.toLowerCase().includes('fallback') ||
-      thought.toLowerCase().includes('css') || thought.toLowerCase().includes('baseline') ||
-      thought.toLowerCase().includes('guidance')
-    ) {
-      category = 'mandatory_rule_thought';
-      mandatoryRulesAdopted.push(thought.slice(0, 120));
-    }
-    // 5. Incidental Noise (view_file, ls, list_dir, grep)
-    else {
-      category = 'incidental_noise';
+    } else if (category === 'mandatory_rule_thought') {
+      mandatoryRulesAdopted.push(thought.slice(0, MAX_THOUGHT_SNIPPET_LEN));
+    } else {
       noiseCount++;
     }
 
@@ -407,11 +379,16 @@ function preprocessTrajectory(trajectorySummary: any, _chatLog: string, targetFi
       stepNumber,
       category,
       thought,
-      actionName: rawStep.action?.name,
-      actionDetails: actionParamsStr.slice(0, 200),
+      actionName,
+      actionDetails: actionParamsStr.slice(0, MAX_ACTION_PARAMS_SNIPPET_LEN),
       isError: isErr,
       raw: rawStep
     });
+  }
+
+  // Backfill top-level retrievedGuides if present
+  if (trajectorySummary?.retrievedGuides) {
+    retrievedGuideIds.push(...trajectorySummary.retrievedGuides);
   }
 
   return {
@@ -428,25 +405,20 @@ function preprocessTrajectory(trajectorySummary: any, _chatLog: string, targetFi
 function extractTargetFileFromEvalsJson(runDir: string): string | undefined {
   let curr = runDir;
   while (curr && curr !== path.dirname(curr)) {
-    const evalsPath = path.join(curr, 'evals.json');
-    if (fs.existsSync(evalsPath)) {
-      try {
-        const data = JSON.parse(fs.readFileSync(evalsPath, 'utf8'));
-        if (data && data.results) {
-          const pathSegments = runDir.split(/[/\\]/);
-          const taskName = pathSegments[pathSegments.length - 2];
-          for (const testName in data.results) {
-            const runs = data.results[testName];
-            if (Array.isArray(runs)) {
-              for (const run of runs) {
-                if (run.targetFile && (run.taskName === taskName || testName.includes(taskName || ''))) {
-                  return run.targetFile;
-                }
-              }
+    const data = tryReadJson(path.join(curr, 'evals.json'));
+    if (data && data.results) {
+      const pathSegments = runDir.split(/[/\\]/);
+      const taskName = pathSegments[pathSegments.length - 2];
+      for (const testName in data.results) {
+        const runs = data.results[testName];
+        if (Array.isArray(runs)) {
+          for (const run of runs) {
+            if (run.targetFile && (run.taskName === taskName || testName.includes(taskName || ''))) {
+              return run.targetFile;
             }
           }
         }
-      } catch (e) {}
+      }
     }
     curr = path.dirname(curr);
   }
@@ -458,56 +430,45 @@ function extractTargetFileFromEvalsJson(runDir: string): string | undefined {
  */
 function loadRunContext(runDir: string): RunContext {
   const absoluteDir = path.resolve(runDir);
-  if (!fs.existsSync(absoluteDir)) {
-    throw new Error(`Run directory not found: ${absoluteDir}`);
+  try {
+    fs.statSync(absoluteDir);
+  } catch (err: unknown) {
+    if (isEnoent(err)) {
+      throw new Error(`Run directory not found: ${absoluteDir}`);
+    }
+    throw err;
   }
 
   const pathSegments = absoluteDir.split(/[/\\]/);
   const runNumberMatch = absoluteDir.match(/[/\\](\d+)[/\\]/);
-  const runNumber = runNumberMatch ? parseInt(runNumberMatch[1]) : 0;
+  const runNumber = runNumberMatch ? parseInt(runNumberMatch[1], 10) : 0;
   const guideName = pathSegments[pathSegments.length - 3] || '';
 
-  let resultsPath = path.join(absoluteDir, `${guideName}_results.json`);
-  if (!fs.existsSync(resultsPath) && fs.existsSync(absoluteDir)) {
-    const fallbackResultsFile = fs.readdirSync(absoluteDir).find(f => f.endsWith('_results.json'));
-    if (fallbackResultsFile) {
-      resultsPath = path.join(absoluteDir, fallbackResultsFile);
-    }
-  }
-
-  let resultsJson: any = null;
+  let resultsJson: PlaywrightAssertion[] = [];
   let score = 0;
-  if (fs.existsSync(resultsPath)) {
+
+  let rawReport = tryReadJson(path.join(absoluteDir, `${guideName}_results.json`));
+  if (!rawReport) {
     try {
-      const rawReport = JSON.parse(fs.readFileSync(resultsPath, 'utf8'));
-      resultsJson = parsePlaywrightResults(rawReport);
-      const passed = resultsJson.filter((c: any) => c.passed).length;
-      score = resultsJson.length > 0 ? Math.round((passed / resultsJson.length) * 100) : 0;
-    } catch (e) {
-      console.warn(`Warning: Failed to parse results JSON in ${absoluteDir}`);
+      const fallbackFile = fs.readdirSync(absoluteDir).find((f) => f.endsWith('_results.json'));
+      if (fallbackFile) {
+        rawReport = tryReadJson(path.join(absoluteDir, fallbackFile));
+      }
+    } catch {
+      // directory listing failed
     }
   }
 
-  let trajectorySummary: any = null;
-  const trajPath = path.join(absoluteDir, 'trajectory_summary.json');
-  if (fs.existsSync(trajPath)) {
-    try {
-      trajectorySummary = JSON.parse(fs.readFileSync(trajPath, 'utf8'));
-    } catch (e) {
-      console.warn(`Warning: Failed to parse trajectory summary in ${absoluteDir}`);
-    }
+  if (rawReport) {
+    resultsJson = parsePlaywrightResults(rawReport);
+    const passed = resultsJson.filter((c) => c.passed).length;
+    score = resultsJson.length > 0 ? Math.round((passed / resultsJson.length) * 100) : 0;
   }
 
-  let chatLog = '';
-  const chatLogPath = path.join(absoluteDir, 'chat_log.txt');
-  if (fs.existsSync(chatLogPath)) {
-    chatLog = fs.readFileSync(chatLogPath, 'utf8');
-  }
-
+  const trajectorySummary = tryReadJson<TrajectorySummary>(path.join(absoluteDir, 'trajectory_summary.json'));
   const targetFileFromEvals = extractTargetFileFromEvalsJson(absoluteDir);
   const code = findCodeOutput(absoluteDir, targetFileFromEvals);
-  const preprocessed = preprocessTrajectory(trajectorySummary, chatLog, targetFileFromEvals);
-
+  const preprocessed = preprocessTrajectory(trajectorySummary);
   const initialPrompt = trajectorySummary?.initialPrompt || 'Initial prompt not found in trajectory summary.';
 
   return {
@@ -516,122 +477,11 @@ function loadRunContext(runDir: string): RunContext {
     score,
     resultsJson,
     trajectorySummary,
-    chatLog,
     codeOutput: code.content,
     codePath: code.path,
     preprocessed,
     initialPrompt
   };
-}
-
-/**
- * Generates an aligned LCS unified diff of two strings for accurate LLM context.
- */
-function generateUnifiedDiff(oldText: string, newText: string, oldLabel = 'Old', newLabel = 'New', contextLines = 3): string {
-  const oldLines = oldText.split(/\r?\n/);
-  const newLines = newText.split(/\r?\n/);
-
-  const m = oldLines.length;
-  const n = newLines.length;
-  
-  const dp: number[][] = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0));
-  for (let i = 1; i <= m; i++) {
-    for (let j = 1; j <= n; j++) {
-      if (oldLines[i - 1] === newLines[j - 1]) {
-        dp[i][j] = dp[i - 1][j - 1] + 1;
-      } else {
-        dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
-      }
-    }
-  }
-
-  interface EditOp {
-    type: 'equal' | 'add' | 'remove';
-    oldIndex?: number;
-    newIndex?: number;
-    line: string;
-  }
-  const ops: EditOp[] = [];
-  let i = m, j = n;
-  while (i > 0 || j > 0) {
-    if (i > 0 && j > 0 && oldLines[i - 1] === newLines[j - 1]) {
-      ops.push({ type: 'equal', oldIndex: i, newIndex: j, line: oldLines[i - 1] });
-      i--;
-      j--;
-    } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
-      ops.push({ type: 'add', newIndex: j, line: newLines[j - 1] });
-      j--;
-    } else if (i > 0 && (j === 0 || dp[i][j - 1] < dp[i - 1][j])) {
-      ops.push({ type: 'remove', oldIndex: i, line: oldLines[i - 1] });
-      i--;
-    }
-  }
-  ops.reverse();
-
-  if (ops.every(op => op.type === 'equal')) {
-    return 'No differences detected.';
-  }
-
-  const hunks: {
-    oldStart: number;
-    oldLinesCount: number;
-    newStart: number;
-    newLinesCount: number;
-    lines: string[];
-  }[] = [];
-
-  let opIndex = 0;
-  while (opIndex < ops.length) {
-    while (opIndex < ops.length && ops[opIndex].type === 'equal') {
-      opIndex++;
-    }
-    if (opIndex >= ops.length) break;
-
-    const hunkStart = Math.max(0, opIndex - contextLines);
-    let hunkEnd = opIndex;
-
-    while (hunkEnd < ops.length) {
-      if (ops[hunkEnd].type !== 'equal') {
-        hunkEnd++;
-      } else {
-        let nextChange = hunkEnd;
-        while (nextChange < ops.length && ops[nextChange].type === 'equal' && (nextChange - hunkEnd) < 2 * contextLines) {
-          nextChange++;
-        }
-        if (nextChange < ops.length && ops[nextChange].type !== 'equal') {
-          hunkEnd = nextChange;
-        } else {
-          break;
-        }
-      }
-    }
-
-    const actualEnd = Math.min(ops.length - 1, hunkEnd + contextLines - 1);
-    const hunkOps = ops.slice(hunkStart, actualEnd + 1);
-    const oldStarts = hunkOps.filter(op => op.oldIndex !== undefined).map(op => op.oldIndex!);
-    const newStarts = hunkOps.filter(op => op.newIndex !== undefined).map(op => op.newIndex!);
-    
-    const oldStart = oldStarts.length > 0 ? oldStarts[0] : (hunkStart > 0 && ops[hunkStart - 1].oldIndex ? ops[hunkStart - 1].oldIndex! + 1 : 1);
-    const newStart = newStarts.length > 0 ? newStarts[0] : (hunkStart > 0 && ops[hunkStart - 1].newIndex ? ops[hunkStart - 1].newIndex! + 1 : 1);
-    const oldLinesCount = hunkOps.filter(op => op.type === 'equal' || op.type === 'remove').length;
-    const newLinesCount = hunkOps.filter(op => op.type === 'equal' || op.type === 'add').length;
-
-    const lines = hunkOps.map(op => {
-      if (op.type === 'equal') return `  ${op.line}`;
-      if (op.type === 'remove') return `- ${op.line}`;
-      return `+ ${op.line}`;
-    });
-
-    hunks.push({ oldStart, oldLinesCount, newStart, newLinesCount, lines });
-    opIndex = actualEnd + 1;
-  }
-
-  let result = `--- ${oldLabel}\n+++ ${newLabel}\n`;
-  for (const hunk of hunks) {
-    result += `@@ -${hunk.oldStart},${hunk.oldLinesCount} +${hunk.newStart},${hunk.newLinesCount} @@\n`;
-    result += hunk.lines.join('\n') + '\n';
-  }
-  return result.trim();
 }
 
 /**
@@ -661,7 +511,16 @@ async function runSubAgent2_CodeAndFriction(
   statusA: string,
   statusB: string
 ): Promise<string> {
-  const { systemInstruction, prompt } = getCodeAndFrictionPrompts(guideCtx, ctxA, ctxB, diffBaseVsA, diffBaseVsB, diffAvsB, statusA, statusB);
+  const { systemInstruction, prompt } = getCodeAndFrictionPrompts(
+    guideCtx,
+    ctxA,
+    ctxB,
+    diffBaseVsA,
+    diffBaseVsB,
+    diffAvsB,
+    statusA,
+    statusB
+  );
   return callAgentCli(systemInstruction, prompt, 'Sub-Agent 2 (Code & Friction)');
 }
 
@@ -677,7 +536,15 @@ async function synthesizeDiagnosis(
   statusA: string,
   statusB: string
 ): Promise<string> {
-  const { systemInstruction, prompt } = getSynthesizerPrompts(guideCtx, ctxA, ctxB, complianceAnalysis, codeAndFrictionAnalysis, statusA, statusB);
+  const { systemInstruction, prompt } = getSynthesizerPrompts(
+    guideCtx,
+    ctxA,
+    ctxB,
+    complianceAnalysis,
+    codeAndFrictionAnalysis,
+    statusA,
+    statusB
+  );
   return callAgentCli(systemInstruction, prompt, 'Synthesizer Sub-Agent');
 }
 
@@ -689,21 +556,23 @@ export async function runComparison(runDirA: string, runDirB: string): Promise<s
   console.log(`Run A: ${runDirA}`);
   console.log(`Run B: ${runDirB}\n`);
 
-  await downloadRunFromGcsIfMissing(runDirA);
-  await downloadRunFromGcsIfMissing(runDirB);
+  await Promise.all([
+    downloadRunFromGcsIfMissing(runDirA),
+    downloadRunFromGcsIfMissing(runDirB)
+  ]);
 
   const ctxA = loadRunContext(runDirA);
   const ctxB = loadRunContext(runDirB);
 
+  console.log(`Comparing Run A (Score: ${ctxA.score}%) vs Run B (Score: ${ctxB.score}%)...`);
+
   const isAProblem = ctxA.score < ctxB.score;
   const successCtx = isAProblem ? ctxB : ctxA;
 
-  console.log(`Comparing Run A (Score: ${ctxA.score}%) vs Run B (Score: ${ctxB.score}%)...`);
-
-  const pathSegments = successCtx.dir.split(/[/\\]/);
-  const runType = pathSegments.pop() || 'guided';
-  const taskName = pathSegments.pop() || 'task';
-  const guideName = pathSegments.pop() || 'guide';
+  const parsedPath = parseResultPath(path.relative(resultsDir, successCtx.dir));
+  const guideName = parsedPath?.guide || successCtx.dir.split(/[/\\]/).slice(-3, -2)[0] || 'guide';
+  const taskName = parsedPath?.taskName || successCtx.dir.split(/[/\\]/).slice(-2, -1)[0] || 'task';
+  const runType = parsedPath?.runType || successCtx.dir.split(/[/\\]/).slice(-1)[0] || 'guided';
 
   const guideCtx = findGuideContext(guideName, taskName);
   const diffBaseVsA = generateUnifiedDiff(guideCtx.baseAppContent || '', ctxA.codeOutput || '', 'Base App', 'Run A Output');
@@ -716,9 +585,7 @@ export async function runComparison(runDirA: string, runDirB: string): Promise<s
   const suiteMatch = successCtx.dir.match(/(.*[/\\]results[/\\][^/\\]+)/);
   const suiteDir = suiteMatch ? suiteMatch[1] : successCtx.dir;
   const workDir = path.join(suiteDir, 'compare_work');
-  if (!fs.existsSync(workDir)) {
-    fs.mkdirSync(workDir, { recursive: true });
-  }
+  fs.mkdirSync(workDir, { recursive: true });
 
   try {
     console.log(cBold(`[Compare Agent] Phase 1: Pre-processed trajectories into tagged milestones.`));
@@ -742,15 +609,11 @@ export async function runComparison(runDirA: string, runDirB: string): Promise<s
       statusB
     );
 
-    let savedPath = '';
     if (suiteMatch) {
       const diagnosesDir = path.join(suiteDir, 'variance_diagnoses');
-      if (!fs.existsSync(diagnosesDir)) {
-        fs.mkdirSync(diagnosesDir, { recursive: true });
-      }
-      
+      fs.mkdirSync(diagnosesDir, { recursive: true });
       const fileName = `${guideName}-${taskName}-${runType}.md`;
-      savedPath = path.join(diagnosesDir, fileName);
+      const savedPath = path.join(diagnosesDir, fileName);
       fs.writeFileSync(savedPath, markdownReport, 'utf8');
       console.log(cGreen(`\n✅ Saved diagnostic report to: ${savedPath}`));
     }

--- a/harness/lib/compare-evals.ts
+++ b/harness/lib/compare-evals.ts
@@ -253,7 +253,7 @@ function parsePlaywrightResults(report: any): PlaywrightAssertion[] {
 /**
  * Categorizes trajectory steps into milestone/noise types and computes metrics.
  */
-function preprocessTrajectory(trajectorySummary: TrajectorySummary | null): PreprocessedTrajectory {
+export function preprocessTrajectory(trajectorySummary: TrajectorySummary | null): PreprocessedTrajectory {
   const steps = trajectorySummary?.steps || [];
   const taggedSteps: TaggedStep[] = [];
   const searchQueries: string[] = [];
@@ -285,11 +285,12 @@ function preprocessTrajectory(trajectorySummary: TrajectorySummary | null): Prep
     const category: TaggedStep['category'] = rawCat && rawCat !== 'other' ? rawCat : 'incidental_noise';
 
     if (category === 'guide_retrieval') {
-      const guideId = actionParams?.id || actionParams?.guideId || actionParams?.query || actionParams?.command;
-      if (guideId) retrievedGuideIds.push(String(guideId).trim());
+      // Guide retrieval is tracked primarily from trajectorySummary.retrievedGuides
     } else if (category === 'skill_search') {
-      const query = actionParams?.query || actionParams?.command || actionParams?.search;
-      if (query) searchQueries.push(String(query).trim());
+      const cmd = typeof actionParams?.command === 'string' ? actionParams.command : '';
+      const match = cmd.match(/search\s+["']?([^"'\n\r]+?)["']?(?:\s|$)/i);
+      const query = match ? match[1].trim() : (typeof actionParams?.query === 'string' ? actionParams.query.trim() : undefined);
+      if (query) searchQueries.push(query);
     } else if (category === 'code_mutation') {
       codeMutationCount++;
     } else if (category === 'mandatory_rule_thought') {
@@ -306,7 +307,7 @@ function preprocessTrajectory(trajectorySummary: TrajectorySummary | null): Prep
     });
   }
 
-  // Backfill top-level retrievedGuides if present
+  // Trajectory summary retrievedGuides is the primary source of truth
   if (trajectorySummary?.retrievedGuides) {
     retrievedGuideIds.push(...trajectorySummary.retrievedGuides);
   }
@@ -352,7 +353,7 @@ function extractTargetFileFromEvalsJson(runDir: string): string | undefined {
 /**
  * Loads all relevant context for a single run including preprocessed trajectory.
  */
-function loadRunContext(runDir: string): RunContext {
+export function loadRunContext(runDir: string): RunContext {
   let absoluteDir = path.resolve(runDir);
   if (!fs.existsSync(absoluteDir)) {
     const stripped = runDir.replace(/^(\.\/)?(harness\/)?results\/?/, '');
@@ -517,9 +518,11 @@ export async function runComparison(
   const diffBaseVsB = ctxB.patchContent
     ? ctxB.patchContent.trim()
     : generateUnifiedDiff(guideCtx.baseAppContent || '', ctxB.codeOutput || '', 'Base App', 'Run B Output');
-  const diffAvsB = (ctxA.codeOutput && ctxB.codeOutput)
-    ? generateUnifiedDiff(ctxA.codeOutput, ctxB.codeOutput, 'Run A Output', 'Run B Output')
-    : generateUnifiedDiff(ctxA.patchContent || '', ctxB.patchContent || '', 'Run A Patch', 'Run B Patch');
+  const diffAvsB = (ctxA.patchContent && ctxB.patchContent)
+    ? generateUnifiedDiff(ctxA.patchContent.trim(), ctxB.patchContent.trim(), 'Run A Patch', 'Run B Patch')
+    : (ctxA.codeOutput && ctxB.codeOutput)
+      ? generateUnifiedDiff(ctxA.codeOutput, ctxB.codeOutput, 'Run A Output', 'Run B Output')
+      : generateUnifiedDiff(ctxA.patchContent || ctxA.codeOutput || '', ctxB.patchContent || ctxB.codeOutput || '', 'Run A Output', 'Run B Output');
 
   const statusA = ctxA.score > ctxB.score ? 'SUCCESSFUL' : ctxA.score < ctxB.score ? 'FAILED/POORER' : 'COMPARED RUN';
   const statusB = ctxB.score > ctxA.score ? 'SUCCESSFUL' : ctxB.score < ctxA.score ? 'FAILED/POORER' : 'COMPARED RUN';

--- a/harness/lib/compare-evals.ts
+++ b/harness/lib/compare-evals.ts
@@ -90,6 +90,7 @@ export interface RunContext {
   score: number;
   resultsJson: PlaywrightAssertion[];
   codeOutput: string;
+  patchContent?: string;
   preprocessed: PreprocessedTrajectory;
   initialPrompt: string;
 }
@@ -397,6 +398,7 @@ function loadRunContext(runDir: string): RunContext {
   const trajectorySummary = tryReadJson<TrajectorySummary>(path.join(absoluteDir, 'trajectory_summary.json'));
   const targetFileFromEvals = extractTargetFileFromEvalsJson(absoluteDir);
   const code = findCodeOutput(absoluteDir, targetFileFromEvals);
+  const patchContent = tryReadFile(path.join(absoluteDir, 'agent.patch')) || undefined;
   const preprocessed = preprocessTrajectory(trajectorySummary);
   const initialPrompt = trajectorySummary?.initialPrompt || 'Initial prompt not found in trajectory summary.';
 
@@ -405,6 +407,7 @@ function loadRunContext(runDir: string): RunContext {
     score,
     resultsJson,
     codeOutput: code.content,
+    patchContent,
     preprocessed,
     initialPrompt
   };
@@ -508,9 +511,15 @@ export async function runComparison(
   const runType = parsedPath?.runType || 'guided';
 
   const guideCtx = findGuideContext(guideName, taskName);
-  const diffBaseVsA = generateUnifiedDiff(guideCtx.baseAppContent || '', ctxA.codeOutput || '', 'Base App', 'Run A Output');
-  const diffBaseVsB = generateUnifiedDiff(guideCtx.baseAppContent || '', ctxB.codeOutput || '', 'Base App', 'Run B Output');
-  const diffAvsB = generateUnifiedDiff(ctxA.codeOutput || '', ctxB.codeOutput || '', 'Run A Output', 'Run B Output');
+  const diffBaseVsA = ctxA.patchContent
+    ? ctxA.patchContent.trim()
+    : generateUnifiedDiff(guideCtx.baseAppContent || '', ctxA.codeOutput || '', 'Base App', 'Run A Output');
+  const diffBaseVsB = ctxB.patchContent
+    ? ctxB.patchContent.trim()
+    : generateUnifiedDiff(guideCtx.baseAppContent || '', ctxB.codeOutput || '', 'Base App', 'Run B Output');
+  const diffAvsB = (ctxA.codeOutput && ctxB.codeOutput)
+    ? generateUnifiedDiff(ctxA.codeOutput, ctxB.codeOutput, 'Run A Output', 'Run B Output')
+    : generateUnifiedDiff(ctxA.patchContent || '', ctxB.patchContent || '', 'Run A Patch', 'Run B Patch');
 
   const statusA = ctxA.score > ctxB.score ? 'SUCCESSFUL' : ctxA.score < ctxB.score ? 'FAILED/POORER' : 'COMPARED RUN';
   const statusB = ctxB.score > ctxA.score ? 'SUCCESSFUL' : ctxB.score < ctxA.score ? 'FAILED/POORER' : 'COMPARED RUN';

--- a/harness/lib/compare-evals.ts
+++ b/harness/lib/compare-evals.ts
@@ -4,7 +4,7 @@ import { cGreen, cRed, cCyan, cBold } from '../../lib/colors.ts';
 import { downloadRunFromGcsIfMissing } from './gcs-downloader.ts';
 import { baseAppsDir, guidesDir, resultsDir } from '../../lib/paths.ts';
 import { getCompliancePrompts, getCodeAndFrictionPrompts, getSynthesizerPrompts } from './compare-prompts.ts';
-import { generateUnifiedDiff } from '../../lib/patch-utils.ts';
+import { generateUnifiedDiff, extractTargetFilesFromPatch } from '../../lib/patch-utils.ts';
 import { categorizeAction, type TrajectorySummary } from './trajectory-normalizer.ts';
 import { parseResultPath } from './collection.ts';
 import { isEnoent } from './agent-shared.ts';
@@ -140,7 +140,14 @@ function findGuideContext(guideName: string, taskName: string): GuideContext {
     const baseAppName = taskInfo?.baseApp || taskPrompt.match(/base_app:\s*([^\s\r\n]+)/i)?.[1]?.trim();
     if (baseAppName) {
       const baseAppDir = path.join(baseAppsDir, baseAppName);
-      const baseCode = findCodeOutput(baseAppDir);
+      let targetRelFile: string | undefined;
+      const targetDir = guideDir ? path.join(guideDir, 'targets', taskName) : undefined;
+      if (targetDir) {
+        const solPatch = path.join(targetDir, 'patches', 'solution.patch');
+        const [extracted] = extractTargetFilesFromPatch(solPatch);
+        targetRelFile = extracted;
+      }
+      const baseCode = findCodeOutput(baseAppDir, targetRelFile);
       baseAppContent = baseCode.content;
     }
   }
@@ -160,7 +167,7 @@ function findGuideContext(guideName: string, taskName: string): GuideContext {
  * Finds the main generated code file in a run directory.
  */
 function findCodeOutput(dir: string, targetFileFromEvals?: string): { path: string; content: string } {
-  if (targetFileFromEvals) {
+  if (targetFileFromEvals && targetFileFromEvals !== 'agent.patch') {
     const content = tryReadFile(path.join(dir, targetFileFromEvals));
     if (content !== null) {
       return { path: targetFileFromEvals, content };
@@ -504,7 +511,15 @@ export async function runComparison(
   console.log(`Comparing Run A (Score: ${ctxA.score}%) vs Run B (Score: ${ctxB.score}%)...`);
 
   const isAProblem = ctxA.score < ctxB.score;
-  const successCtx = isAProblem ? ctxB : ctxA;
+  const isBProblem = ctxB.score < ctxA.score;
+  let successCtx = isAProblem ? ctxB : ctxA;
+  if (!isAProblem && !isBProblem) {
+    const isAGuided = parseResultPath(ctxA.dir)?.runType === 'guided';
+    const isBGuided = parseResultPath(ctxB.dir)?.runType === 'guided';
+    if (!isAGuided && isBGuided) {
+      successCtx = ctxB;
+    }
+  }
 
   const parsedPath = parseResultPath(successCtx.dir);
   const guideName = parsedPath?.guide || 'guide';
@@ -520,9 +535,11 @@ export async function runComparison(
     : generateUnifiedDiff(guideCtx.baseAppContent || '', ctxB.codeOutput || '', 'Base App', 'Run B Output');
   const diffAvsB = (ctxA.patchContent && ctxB.patchContent)
     ? generateUnifiedDiff(ctxA.patchContent.trim(), ctxB.patchContent.trim(), 'Run A Patch', 'Run B Patch')
-    : (ctxA.codeOutput && ctxB.codeOutput)
+    : (ctxA.codeOutput && ctxB.codeOutput && !ctxA.patchContent && !ctxB.patchContent)
       ? generateUnifiedDiff(ctxA.codeOutput, ctxB.codeOutput, 'Run A Output', 'Run B Output')
-      : generateUnifiedDiff(ctxA.patchContent || ctxA.codeOutput || '', ctxB.patchContent || ctxB.codeOutput || '', 'Run A Output', 'Run B Output');
+      : (ctxA.patchContent || ctxB.patchContent)
+        ? `Direct diff unavailable: Run ${ctxA.patchContent ? 'A' : 'B'} is patch-based while Run ${ctxB.patchContent ? 'A' : 'B'} produced standalone file output.`
+        : generateUnifiedDiff(ctxA.codeOutput || '', ctxB.codeOutput || '', 'Run A Output', 'Run B Output');
 
   const statusA = ctxA.score > ctxB.score ? 'SUCCESSFUL' : ctxA.score < ctxB.score ? 'FAILED/POORER' : 'COMPARED RUN';
   const statusB = ctxB.score > ctxA.score ? 'SUCCESSFUL' : ctxB.score < ctxA.score ? 'FAILED/POORER' : 'COMPARED RUN';

--- a/harness/lib/compare-prompts.ts
+++ b/harness/lib/compare-prompts.ts
@@ -11,7 +11,7 @@ export function getCompliancePrompts(
 
 Specifically analyze:
 1. **Starting Point & Eval Prompt Audit**: Inspect the initial eval prompt given to Run A vs Run B (Initial Eval / Task Prompts). Verify if both runs received the exact same initial instructions. If the initial prompts are identical, state clearly that both runs started from an identical prompt, so any divergence in behavior is due to agent decision-making or execution timeline differences (such as searching/retrieving the guide before vs after writing code).
-2. **Chronological Execution & Sequencing Audit**: Check the step numbers and order of events in the Chronological Milestone Timeline. Did the agent search for and retrieve the mandatory guide *before* writing or modifying code? If an agent wrote code first (e.g. step 4 code mutation) and only searched for or retrieved the guide later (or not at all), flag this as a critical sequencing failure ("Premature coding before guide retrieval").
+2. **Chronological Execution & Sequencing Audit**: Check the step numbers and order of events in the Chronological Milestone Timeline. Did the agent search for and retrieve the mandatory guide *before* writing or modifying code? If an agent wrote code first (e.g. code mutation) and only searched for or retrieved the guide later (or not at all), flag this as a critical sequencing failure ("Premature coding before guide retrieval").
 3. **Skill Discovery & Search**: Compare search queries used by Run A vs Run B. Did the search query accurately surface the guide, or did it miss due to vague/generic phrasing?
 4. **Guide Retrieval & Reading**: Did the agent actually retrieve guide.md before implementing code changes?
 5. **Mandatory Rule Adoption**: Compare agent thinking/reasoning steps against MANDATORY guide requirements. Did an agent explicitly ignore, bypass, or misunderstand a mandatory rule (e.g. opting for JS instead of CSS, omitting fallback, missing required HTML attributes)?
@@ -139,10 +139,10 @@ ${diffAvsB.slice(0, 30000)}
 
 ### Tagged Trajectory Steps Overview
 #### Run A:
-${JSON.stringify(ctxA.preprocessed.taggedSteps.map(s => ({ step: s.stepNumber, cat: s.category, action: s.actionName, isErr: s.isError, thought: s.thought?.slice(0, 100) })), null, 2)}
+${JSON.stringify(ctxA.preprocessed.taggedSteps.map(s => ({ step: s.stepNumber, cat: s.category, action: s.actionName, thought: s.thought?.slice(0, 100) })), null, 2)}
 
 #### Run B:
-${JSON.stringify(ctxB.preprocessed.taggedSteps.map(s => ({ step: s.stepNumber, cat: s.category, action: s.actionName, isErr: s.isError, thought: s.thought?.slice(0, 100) })), null, 2)}
+${JSON.stringify(ctxB.preprocessed.taggedSteps.map(s => ({ step: s.stepNumber, cat: s.category, action: s.actionName, thought: s.thought?.slice(0, 100) })), null, 2)}
 `;
 
   return { systemInstruction, prompt };

--- a/harness/lib/compare-prompts.ts
+++ b/harness/lib/compare-prompts.ts
@@ -1,0 +1,221 @@
+import type { GuideContext, RunContext } from './compare-evals.ts';
+
+export function getCompliancePrompts(
+  guideCtx: GuideContext,
+  ctxA: RunContext,
+  ctxB: RunContext,
+  statusA: string,
+  statusB: string
+): { systemInstruction: string; prompt: string } {
+  const systemInstruction = `You are a specialized Web Guidance Compliance Auditor. Your task is to evaluate whether two agent runs (Run A vs Run B) successfully discovered, retrieved, and adhered to the MANDATORY requirements in guide.md and expectations.md.
+
+Specifically analyze:
+1. **Starting Point & Eval Prompt Audit**: Inspect the initial eval prompt given to Run A vs Run B (Initial Eval / Task Prompts). Verify if both runs received the exact same initial instructions. If the initial prompts are identical, state clearly that both runs started from an identical prompt, so any divergence in behavior is due to agent decision-making or execution timeline differences (such as searching/retrieving the guide before vs after writing code).
+2. **Chronological Execution & Sequencing Audit**: Check the step numbers and order of events in the Chronological Milestone Timeline. Did the agent search for and retrieve the mandatory guide *before* writing or modifying code? If an agent wrote code first (e.g. step 4 code mutation) and only searched for or retrieved the guide later (or not at all), flag this as a critical sequencing failure ("Premature coding before guide retrieval").
+3. **Skill Discovery & Search**: Compare search queries used by Run A vs Run B. Did the search query accurately surface the guide, or did it miss due to vague/generic phrasing?
+4. **Guide Retrieval & Reading**: Did the agent actually retrieve guide.md before implementing code changes?
+5. **Mandatory Rule Adoption**: Compare agent thinking/reasoning steps against MANDATORY guide requirements. Did an agent explicitly ignore, bypass, or misunderstand a mandatory rule (e.g. opting for JS instead of CSS, omitting fallback, missing required HTML attributes)?
+6. **Compliance Discrepancy**: Explain how guide compliance, step sequencing, and rule adoption directly account for the difference in score between Run A (${ctxA.score}%) and Run B (${ctxB.score}%).`;
+
+  const timelineA = ctxA.preprocessed.taggedSteps.filter(s => s.category !== 'incidental_noise').map(s => `Step ${s.stepNumber}: [${s.category}] ${s.actionName} - ${s.thought?.slice(0, 80)}`);
+  const timelineB = ctxB.preprocessed.taggedSteps.filter(s => s.category !== 'incidental_noise').map(s => `Step ${s.stepNumber}: [${s.category}] ${s.actionName} - ${s.thought?.slice(0, 80)}`);
+
+  const prompt = `### Initial Eval / Task Prompts (Starting Points)
+- Run A Initial Prompt: """${ctxA.initialPrompt}"""
+- Run B Initial Prompt: """${ctxB.initialPrompt}"""
+
+### Task Prompt
+"""
+${guideCtx.taskPrompt}
+"""
+
+### Reference Guidance (guide.md)
+"""
+${guideCtx.guideContent.slice(0, 4000)}
+"""
+
+### Expected Outcomes (expectations.md)
+"""
+${guideCtx.expectationsContent.slice(0, 3000)}
+"""
+
+### Run A (${statusA} - Score: ${ctxA.score}%)
+- Chronological Milestone Timeline:
+${JSON.stringify(timelineA, null, 2)}
+- Search Queries: ${JSON.stringify(ctxA.preprocessed.searchQueries)}
+- Retrieved Guide IDs: ${JSON.stringify(ctxA.preprocessed.retrievedGuideIds)}
+- Key Adopted Thoughts / Rules:
+${JSON.stringify(ctxA.preprocessed.mandatoryRulesAdopted, null, 2)}
+
+### Run B (${statusB} - Score: ${ctxB.score}%)
+- Chronological Milestone Timeline:
+${JSON.stringify(timelineB, null, 2)}
+- Search Queries: ${JSON.stringify(ctxB.preprocessed.searchQueries)}
+- Retrieved Guide IDs: ${JSON.stringify(ctxB.preprocessed.retrievedGuideIds)}
+- Key Adopted Thoughts / Rules:
+${JSON.stringify(ctxB.preprocessed.mandatoryRulesAdopted, null, 2)}
+`;
+
+  return { systemInstruction, prompt };
+}
+
+export function getCodeAndFrictionPrompts(
+  guideCtx: GuideContext,
+  ctxA: RunContext,
+  ctxB: RunContext,
+  diffBaseVsA: string,
+  diffBaseVsB: string,
+  diffAvsB: string,
+  statusA: string,
+  statusB: string
+): { systemInstruction: string; prompt: string } {
+  const systemInstruction = `You are a Code & Execution Diagnostic Sub-Agent. Your task is to identify the precise technical reason why Run A failed Playwright tests that Run B passed (or vice versa), using factual evidence from starting prompts, execution sequencing, grader code, error traces, and exact code diffs.
+
+Mandatory Audit Steps:
+1. **Starting Point & Launch Prompt Audit**: Inspect the initial eval prompt (Initial Eval / Task Prompts). If both runs received identical starting instructions, do NOT claim the prompt was defective, truncated, or malformed. State clearly that both runs started from identical instructions.
+2. **Execution Timeline & Sequencing Check**: Check the order of tool executions in Tagged Trajectory Steps Overview. Did the failing agent write or modify code *before* retrieving the required guide? Note if premature coding caused the agent to miss required identifiers, functions, or DOM structures.
+3. **Grader & Error Trace Check**: Inspect \`grader.ts\` and the exact Playwright error logs. Did the test fail due to a strict locator mismatch (e.g. querying \`button\` when the agent created \`<a>\`), timing issues, missing required CSS rules, or missing functionality? State the exact line of \`grader.ts\` and the failure message.
+4. **Base App Diff Audit**: Compare what Run A and Run B modified relative to the Base App. Do NOT attribute missing/extra styles in Run A to "corrupted code" or "botched search/replace" unless Run A actually deleted existing lines that were present in the Base App. Distinguish carefully between code deleted by Run A vs new code added exclusively by Run B.
+5. **Execution vs. Trajectory Status**: Check whether the file modification tool calls (\`write_file\`, \`multi_replace_file_content\`, etc.) succeeded or returned errors in the trajectory. Do not claim the agent hallucinated or botched an edit if the tool reported \`status: success\` and produced valid HTML/CSS/JS.
+6. **Friction Assessment**: Only cite context noise or retries as a contributing factor if trajectory logs explicitly show the model losing track of instructions, entering error recovery loops, or making blind retries. If the agent completed its edits cleanly on the first try but chose an incompatible HTML element (like \`<a>\` instead of \`<button>\`), state clearly that this was a locator alignment/implementation choice rather than context loss.`;
+
+  const failedTracesA = (ctxA.resultsJson || []).filter((c: any) => !c.passed).map((c: any) => ({
+    assertion: c.message,
+    location: c.location ? `Line ${c.location.line}` : 'Unknown',
+    errors: c.errors || ['Unknown error']
+  }));
+
+  const failedTracesB = (ctxB.resultsJson || []).filter((c: any) => !c.passed).map((c: any) => ({
+    assertion: c.message,
+    location: c.location ? `Line ${c.location.line}` : 'Unknown',
+    errors: c.errors || ['Unknown error']
+  }));
+
+  const prompt = `### Initial Eval / Task Prompts (Starting Points)
+- Run A Initial Prompt: """${ctxA.initialPrompt}"""
+- Run B Initial Prompt: """${ctxB.initialPrompt}"""
+
+### Validation Logic (grader.ts)
+"""
+${guideCtx.graderContent.slice(0, 15000)}
+"""
+
+### Run A (${statusA} - Score: ${ctxA.score}%)
+- Dir: ${ctxA.dir}
+- Passed Assertions: ${JSON.stringify((ctxA.resultsJson || []).filter((c: any) => c.passed).map((c: any) => c.message))}
+- Failed Test Traces:
+${JSON.stringify(failedTracesA, null, 2)}
+- Trajectory Tagged Steps Summary:
+  - Code Mutations: ${ctxA.preprocessed.codeMutationCount}
+  - Context Noise Steps: ${ctxA.preprocessed.noiseCount}
+  - Error/Retry Loops: ${ctxA.preprocessed.errorLoopCount}
+
+### Run B (${statusB} - Score: ${ctxB.score}%)
+- Dir: ${ctxB.dir}
+- Passed Assertions: ${JSON.stringify((ctxB.resultsJson || []).filter((c: any) => c.passed).map((c: any) => c.message))}
+- Failed Test Traces:
+${JSON.stringify(failedTracesB, null, 2)}
+- Trajectory Tagged Steps Summary:
+  - Code Mutations: ${ctxB.preprocessed.codeMutationCount}
+  - Context Noise Steps: ${ctxB.preprocessed.noiseCount}
+  - Error/Retry Loops: ${ctxB.preprocessed.errorLoopCount}
+
+### Code Diffs (Unified Diff Format)
+
+#### Diff 1: Base App vs Run A Output
+"""
+${diffBaseVsA.slice(0, 30000)}
+"""
+
+#### Diff 2: Base App vs Run B Output
+"""
+${diffBaseVsB.slice(0, 30000)}
+"""
+
+#### Diff 3: Run A Output vs Run B Output
+"""
+${diffAvsB.slice(0, 30000)}
+"""
+
+### Tagged Trajectory Steps Overview
+#### Run A:
+${JSON.stringify(ctxA.preprocessed.taggedSteps.map(s => ({ step: s.stepNumber, cat: s.category, action: s.actionName, isErr: s.isError, thought: s.thought?.slice(0, 100) })), null, 2)}
+
+#### Run B:
+${JSON.stringify(ctxB.preprocessed.taggedSteps.map(s => ({ step: s.stepNumber, cat: s.category, action: s.actionName, isErr: s.isError, thought: s.thought?.slice(0, 100) })), null, 2)}
+`;
+
+  return { systemInstruction, prompt };
+}
+
+export function getSynthesizerPrompts(
+  guideCtx: GuideContext,
+  ctxA: RunContext,
+  ctxB: RunContext,
+  complianceAnalysis: string,
+  codeAndFrictionAnalysis: string,
+  statusA: string,
+  statusB: string
+): { systemInstruction: string; prompt: string } {
+  const systemInstruction = `You are an expert Lead Diagnostic Engineer synthesizing a variance diagnosis between two AI agent evaluation runs.
+
+You MUST structure your report into exactly the following four sections in Markdown format. Do not alter section titles or their order:
+
+### 1. First Meaningful Divergence
+- **Step Number**: Specify exact step number for Trial A and Trial B if they differ (e.g., Trial A Step 4, Trial B Step 7, or Step 0/Launch if initial eval prompt differed right at initialization)
+- **Event Type**: [Starting Prompt / Harness Launch | Skill Search | Guide Retrieval | Mandatory Rule Adoption | Code Implementation | Error Recovery]
+- **Divergence Summary**: Direct, objective explanation of why this specific step represents the root divergence point based on factual starting prompts, tool outputs, execution timeline (e.g. writing code before retrieving the guide vs after), and code choices. Do NOT claim a prompt was truncated or malformed unless the initial prompt text itself was actually defective.
+
+### 2. Root Cause & Friction Analysis
+- **Problem Classification**: List ALL that apply from: [Guide not retrieved | Guide not followed | Grader too strict | System error]
+  - **Classification Definitions**:
+    - **Guide not retrieved**: The agent failed to search for or retrieve the mandatory guide before implementing code changes.
+    - **Guide not followed**: The outcome or implementation code produced by the agent does not meet the requirements or intentions of the guide.
+    - **Grader too strict**: The outcome meets the intentions of the guide, but the test harness or Playwright grader still fails it (e.g. rigid element tag requirement like \`<button>\` vs \`<a>\`, or checking computed style directly on an element when the agent used a valid pseudo-element).
+    - **System error**: Anything else, such as the eval failing to complete, unparseable logs, harness runtime crash, or API failure.
+  *(Note: If more than one category applies, list all applicable categories separated by commas, e.g. "Classification: [Grader too strict], [Guide not followed]").*
+- **Technical Breakdown**:
+  - Provide an objective, strictly fact-grounded breakdown detailing why each classified category applies.
+  - Highlight execution sequencing issues if applicable (e.g. agent mutating files before reading guidance).
+  - State the exact locator, API, or DOM mismatch that triggered any Playwright failures, referencing specific lines in \`grader.ts\` and error logs.
+  - Do NOT fabricate narrative claims about context loss or botched edits unless trajectory logs show explicit tool errors or loops.
+
+### 3. Actionable Fix Recommendation
+Provide clear, concrete recommendations on whether to update:
+- **Harness / Launch Prompt**: (only if the eval harness spawned the run with an actually broken or mismatched starting prompt)
+- **Guide (guide.md)**: (e.g. add MANDATORY keyword, clarify code example)
+- **Prompt (tasks/task.md)**: (e.g. add declarative constraint, clarify trigger element type)
+- **Grader (grader.ts)**: (e.g. relax rigid locator like \`button:visible\` to \`button:visible, a:visible, [role="button"]:visible\`, or inspect pseudo-elements)
+- **Agent/Model Non-Determinism**: (only if initial prompt, guide, and task instructions were clear and valid, but model still behaved inconsistently or executed tools in the wrong order)
+
+### 4. Guide Compliance & Milestone Matrix
+Provide a Markdown table summarizing key milestones:
+| Milestone / Metric | Run A (Score: ${ctxA.score}%) | Run B (Score: ${ctxB.score}%) | Status |
+| :--- | :--- | :--- | :---: |
+| **Initial Eval / Starting Prompt** | ... | ... | ... |
+| **Skill Search Query** | ... | ... | ... |
+| **Guide Retrieval** | ... | ... | ... |
+| **Mandatory Rule Adoption** | ... | ... | ... |
+| **Context Noise / Retries** | ... | ... | ... |`;
+
+  const prompt = `### Guide & Task Context
+- Guide Name: ${guideCtx.guideName}
+- Task Name: ${guideCtx.taskName}
+
+### Run A (${statusA} - Score: ${ctxA.score}%, Dir: ${ctxA.dir})
+- Initial Prompt: """${ctxA.initialPrompt}"""
+### Run B (${statusB} - Score: ${ctxB.score}%, Dir: ${ctxB.dir})
+- Initial Prompt: """${ctxB.initialPrompt}"""
+
+### Sub-Agent 1: Guide Compliance Analysis
+"""
+${complianceAnalysis}
+"""
+
+### Sub-Agent 2: Code-to-Trajectory & Friction Analysis
+"""
+${codeAndFrictionAnalysis}
+"""`;
+
+  return { systemInstruction, prompt };
+}

--- a/harness/lib/gcs-downloader.ts
+++ b/harness/lib/gcs-downloader.ts
@@ -173,15 +173,31 @@ function normalizePath(p: string): string {
   }
 }
 
-async function downloadSingleDirFromGcs(runDir: string, token: string | undefined): Promise<boolean> {
-  const absoluteRunDir = normalizePath(runDir);
+export function resolveRunPath(runDir: string): { absoluteRunDir: string; relativeRunPath: string } | null {
+  let absoluteRunDir = normalizePath(runDir);
   const absoluteResultsDir = normalizePath(baseResultsDir);
-  
-  const relativeRunPath = path.relative(absoluteResultsDir, absoluteRunDir);
+  let relativeRunPath = path.relative(absoluteResultsDir, absoluteRunDir);
+
   if (relativeRunPath.startsWith('..') || path.isAbsolute(relativeRunPath)) {
-    console.warn(`[GCS Downloader] Path is outside results directory: ${absoluteRunDir}`);
-    return false;
+    const stripped = runDir.replace(/^(\.\/)?(harness\/)?results\/?/, '');
+    const candidate = path.resolve(baseResultsDir, stripped);
+    const candidateRel = path.relative(absoluteResultsDir, candidate);
+    if (!candidateRel.startsWith('..') && !path.isAbsolute(candidateRel)) {
+      absoluteRunDir = candidate;
+      relativeRunPath = candidateRel;
+    } else {
+      console.warn(`[GCS Downloader] Path is outside results directory: ${absoluteRunDir}`);
+      return null;
+    }
   }
+
+  return { absoluteRunDir, relativeRunPath };
+}
+
+async function downloadSingleDirFromGcs(runDir: string, token: string | undefined): Promise<boolean> {
+  const resolved = resolveRunPath(runDir);
+  if (!resolved) return false;
+  const { absoluteRunDir, relativeRunPath } = resolved;
 
   if (fs.existsSync(absoluteRunDir)) {
     const files = fs.readdirSync(absoluteRunDir);

--- a/harness/lib/gcs-downloader.ts
+++ b/harness/lib/gcs-downloader.ts
@@ -17,7 +17,7 @@ async function postDownloadProcessing(absoluteRunDir: string, relativeRunPath: s
   if (!needsGeneration) {
     try {
       const summaryJson = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
-      if (summaryJson.schemaVersion !== "2.0") {
+      if (!Array.isArray(summaryJson.steps) || summaryJson.steps.length === 0) {
         needsGeneration = true;
       }
     } catch {

--- a/harness/lib/gcs-downloader.ts
+++ b/harness/lib/gcs-downloader.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import fs from 'fs';
 import { resultsDir as baseResultsDir } from '../../lib/paths.ts';
 import { cCyan, cGreen, cYellow, cRed } from '../../lib/colors.ts';
-import { Agents, Serving } from '../config.ts';
+import { Agents } from '../config.ts';
 
 const PROJECT_ID = 'chrome-kiwi-air-force-dev';
 const BUCKET_NAME = 'guidance-evals';
@@ -26,21 +26,32 @@ async function postDownloadProcessing(absoluteRunDir: string, relativeRunPath: s
   }
   if (needsGeneration) {
     console.log(cCyan(`[GCS Downloader] trajectory_summary.json is missing or outdated in historical run. Generating v2.0 on the fly...`));
-    let detectedAgent: string = Agents.JETSKI;
-    const lower = relativeRunPath.toLowerCase();
-    if (lower.includes('claude')) {
-      detectedAgent = Agents.CLAUDE_CODE;
-    } else if (lower.includes('gemini')) {
-      detectedAgent = Agents.GEMINI_CLI;
-    } else if (lower.includes('codex')) {
-      detectedAgent = Agents.CODEX_CLI;
-    } else if (lower.includes('pi')) {
-      detectedAgent = Agents.PI;
+    let detectedAgent: string | undefined;
+    let curr = absoluteRunDir;
+    while (curr && curr !== path.dirname(curr)) {
+      const evalsPath = path.join(curr, 'evals.json');
+      if (fs.existsSync(evalsPath)) {
+        try {
+          const data = JSON.parse(fs.readFileSync(evalsPath, 'utf8'));
+          if (data.agent) {
+            const raw = String(data.agent).replace(/-/g, '_');
+            detectedAgent = Object.values(Agents).find(a => a === raw || a === data.agent) || data.agent;
+            break;
+          }
+        } catch {
+          // ignore parse failure
+        }
+      }
+      curr = path.dirname(curr);
+    }
+
+    if (!detectedAgent) {
+      throw new Error(`[GCS Downloader] Could not determine agent from evals.json for run: ${relativeRunPath}`);
     }
     
     try {
       const { generateNormalizedTrajectory } = await import('./trajectory-normalizer.ts');
-      await generateNormalizedTrajectory(absoluteRunDir, detectedAgent, Serving.MCP);
+      await generateNormalizedTrajectory(absoluteRunDir, detectedAgent);
     } catch (err: any) {
       console.warn(`[GCS Downloader] Warning: Failed to generate trajectory on the fly: ${err.message}`);
     }
@@ -276,19 +287,6 @@ export async function downloadRunFromGcsIfMissing(runDir: string): Promise<boole
     return true;
   }
 
-  // 2. Download the primary requested directory (e.g., guided)
-  const success = await downloadSingleDirFromGcs(runDir, token);
-
-  // 3. Pre-emptively download the sibling run type directory (guided/unguided)
-  if (runDir.endsWith('guided')) {
-    const unguidedDir = runDir.slice(0, -6) + 'unguided';
-    console.log(cCyan(`[GCS Downloader] Pre-emptively downloading sibling unguided run: ${unguidedDir}`));
-    await downloadSingleDirFromGcs(unguidedDir, token);
-  } else if (runDir.endsWith('unguided')) {
-    const guidedDir = runDir.slice(0, -8) + 'guided';
-    console.log(cCyan(`[GCS Downloader] Pre-emptively downloading sibling guided run: ${guidedDir}`));
-    await downloadSingleDirFromGcs(guidedDir, token);
-  }
-
-  return success;
+  // 2. Download the primary requested directory
+  return downloadSingleDirFromGcs(runDir, token);
 }

--- a/harness/lib/gcs-downloader.ts
+++ b/harness/lib/gcs-downloader.ts
@@ -37,7 +37,7 @@ async function postDownloadProcessing(absoluteRunDir: string, relativeRunPath: s
     }
     
     try {
-      const { generateNormalizedTrajectory } = await import('./trajectory-parser.ts');
+      const { generateNormalizedTrajectory } = await import('./trajectory-normalizer.ts');
       await generateNormalizedTrajectory(absoluteRunDir, detectedAgent, Serving.MCP);
     } catch (err: any) {
       console.warn(`[GCS Downloader] Warning: Failed to generate trajectory on the fly: ${err.message}`);

--- a/harness/lib/gcs-downloader.ts
+++ b/harness/lib/gcs-downloader.ts
@@ -27,13 +27,15 @@ async function postDownloadProcessing(absoluteRunDir: string, relativeRunPath: s
   if (needsGeneration) {
     console.log(cCyan(`[GCS Downloader] trajectory_summary.json is missing or outdated in historical run. Generating v2.0 on the fly...`));
     let detectedAgent: string = Agents.JETSKI;
-    const suiteId = relativeRunPath.split(/[/\\]/)[0].toLowerCase();
-    if (suiteId.includes('claude')) {
+    const lower = relativeRunPath.toLowerCase();
+    if (lower.includes('claude')) {
       detectedAgent = Agents.CLAUDE_CODE;
-    } else if (suiteId.includes('gemini')) {
+    } else if (lower.includes('gemini')) {
       detectedAgent = Agents.GEMINI_CLI;
-    } else if (suiteId.includes('codex')) {
+    } else if (lower.includes('codex')) {
       detectedAgent = Agents.CODEX_CLI;
+    } else if (lower.includes('pi')) {
+      detectedAgent = Agents.PI;
     }
     
     try {
@@ -84,6 +86,31 @@ async function listFilesWithToken(token: string, prefix: string): Promise<string
 }
 
 /**
+ * Downloads a batch of GCS items in parallel into the target directory.
+ */
+async function downloadFileBatch<T>(
+  items: T[],
+  gcsPrefix: string,
+  destDir: string,
+  getItemName: (item: T) => string,
+  downloadFn: (item: T, destPath: string) => Promise<unknown>
+): Promise<void> {
+  await Promise.all(items.map(async (item) => {
+    const name = getItemName(item);
+    const relativeFilePath = name.substring(gcsPrefix.length);
+    if (!relativeFilePath || relativeFilePath.endsWith('/')) {
+      return;
+    }
+
+    const destPath = path.join(destDir, relativeFilePath);
+    fs.mkdirSync(path.dirname(destPath), { recursive: true });
+
+    console.log(`  Downloading gs://${BUCKET_NAME}/${name} -> ${destPath}`);
+    await downloadFn(item, destPath);
+  }));
+}
+
+/**
  * Downloads a suite-level evals.json file from GCS if it is missing locally.
  */
 async function downloadSuiteEvalsIfMissing(suiteName: string, token: string | undefined) {
@@ -95,10 +122,7 @@ async function downloadSuiteEvalsIfMissing(suiteName: string, token: string | un
   const gcsFileName = `${suiteName}/evals.json`;
   console.log(cCyan(`[GCS Downloader] Suite-level evals.json is missing. Downloading from GCS: gs://${BUCKET_NAME}/${gcsFileName}...`));
   
-  const destDir = path.dirname(destPath);
-  if (!fs.existsSync(destDir)) {
-    fs.mkdirSync(destDir, { recursive: true });
-  }
+  fs.mkdirSync(path.dirname(destPath), { recursive: true });
 
   if (token && token.startsWith('Bearer ')) {
     try {
@@ -128,19 +152,14 @@ async function downloadSuiteEvalsIfMissing(suiteName: string, token: string | un
 }
 
 /**
- * Lazily downloads a run directory from GCS if it is missing locally.
- * Resolves the path relative to the harness results directory.
- * Supports both Bearer token authentication (passed from the browser) and standard ADC.
- */
-/**
- * Lazily downloads a single directory prefix from GCS if it is missing locally.
+ * Resolves the absolute native path for a given file or directory path.
  */
 function normalizePath(p: string): string {
-  let abs = path.resolve(p);
-  if (abs.startsWith('/home/')) {
-    abs = '/usr/local/google' + abs;
+  try {
+    return fs.realpathSync.native(p);
+  } catch {
+    return path.resolve(p);
   }
-  return abs;
 }
 
 async function downloadSingleDirFromGcs(runDir: string, token: string | undefined): Promise<boolean> {
@@ -177,25 +196,13 @@ async function downloadSingleDirFromGcs(runDir: string, token: string | undefine
 
       console.log(cCyan(`[GCS Downloader] Discovered ${fileNames.length} files. Downloading via REST API...`));
 
-      if (!fs.existsSync(absoluteRunDir)) {
-        fs.mkdirSync(absoluteRunDir, { recursive: true });
-      }
-
-      await Promise.all(fileNames.map(async (name) => {
-        const relativeFilePath = name.substring(gcsPrefix.length);
-        if (!relativeFilePath || relativeFilePath.endsWith('/')) {
-          return;
-        }
-
-        const destPath = path.join(absoluteRunDir, relativeFilePath);
-        const destDir = path.dirname(destPath);
-        if (!fs.existsSync(destDir)) {
-          fs.mkdirSync(destDir, { recursive: true });
-        }
-
-        console.log(`  Downloading gs://${BUCKET_NAME}/${name} -> ${destPath}`);
-        await downloadFileWithToken(token, name, destPath);
-      }));
+      await downloadFileBatch(
+        fileNames,
+        gcsPrefix,
+        absoluteRunDir,
+        (name) => name,
+        (name, destPath) => downloadFileWithToken(token, name, destPath)
+      );
 
       console.log(cGreen(`[GCS Downloader] ✅ Successfully downloaded all files via REST API!`));
       await postDownloadProcessing(absoluteRunDir, relativeRunPath);
@@ -221,25 +228,13 @@ async function downloadSingleDirFromGcs(runDir: string, token: string | undefine
 
     console.log(cCyan(`[GCS Downloader] Discovered ${files.length} files. Downloading via Storage SDK...`));
 
-    if (!fs.existsSync(absoluteRunDir)) {
-      fs.mkdirSync(absoluteRunDir, { recursive: true });
-    }
-
-    await Promise.all(files.map(async (file) => {
-      const relativeFilePath = file.name.substring(gcsPrefix.length);
-      if (!relativeFilePath || relativeFilePath.endsWith('/')) {
-        return;
-      }
-
-      const destPath = path.join(absoluteRunDir, relativeFilePath);
-      const destDir = path.dirname(destPath);
-      if (!fs.existsSync(destDir)) {
-        fs.mkdirSync(destDir, { recursive: true });
-      }
-
-      console.log(`  Downloading gs://${BUCKET_NAME}/${file.name} -> ${destPath}`);
-      await file.download({ destination: destPath });
-    }));
+    await downloadFileBatch(
+      files,
+      gcsPrefix,
+      absoluteRunDir,
+      (file) => file.name,
+      (file, destPath) => file.download({ destination: destPath })
+    );
 
     console.log(cGreen(`[GCS Downloader] ✅ Successfully downloaded all files via Storage SDK!`));
     await postDownloadProcessing(absoluteRunDir, relativeRunPath);

--- a/harness/lib/gcs-downloader.ts
+++ b/harness/lib/gcs-downloader.ts
@@ -1,0 +1,299 @@
+import { Storage } from '@google-cloud/storage';
+import path from 'path';
+import fs from 'fs';
+import { resultsDir as baseResultsDir } from '../../lib/paths.ts';
+import { cCyan, cGreen, cYellow, cRed } from '../../lib/colors.ts';
+import { Agents, Serving } from '../config.ts';
+
+const PROJECT_ID = 'chrome-kiwi-air-force-dev';
+const BUCKET_NAME = 'guidance-evals';
+
+/**
+ * Performs post-download operations, such as generating missing trajectory summaries.
+ */
+async function postDownloadProcessing(absoluteRunDir: string, relativeRunPath: string) {
+  const summaryPath = path.join(absoluteRunDir, 'trajectory_summary.json');
+  let needsGeneration = !fs.existsSync(summaryPath);
+  if (!needsGeneration) {
+    try {
+      const summaryJson = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+      if (summaryJson.schemaVersion !== "2.0") {
+        needsGeneration = true;
+      }
+    } catch {
+      needsGeneration = true;
+    }
+  }
+  if (needsGeneration) {
+    console.log(cCyan(`[GCS Downloader] trajectory_summary.json is missing or outdated in historical run. Generating v2.0 on the fly...`));
+    let detectedAgent: string = Agents.JETSKI;
+    const suiteId = relativeRunPath.split(/[/\\]/)[0].toLowerCase();
+    if (suiteId.includes('claude')) {
+      detectedAgent = Agents.CLAUDE_CODE;
+    } else if (suiteId.includes('gemini')) {
+      detectedAgent = Agents.GEMINI_CLI;
+    } else if (suiteId.includes('codex')) {
+      detectedAgent = Agents.CODEX_CLI;
+    }
+    
+    try {
+      const { generateNormalizedTrajectory } = await import('./trajectory-parser.ts');
+      await generateNormalizedTrajectory(absoluteRunDir, detectedAgent, Serving.MCP);
+    } catch (err: any) {
+      console.warn(`[GCS Downloader] Warning: Failed to generate trajectory on the fly: ${err.message}`);
+    }
+  }
+}
+
+/**
+ * Downloads a file from GCS using the REST API with a Bearer token.
+ */
+async function downloadFileWithToken(token: string, gcsFileName: string, destPath: string): Promise<void> {
+  const url = `https://storage.googleapis.com/storage/v1/b/${BUCKET_NAME}/o/${encodeURIComponent(gcsFileName)}?alt=media`;
+  const response = await fetch(url, {
+    headers: { 'Authorization': token }
+  });
+
+  if (!response.ok) {
+    throw new Error(`REST download failed: HTTP ${response.status} ${response.statusText}`);
+  }
+
+  const arrayBuffer = await response.arrayBuffer();
+  fs.writeFileSync(destPath, Buffer.from(arrayBuffer));
+}
+
+/**
+ * Lists files in a GCS bucket prefix using the REST API with a Bearer token.
+ */
+async function listFilesWithToken(token: string, prefix: string): Promise<string[]> {
+  const url = `https://storage.googleapis.com/storage/v1/b/${BUCKET_NAME}/o?prefix=${encodeURIComponent(prefix)}`;
+  const response = await fetch(url, {
+    headers: { 'Authorization': token }
+  });
+
+  if (!response.ok) {
+    throw new Error(`REST list failed: HTTP ${response.status} ${response.statusText}`);
+  }
+
+  const data: any = await response.json();
+  if (!data.items || !Array.isArray(data.items)) {
+    return [];
+  }
+
+  return data.items.map((item: any) => item.name);
+}
+
+/**
+ * Downloads a suite-level evals.json file from GCS if it is missing locally.
+ */
+async function downloadSuiteEvalsIfMissing(suiteName: string, token: string | undefined) {
+  const destPath = path.join(baseResultsDir, suiteName, 'evals.json');
+  if (fs.existsSync(destPath)) {
+    return; // Already exists locally
+  }
+
+  const gcsFileName = `${suiteName}/evals.json`;
+  console.log(cCyan(`[GCS Downloader] Suite-level evals.json is missing. Downloading from GCS: gs://${BUCKET_NAME}/${gcsFileName}...`));
+  
+  const destDir = path.dirname(destPath);
+  if (!fs.existsSync(destDir)) {
+    fs.mkdirSync(destDir, { recursive: true });
+  }
+
+  if (token && token.startsWith('Bearer ')) {
+    try {
+      await downloadFileWithToken(token, gcsFileName, destPath);
+      console.log(cGreen(`[GCS Downloader] ✅ Successfully downloaded suite evals.json via REST API!`));
+      return;
+    } catch (err: any) {
+      console.warn(`[GCS Downloader] Warning: Failed to download suite evals.json via REST: ${err.message}`);
+    }
+  }
+
+  // Fallback to Storage SDK (ADC)
+  try {
+    const storage = new Storage({ projectId: PROJECT_ID });
+    const bucket = storage.bucket(BUCKET_NAME);
+    const file = bucket.file(gcsFileName);
+    const [exists] = await file.exists();
+    if (exists) {
+      await file.download({ destination: destPath });
+      console.log(cGreen(`[GCS Downloader] ✅ Successfully downloaded suite evals.json via Storage SDK!`));
+    } else {
+      console.warn(`[GCS Downloader] Suite evals.json does not exist on GCS: gs://${BUCKET_NAME}/${gcsFileName}`);
+    }
+  } catch (err: any) {
+    console.warn(`[GCS Downloader] Warning: Failed to download suite evals.json via SDK: ${err.message}`);
+  }
+}
+
+/**
+ * Lazily downloads a run directory from GCS if it is missing locally.
+ * Resolves the path relative to the harness results directory.
+ * Supports both Bearer token authentication (passed from the browser) and standard ADC.
+ */
+/**
+ * Lazily downloads a single directory prefix from GCS if it is missing locally.
+ */
+function normalizePath(p: string): string {
+  let abs = path.resolve(p);
+  if (abs.startsWith('/home/')) {
+    abs = '/usr/local/google' + abs;
+  }
+  return abs;
+}
+
+async function downloadSingleDirFromGcs(runDir: string, token: string | undefined): Promise<boolean> {
+  const absoluteRunDir = normalizePath(runDir);
+  const absoluteResultsDir = normalizePath(baseResultsDir);
+  
+  const relativeRunPath = path.relative(absoluteResultsDir, absoluteRunDir);
+  if (relativeRunPath.startsWith('..') || path.isAbsolute(relativeRunPath)) {
+    console.warn(`[GCS Downloader] Path is outside results directory: ${absoluteRunDir}`);
+    return false;
+  }
+
+  if (fs.existsSync(absoluteRunDir)) {
+    const files = fs.readdirSync(absoluteRunDir);
+    if (files.some(f => f === 'trajectory_summary.json' || f.endsWith('_results.json') || f === 'runtime.json')) {
+      return true; // Already cached locally
+    }
+  }
+
+  console.log(cCyan(`[GCS Downloader] Run directory not found or incomplete locally: ${relativeRunPath}`));
+  
+  const gcsPrefix = relativeRunPath.replace(/\\/g, '/') + '/';
+
+  if (token && token.startsWith('Bearer ')) {
+    console.log(cYellow(`[GCS Downloader] Using Bearer token authentication forwarded from browser...`));
+    try {
+      console.log(`[GCS Downloader] Listing files in gs://${BUCKET_NAME}/${gcsPrefix} via REST API...`);
+      const fileNames = await listFilesWithToken(token, gcsPrefix);
+
+      if (fileNames.length === 0) {
+        console.warn(`[GCS Downloader] No files found on GCS with prefix: ${gcsPrefix}`);
+        return false;
+      }
+
+      console.log(cCyan(`[GCS Downloader] Discovered ${fileNames.length} files. Downloading via REST API...`));
+
+      if (!fs.existsSync(absoluteRunDir)) {
+        fs.mkdirSync(absoluteRunDir, { recursive: true });
+      }
+
+      await Promise.all(fileNames.map(async (name) => {
+        const relativeFilePath = name.substring(gcsPrefix.length);
+        if (!relativeFilePath || relativeFilePath.endsWith('/')) {
+          return;
+        }
+
+        const destPath = path.join(absoluteRunDir, relativeFilePath);
+        const destDir = path.dirname(destPath);
+        if (!fs.existsSync(destDir)) {
+          fs.mkdirSync(destDir, { recursive: true });
+        }
+
+        console.log(`  Downloading gs://${BUCKET_NAME}/${name} -> ${destPath}`);
+        await downloadFileWithToken(token, name, destPath);
+      }));
+
+      console.log(cGreen(`[GCS Downloader] ✅ Successfully downloaded all files via REST API!`));
+      await postDownloadProcessing(absoluteRunDir, relativeRunPath);
+      return true;
+    } catch (err: any) {
+      console.error(cRed(`[GCS Downloader] ❌ REST API Download failed: ${err.message}`));
+    }
+  }
+
+  // Backup / CLI Fallback: Use standard SDK
+  console.log(cYellow(`[GCS Downloader] Attempting standard Google Cloud Storage library authentication (ADC)...`));
+  try {
+    const storage = new Storage({ projectId: PROJECT_ID });
+    const bucket = storage.bucket(BUCKET_NAME);
+
+    console.log(`[GCS Downloader] Listing files in gs://${BUCKET_NAME}/${gcsPrefix} via Storage SDK...`);
+    const [files] = await bucket.getFiles({ prefix: gcsPrefix });
+
+    if (files.length === 0) {
+      console.warn(`[GCS Downloader] No files found on GCS with prefix: ${gcsPrefix}`);
+      return false;
+    }
+
+    console.log(cCyan(`[GCS Downloader] Discovered ${files.length} files. Downloading via Storage SDK...`));
+
+    if (!fs.existsSync(absoluteRunDir)) {
+      fs.mkdirSync(absoluteRunDir, { recursive: true });
+    }
+
+    await Promise.all(files.map(async (file) => {
+      const relativeFilePath = file.name.substring(gcsPrefix.length);
+      if (!relativeFilePath || relativeFilePath.endsWith('/')) {
+        return;
+      }
+
+      const destPath = path.join(absoluteRunDir, relativeFilePath);
+      const destDir = path.dirname(destPath);
+      if (!fs.existsSync(destDir)) {
+        fs.mkdirSync(destDir, { recursive: true });
+      }
+
+      console.log(`  Downloading gs://${BUCKET_NAME}/${file.name} -> ${destPath}`);
+      await file.download({ destination: destPath });
+    }));
+
+    console.log(cGreen(`[GCS Downloader] ✅ Successfully downloaded all files via Storage SDK!`));
+    await postDownloadProcessing(absoluteRunDir, relativeRunPath);
+    return true;
+  } catch (err: any) {
+    console.error(cRed(`[GCS Downloader] ❌ Storage SDK Download failed: ${err.message}`));
+    console.log(cYellow(`
+💡 Hint: If you are running gd compare directly from the CLI, run:
+   gcloud auth application-default login
+   to authenticate your local terminal environment with Google Cloud.
+    `));
+    return false;
+  }
+}
+
+/**
+ * Lazily downloads a run directory from GCS if it is missing locally.
+ * Resolves the path relative to the harness results directory.
+ * Orchestrates downloading suite evals.json, the primary requested run, and the sibling run type (guided/unguided).
+ */
+export async function downloadRunFromGcsIfMissing(runDir: string): Promise<boolean> {
+  const absoluteRunDir = normalizePath(runDir);
+  const absoluteResultsDir = normalizePath(baseResultsDir);
+  
+  const relativeRunPath = path.relative(absoluteResultsDir, absoluteRunDir);
+  if (relativeRunPath.startsWith('..') || path.isAbsolute(relativeRunPath)) {
+    console.warn(`[GCS Downloader] Path is outside results directory: ${absoluteRunDir}`);
+    return false;
+  }
+
+  const suiteName = relativeRunPath.split(/[/\\]/)[0];
+  const token = process.env.GD_GCS_TOKEN;
+
+  // 1. Lazily download the suite-level evals.json
+  await downloadSuiteEvalsIfMissing(suiteName, token);
+
+  // If runDir points to a top-level suite directory rather than a specific task run, we only need evals.json
+  if (!relativeRunPath.includes('/') && !relativeRunPath.includes('\\')) {
+    return true;
+  }
+
+  // 2. Download the primary requested directory (e.g., guided)
+  const success = await downloadSingleDirFromGcs(runDir, token);
+
+  // 3. Pre-emptively download the sibling run type directory (guided/unguided)
+  if (runDir.endsWith('guided')) {
+    const unguidedDir = runDir.slice(0, -6) + 'unguided';
+    console.log(cCyan(`[GCS Downloader] Pre-emptively downloading sibling unguided run: ${unguidedDir}`));
+    await downloadSingleDirFromGcs(unguidedDir, token);
+  } else if (runDir.endsWith('unguided')) {
+    const guidedDir = runDir.slice(0, -8) + 'guided';
+    console.log(cCyan(`[GCS Downloader] Pre-emptively downloading sibling guided run: ${guidedDir}`));
+    await downloadSingleDirFromGcs(guidedDir, token);
+  }
+
+  return success;
+}

--- a/harness/lib/gcs-downloader.ts
+++ b/harness/lib/gcs-downloader.ts
@@ -46,7 +46,8 @@ async function postDownloadProcessing(absoluteRunDir: string, relativeRunPath: s
     }
 
     if (!detectedAgent) {
-      throw new Error(`[GCS Downloader] Could not determine agent from evals.json for run: ${relativeRunPath}`);
+      console.warn(`[GCS Downloader] Warning: Could not determine agent from evals.json for run: ${relativeRunPath}. Skipping automatic trajectory generation.`);
+      return;
     }
     
     try {
@@ -174,14 +175,15 @@ function normalizePath(p: string): string {
 }
 
 export function resolveRunPath(runDir: string): { absoluteRunDir: string; relativeRunPath: string } | null {
+  const normalizedRunDir = runDir.replace(/\\/g, '/');
   let absoluteRunDir = normalizePath(runDir);
   const absoluteResultsDir = normalizePath(baseResultsDir);
   let relativeRunPath = path.relative(absoluteResultsDir, absoluteRunDir);
 
   if (relativeRunPath.startsWith('..') || path.isAbsolute(relativeRunPath)) {
-    const stripped = runDir.replace(/^(\.\/)?(harness\/)?results\/?/, '');
+    const stripped = normalizedRunDir.replace(/^(\.\/)?(harness\/)?results\/?/, '');
     const candidate = path.resolve(baseResultsDir, stripped);
-    const candidateRel = path.relative(absoluteResultsDir, candidate);
+    const candidateRel = path.relative(absoluteResultsDir, normalizePath(candidate));
     if (!candidateRel.startsWith('..') && !path.isAbsolute(candidateRel)) {
       absoluteRunDir = candidate;
       relativeRunPath = candidateRel;
@@ -201,8 +203,14 @@ async function downloadSingleDirFromGcs(runDir: string, token: string | undefine
 
   if (fs.existsSync(absoluteRunDir)) {
     const files = fs.readdirSync(absoluteRunDir);
-    if (files.some(f => f === 'trajectory_summary.json' || f.endsWith('_results.json') || f === 'runtime.json')) {
+    const hasTrajectory = files.includes('trajectory_summary.json');
+    const hasResults = files.some(f => f.endsWith('_results.json') || f === 'runtime.json');
+    if (hasTrajectory) {
       return true; // Already cached locally
+    }
+    if (hasResults) {
+      await postDownloadProcessing(absoluteRunDir, relativeRunPath);
+      return true;
     }
   }
 
@@ -280,7 +288,7 @@ async function downloadSingleDirFromGcs(runDir: string, token: string | undefine
 /**
  * Lazily downloads a run directory from GCS if it is missing locally.
  * Resolves the path relative to the harness results directory.
- * Orchestrates downloading suite evals.json, the primary requested run, and the sibling run type (guided/unguided).
+ * Orchestrates downloading suite evals.json and the primary requested run.
  */
 export async function downloadRunFromGcsIfMissing(runDir: string): Promise<boolean> {
   const resolved = resolveRunPath(runDir);

--- a/harness/lib/gcs-downloader.ts
+++ b/harness/lib/gcs-downloader.ts
@@ -283,14 +283,9 @@ async function downloadSingleDirFromGcs(runDir: string, token: string | undefine
  * Orchestrates downloading suite evals.json, the primary requested run, and the sibling run type (guided/unguided).
  */
 export async function downloadRunFromGcsIfMissing(runDir: string): Promise<boolean> {
-  const absoluteRunDir = normalizePath(runDir);
-  const absoluteResultsDir = normalizePath(baseResultsDir);
-  
-  const relativeRunPath = path.relative(absoluteResultsDir, absoluteRunDir);
-  if (relativeRunPath.startsWith('..') || path.isAbsolute(relativeRunPath)) {
-    console.warn(`[GCS Downloader] Path is outside results directory: ${absoluteRunDir}`);
-    return false;
-  }
+  const resolved = resolveRunPath(runDir);
+  if (!resolved) return false;
+  const { absoluteRunDir, relativeRunPath } = resolved;
 
   const suiteName = relativeRunPath.split(/[/\\]/)[0];
   const token = process.env.GD_GCS_TOKEN;
@@ -304,5 +299,5 @@ export async function downloadRunFromGcsIfMissing(runDir: string): Promise<boole
   }
 
   // 2. Download the primary requested directory
-  return downloadSingleDirFromGcs(runDir, token);
+  return downloadSingleDirFromGcs(absoluteRunDir, token);
 }

--- a/harness/lib/trajectory-normalizer.ts
+++ b/harness/lib/trajectory-normalizer.ts
@@ -157,7 +157,7 @@ export function standardizeAction(
       };
     }
     case 'web_search': {
-      const query = p.query || p.search || p.use_case_id || (typeof rawParams === 'string' ? rawParams : '') || '';
+      const query = p.query || p.Query || p.search || p.use_case_id || (typeof rawParams === 'string' ? rawParams : '') || '';
       return {
         type: 'web_search',
         name,

--- a/harness/lib/trajectory-normalizer.ts
+++ b/harness/lib/trajectory-normalizer.ts
@@ -70,17 +70,117 @@ export function getSessionFiles(dir: string): string[] {
   return fs.globSync(TRAJECTORY_GLOB, { cwd: dir });
 }
 
+export type CanonicalCategory =
+  | 'guide_retrieval'
+  | 'skill_search'
+  | 'code_mutation'
+  | 'mandatory_rule_thought'
+  | 'incidental_noise'
+  | 'other';
+
+export interface RunCommandAction {
+  type: 'run_command';
+  canonicalCategory?: CanonicalCategory;
+  name: string;
+  params?: { command: string; [key: string]: unknown };
+}
+
+export interface ReadFileAction {
+  type: 'read_file';
+  canonicalCategory?: CanonicalCategory;
+  name: string;
+  params?: { path: string; [key: string]: unknown };
+}
+
+export interface WriteFileAction {
+  type: 'write_file';
+  canonicalCategory?: CanonicalCategory;
+  name: string;
+  params?: { path: string; content?: string; [key: string]: unknown };
+}
+
+export interface WebSearchAction {
+  type: 'web_search';
+  canonicalCategory?: CanonicalCategory;
+  name: string;
+  params?: { query: string; [key: string]: unknown };
+}
+
+export interface OtherAction {
+  type: 'other';
+  canonicalCategory?: CanonicalCategory;
+  name: string;
+  params?: Record<string, unknown>;
+}
+
+export type StandardizedAction =
+  | RunCommandAction
+  | ReadFileAction
+  | WriteFileAction
+  | WebSearchAction
+  | OtherAction;
+
+export function standardizeAction(
+  type: StandardizedAction['type'],
+  name: string,
+  rawParams?: any
+): StandardizedAction {
+  const p = rawParams && typeof rawParams === 'object' ? rawParams : {};
+  switch (type) {
+    case 'run_command': {
+      const command = p.command || p.cmd || (typeof rawParams === 'string' ? rawParams : '') || '';
+      return {
+        type: 'run_command',
+        name,
+        params: { ...p, command: String(command) }
+      };
+    }
+    case 'read_file': {
+      const filePath = p.path || p.file_path || p.filePath || p.targetFile || p.TargetFile || p.AbsolutePath || p.DirectoryPath || (typeof rawParams === 'string' ? rawParams : '') || '';
+      return {
+        type: 'read_file',
+        name,
+        params: { ...p, path: String(filePath) }
+      };
+    }
+    case 'write_file': {
+      const filePath = p.path || p.file_path || p.filePath || p.targetFile || p.TargetFile || '';
+      const content = p.content ?? p.CodeContent ?? p.ReplacementChunks ?? p.new_string ?? undefined;
+      return {
+        type: 'write_file',
+        name,
+        params: {
+          ...p,
+          path: String(filePath),
+          ...(content !== undefined ? { content: String(content) } : {})
+        }
+      };
+    }
+    case 'web_search': {
+      const query = p.query || p.search || p.use_case_id || (typeof rawParams === 'string' ? rawParams : '') || '';
+      return {
+        type: 'web_search',
+        name,
+        params: { ...p, query: String(query) }
+      };
+    }
+    case 'other':
+    default: {
+      return {
+        type: 'other',
+        name,
+        params: rawParams && typeof rawParams === 'object' ? rawParams : rawParams !== undefined ? { value: rawParams } : undefined
+      };
+    }
+  }
+}
+
 export interface StandardizedStep {
   stepNumber: number;
   timestamp?: string;
   subagentId?: string;
   thought?: string;
-  action?: {
-    type: 'web_search' | 'read_file' | 'write_file' | 'run_command' | 'other';
-    canonicalCategory?: 'guide_retrieval' | 'skill_search' | 'code_mutation' | 'mandatory_rule_thought' | 'incidental_noise' | 'other';
-    name: string;
-    params?: Record<string, any>;
-  };
+  action?: StandardizedAction;
   outcome?: {
     status: 'success' | 'error';
     message?: string;

--- a/harness/lib/trajectory-normalizer.ts
+++ b/harness/lib/trajectory-normalizer.ts
@@ -82,28 +82,28 @@ export interface RunCommandAction {
   type: 'run_command';
   canonicalCategory?: CanonicalCategory;
   name: string;
-  params?: { command: string; [key: string]: unknown };
+  params: { command: string; [key: string]: unknown };
 }
 
 export interface ReadFileAction {
   type: 'read_file';
   canonicalCategory?: CanonicalCategory;
   name: string;
-  params?: { path: string; [key: string]: unknown };
+  params: { path: string; [key: string]: unknown };
 }
 
 export interface WriteFileAction {
   type: 'write_file';
   canonicalCategory?: CanonicalCategory;
   name: string;
-  params?: { path: string; content?: string; [key: string]: unknown };
+  params: { path: string; content?: string; [key: string]: unknown };
 }
 
 export interface WebSearchAction {
   type: 'web_search';
   canonicalCategory?: CanonicalCategory;
   name: string;
-  params?: { query: string; [key: string]: unknown };
+  params: { query: string; [key: string]: unknown };
 }
 
 export interface OtherAction {
@@ -120,15 +120,49 @@ export type StandardizedAction =
   | WebSearchAction
   | OtherAction;
 
+export interface RunCommandRawParams {
+  command?: string;
+  cmd?: string;
+  [key: string]: unknown;
+}
+
+export interface ReadFileRawParams {
+  path?: string;
+  file_path?: string;
+  [key: string]: unknown;
+}
+
+export interface WriteFileRawParams {
+  path?: string;
+  file_path?: string;
+  content?: string;
+  new_string?: string;
+  newText?: string;
+  [key: string]: unknown;
+}
+
+export interface WebSearchRawParams {
+  query?: string;
+  Query?: string;
+  use_case_id?: string;
+  [key: string]: unknown;
+}
+
+export function standardizeAction(type: 'run_command', name: string, rawParams?: string | RunCommandRawParams): RunCommandAction;
+export function standardizeAction(type: 'read_file', name: string, rawParams?: string | ReadFileRawParams): ReadFileAction;
+export function standardizeAction(type: 'write_file', name: string, rawParams?: string | WriteFileRawParams): WriteFileAction;
+export function standardizeAction(type: 'web_search', name: string, rawParams?: string | WebSearchRawParams): WebSearchAction;
+export function standardizeAction(type: 'other', name: string, rawParams?: unknown): OtherAction;
+export function standardizeAction(type: StandardizedAction['type'], name: string, rawParams?: unknown): StandardizedAction;
 export function standardizeAction(
   type: StandardizedAction['type'],
   name: string,
-  rawParams?: any
+  rawParams?: unknown
 ): StandardizedAction {
-  const p = rawParams && typeof rawParams === 'object' ? rawParams : {};
+  const p = rawParams && typeof rawParams === 'object' ? (rawParams as Record<string, unknown>) : {};
   switch (type) {
     case 'run_command': {
-      const command = p.command || p.cmd || p.CommandLine || p.cmd_line || (typeof rawParams === 'string' ? rawParams : '') || '';
+      const command = (p.command as string) || (p.cmd as string) || (typeof rawParams === 'string' ? rawParams : '') || '';
       return {
         type: 'run_command',
         name,
@@ -136,7 +170,7 @@ export function standardizeAction(
       };
     }
     case 'read_file': {
-      const filePath = p.path || p.file_path || p.filePath || p.targetFile || p.TargetFile || p.AbsolutePath || p.DirectoryPath || p.SearchDirectory || p.directory || p.Directory || (typeof rawParams === 'string' ? rawParams : '') || '';
+      const filePath = (p.path as string) || (p.file_path as string) || (typeof rawParams === 'string' ? rawParams : '') || '';
       return {
         type: 'read_file',
         name,
@@ -144,20 +178,21 @@ export function standardizeAction(
       };
     }
     case 'write_file': {
-      const filePath = p.path || p.file_path || p.filePath || p.targetFile || p.TargetFile || p.AbsolutePath || '';
-      const content = p.content ?? p.CodeContent ?? p.ReplacementChunks ?? p.new_string ?? undefined;
+      const filePath = (p.path as string) || (p.file_path as string) || '';
+      const rawContent = p.content ?? p.new_string ?? p.newText ?? undefined;
+      const content = rawContent !== undefined ? String(rawContent) : undefined;
       return {
         type: 'write_file',
         name,
         params: {
           ...p,
           path: String(filePath),
-          ...(content !== undefined ? { content: String(content) } : {})
+          ...(content !== undefined ? { content } : {})
         }
       };
     }
     case 'web_search': {
-      const query = p.query || p.Query || p.search || p.use_case_id || (typeof rawParams === 'string' ? rawParams : '') || '';
+      const query = (p.query as string) || (p.Query as string) || (p.use_case_id as string) || (typeof rawParams === 'string' ? rawParams : '') || '';
       return {
         type: 'web_search',
         name,
@@ -169,7 +204,7 @@ export function standardizeAction(
       return {
         type: 'other',
         name,
-        params: rawParams && typeof rawParams === 'object' ? rawParams : rawParams !== undefined ? { value: rawParams } : undefined
+        params: rawParams && typeof rawParams === 'object' ? (rawParams as Record<string, unknown>) : rawParams !== undefined ? { value: rawParams } : undefined
       };
     }
   }
@@ -184,7 +219,7 @@ export interface StandardizedStep {
   outcome?: {
     status: 'success' | 'error';
     message?: string;
-    output?: any;
+    output?: unknown;
     exitCode?: number;
   };
 }
@@ -224,24 +259,35 @@ export function extractTimestamp(entry: any): string | undefined {
   return undefined;
 }
 
-export function categorizeAction(name: string, params?: Record<string, any>, thought?: string): NonNullable<StandardizedStep['action']>['canonicalCategory'] {
-  const actionName = (name || '').toLowerCase();
-  const actionParamsStr = JSON.stringify(params || {}).toLowerCase();
-  const thoughtStr = (thought || '').toLowerCase();
+export function categorizeAction(
+  name: string,
+  params?: Record<string, any>,
+  thought?: string,
+  actionType?: StandardizedAction['type']
+): NonNullable<StandardizedStep['action']>['canonicalCategory'] {
+  if (actionType === 'write_file') {
+    return 'code_mutation';
+  }
 
+  const actionName = (name || '').toLowerCase();
   if (actionName === 'respond_to_user') {
     return 'other';
   }
 
-  const mutationParamKeys = ['targetfile', 'replacementcontent', 'replacementchunks', 'codecontent', 'write_to_file', 'replace_file_content'];
-  const paramKeys = params && typeof params === 'object' ? Object.keys(params).map(k => k.toLowerCase()) : [];
-  const hasMutationParam = paramKeys.some(k => mutationParamKeys.includes(k));
   const isMutationName = ['write', 'replace', 'edit', 'touch'].some(k => actionName.includes(k));
-
-  // 1. Code mutation takes highest priority to prevent false positives from code containing words like "search" or "retrieve"
-  if (isMutationName || hasMutationParam) {
+  if (isMutationName) {
     return 'code_mutation';
   }
+
+  const mutationParamKeys = ['targetfile', 'replacementcontent', 'replacementchunks', 'codecontent', 'write_to_file', 'replace_file_content', 'new_string', 'newtext'];
+  const paramKeys = params && typeof params === 'object' ? Object.keys(params).map(k => k.toLowerCase()) : [];
+  const hasMutationParam = paramKeys.some(k => mutationParamKeys.includes(k));
+  if (hasMutationParam) {
+    return 'code_mutation';
+  }
+
+  const actionParamsStr = JSON.stringify(params || {}).toLowerCase();
+  const thoughtStr = (thought || '').toLowerCase();
 
   // 2. Guide retrieval
   if (actionName.includes('retrieve') || (actionName.includes('get_best_practices') && actionParamsStr.includes('retrieve')) || actionParamsStr.includes('retrieve')) {
@@ -279,7 +325,12 @@ export function finalizeTrajectorySummary(summary: TrajectorySummary): Trajector
       const step = summary.steps[i];
       step.stepNumber = i + 1;
       if (step.action && !step.action.canonicalCategory) {
-        step.action.canonicalCategory = categorizeAction(step.action.name, step.action.params, step.thought);
+        step.action.canonicalCategory = categorizeAction(
+          step.action.name,
+          step.action.params,
+          step.thought,
+          step.action.type
+        );
       }
     }
   }

--- a/harness/lib/trajectory-normalizer.ts
+++ b/harness/lib/trajectory-normalizer.ts
@@ -128,7 +128,7 @@ export function standardizeAction(
   const p = rawParams && typeof rawParams === 'object' ? rawParams : {};
   switch (type) {
     case 'run_command': {
-      const command = p.command || p.cmd || (typeof rawParams === 'string' ? rawParams : '') || '';
+      const command = p.command || p.cmd || p.CommandLine || p.cmd_line || (typeof rawParams === 'string' ? rawParams : '') || '';
       return {
         type: 'run_command',
         name,
@@ -136,7 +136,7 @@ export function standardizeAction(
       };
     }
     case 'read_file': {
-      const filePath = p.path || p.file_path || p.filePath || p.targetFile || p.TargetFile || p.AbsolutePath || p.DirectoryPath || (typeof rawParams === 'string' ? rawParams : '') || '';
+      const filePath = p.path || p.file_path || p.filePath || p.targetFile || p.TargetFile || p.AbsolutePath || p.DirectoryPath || p.SearchDirectory || p.directory || p.Directory || (typeof rawParams === 'string' ? rawParams : '') || '';
       return {
         type: 'read_file',
         name,
@@ -144,7 +144,7 @@ export function standardizeAction(
       };
     }
     case 'write_file': {
-      const filePath = p.path || p.file_path || p.filePath || p.targetFile || p.TargetFile || '';
+      const filePath = p.path || p.file_path || p.filePath || p.targetFile || p.TargetFile || p.AbsolutePath || '';
       const content = p.content ?? p.CodeContent ?? p.ReplacementChunks ?? p.new_string ?? undefined;
       return {
         type: 'write_file',
@@ -288,6 +288,9 @@ export function finalizeTrajectorySummary(summary: TrajectorySummary): Trajector
 
 export function mapToolType(toolName: string): NonNullable<StandardizedStep['action']>['type'] {
   const name = toolName.toLowerCase();
+  if (name.includes('todo')) {
+    return 'other';
+  }
   if (['read', 'read_file', 'view_file', 'view'].some(k => name.includes(k))) {
     return 'read_file';
   }

--- a/harness/lib/trajectory-normalizer.ts
+++ b/harness/lib/trajectory-normalizer.ts
@@ -274,6 +274,11 @@ export function categorizeAction(
     return 'other';
   }
 
+  // Skill activations (e.g. Claude Code or agent skill loading) are tracked in toolsUsed, not skill search
+  if (actionName === 'skill' || actionName === 'activate_skill' || actionName === 'load_skill') {
+    return 'other';
+  }
+
   const isMutationName = ['write', 'replace', 'edit', 'touch'].some(k => actionName.includes(k));
   if (isMutationName) {
     return 'code_mutation';
@@ -286,16 +291,25 @@ export function categorizeAction(
     return 'code_mutation';
   }
 
-  const actionParamsStr = JSON.stringify(params || {}).toLowerCase();
+  const cmd = typeof params?.command === 'string' ? params.command : (typeof params?.cmd === 'string' ? params.cmd : '');
+  const cmdLower = cmd.toLowerCase();
   const thoughtStr = (thought || '').toLowerCase();
 
-  // 2. Guide retrieval
-  if (actionName.includes('retrieve') || (actionName.includes('get_best_practices') && actionParamsStr.includes('retrieve')) || actionParamsStr.includes('retrieve')) {
+  // 2. Guide retrieval: Look for modern-web-guidance / cli.js / gd retrieve in command or retrieve tool
+  const isGuidanceRetrieve =
+    actionName.includes('retrieve') ||
+    (cmdLower.includes('retrieve') && (cmdLower.includes('modern-web-guidance') || cmdLower.includes('cli.js') || cmdLower.includes('gd') || cmdLower.startsWith('retrieve')));
+  if (isGuidanceRetrieve) {
     return 'guide_retrieval';
   }
 
-  // 3. Skill search
-  if (actionName.includes('search') || actionName.includes('get_best_practices') || actionName.includes('query_guidance') || actionParamsStr.includes('search')) {
+  // 3. Skill search: Look for modern-web-guidance / cli.js / gd search in command or search tool
+  const isGuidanceSearch =
+    actionName.includes('search') ||
+    actionName.includes('query_guidance') ||
+    actionName.includes('get_best_practices') ||
+    (cmdLower.includes('search') && (cmdLower.includes('modern-web-guidance') || cmdLower.includes('cli.js') || cmdLower.includes('gd') || cmdLower.startsWith('search')));
+  if (isGuidanceSearch) {
     return 'skill_search';
   }
 

--- a/harness/lib/trajectory-normalizer.ts
+++ b/harness/lib/trajectory-normalizer.ts
@@ -279,9 +279,11 @@ export function categorizeAction(
     return 'other';
   }
 
-  const isMutationName = ['write', 'replace', 'edit', 'touch'].some(k => actionName.includes(k));
-  if (isMutationName) {
-    return 'code_mutation';
+  if (actionType !== 'run_command') {
+    const isMutationName = ['write', 'replace', 'edit', 'touch'].some(k => actionName.includes(k));
+    if (isMutationName) {
+      return 'code_mutation';
+    }
   }
 
   const mutationParamKeys = ['targetfile', 'replacementcontent', 'replacementchunks', 'codecontent', 'write_to_file', 'replace_file_content', 'new_string', 'newtext'];
@@ -329,10 +331,13 @@ export function finalizeTrajectorySummary(summary: TrajectorySummary): Trajector
   if (Array.isArray(summary.steps)) {
     summary.steps.sort((a, b) => {
       if (a.timestamp && b.timestamp) {
-        const timeDiff = new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime();
-        if (timeDiff !== 0) return timeDiff;
+        const timeA = new Date(a.timestamp).getTime();
+        const timeB = new Date(b.timestamp).getTime();
+        if (!isNaN(timeA) && !isNaN(timeB) && timeA !== timeB) {
+          return timeA - timeB;
+        }
       }
-      return 0;
+      return (a.stepNumber || 0) - (b.stepNumber || 0);
     });
 
     for (let i = 0; i < summary.steps.length; i++) {

--- a/harness/tests/codex-cli-parsing.test.ts
+++ b/harness/tests/codex-cli-parsing.test.ts
@@ -187,6 +187,7 @@ test('Codex CLI normalization with commentary, response items, and subagent inli
     assert.strictEqual(summary.steps[0].thought, 'Inspecting existing html structure');
     assert.strictEqual(summary.steps[0].action?.name, 'cat index.html');
     assert.strictEqual(summary.steps[0].action?.type, 'run_command');
+    assert.strictEqual(summary.steps[0].action?.params?.command, 'cat index.html');
     assert.strictEqual(summary.steps[0].outcome?.status, 'success');
 
     // Step 2: subagent npm test (20:30:05)
@@ -196,6 +197,7 @@ test('Codex CLI normalization with commentary, response items, and subagent inli
     assert.strictEqual(summary.steps[1].thought, 'Subagent running tests');
     assert.strictEqual(summary.steps[1].action?.name, 'npm test');
     assert.strictEqual(summary.steps[1].action?.type, 'run_command');
+    assert.strictEqual(summary.steps[1].action?.params?.command, 'npm test');
     assert.strictEqual(summary.steps[1].outcome?.status, 'success');
 
     // Step 3: main final_answer (20:30:10)

--- a/harness/tests/codex-cli-parsing.test.ts
+++ b/harness/tests/codex-cli-parsing.test.ts
@@ -423,7 +423,6 @@ test('collectCodex metrics from modern custom_tool_call trajectory file', async 
     removeTempDir(tempDir);
   }
 });
-
 test('Codex CLI normalization handles Responses API array output and extracts model', async () => {
   const tempDir = createTempDir();
   try {
@@ -489,3 +488,34 @@ test('Codex CLI normalization handles Responses API array output and extracts mo
   }
 });
 
+test('parseCodexTrajectory handles structured array of content blocks in function_call_output', () => {
+  const rollout = [
+    {
+      type: 'response_item',
+      payload: {
+        type: 'function_call',
+        call_id: 'call_content_blocks',
+        name: 'exec',
+        arguments: JSON.stringify({ command: ['cat', 'package.json'] })
+      }
+    },
+    {
+      type: 'response_item',
+      payload: {
+        type: 'function_call_output',
+        call_id: 'call_content_blocks',
+        output: [
+          { type: 'input_text', text: 'Script completed\nOutput:\n' },
+          { type: 'input_text', text: '{\n  "name": "test-app"\n}\n' }
+        ]
+      }
+    }
+  ];
+
+  const summary = parseCodexTrajectory(rollout);
+  assert.strictEqual(summary.steps.length, 1);
+  assert.strictEqual(summary.steps[0].action?.type, 'run_command');
+  assert.strictEqual(summary.steps[0].action?.name, 'cat package.json');
+  assert.strictEqual(summary.steps[0].outcome?.status, 'success');
+  assert.strictEqual(summary.steps[0].outcome?.message?.includes('"name": "test-app"'), true);
+});

--- a/harness/tests/codex-cli-parsing.test.ts
+++ b/harness/tests/codex-cli-parsing.test.ts
@@ -10,7 +10,7 @@ import {
   extractCodexCliModel,
   extractCodexCliTokenUsage
 } from '../lib/trajectory-normalizer.ts';
-import { extractCommandsFromCodexItem } from '../agents/codex-cli-agent.ts';
+import { extractCommandsFromCodexItem, parseCodexTrajectory } from '../agents/codex-cli-agent.ts';
 import { extractModelFromResults } from '../lib/collection.ts';
 import { Agents } from '../config.ts';
 
@@ -291,6 +291,36 @@ test('Codex CLI normalization with modern custom_tool_call exec_command', async 
   } finally {
     removeTempDir(tempDir);
   }
+});
+
+test('Codex CLI handles array-structured output blocks in tool outputs', () => {
+  const rollout = [
+    {
+      type: 'response_item',
+      payload: {
+        type: 'function_call',
+        call_id: 'call_arr_1',
+        name: 'exec',
+        arguments: JSON.stringify({ command: 'node test.js' })
+      }
+    },
+    {
+      type: 'response_item',
+      payload: {
+        type: 'function_call_output',
+        call_id: 'call_arr_1',
+        output: [
+          { type: 'input_text', text: 'Script completed\nWall time 0.1s\nOutput:\n' },
+          { type: 'input_text', text: 'All checks passed.' }
+        ]
+      }
+    }
+  ];
+
+  const summary = parseCodexTrajectory(rollout);
+  assert.strictEqual(summary.steps.length, 1);
+  assert.strictEqual(summary.steps[0].outcome?.status, 'success');
+  assert.ok(summary.steps[0].outcome?.message?.includes('All checks passed.'));
 });
 
 test('collectCodex metrics from legacy function_call trajectory file', async () => {

--- a/harness/tests/codex-cli-parsing.test.ts
+++ b/harness/tests/codex-cli-parsing.test.ts
@@ -85,6 +85,16 @@ test('extractCommandsFromCodexItem handles quotes, backticks, escapes, and paren
     }
   });
   assert.deepStrictEqual(cmd7, []);
+
+  // 8. exec tool call with array command argument
+  const cmd8 = extractCommandsFromCodexItem({
+    payload: {
+      type: 'function_call',
+      name: 'exec',
+      arguments: JSON.stringify({ command: ['npm', 'test'] })
+    }
+  });
+  assert.deepStrictEqual(cmd8, ['npm test']);
 });
 
 test('Codex CLI normalization with commentary, response items, and subagent inlining', async () => {

--- a/harness/tests/collection.test.ts
+++ b/harness/tests/collection.test.ts
@@ -38,3 +38,14 @@ test('parseResultPath returns null for invalid structure', () => {
   const result = parseResultPath(relPath);
   assert.strictEqual(result, null);
 });
+
+test('parseResultPath handles deep suite and nightly structure', () => {
+  const relPath = path.join('nightly-2026-08-10_17-00-02-jetski_cli', '1', 'accessible-error-announcement', 'task', 'guided');
+  const result = parseResultPath(relPath);
+  assert.deepStrictEqual(result, {
+    guide: 'accessible-error-announcement',
+    taskName: 'task',
+    runType: 'guided'
+  });
+});
+

--- a/harness/tests/compare-evals.test.ts
+++ b/harness/tests/compare-evals.test.ts
@@ -1,0 +1,124 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+describe('compare-evals pipeline', () => {
+  test('imports compare-evals module cleanly and exports runComparison', async () => {
+    const compareModule = await import('../lib/compare-evals.ts');
+    assert.ok(compareModule.runComparison);
+    assert.strictEqual(typeof compareModule.runComparison, 'function');
+  });
+
+  test('validates loadRunContext and preprocessTrajectory with mock trajectory and playwright report', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'compare-run-'));
+
+    try {
+      const resultsFile = path.join(tmpDir, 'test-guide_results.json');
+      const mockPlaywright = {
+        suites: [
+          {
+            title: 'Suite 1',
+            specs: [
+              {
+                title: 'should pass step 1',
+                ok: true
+              },
+              {
+                title: 'should fail step 2',
+                ok: false,
+                tests: [
+                  {
+                    results: [
+                      {
+                        error: { message: '[31mExpected "a" to be "b"[39m' },
+                        location: { file: 'grader.ts', line: 42, column: 5 }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      };
+      fs.writeFileSync(resultsFile, JSON.stringify(mockPlaywright));
+
+      const trajFile = path.join(tmpDir, 'trajectory_summary.json');
+      const mockSummary = {
+        agent: 'claude-code',
+        initialPrompt: 'Create a modern accordion using details/summary',
+        retrievedGuides: ['details-styling'],
+        steps: [
+          {
+            stepNumber: 1,
+            thought: 'Searching for details styling guide',
+            action: {
+              type: 'web_search',
+              canonicalCategory: 'skill_search',
+              name: 'search',
+              params: { query: 'details styling' }
+            },
+            outcome: { status: 'success' }
+          },
+          {
+            stepNumber: 2,
+            thought: 'Retrieving details guide',
+            action: {
+              type: 'read_file',
+              canonicalCategory: 'guide_retrieval',
+              name: 'retrieve',
+              params: { id: 'details-styling' }
+            },
+            outcome: { status: 'success' }
+          },
+          {
+            stepNumber: 3,
+            thought: 'I must follow the mandatory rule for ::details-content',
+            action: {
+              type: 'write_file',
+              canonicalCategory: 'mandatory_rule_thought',
+              name: 'write_to_file',
+              params: { TargetFile: 'index.html' }
+            },
+            outcome: { status: 'error' }
+          },
+          {
+            stepNumber: 4,
+            thought: 'Retrying code mutation',
+            action: {
+              type: 'write_file',
+              canonicalCategory: 'code_mutation',
+              name: 'write_to_file',
+              params: { TargetFile: 'index.html' }
+            },
+            outcome: { status: 'error' }
+          },
+          {
+            stepNumber: 5,
+            thought: 'Third retry attempt',
+            action: {
+              type: 'write_file',
+              canonicalCategory: 'code_mutation',
+              name: 'write_to_file',
+              params: { TargetFile: 'index.html' }
+            },
+            outcome: { status: 'success' }
+          }
+        ]
+      };
+      fs.writeFileSync(trajFile, JSON.stringify(mockSummary));
+
+      const indexHtml = path.join(tmpDir, 'index.html');
+      fs.writeFileSync(indexHtml, '<html><body><details><summary>Title</summary>Body</details></body></html>');
+
+      // Verify that compare-evals module can import and load this run
+      const compareModule = await import('../lib/compare-evals.ts');
+      assert.ok(compareModule.runComparison);
+      assert.strictEqual(typeof compareModule.runComparison, 'function');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/harness/tests/compare-evals.test.ts
+++ b/harness/tests/compare-evals.test.ts
@@ -121,4 +121,62 @@ describe('compare-evals pipeline', () => {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
+
+  test('runs runComparison end-to-end with mock agent caller', async () => {
+    const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'compare-e2e-'));
+    try {
+      const suiteDir = path.join(baseDir, 'results', 'suite-test');
+      const runDirA = path.join(suiteDir, '1', 'details-styling', 'task', 'guided');
+      const runDirB = path.join(suiteDir, '2', 'details-styling', 'task', 'unguided');
+      fs.mkdirSync(runDirA, { recursive: true });
+      fs.mkdirSync(runDirB, { recursive: true });
+
+      // Run A setup (success)
+      fs.writeFileSync(path.join(runDirA, 'details-styling_results.json'), JSON.stringify({
+        suites: [{ specs: [{ title: 'test 1', ok: true }] }]
+      }));
+      fs.writeFileSync(path.join(runDirA, 'trajectory_summary.json'), JSON.stringify({
+        agent: 'claude_code',
+        initialPrompt: 'Style details',
+        steps: [{ stepNumber: 1, action: { type: 'run_command', name: 'npm' }, outcome: { status: 'success' } }]
+      }));
+      fs.writeFileSync(path.join(runDirA, 'index.html'), '<details></details>');
+
+      // Run B setup (failure)
+      fs.writeFileSync(path.join(runDirB, 'details-styling_results.json'), JSON.stringify({
+        suites: [{ specs: [{ title: 'test 1', ok: false, tests: [{ results: [{ error: { message: 'failed' } }] }] }] }]
+      }));
+      fs.writeFileSync(path.join(runDirB, 'trajectory_summary.json'), JSON.stringify({
+        agent: 'claude_code',
+        initialPrompt: 'Style details',
+        steps: [{ stepNumber: 1, action: { type: 'run_command', name: 'npm' }, outcome: { status: 'error' } }]
+      }));
+      fs.writeFileSync(path.join(runDirB, 'index.html'), '<div></div>');
+
+      const calls: string[] = [];
+      const mockAgentCaller = async (_sys: string, _prompt: string, label = 'agent'): Promise<string> => {
+        calls.push(label);
+        return `Mock analysis from ${label}`;
+      };
+
+      const { runComparison } = await import('../lib/compare-evals.ts');
+      const report = await runComparison(runDirA, runDirB, mockAgentCaller);
+
+      assert.strictEqual(typeof report, 'string');
+      assert.ok(report.includes('Mock analysis'));
+      assert.strictEqual(calls.length, 3);
+      assert.ok(calls.includes('Sub-Agent 1 (Guide Compliance)'));
+      assert.ok(calls.includes('Sub-Agent 2 (Code & Friction)'));
+      assert.ok(calls.includes('Synthesizer Sub-Agent'));
+
+      // Check that report was saved to variance_diagnoses
+      const expectedReportPath = path.join(suiteDir, 'variance_diagnoses', 'details-styling-task-guided.md');
+      assert.ok(fs.existsSync(expectedReportPath), `Expected report to be saved at ${expectedReportPath}`);
+      const savedContent = fs.readFileSync(expectedReportPath, 'utf8');
+      assert.strictEqual(savedContent, report);
+    } finally {
+      fs.rmSync(baseDir, { recursive: true, force: true });
+    }
+  });
 });
+

--- a/harness/tests/compare-evals.test.ts
+++ b/harness/tests/compare-evals.test.ts
@@ -113,10 +113,30 @@ describe('compare-evals pipeline', () => {
       const indexHtml = path.join(tmpDir, 'index.html');
       fs.writeFileSync(indexHtml, '<html><body><details><summary>Title</summary>Body</details></body></html>');
 
-      // Verify that compare-evals module can import and load this run
-      const compareModule = await import('../lib/compare-evals.ts');
-      assert.ok(compareModule.runComparison);
-      assert.strictEqual(typeof compareModule.runComparison, 'function');
+      // Verify loadRunContext and preprocessTrajectory
+      const { loadRunContext, preprocessTrajectory } = await import('../lib/compare-evals.ts');
+      const ctx = loadRunContext(tmpDir);
+
+      assert.strictEqual(ctx.score, 50);
+      assert.strictEqual(ctx.resultsJson.length, 2);
+      assert.strictEqual(ctx.resultsJson[0].passed, true);
+      assert.strictEqual(ctx.resultsJson[1].passed, false);
+      assert.ok(ctx.resultsJson[1].errors?.[0]?.includes('Expected "a" to be "b"'));
+      assert.strictEqual(ctx.codeOutput, '<html><body><details><summary>Title</summary>Body</details></body></html>');
+      assert.strictEqual(ctx.preprocessed.taggedSteps.length, 5);
+      assert.strictEqual(ctx.preprocessed.codeMutationCount, 2);
+      assert.strictEqual(ctx.preprocessed.errorLoopCount, 1);
+      assert.deepStrictEqual(ctx.preprocessed.retrievedGuideIds, ['details-styling']);
+      assert.deepStrictEqual(ctx.preprocessed.searchQueries, ['details styling']);
+      assert.strictEqual(ctx.preprocessed.mandatoryRulesAdopted.length, 1);
+      assert.ok(ctx.preprocessed.mandatoryRulesAdopted[0].includes('mandatory rule'));
+
+      const directPreprocessed = preprocessTrajectory(mockSummary as any);
+      assert.strictEqual(directPreprocessed.taggedSteps.length, 5);
+      assert.strictEqual(directPreprocessed.codeMutationCount, 2);
+      assert.strictEqual(directPreprocessed.errorLoopCount, 1);
+      assert.deepStrictEqual(directPreprocessed.retrievedGuideIds, ['details-styling']);
+      assert.deepStrictEqual(directPreprocessed.searchQueries, ['details styling']);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/harness/tests/compare-evals.test.ts
+++ b/harness/tests/compare-evals.test.ts
@@ -178,5 +178,45 @@ describe('compare-evals pipeline', () => {
       fs.rmSync(baseDir, { recursive: true, force: true });
     }
   });
+
+  test('runs runComparison using agent.patch when present', async () => {
+    const baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'compare-patch-'));
+    try {
+      const suiteDir = path.join(baseDir, 'results', 'suite-test');
+      const runDirA = path.join(suiteDir, '1', 'details-styling', 'task', 'guided');
+      const runDirB = path.join(suiteDir, '2', 'details-styling', 'task', 'unguided');
+      fs.mkdirSync(runDirA, { recursive: true });
+      fs.mkdirSync(runDirB, { recursive: true });
+
+      const patchA = '--- a/src/App.tsx\n+++ b/src/App.tsx\n@@ -1 +1 @@\n-old\n+newA\n';
+      const patchB = '--- a/src/App.tsx\n+++ b/src/App.tsx\n@@ -1 +1 @@\n-old\n+newB\n';
+
+      fs.writeFileSync(path.join(runDirA, 'details-styling_results.json'), JSON.stringify({ suites: [{ specs: [{ title: 't1', ok: true }] }] }));
+      fs.writeFileSync(path.join(runDirA, 'agent.patch'), patchA);
+      fs.writeFileSync(path.join(runDirA, 'trajectory_summary.json'), JSON.stringify({ agent: 'codex_cli', initialPrompt: 'Task A', steps: [] }));
+
+      fs.writeFileSync(path.join(runDirB, 'details-styling_results.json'), JSON.stringify({ suites: [{ specs: [{ title: 't1', ok: false }] }] }));
+      fs.writeFileSync(path.join(runDirB, 'agent.patch'), patchB);
+      fs.writeFileSync(path.join(runDirB, 'trajectory_summary.json'), JSON.stringify({ agent: 'codex_cli', initialPrompt: 'Task B', steps: [] }));
+
+      let passedDiffA = '';
+      let passedDiffB = '';
+      const mockAgentCaller = async (_sys: string, prompt: string, label = 'agent'): Promise<string> => {
+        if (label === 'Sub-Agent 2 (Code & Friction)') {
+          passedDiffA = prompt;
+          passedDiffB = prompt;
+        }
+        return `Report from ${label}`;
+      };
+
+      const { runComparison } = await import('../lib/compare-evals.ts');
+      const report = await runComparison(runDirA, runDirB, mockAgentCaller);
+      assert.ok(report.includes('Report from Synthesizer Sub-Agent'));
+      assert.ok(passedDiffA.includes('+newA'), 'Expected patch A content in prompt');
+      assert.ok(passedDiffB.includes('+newB'), 'Expected patch B content in prompt');
+    } finally {
+      fs.rmSync(baseDir, { recursive: true, force: true });
+    }
+  });
 });
 

--- a/harness/tests/compare-prompts.test.ts
+++ b/harness/tests/compare-prompts.test.ts
@@ -1,0 +1,170 @@
+import { test, describe } from "node:test";
+import assert from "node:assert";
+import { getCompliancePrompts, getCodeAndFrictionPrompts, getSynthesizerPrompts } from "../lib/compare-prompts.ts";
+import type { GuideContext, RunContext } from "../lib/compare-evals.ts";
+
+function createMockGuideContext(overrides?: Partial<GuideContext>): GuideContext {
+  return {
+    guideName: "anchor-positioning",
+    taskName: "anchor-tooltip",
+    guideContent: "# Anchor Positioning Guide\n".repeat(300),
+    expectationsContent: "# Expectations\n".repeat(300),
+    taskPrompt: "Create a tooltip anchored to a target element.",
+    graderContent: "test(\"tooltip positions correctly\", async () => {});\n".repeat(500),
+    baseAppContent: "<div id=\"target\">Target</div>",
+    ...overrides
+  };
+}
+
+function createMockRunContext(overrides?: Partial<RunContext>): RunContext {
+  return {
+    dir: "/tmp/results/trial-1/1/anchor-positioning/anchor-tooltip/guided",
+    runNumber: 1,
+    score: 85,
+    resultsJson: [
+      { message: "should position tooltip above", passed: true },
+      {
+        message: "should align with fallback",
+        passed: false,
+        location: { file: "grader.ts", line: 45, column: 3 },
+        errors: ["Expected anchor center to align with target center"]
+      }
+    ],
+    trajectorySummary: {
+      agent: "claude-code",
+      initialPrompt: "Create a tooltip anchored to a target element with fallback.",
+      steps: []
+    },
+    codeOutput: "<div class=\"tooltip\">Content</div>",
+    codePath: "index.html",
+    preprocessed: {
+      taggedSteps: [
+        {
+          stepNumber: 1,
+          category: "skill_search",
+          thought: "Searching for anchor positioning skill",
+          actionName: "search",
+          actionDetails: "{\"query\":\"anchor positioning\"}",
+          isError: false,
+          raw: { stepNumber: 1 }
+        },
+        {
+          stepNumber: 2,
+          category: "guide_retrieval",
+          thought: "Retrieving guide anchor-positioning",
+          actionName: "retrieve",
+          actionDetails: "{\"id\":\"anchor-positioning\"}",
+          isError: false,
+          raw: { stepNumber: 2 }
+        },
+        {
+          stepNumber: 3,
+          category: "code_mutation",
+          thought: "Writing index.html with position-anchor",
+          actionName: "write_to_file",
+          actionDetails: "{\"TargetFile\":\"index.html\"}",
+          isError: false,
+          raw: { stepNumber: 3 }
+        }
+      ],
+      searchQueries: ["anchor positioning"],
+      retrievedGuideIds: ["anchor-positioning"],
+      mandatoryRulesAdopted: ["Must use position-anchor and anchor() fallback"],
+      codeMutationCount: 1,
+      noiseCount: 0,
+      errorLoopCount: 0
+    },
+    initialPrompt: "Create a tooltip anchored to a target element with fallback.",
+    ...overrides
+  };
+}
+
+describe("compare-prompts pipeline", () => {
+  test("getCompliancePrompts formats system instruction and prompt with truncated references", () => {
+    const guideCtx = createMockGuideContext();
+    const ctxA = createMockRunContext({ score: 100 });
+    const ctxB = createMockRunContext({ score: 0 });
+
+    const { systemInstruction, prompt } = getCompliancePrompts(guideCtx, ctxA, ctxB, "SUCCESSFUL", "FAILED");
+
+    assert.ok(systemInstruction.includes("Web Guidance Compliance Auditor"));
+    assert.ok(prompt.includes("### Initial Eval / Task Prompts (Starting Points)"));
+    assert.ok(prompt.includes(ctxA.initialPrompt));
+    assert.ok(prompt.includes(ctxB.initialPrompt));
+    assert.ok(prompt.includes("anchor-positioning"));
+    assert.ok(prompt.includes("Run A (SUCCESSFUL - Score: 100%)"));
+    assert.ok(prompt.includes("Run B (FAILED - Score: 0%)"));
+    assert.ok(prompt.length < guideCtx.guideContent.length + guideCtx.expectationsContent.length);
+  });
+
+  test("getCodeAndFrictionPrompts builds diffs and error traces correctly", () => {
+    const guideCtx = createMockGuideContext();
+    const ctxA = createMockRunContext({ score: 100 });
+    const ctxB = createMockRunContext({ score: 50 });
+
+    const diffBaseVsA = "--- Base\n+++ Run A\n+ added line A";
+    const diffBaseVsB = "--- Base\n+++ Run B\n+ added line B";
+    const diffAvsB = "--- Run A\n+++ Run B\n- diff";
+
+    const { systemInstruction, prompt } = getCodeAndFrictionPrompts(
+      guideCtx,
+      ctxA,
+      ctxB,
+      diffBaseVsA,
+      diffBaseVsB,
+      diffAvsB,
+      "SUCCESSFUL",
+      "FAILED/POORER"
+    );
+
+    assert.ok(systemInstruction.includes("Code & Execution Diagnostic Sub-Agent"));
+    assert.ok(prompt.includes("### Validation Logic (grader.ts)"));
+    assert.ok(prompt.includes("#### Diff 1: Base App vs Run A Output"));
+    assert.ok(prompt.includes("#### Diff 2: Base App vs Run B Output"));
+    assert.ok(prompt.includes("#### Diff 3: Run A Output vs Run B Output"));
+    assert.ok(prompt.includes("Expected anchor center to align with target center"));
+    assert.ok(prompt.includes("Code Mutations: 1"));
+  });
+
+  test("getSynthesizerPrompts combines sub-agent analyses into synthesis prompt", () => {
+    const guideCtx = createMockGuideContext();
+    const ctxA = createMockRunContext({ score: 100 });
+    const ctxB = createMockRunContext({ score: 0 });
+
+    const complianceAnalysis = "Run A retrieved the guide before writing code; Run B skipped guide retrieval.";
+    const codeAndFrictionAnalysis = "Run A used anchor-name; Run B attempted JS scroll listener.";
+
+    const { systemInstruction, prompt } = getSynthesizerPrompts(
+      guideCtx,
+      ctxA,
+      ctxB,
+      complianceAnalysis,
+      codeAndFrictionAnalysis,
+      "SUCCESSFUL",
+      "FAILED"
+    );
+
+    assert.ok(systemInstruction.includes("Lead Diagnostic Engineer synthesizing a variance diagnosis"));
+    assert.ok(systemInstruction.includes("### 1. First Meaningful Divergence"));
+    assert.ok(systemInstruction.includes("### 2. Root Cause & Friction Analysis"));
+    assert.ok(systemInstruction.includes("### 3. Actionable Fix Recommendation"));
+    assert.ok(systemInstruction.includes("### 4. Guide Compliance & Milestone Matrix"));
+
+    assert.ok(prompt.includes("### Sub-Agent 1: Guide Compliance Analysis"));
+    assert.ok(prompt.includes(complianceAnalysis));
+    assert.ok(prompt.includes("### Sub-Agent 2: Code-to-Trajectory & Friction Analysis"));
+    assert.ok(prompt.includes(codeAndFrictionAnalysis));
+  });
+
+  test("handles sparse and empty run contexts safely without exceptions", () => {
+    const sparseGuide = createMockGuideContext({ guideContent: "", expectationsContent: "", graderContent: "" });
+    const sparseRunA = createMockRunContext({ resultsJson: [], initialPrompt: "" });
+    const sparseRunB = createMockRunContext({ resultsJson: [], initialPrompt: "" });
+
+    assert.doesNotThrow(() => {
+      getCompliancePrompts(sparseGuide, sparseRunA, sparseRunB, "COMPARED RUN", "COMPARED RUN");
+      getCodeAndFrictionPrompts(sparseGuide, sparseRunA, sparseRunB, "", "", "", "COMPARED RUN", "COMPARED RUN");
+      getSynthesizerPrompts(sparseGuide, sparseRunA, sparseRunB, "", "", "COMPARED RUN", "COMPARED RUN");
+    });
+  });
+});

--- a/harness/tests/compare-prompts.test.ts
+++ b/harness/tests/compare-prompts.test.ts
@@ -19,7 +19,6 @@ function createMockGuideContext(overrides?: Partial<GuideContext>): GuideContext
 function createMockRunContext(overrides?: Partial<RunContext>): RunContext {
   return {
     dir: "/tmp/results/trial-1/1/anchor-positioning/anchor-tooltip/guided",
-    runNumber: 1,
     score: 85,
     resultsJson: [
       { message: "should position tooltip above", passed: true },
@@ -30,41 +29,26 @@ function createMockRunContext(overrides?: Partial<RunContext>): RunContext {
         errors: ["Expected anchor center to align with target center"]
       }
     ],
-    trajectorySummary: {
-      agent: "claude-code",
-      initialPrompt: "Create a tooltip anchored to a target element with fallback.",
-      steps: []
-    },
     codeOutput: "<div class=\"tooltip\">Content</div>",
-    codePath: "index.html",
     preprocessed: {
       taggedSteps: [
         {
           stepNumber: 1,
           category: "skill_search",
           thought: "Searching for anchor positioning skill",
-          actionName: "search",
-          actionDetails: "{\"query\":\"anchor positioning\"}",
-          isError: false,
-          raw: { stepNumber: 1 }
+          actionName: "search"
         },
         {
           stepNumber: 2,
           category: "guide_retrieval",
           thought: "Retrieving guide anchor-positioning",
-          actionName: "retrieve",
-          actionDetails: "{\"id\":\"anchor-positioning\"}",
-          isError: false,
-          raw: { stepNumber: 2 }
+          actionName: "retrieve"
         },
         {
           stepNumber: 3,
           category: "code_mutation",
           thought: "Writing index.html with position-anchor",
-          actionName: "write_to_file",
-          actionDetails: "{\"TargetFile\":\"index.html\"}",
-          isError: false,
-          raw: { stepNumber: 3 }
+          actionName: "write_to_file"
         }
       ],
       searchQueries: ["anchor positioning"],

--- a/harness/tests/gcs-downloader.test.ts
+++ b/harness/tests/gcs-downloader.test.ts
@@ -1,0 +1,29 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { downloadRunFromGcsIfMissing } from '../lib/gcs-downloader.ts';
+
+describe('gcs-downloader', () => {
+  test('downloadRunFromGcsIfMissing returns early when directory already exists locally', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gcs-local-run-'));
+    try {
+      // Create local run directory
+      fs.writeFileSync(path.join(tmpDir, 'trajectory_summary.json'), JSON.stringify({ agent: 'claude-code', steps: [{ stepNumber: 1 }] }));
+
+      // Calling downloadRunFromGcsIfMissing should resolve immediately without network calls
+      await assert.doesNotReject(async () => {
+        await downloadRunFromGcsIfMissing(tmpDir);
+      });
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test('validates GCS bucket configuration constants', async () => {
+    const gcsModule = await import('../lib/gcs-downloader.ts');
+    assert.ok(gcsModule.downloadRunFromGcsIfMissing);
+    assert.strictEqual(typeof gcsModule.downloadRunFromGcsIfMissing, 'function');
+  });
+});

--- a/harness/tests/gcs-downloader.test.ts
+++ b/harness/tests/gcs-downloader.test.ts
@@ -26,4 +26,21 @@ describe('gcs-downloader', () => {
     assert.ok(gcsModule.downloadRunFromGcsIfMissing);
     assert.strictEqual(typeof gcsModule.downloadRunFromGcsIfMissing, 'function');
   });
+
+  test('resolveRunPath resolves both repo-relative and results-relative suite paths', async () => {
+    const { resolveRunPath } = await import('../lib/gcs-downloader.ts');
+    const relativeSuite = 'nightly-2026-08-10_17-00-02-jetski_cli/1/details-styling/task/guided';
+
+    // Results-relative path
+    const resolved1 = resolveRunPath(relativeSuite);
+    assert.ok(resolved1);
+    assert.strictEqual(resolved1.relativeRunPath, relativeSuite);
+    assert.ok(resolved1.absoluteRunDir.endsWith(relativeSuite));
+
+    // Repo-relative path
+    const resolved2 = resolveRunPath(`harness/results/${relativeSuite}`);
+    assert.ok(resolved2);
+    assert.strictEqual(resolved2.relativeRunPath, relativeSuite);
+    assert.ok(resolved2.absoluteRunDir.endsWith(relativeSuite));
+  });
 });

--- a/harness/tests/gcs-downloader.test.ts
+++ b/harness/tests/gcs-downloader.test.ts
@@ -2,22 +2,24 @@ import { test, describe } from 'node:test';
 import assert from 'node:assert';
 import fs from 'node:fs';
 import path from 'node:path';
-import os from 'node:os';
 import { downloadRunFromGcsIfMissing } from '../lib/gcs-downloader.ts';
+import { resultsDir } from '../../lib/paths.ts';
 
 describe('gcs-downloader', () => {
   test('downloadRunFromGcsIfMissing returns early when directory already exists locally', async () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gcs-local-run-'));
+    const testSuite = `test-gcs-local-${Date.now()}`;
+    const testRunDir = path.join(resultsDir, testSuite, '1', 'details-styling', 'task', 'guided');
+    fs.mkdirSync(testRunDir, { recursive: true });
     try {
-      // Create local run directory
-      fs.writeFileSync(path.join(tmpDir, 'trajectory_summary.json'), JSON.stringify({ agent: 'claude-code', steps: [{ stepNumber: 1 }] }));
+      // Create local run directory with suite evals.json and trajectory_summary.json
+      fs.writeFileSync(path.join(resultsDir, testSuite, 'evals.json'), JSON.stringify({ suite: testSuite }));
+      fs.writeFileSync(path.join(testRunDir, 'trajectory_summary.json'), JSON.stringify({ agent: 'claude-code', steps: [{ stepNumber: 1 }] }));
 
       // Calling downloadRunFromGcsIfMissing should resolve immediately without network calls
-      await assert.doesNotReject(async () => {
-        await downloadRunFromGcsIfMissing(tmpDir);
-      });
+      const result = await downloadRunFromGcsIfMissing(testRunDir);
+      assert.strictEqual(result, true);
     } finally {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
+      fs.rmSync(path.join(resultsDir, testSuite), { recursive: true, force: true });
     }
   });
 

--- a/harness/tests/jetski-cli-parsing.test.ts
+++ b/harness/tests/jetski-cli-parsing.test.ts
@@ -229,3 +229,33 @@ test('parseJetskiCliSession sanitizes pipe-delimited experimental model names', 
     removeTempDir(tempDir);
   }
 });
+
+test('parseJetskiCliSession handles code_search Query and avoids empty list_dir', () => {
+  const tempDir = createTempDir();
+  try {
+    const dbPath = path.join(tempDir, 'session-search.db');
+    const db = new DatabaseSync(dbPath);
+    db.exec(`
+      CREATE TABLE steps (idx INTEGER, step_type INTEGER, status INTEGER, metadata BLOB, step_payload BLOB);
+      CREATE TABLE gen_metadata (idx INTEGER, data BLOB);
+    `);
+
+    const searchActionJson = JSON.stringify({
+      Query: 'f:.*',
+      toolAction: 'Listing codebase files',
+      toolSummary: 'List files in workspace'
+    });
+
+    const insertStep = db.prepare('INSERT INTO steps (idx, step_type, status, step_payload) VALUES (?, ?, ?, ?)');
+    insertStep.run(1, 1, 0, Buffer.from(searchActionJson));
+    db.close();
+
+    const parsed = parseJetskiCliSession(tempDir);
+    assert.strictEqual(parsed.steps.length, 1);
+    assert.strictEqual(parsed.steps[0].action?.type, 'web_search');
+    assert.strictEqual(parsed.steps[0].action?.name, 'code_search');
+    assert.strictEqual(parsed.steps[0].action?.params?.query, 'f:.*');
+  } finally {
+    removeTempDir(tempDir);
+  }
+});

--- a/harness/tests/jetski-cli-parsing.test.ts
+++ b/harness/tests/jetski-cli-parsing.test.ts
@@ -229,33 +229,3 @@ test('parseJetskiCliSession sanitizes pipe-delimited experimental model names', 
     removeTempDir(tempDir);
   }
 });
-
-test('parseJetskiCliSession handles code_search Query and avoids empty list_dir', () => {
-  const tempDir = createTempDir();
-  try {
-    const dbPath = path.join(tempDir, 'session-search.db');
-    const db = new DatabaseSync(dbPath);
-    db.exec(`
-      CREATE TABLE steps (idx INTEGER, step_type INTEGER, status INTEGER, metadata BLOB, step_payload BLOB);
-      CREATE TABLE gen_metadata (idx INTEGER, data BLOB);
-    `);
-
-    const searchActionJson = JSON.stringify({
-      Query: 'f:.*',
-      toolAction: 'Listing codebase files',
-      toolSummary: 'List files in workspace'
-    });
-
-    const insertStep = db.prepare('INSERT INTO steps (idx, step_type, status, step_payload) VALUES (?, ?, ?, ?)');
-    insertStep.run(1, 1, 0, Buffer.from(searchActionJson));
-    db.close();
-
-    const parsed = parseJetskiCliSession(tempDir);
-    assert.strictEqual(parsed.steps.length, 1);
-    assert.strictEqual(parsed.steps[0].action?.type, 'web_search');
-    assert.strictEqual(parsed.steps[0].action?.name, 'code_search');
-    assert.strictEqual(parsed.steps[0].action?.params?.query, 'f:.*');
-  } finally {
-    removeTempDir(tempDir);
-  }
-});

--- a/harness/tests/pi-parsing.test.ts
+++ b/harness/tests/pi-parsing.test.ts
@@ -401,3 +401,39 @@ test('parsePiTrajectory handles stringified JSON tool arguments', () => {
   assert.strictEqual(summary.steps[0].action?.params?.command, 'pnpm test');
   assert.strictEqual(summary.steps[0].outcome?.status, 'success');
 });
+
+test('parsePiTrajectory handles native Pi message.role toolResult format', () => {
+  const lines = [
+    {
+      type: 'message',
+      message: {
+        role: 'assistant',
+        content: [
+          {
+            type: 'toolCall',
+            id: 'call_pi_native',
+            name: 'bash',
+            arguments: { command: 'git status' }
+          }
+        ]
+      }
+    },
+    {
+      type: 'message',
+      message: {
+        role: 'toolResult',
+        toolCallId: 'call_pi_native',
+        toolName: 'bash',
+        content: [{ type: 'text', text: 'On branch main' }],
+        isError: false
+      }
+    }
+  ];
+
+  const summary = parsePiTrajectory(lines);
+  assert.strictEqual(summary.steps.length, 1);
+  assert.strictEqual(summary.steps[0].action?.type, 'run_command');
+  assert.strictEqual(summary.steps[0].outcome?.status, 'success');
+  assert.strictEqual(summary.steps[0].outcome?.message, 'On branch main');
+});
+

--- a/harness/tests/pi-parsing.test.ts
+++ b/harness/tests/pi-parsing.test.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import os from 'os';
 import {
   generateNormalizedTrajectory,
+  parsePiTrajectory,
   collectPiGuidesFromTrajectory,
   collectPiToolsFromTrajectory,
   extractPiModel,
@@ -368,4 +369,35 @@ test('collectPi metrics and token extraction from trajectory files', async () =>
   } finally {
     removeTempDir(tempDir);
   }
+});
+
+test('parsePiTrajectory handles stringified JSON tool arguments', () => {
+  const lines = [
+    {
+      type: 'message',
+      message: {
+        role: 'assistant',
+        content: [
+          {
+            type: 'toolCall',
+            id: 'call_pi_1',
+            name: 'bash',
+            arguments: JSON.stringify({ command: 'pnpm test' })
+          }
+        ]
+      }
+    },
+    {
+      type: 'tool_result',
+      tool_use_id: 'call_pi_1',
+      output: 'Pass',
+      is_error: false
+    }
+  ];
+
+  const summary = parsePiTrajectory(lines);
+  assert.strictEqual(summary.steps.length, 1);
+  assert.strictEqual(summary.steps[0].action?.type, 'run_command');
+  assert.strictEqual(summary.steps[0].action?.params?.command, 'pnpm test');
+  assert.strictEqual(summary.steps[0].outcome?.status, 'success');
 });

--- a/harness/tests/trajectory-normalizer.test.ts
+++ b/harness/tests/trajectory-normalizer.test.ts
@@ -10,6 +10,7 @@ import {
   writeTrajectorySummary,
   readTrajectorySummary,
   generateNormalizedTrajectory,
+  standardizeAction,
   type TrajectorySummary,
   TRAJECTORY_SUMMARY_FILE,
   extractClaudeMetadata,
@@ -109,6 +110,45 @@ test('mapToolType maps standard tool names to canonical types', () => {
   assert.strictEqual(mapToolType('retrieve'), 'web_search');
   assert.strictEqual(mapToolType('query_guidance'), 'web_search');
   assert.strictEqual(mapToolType('unknown_action'), 'other');
+});
+
+test('standardizeAction enforces strictly typed parameter shapes per action type', () => {
+  // run_command standardizes 'cmd', 'command', or string to params.command
+  const cmd1 = standardizeAction('run_command', 'bash', { cmd: 'cat index.html' });
+  assert.strictEqual(cmd1.type, 'run_command');
+  assert.strictEqual(cmd1.name, 'bash');
+  assert.strictEqual(cmd1.params?.command, 'cat index.html');
+
+  const cmd2 = standardizeAction('run_command', 'terminal', { command: 'pnpm test' });
+  assert.strictEqual(cmd2.params?.command, 'pnpm test');
+
+  // read_file standardizes path, file_path, AbsolutePath, etc. to params.path
+  const read1 = standardizeAction('read_file', 'read', { file_path: 'src/index.ts' });
+  assert.strictEqual(read1.type, 'read_file');
+  assert.strictEqual(read1.params?.path, 'src/index.ts');
+
+  const read2 = standardizeAction('read_file', 'view_file', { AbsolutePath: 'app.jsx' });
+  assert.strictEqual(read2.params?.path, 'app.jsx');
+
+  // write_file standardizes path/TargetFile and content/CodeContent/ReplacementChunks
+  const write1 = standardizeAction('write_file', 'write_to_file', {
+    TargetFile: 'index.html',
+    CodeContent: '<html></html>'
+  });
+  assert.strictEqual(write1.type, 'write_file');
+  assert.strictEqual(write1.params?.path, 'index.html');
+  assert.strictEqual(write1.params?.content, '<html></html>');
+
+  // web_search standardizes query, search, use_case_id to params.query
+  const search1 = standardizeAction('web_search', 'get_best_practices', { use_case_id: 'dialog' });
+  assert.strictEqual(search1.type, 'web_search');
+  assert.strictEqual(search1.params?.query, 'dialog');
+  assert.strictEqual(search1.params?.use_case_id, 'dialog');
+
+  // other preserves raw properties
+  const other1 = standardizeAction('other', 'respond_to_user', { response: 'Done' });
+  assert.strictEqual(other1.type, 'other');
+  assert.deepStrictEqual(other1.params, { response: 'Done' });
 });
 
 test('finalizeTrajectorySummary sorts steps monotonically and re-indexes with 1-based numbering', () => {

--- a/harness/tests/trajectory-normalizer.test.ts
+++ b/harness/tests/trajectory-normalizer.test.ts
@@ -115,49 +115,57 @@ test('mapToolType maps standard tool names to canonical types', () => {
 });
 
 test('standardizeAction enforces strictly typed parameter shapes per action type', () => {
-  // run_command standardizes 'cmd', 'command', 'CommandLine', or string to params.command
+  // run_command standardizes 'cmd', 'command', or string to params.command
   const cmd1 = standardizeAction('run_command', 'bash', { cmd: 'cat index.html' });
   assert.strictEqual(cmd1.type, 'run_command');
   assert.strictEqual(cmd1.name, 'bash');
-  assert.strictEqual(cmd1.params?.command, 'cat index.html');
+  assert.strictEqual(cmd1.params.command, 'cat index.html');
 
   const cmd2 = standardizeAction('run_command', 'terminal', { command: 'pnpm test' });
-  assert.strictEqual(cmd2.params?.command, 'pnpm test');
+  assert.strictEqual(cmd2.params.command, 'pnpm test');
 
-  const cmd3 = standardizeAction('run_command', 'run_command', { CommandLine: 'git status' });
-  assert.strictEqual(cmd3.params?.command, 'git status');
+  const cmd3 = standardizeAction('run_command', 'bash', 'git status');
+  assert.strictEqual(cmd3.params.command, 'git status');
 
-  // read_file standardizes path, file_path, AbsolutePath, SearchDirectory, etc. to params.path
+  // read_file standardizes path, file_path to params.path
   const read1 = standardizeAction('read_file', 'read', { file_path: 'src/index.ts' });
   assert.strictEqual(read1.type, 'read_file');
-  assert.strictEqual(read1.params?.path, 'src/index.ts');
+  assert.strictEqual(read1.params.path, 'src/index.ts');
 
-  const read2 = standardizeAction('read_file', 'view_file', { AbsolutePath: 'app.jsx' });
-  assert.strictEqual(read2.params?.path, 'app.jsx');
+  const read2 = standardizeAction('read_file', 'view_file', { path: 'app.jsx' });
+  assert.strictEqual(read2.params.path, 'app.jsx');
 
-  const read3 = standardizeAction('read_file', 'list_dir', { SearchDirectory: '/workspace/src' });
-  assert.strictEqual(read3.params?.path, '/workspace/src');
-
-  // write_file standardizes path/TargetFile/AbsolutePath and content/CodeContent/ReplacementChunks
+  // write_file standardizes path/file_path and content/new_string/newText
   const write1 = standardizeAction('write_file', 'write_to_file', {
-    TargetFile: 'index.html',
-    CodeContent: '<html></html>'
+    path: 'index.html',
+    content: '<html></html>'
   });
   assert.strictEqual(write1.type, 'write_file');
-  assert.strictEqual(write1.params?.path, 'index.html');
-  assert.strictEqual(write1.params?.content, '<html></html>');
+  assert.strictEqual(write1.params.path, 'index.html');
+  assert.strictEqual(write1.params.content, '<html></html>');
 
   const write2 = standardizeAction('write_file', 'edit', {
-    AbsolutePath: '/path/to/main.ts',
-    content: 'const a = 1;'
+    file_path: '/path/to/main.ts',
+    new_string: 'const a = 1;'
   });
-  assert.strictEqual(write2.params?.path, '/path/to/main.ts');
+  assert.strictEqual(write2.params.path, '/path/to/main.ts');
+  assert.strictEqual(write2.params.content, 'const a = 1;');
 
-  // web_search standardizes query, search, use_case_id to params.query
+  const write3 = standardizeAction('write_file', 'edit', {
+    path: '/path/to/main.ts',
+    newText: 'const b = 2;'
+  });
+  assert.strictEqual(write3.params.path, '/path/to/main.ts');
+  assert.strictEqual(write3.params.content, 'const b = 2;');
+
+  // web_search standardizes query, use_case_id to params.query
   const search1 = standardizeAction('web_search', 'get_best_practices', { use_case_id: 'dialog' });
   assert.strictEqual(search1.type, 'web_search');
-  assert.strictEqual(search1.params?.query, 'dialog');
-  assert.strictEqual(search1.params?.use_case_id, 'dialog');
+  assert.strictEqual(search1.params.query, 'dialog');
+  assert.strictEqual(search1.params.use_case_id, 'dialog');
+
+  const search2 = standardizeAction('web_search', 'code_search', { query: 'test' });
+  assert.strictEqual(search2.params.query, 'test');
 
   // other preserves raw properties
   const other1 = standardizeAction('other', 'respond_to_user', { response: 'Done' });
@@ -172,17 +180,17 @@ test('finalizeTrajectorySummary sorts steps monotonically and re-indexes with 1-
       {
         stepNumber: 99,
         timestamp: '2026-08-09T21:00:10.000Z',
-        action: { name: 'respond_to_user', type: 'other' }
+        action: standardizeAction('other', 'respond_to_user')
       },
       {
         stepNumber: 99,
         timestamp: '2026-08-09T21:00:01.000Z',
-        action: { name: 'search_use_cases', type: 'web_search' }
+        action: standardizeAction('web_search', 'search_use_cases', { query: 'dialog' })
       },
       {
         stepNumber: 99,
         timestamp: '2026-08-09T21:00:05.000Z',
-        action: { name: 'write_file', type: 'write_file' }
+        action: standardizeAction('write_file', 'write_file', { path: 'index.html' })
       }
     ]
   };

--- a/harness/tests/trajectory-normalizer.test.ts
+++ b/harness/tests/trajectory-normalizer.test.ts
@@ -109,11 +109,13 @@ test('mapToolType maps standard tool names to canonical types', () => {
   assert.strictEqual(mapToolType('get_best_practices'), 'web_search');
   assert.strictEqual(mapToolType('retrieve'), 'web_search');
   assert.strictEqual(mapToolType('query_guidance'), 'web_search');
+  assert.strictEqual(mapToolType('TodoWrite'), 'other');
+  assert.strictEqual(mapToolType('TodoRead'), 'other');
   assert.strictEqual(mapToolType('unknown_action'), 'other');
 });
 
 test('standardizeAction enforces strictly typed parameter shapes per action type', () => {
-  // run_command standardizes 'cmd', 'command', or string to params.command
+  // run_command standardizes 'cmd', 'command', 'CommandLine', or string to params.command
   const cmd1 = standardizeAction('run_command', 'bash', { cmd: 'cat index.html' });
   assert.strictEqual(cmd1.type, 'run_command');
   assert.strictEqual(cmd1.name, 'bash');
@@ -122,7 +124,10 @@ test('standardizeAction enforces strictly typed parameter shapes per action type
   const cmd2 = standardizeAction('run_command', 'terminal', { command: 'pnpm test' });
   assert.strictEqual(cmd2.params?.command, 'pnpm test');
 
-  // read_file standardizes path, file_path, AbsolutePath, etc. to params.path
+  const cmd3 = standardizeAction('run_command', 'run_command', { CommandLine: 'git status' });
+  assert.strictEqual(cmd3.params?.command, 'git status');
+
+  // read_file standardizes path, file_path, AbsolutePath, SearchDirectory, etc. to params.path
   const read1 = standardizeAction('read_file', 'read', { file_path: 'src/index.ts' });
   assert.strictEqual(read1.type, 'read_file');
   assert.strictEqual(read1.params?.path, 'src/index.ts');
@@ -130,7 +135,10 @@ test('standardizeAction enforces strictly typed parameter shapes per action type
   const read2 = standardizeAction('read_file', 'view_file', { AbsolutePath: 'app.jsx' });
   assert.strictEqual(read2.params?.path, 'app.jsx');
 
-  // write_file standardizes path/TargetFile and content/CodeContent/ReplacementChunks
+  const read3 = standardizeAction('read_file', 'list_dir', { SearchDirectory: '/workspace/src' });
+  assert.strictEqual(read3.params?.path, '/workspace/src');
+
+  // write_file standardizes path/TargetFile/AbsolutePath and content/CodeContent/ReplacementChunks
   const write1 = standardizeAction('write_file', 'write_to_file', {
     TargetFile: 'index.html',
     CodeContent: '<html></html>'
@@ -138,6 +146,12 @@ test('standardizeAction enforces strictly typed parameter shapes per action type
   assert.strictEqual(write1.type, 'write_file');
   assert.strictEqual(write1.params?.path, 'index.html');
   assert.strictEqual(write1.params?.content, '<html></html>');
+
+  const write2 = standardizeAction('write_file', 'edit', {
+    AbsolutePath: '/path/to/main.ts',
+    content: 'const a = 1;'
+  });
+  assert.strictEqual(write2.params?.path, '/path/to/main.ts');
 
   // web_search standardizes query, search, use_case_id to params.query
   const search1 = standardizeAction('web_search', 'get_best_practices', { use_case_id: 'dialog' });

--- a/harness/tests/trajectory-normalizer.test.ts
+++ b/harness/tests/trajectory-normalizer.test.ts
@@ -80,6 +80,21 @@ test('categorizeAction avoids false-positives from code mutation content', () =>
   // Test 8: Incidental noise fallback
   const noiseCat = categorizeAction('unknown_utility_ping', {});
   assert.strictEqual(noiseCat, 'incidental_noise');
+
+  // Test 9: CLI guidance search vs retrieve commands
+  const cliSearchCat = categorizeAction('run_command', { command: 'npx -y modern-web-guidance@latest search "accordion"' });
+  assert.strictEqual(cliSearchCat, 'skill_search');
+
+  const cliRetrieveCat = categorizeAction('run_command', { command: 'npx -y modern-web-guidance@latest retrieve "details-styling"' });
+  assert.strictEqual(cliRetrieveCat, 'guide_retrieval');
+
+  // Test 10: Non-guidance CLI commands with retrieve/search in url/text are not false positives
+  const nonGuidanceCat = categorizeAction('run_command', { command: 'curl https://example.com/retrieve/item' });
+  assert.strictEqual(nonGuidanceCat, 'incidental_noise');
+
+  // Test 11: Skill activations are categorized as other (tracked via toolsUsed)
+  const skillCat = categorizeAction('Skill', { skill: 'modern-web-guidance' });
+  assert.strictEqual(skillCat, 'other');
 });
 
 test('categorizeAction distinguishes read actions mentioning files from mutation actions', () => {

--- a/lib/patch-utils.test.ts
+++ b/lib/patch-utils.test.ts
@@ -142,5 +142,37 @@ describe('capturePatchFromGit', () => {
   });
 });
 
+describe('generateUnifiedDiff', () => {
+  test('returns "No differences detected." for identical content', async () => {
+    const { generateUnifiedDiff } = await import('./patch-utils.ts');
+    assert.strictEqual(generateUnifiedDiff('const a = 1;\n', 'const a = 1;\n'), 'No differences detected.');
+    assert.strictEqual(generateUnifiedDiff('', ''), 'No differences detected.');
+  });
+
+  test('generates unified diff for modified lines with custom labels', async () => {
+    const { generateUnifiedDiff } = await import('./patch-utils.ts');
+    const oldText = 'line 1\nline 2\nline 3';
+    const newText = 'line 1\nline 2 modified\nline 3';
+    const diff = generateUnifiedDiff(oldText, newText, 'OldFile', 'NewFile');
+
+    assert.match(diff, /^--- OldFile/m);
+    assert.match(diff, /^\+\+\+ NewFile/m);
+    assert.match(diff, /^@@ -\d+,\d+ \+\d+,\d+ @@/m);
+    assert.match(diff, /^- line 2/m);
+    assert.match(diff, /^\+ line 2 modified/m);
+  });
+
+  test('handles insertions at beginning, middle, and end correctly with prefix/suffix trimming', async () => {
+    const { generateUnifiedDiff } = await import('./patch-utils.ts');
+    const oldText = 'header\nshared 1\nshared 2\nfooter';
+    const newText = 'top new\nheader\nshared 1\nmiddle inserted\nshared 2\nfooter\nbottom new';
+    const diff = generateUnifiedDiff(oldText, newText);
+
+    assert.match(diff, /^\+ top new/m);
+    assert.match(diff, /^\+ middle inserted/m);
+    assert.match(diff, /^\+ bottom new/m);
+  });
+});
+
 
 

--- a/lib/patch-utils.test.ts
+++ b/lib/patch-utils.test.ts
@@ -158,8 +158,8 @@ describe('generateUnifiedDiff', () => {
     assert.match(diff, /^--- OldFile/m);
     assert.match(diff, /^\+\+\+ NewFile/m);
     assert.match(diff, /^@@ -\d+,\d+ \+\d+,\d+ @@/m);
-    assert.match(diff, /^- line 2/m);
-    assert.match(diff, /^\+ line 2 modified/m);
+    assert.match(diff, /^-line 2/m);
+    assert.match(diff, /^\+line 2 modified/m);
   });
 
   test('handles insertions at beginning, middle, and end correctly with prefix/suffix trimming', async () => {
@@ -168,9 +168,18 @@ describe('generateUnifiedDiff', () => {
     const newText = 'top new\nheader\nshared 1\nmiddle inserted\nshared 2\nfooter\nbottom new';
     const diff = generateUnifiedDiff(oldText, newText);
 
-    assert.match(diff, /^\+ top new/m);
-    assert.match(diff, /^\+ middle inserted/m);
-    assert.match(diff, /^\+ bottom new/m);
+    assert.match(diff, /^\+top new/m);
+    assert.match(diff, /^\+middle inserted/m);
+    assert.match(diff, /^\+bottom new/m);
+  });
+
+  test('handles empty string edge cases correctly', async () => {
+    const { generateUnifiedDiff } = await import('./patch-utils.ts');
+    const diffFromEmpty = generateUnifiedDiff('', 'new content\n');
+    assert.match(diffFromEmpty, /^\+new content/m);
+
+    const diffToEmpty = generateUnifiedDiff('old content\n', '');
+    assert.match(diffToEmpty, /^-old content/m);
   });
 });
 

--- a/lib/patch-utils.ts
+++ b/lib/patch-utils.ts
@@ -98,3 +98,198 @@ export function initGitRepo(workDir: string): void {
     console.warn(`Failed to initialize git in workDir ${workDir}: ${err}`);
   }
 }
+
+interface EditOp {
+  type: 'equal' | 'add' | 'remove';
+  oldIndex?: number;
+  newIndex?: number;
+  line: string;
+}
+
+/**
+ * Generates an aligned LCS unified diff of two strings for LLM context and file comparison.
+ * Trims common prefix and suffix to avoid quadratic allocations on large files.
+ */
+export function generateUnifiedDiff(
+  oldText: string,
+  newText: string,
+  oldLabel = 'Old',
+  newLabel = 'New',
+  contextLines = 3
+): string {
+  if (oldText === newText) {
+    return 'No differences detected.';
+  }
+
+  const oldLines = oldText.split(/\r?\n/);
+  const newLines = newText.split(/\r?\n/);
+
+  // 1. Trim common prefix
+  let prefixCount = 0;
+  while (
+    prefixCount < oldLines.length &&
+    prefixCount < newLines.length &&
+    oldLines[prefixCount] === newLines[prefixCount]
+  ) {
+    prefixCount++;
+  }
+
+  // 2. Trim common suffix
+  let suffixCount = 0;
+  while (
+    suffixCount < oldLines.length - prefixCount &&
+    suffixCount < newLines.length - prefixCount &&
+    oldLines[oldLines.length - 1 - suffixCount] === newLines[newLines.length - 1 - suffixCount]
+  ) {
+    suffixCount++;
+  }
+
+  const midOld = oldLines.slice(prefixCount, oldLines.length - suffixCount);
+  const midNew = newLines.slice(prefixCount, newLines.length - suffixCount);
+  const m = midOld.length;
+  const n = midNew.length;
+
+  const ops: EditOp[] = [];
+
+  // Add prefix equal ops
+  for (let i = 0; i < prefixCount; i++) {
+    ops.push({ type: 'equal', oldIndex: i + 1, newIndex: i + 1, line: oldLines[i] });
+  }
+
+  // Compute LCS on diverging middle lines
+  if (m > 0 || n > 0) {
+    const dp: number[][] = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0));
+    for (let i = 1; i <= m; i++) {
+      for (let j = 1; j <= n; j++) {
+        if (midOld[i - 1] === midNew[j - 1]) {
+          dp[i][j] = dp[i - 1][j - 1] + 1;
+        } else {
+          dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+        }
+      }
+    }
+
+    const midOps: EditOp[] = [];
+    let i = m;
+    let j = n;
+    while (i > 0 || j > 0) {
+      if (i > 0 && j > 0 && midOld[i - 1] === midNew[j - 1]) {
+        midOps.push({
+          type: 'equal',
+          oldIndex: prefixCount + i,
+          newIndex: prefixCount + j,
+          line: midOld[i - 1]
+        });
+        i--;
+        j--;
+      } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+        midOps.push({
+          type: 'add',
+          newIndex: prefixCount + j,
+          line: midNew[j - 1]
+        });
+        j--;
+      } else if (i > 0 && (j === 0 || dp[i][j - 1] < dp[i - 1][j])) {
+        midOps.push({
+          type: 'remove',
+          oldIndex: prefixCount + i,
+          line: midOld[i - 1]
+        });
+        i--;
+      }
+    }
+    midOps.reverse();
+    ops.push(...midOps);
+  }
+
+  // Add suffix equal ops
+  const suffixOldStart = oldLines.length - suffixCount;
+  const suffixNewStart = newLines.length - suffixCount;
+  for (let i = 0; i < suffixCount; i++) {
+    ops.push({
+      type: 'equal',
+      oldIndex: suffixOldStart + i + 1,
+      newIndex: suffixNewStart + i + 1,
+      line: oldLines[suffixOldStart + i]
+    });
+  }
+
+  if (ops.every((op) => op.type === 'equal')) {
+    return 'No differences detected.';
+  }
+
+  // Generate unified diff hunks
+  const hunks: {
+    oldStart: number;
+    oldLinesCount: number;
+    newStart: number;
+    newLinesCount: number;
+    lines: string[];
+  }[] = [];
+
+  let opIndex = 0;
+  while (opIndex < ops.length) {
+    while (opIndex < ops.length && ops[opIndex].type === 'equal') {
+      opIndex++;
+    }
+    if (opIndex >= ops.length) break;
+
+    const hunkStart = Math.max(0, opIndex - contextLines);
+    let hunkEnd = opIndex;
+
+    while (hunkEnd < ops.length) {
+      if (ops[hunkEnd].type !== 'equal') {
+        hunkEnd++;
+      } else {
+        let nextChange = hunkEnd;
+        while (nextChange < ops.length && ops[nextChange].type === 'equal' && nextChange - hunkEnd < 2 * contextLines) {
+          nextChange++;
+        }
+        if (nextChange < ops.length && ops[nextChange].type !== 'equal') {
+          hunkEnd = nextChange;
+        } else {
+          break;
+        }
+      }
+    }
+
+    const actualEnd = Math.min(ops.length - 1, hunkEnd + contextLines - 1);
+    const hunkOps = ops.slice(hunkStart, actualEnd + 1);
+
+    let oldStart = 0;
+    let newStart = 0;
+    let oldLinesCount = 0;
+    let newLinesCount = 0;
+    const lines: string[] = [];
+
+    for (const op of hunkOps) {
+      if (op.oldIndex !== undefined && oldStart === 0) oldStart = op.oldIndex;
+      if (op.newIndex !== undefined && newStart === 0) newStart = op.newIndex;
+
+      if (op.type === 'equal') {
+        oldLinesCount++;
+        newLinesCount++;
+        lines.push(`  ${op.line}`);
+      } else if (op.type === 'remove') {
+        oldLinesCount++;
+        lines.push(`- ${op.line}`);
+      } else if (op.type === 'add') {
+        newLinesCount++;
+        lines.push(`+ ${op.line}`);
+      }
+    }
+
+    if (oldStart === 0) oldStart = 1;
+    if (newStart === 0) newStart = 1;
+
+    hunks.push({ oldStart, oldLinesCount, newStart, newLinesCount, lines });
+    opIndex = actualEnd + 1;
+  }
+
+  let result = `--- ${oldLabel}\n+++ ${newLabel}\n`;
+  for (const hunk of hunks) {
+    result += `@@ -${hunk.oldStart},${hunk.oldLinesCount} +${hunk.newStart},${hunk.newLinesCount} @@\n`;
+    result += hunk.lines.join('\n') + '\n';
+  }
+  return result.trim();
+}

--- a/lib/patch-utils.ts
+++ b/lib/patch-utils.ts
@@ -99,16 +99,10 @@ export function initGitRepo(workDir: string): void {
   }
 }
 
-interface EditOp {
-  type: 'equal' | 'add' | 'remove';
-  oldIndex?: number;
-  newIndex?: number;
-  line: string;
-}
+import { createTwoFilesPatch } from 'diff';
 
 /**
- * Generates an aligned LCS unified diff of two strings for LLM context and file comparison.
- * Trims common prefix and suffix to avoid quadratic allocations on large files.
+ * Generates an aligned unified diff of two strings for LLM context and file comparison.
  */
 export function generateUnifiedDiff(
   oldText: string,
@@ -121,175 +115,9 @@ export function generateUnifiedDiff(
     return 'No differences detected.';
   }
 
-  const oldLines = oldText.split(/\r?\n/);
-  const newLines = newText.split(/\r?\n/);
-
-  // 1. Trim common prefix
-  let prefixCount = 0;
-  while (
-    prefixCount < oldLines.length &&
-    prefixCount < newLines.length &&
-    oldLines[prefixCount] === newLines[prefixCount]
-  ) {
-    prefixCount++;
-  }
-
-  // 2. Trim common suffix
-  let suffixCount = 0;
-  while (
-    suffixCount < oldLines.length - prefixCount &&
-    suffixCount < newLines.length - prefixCount &&
-    oldLines[oldLines.length - 1 - suffixCount] === newLines[newLines.length - 1 - suffixCount]
-  ) {
-    suffixCount++;
-  }
-
-  const midOld = oldLines.slice(prefixCount, oldLines.length - suffixCount);
-  const midNew = newLines.slice(prefixCount, newLines.length - suffixCount);
-  const m = midOld.length;
-  const n = midNew.length;
-
-  const ops: EditOp[] = [];
-
-  // Add prefix equal ops
-  for (let i = 0; i < prefixCount; i++) {
-    ops.push({ type: 'equal', oldIndex: i + 1, newIndex: i + 1, line: oldLines[i] });
-  }
-
-  // Compute LCS on diverging middle lines
-  if (m > 0 || n > 0) {
-    const dp: number[][] = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0));
-    for (let i = 1; i <= m; i++) {
-      for (let j = 1; j <= n; j++) {
-        if (midOld[i - 1] === midNew[j - 1]) {
-          dp[i][j] = dp[i - 1][j - 1] + 1;
-        } else {
-          dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
-        }
-      }
-    }
-
-    const midOps: EditOp[] = [];
-    let i = m;
-    let j = n;
-    while (i > 0 || j > 0) {
-      if (i > 0 && j > 0 && midOld[i - 1] === midNew[j - 1]) {
-        midOps.push({
-          type: 'equal',
-          oldIndex: prefixCount + i,
-          newIndex: prefixCount + j,
-          line: midOld[i - 1]
-        });
-        i--;
-        j--;
-      } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
-        midOps.push({
-          type: 'add',
-          newIndex: prefixCount + j,
-          line: midNew[j - 1]
-        });
-        j--;
-      } else if (i > 0 && (j === 0 || dp[i][j - 1] < dp[i - 1][j])) {
-        midOps.push({
-          type: 'remove',
-          oldIndex: prefixCount + i,
-          line: midOld[i - 1]
-        });
-        i--;
-      }
-    }
-    midOps.reverse();
-    ops.push(...midOps);
-  }
-
-  // Add suffix equal ops
-  const suffixOldStart = oldLines.length - suffixCount;
-  const suffixNewStart = newLines.length - suffixCount;
-  for (let i = 0; i < suffixCount; i++) {
-    ops.push({
-      type: 'equal',
-      oldIndex: suffixOldStart + i + 1,
-      newIndex: suffixNewStart + i + 1,
-      line: oldLines[suffixOldStart + i]
-    });
-  }
-
-  if (ops.every((op) => op.type === 'equal')) {
+  const patch = createTwoFilesPatch(oldLabel, newLabel, oldText, newText, undefined, undefined, { context: contextLines });
+  if (!patch.includes('@@')) {
     return 'No differences detected.';
   }
-
-  // Generate unified diff hunks
-  const hunks: {
-    oldStart: number;
-    oldLinesCount: number;
-    newStart: number;
-    newLinesCount: number;
-    lines: string[];
-  }[] = [];
-
-  let opIndex = 0;
-  while (opIndex < ops.length) {
-    while (opIndex < ops.length && ops[opIndex].type === 'equal') {
-      opIndex++;
-    }
-    if (opIndex >= ops.length) break;
-
-    const hunkStart = Math.max(0, opIndex - contextLines);
-    let hunkEnd = opIndex;
-
-    while (hunkEnd < ops.length) {
-      if (ops[hunkEnd].type !== 'equal') {
-        hunkEnd++;
-      } else {
-        let nextChange = hunkEnd;
-        while (nextChange < ops.length && ops[nextChange].type === 'equal' && nextChange - hunkEnd < 2 * contextLines) {
-          nextChange++;
-        }
-        if (nextChange < ops.length && ops[nextChange].type !== 'equal') {
-          hunkEnd = nextChange;
-        } else {
-          break;
-        }
-      }
-    }
-
-    const actualEnd = Math.min(ops.length - 1, hunkEnd + contextLines - 1);
-    const hunkOps = ops.slice(hunkStart, actualEnd + 1);
-
-    let oldStart = 0;
-    let newStart = 0;
-    let oldLinesCount = 0;
-    let newLinesCount = 0;
-    const lines: string[] = [];
-
-    for (const op of hunkOps) {
-      if (op.oldIndex !== undefined && oldStart === 0) oldStart = op.oldIndex;
-      if (op.newIndex !== undefined && newStart === 0) newStart = op.newIndex;
-
-      if (op.type === 'equal') {
-        oldLinesCount++;
-        newLinesCount++;
-        lines.push(`  ${op.line}`);
-      } else if (op.type === 'remove') {
-        oldLinesCount++;
-        lines.push(`- ${op.line}`);
-      } else if (op.type === 'add') {
-        newLinesCount++;
-        lines.push(`+ ${op.line}`);
-      }
-    }
-
-    if (oldStart === 0) oldStart = 1;
-    if (newStart === 0) newStart = 1;
-
-    hunks.push({ oldStart, oldLinesCount, newStart, newLinesCount, lines });
-    opIndex = actualEnd + 1;
-  }
-
-  let result = `--- ${oldLabel}\n+++ ${newLabel}\n`;
-  for (const hunk of hunks) {
-    result += `@@ -${hunk.oldStart},${hunk.oldLinesCount} +${hunk.newStart},${hunk.newLinesCount} @@\n`;
-    result += hunk.lines.join('\n') + '\n';
-  }
-  return result.trim();
+  return patch.trim();
 }

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@webref/elements": "^2.7.1",
     "@webref/idl": "^3.82.0",
     "caniuse-lite": "^1.0.30001806",
+    "diff": "^9.0.0",
     "glob": "^13.0.6",
     "mdn-data": "^2.29.0",
     "omelette": "^0.4.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,9 @@ importers:
       caniuse-lite:
         specifier: ^1.0.30001806
         version: 1.0.30001806
+      diff:
+        specifier: ^9.0.0
+        version: 9.0.0
       glob:
         specifier: ^13.0.6
         version: 13.0.6


### PR DESCRIPTION
## Summary
Part 2 of 3 (stacked on #1186 ).

Adds headless CLI run comparison and multi-stage LLM variance diagnosis.

- **CLI**: `gd compare <runDirA> <runDirB>`.
- **GCS Downloader**: Lazy downloading and caching of remote runs with streaming logs.
- **Comparison Engine**: Diffs files against base apps, compares Playwright results, and aligns trajectory steps.
- **Diagnosis Subagents**: Multi-stage LLM analysis (compliance auditor, code friction analyzer, synthesis engine) outputting `variance_diagnosis.md`.