### PR TITLE
Fix generation error % to include unguided + guided failures

### DIFF
--- a/eval-view/dashboard.js
+++ b/eval-view/dashboard.js
@@ -510,7 +510,7 @@ function renderSummary(data) {
     });
 
     const rawRate = totalAllRunsCount > 0 ? (totalEarlyFailures / totalAllRunsCount) * 100 : 0;
-    const totalEarlyFailureRate = rawRate > 0 && rawRate < 1 ? rawRate.toFixed(1) : Math.round(rawRate);
+    const totalEarlyFailureRate = rawRate > 0 && rawRate < 1 ? Number(rawRate.toFixed(1)) : Math.round(rawRate);
 
     container.innerHTML = `
         <div class="header-meta-item dog-ear-card">

--- a/eval-view/dashboard.js
+++ b/eval-view/dashboard.js
@@ -502,7 +502,15 @@ function renderSummary(data) {
 
     const upliftDelta = guidedPassRate - unguidedPassRate;
 
-    const unguidedEarlyFailureRate = summary.unguidedEarlyFailureRate || 0;
+    const totalEarlyFailures = (summary.unguidedEarlyFailures || 0) + (summary.guidedEarlyFailures || 0);
+
+    let totalAllRunsCount = 0;
+    Object.keys(data.results || {}).forEach(key => {
+        totalAllRunsCount += (data.results[key] || []).length;
+    });
+
+    const rawRate = totalAllRunsCount > 0 ? (totalEarlyFailures / totalAllRunsCount) * 100 : 0;
+    const totalEarlyFailureRate = rawRate > 0 && rawRate < 1 ? rawRate.toFixed(1) : Math.round(rawRate);
 
     container.innerHTML = `
         <div class="header-meta-item dog-ear-card">
@@ -519,10 +527,10 @@ function renderSummary(data) {
                 Expected Runs: <span style="font-weight: bold; color: var(--text-primary);">${summary.expectedTotalRuns}${summary.taskCount ? ` (${summary.taskCount} tasks x ${summary.runCountPerTask} runs)` : ''}</span>
             </div>
             ` : ''}
-            ${summary.unguidedEarlyFailures !== undefined ? `
+            ${(summary.unguidedEarlyFailures !== undefined || summary.guidedEarlyFailures !== undefined || summary.totalEarlyFailures !== undefined) ? `
             <div style="margin-top: 6px; font-size: 0.85em; color: var(--text-secondary);">
-                Generation Errors: <span style="font-weight: bold; color: ${getColor(100 - unguidedEarlyFailureRate)}">${unguidedEarlyFailureRate}%</span>
-                <span style="opacity: 0.8; color: ${getColor(100 - unguidedEarlyFailureRate)}">(${summary.unguidedEarlyFailures} runs)</span>
+                Generation Errors: <span style="font-weight: bold; color: ${getColor(100 - totalEarlyFailureRate)}">${totalEarlyFailureRate}%</span>
+                <span style="opacity: 0.8; color: ${getColor(100 - totalEarlyFailureRate)}">(${totalEarlyFailures} run${totalEarlyFailures === 1 ? '' : 's'})</span>
             </div>
             ` : ''}
 

--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -551,7 +551,10 @@ function renderSuites() {
         let maxRuns = 1;
         scenarioKeys.forEach(k => { if (data.results[k].length > maxRuns) maxRuns = data.results[k].length; });
 
-        const earlyFailureRate = data.summary?.unguidedEarlyFailureRate || 0;
+        const totalEarlyFailures = (data.summary?.unguidedEarlyFailures || 0) + (data.summary?.guidedEarlyFailures || 0);
+        let totalAllRuns = 0;
+        scenarioKeys.forEach(k => { totalAllRuns += (data.results[k] || []).length; });
+        const earlyFailureRate = totalAllRuns > 0 ? Math.round((totalEarlyFailures / totalAllRuns) * 100) : 0;
         const isFaulty = earlyFailureRate === 100;
 
         const { label, ldap } = formatSuiteLabel(testInfo);


### PR DESCRIPTION
Previously it was only counting the unguided failures. Updated:

<img width="555" height="206" alt="image" src="https://github.com/user-attachments/assets/cd2b5ebd-96c1-434f-8edf-65295d0f2d18" />