### PR TITLE
[#1037] Local Network access restrictions use case

### DIFF
--- a/guides/security/local-network-access/demo.html
+++ b/guides/security/local-network-access/demo.html
@@ -1,0 +1,5 @@
+This demo will have buttons that attempt to contact an address on a local network, triggering the `local-network` permission, and `localhost`, triggering the `loopback-network` permission.
+
+It will show how to handle when users deny the permission.
+
+The requirement for Secure Context and separate locally running servers may make this challenging to test.

--- a/guides/security/local-network-access/guide.md
+++ b/guides/security/local-network-access/guide.md
@@ -1,0 +1,10 @@
+---
+name: local-network-access
+description: Access resources on a user's local network or loopback interface from a public web application.
+web-feature-ids:
+  - local-network-access
+---
+
+# Local Network Access
+
+<!-- Guidance content will be authored later. -->


### PR DESCRIPTION
I don't think this warrants separate use cases for local vs. loopback. Since the previous behavior is that it works without requesting permissions, do we need to show a fallback that manually checks with the user first? Or view this as strictly a progressive enhancement?