### PR TITLE
Fix Jetski CLI trajectory parsing

### DIFF
--- a/harness/agents/jetski-cli-agent.ts
+++ b/harness/agents/jetski-cli-agent.ts
@@ -288,7 +288,7 @@ export function parseJetskiCliSession(dirPath: string): TrajectorySummary {
           }
         }
 
-        // Protobuf token extraction from metadata
+        // Protobuf token extraction from metadata (schema-agnostic across tags)
         if (row.metadata) {
           const proto = parseProtobuf(Buffer.from(row.metadata));
           const visited = new Set<any>();
@@ -302,9 +302,7 @@ export function parseJetskiCliSession(dirPath: string): TrajectorySummary {
             const input = (node[2] && typeof node[2][0] === 'number') ? node[2][0] : 0;
             const output = (node[3] && typeof node[3][0] === 'number') ? node[3][0] : 0;
             const cached = (node[5] && typeof node[5][0] === 'number') ? node[5][0] : 0;
-            // Token usage records contain a session/task reference in tag 7 or tag 8
-            const hasSessionRef = Boolean(node[7] || node[8]);
-            if (hasSessionRef && (input > 0 || output > 0 || cached > 0)) {
+            if (input > 0 || output > 0 || cached > 0) {
               totalInput += input;
               totalOutput += output;
               totalCached += cached;

--- a/harness/agents/jetski-cli-agent.ts
+++ b/harness/agents/jetski-cli-agent.ts
@@ -288,24 +288,33 @@ export function parseJetskiCliSession(dirPath: string): TrajectorySummary {
           }
         }
 
-        // Protobuf token extraction from metadata tag 9
+        // Protobuf token extraction from metadata
         if (row.metadata) {
           const proto = parseProtobuf(Buffer.from(row.metadata));
-          if (proto[9]) {
-            for (const item of proto[9]) {
-              if (typeof item === 'object' && item !== null) {
-                const input = (item[2] && typeof item[2][0] === 'number') ? item[2][0] : 0;
-                const output = (item[3] && typeof item[3][0] === 'number') ? item[3][0] : 0;
-                const cached = (item[5] && typeof item[5][0] === 'number') ? item[5][0] : 0;
-                if (input > 0 || output > 0 || cached > 0) {
-                  totalInput += input;
-                  totalOutput += output;
-                  totalCached += cached;
-                  hasTokens = true;
-                }
-              }
+          const visited = new Set<any>();
+          const extractTokensFromNode = (node: any) => {
+            if (!node || typeof node !== 'object' || visited.has(node)) return;
+            visited.add(node);
+            if (Array.isArray(node)) {
+              for (const item of node) extractTokensFromNode(item);
+              return;
             }
-          }
+            const input = (node[2] && typeof node[2][0] === 'number') ? node[2][0] : 0;
+            const output = (node[3] && typeof node[3][0] === 'number') ? node[3][0] : 0;
+            const cached = (node[5] && typeof node[5][0] === 'number') ? node[5][0] : 0;
+            // Token usage records contain a session/task reference in tag 7 or tag 8
+            const hasSessionRef = Boolean(node[7] || node[8]);
+            if (hasSessionRef && (input > 0 || output > 0 || cached > 0)) {
+              totalInput += input;
+              totalOutput += output;
+              totalCached += cached;
+              hasTokens = true;
+            }
+            for (const key of Object.keys(node)) {
+              extractTokensFromNode(node[key]);
+            }
+          };
+          extractTokensFromNode(proto);
         }
       }
 

--- a/harness/agents/jetski-cli-agent.ts
+++ b/harness/agents/jetski-cli-agent.ts
@@ -257,38 +257,32 @@ export function parseJetskiCliSession(dirPath: string): TrajectorySummary {
       const db = new DatabaseSync(fullPath, { readOnly: true });
       const rows = db.prepare('SELECT step_type, metadata, step_payload FROM steps').all() as Array<{ step_type?: number; metadata?: Uint8Array; step_payload?: Uint8Array }>;
       for (const row of rows) {
-        // Decode Protobuf step_payload for specific tool execution step types
+        // Decode Protobuf step_payload for tool executions
         if (row.step_payload) {
           const proto = parseProtobuf(Buffer.from(row.step_payload));
           const strings = getProtoStrings(proto);
 
-          // Shell commands (step_type = 21: RUN_COMMAND)
-          if (row.step_type === 21) {
-            for (const text of strings) {
-              if (text.includes('retrieve')) {
-                const match = text.match(/(?:--)?retrieve\s+["'\\]*([^"'\s\\]+)["'\\]*/i);
-                if (match && match[1]) {
-                  const parts = match[1].split(',').map(s => s.trim().replace(/^["'\\]+|["'\\]+$/g, '')).filter(s => Boolean(s) && /^[a-zA-Z0-9_-]+$/.test(s) && s.toLowerCase() !== 'id');
-                  retrievedGuides.push(...parts);
-                }
+          for (const text of strings) {
+            // Shell commands & guide retrieval
+            if (text.includes('retrieve')) {
+              const match = text.match(/(?:--)?retrieve\s+["'\\]*([^"'\s\\]+)["'\\]*/i);
+              if (match && match[1]) {
+                const parts = match[1].split(',').map(s => s.trim().replace(/^["'\\]+|["'\\]+$/g, '')).filter(s => Boolean(s) && /^[a-zA-Z0-9_-]+$/.test(s) && s.toLowerCase() !== 'id');
+                retrievedGuides.push(...parts);
               }
             }
-          }
 
-          // File reads (step_type = 8: VIEW_FILE)
-          if (row.step_type === 8) {
-            for (const filePath of strings) {
-              if (filePath.includes('/skills/') && filePath.endsWith('/guide.md')) {
-                const match = filePath.match(/\/skills\/[^/]+\/([^/]+)\/guide\.md$/);
-                if (match) {
-                  fileReadGuides.push(match[1]);
-                }
+            // File reads for guides and skills
+            if (text.includes('/skills/') && text.endsWith('/guide.md')) {
+              const match = text.match(/\/skills\/[^/]+\/([^/]+)\/guide\.md$/);
+              if (match) {
+                fileReadGuides.push(match[1]);
               }
-              if (filePath.includes('/skills/') && filePath.endsWith('/SKILL.md')) {
-                const match = filePath.match(/\/skills\/([^/]+)\/SKILL\.md$/);
-                if (match) {
-                  toolsUsed.push(match[1]);
-                }
+            }
+            if (text.includes('/skills/') && text.endsWith('/SKILL.md')) {
+              const match = text.match(/\/skills\/([^/]+)\/SKILL\.md$/);
+              if (match) {
+                toolsUsed.push(match[1]);
               }
             }
           }
@@ -315,21 +309,19 @@ export function parseJetskiCliSession(dirPath: string): TrajectorySummary {
         }
       }
 
-      // Extract model name from gen_metadata (Protobuf Tag 1 -> Tag 21)
+      // Extract model name from gen_metadata by scanning string values
       try {
         const genRows = db.prepare('SELECT data FROM gen_metadata').all() as Array<{ data?: Uint8Array }>;
         for (const row of genRows) {
           if (!row.data) continue;
           const proto = parseProtobuf(Buffer.from(row.data));
-          if (proto[1]) {
-            for (const item of proto[1]) {
-              if (typeof item === 'object' && item !== null && item[21] && typeof item[21][0] === 'string') {
-                modelName = item[21][0];
-                break;
-              }
-            }
+          const strings = getProtoStrings(proto);
+          // Look for standard Gemini model name patterns across string fields in the Protobuf message
+          const modelCandidate = strings.find(s => /^gemini-/i.test(s));
+          if (modelCandidate) {
+            modelName = modelCandidate;
+            break;
           }
-          if (modelName !== 'unknown') break;
         }
       } catch {}
 

--- a/harness/agents/jetski-cli-agent.ts
+++ b/harness/agents/jetski-cli-agent.ts
@@ -106,11 +106,9 @@ async function run() {
     console.log(`Starting Jetski CLI agent in ${workDir}`);
 
     const command = config.environment.jetskiCliBin;
-    const model = process.env.JETSKI_MODEL;
     const commandArgs = [
       '-p', userPrompt,
-      '--dangerously-skip-permissions',
-      ...(model ? ['--model', model] : [])
+      '--dangerously-skip-permissions'
     ];
 
     console.log(`Executing: ${command} ${commandArgs.join(' ')}`);

--- a/harness/agents/jetski-cli-agent.ts
+++ b/harness/agents/jetski-cli-agent.ts
@@ -316,8 +316,8 @@ export function parseJetskiCliSession(dirPath: string): TrajectorySummary {
           if (!row.data) continue;
           const proto = parseProtobuf(Buffer.from(row.data));
           const strings = getProtoStrings(proto);
-          // Look for standard Gemini model name patterns across string fields in the Protobuf message
-          const modelCandidate = strings.find(s => /^gemini-/i.test(s));
+          // Look for Gemini model name patterns across string fields in the Protobuf message
+          const modelCandidate = strings.find(s => /^gemini/i.test(s));
           if (modelCandidate) {
             modelName = modelCandidate;
             break;

--- a/harness/jetski-cli-smoke.ts
+++ b/harness/jetski-cli-smoke.ts
@@ -41,21 +41,34 @@ export async function runJetskiCliSmokeTest() {
       process.exit(1);
     }
 
-    // Verify the output
+    // Verify the output file
     const filePath = path.join(tempProjectDir, 'hello-cli.txt');
-    if (fs.existsSync(filePath)) {
-      const content = fs.readFileSync(filePath, 'utf8').trim();
-      if (content === 'hello jetski cli') {
-        console.log('✅ Success: hello-cli.txt was created with correct content.');
-        process.exit(0);
-      } else {
-        console.error(`❌ Failure: hello-cli.txt had incorrect content: "${content}"`);
-        process.exit(1);
-      }
-    } else {
+    if (!fs.existsSync(filePath)) {
       console.error('❌ Failure: hello-cli.txt was not created.');
       process.exit(1);
     }
+    const content = fs.readFileSync(filePath, 'utf8').trim();
+    if (content !== 'hello jetski cli') {
+      console.error(`❌ Failure: hello-cli.txt had incorrect content: "${content}"`);
+      process.exit(1);
+    }
+    console.log('✅ Success: hello-cli.txt was created with correct content.');
+
+    // Verify trajectory parsing and metric extraction
+    const { parseJetskiCliSession } = await import('./agents/jetski-cli-agent.ts');
+    const summary = parseJetskiCliSession(tempProjectDir);
+    console.log('📊 Trajectory summary from smoke test:', summary);
+
+    if (!summary.model || summary.model === 'unknown' || !/^gemini/i.test(summary.model)) {
+      console.error(`❌ Failure: Model name was not properly extracted (got "${summary.model}").`);
+      process.exit(1);
+    }
+    if (!summary.tokenUsage || summary.tokenUsage.total <= 0) {
+      console.error('❌ Failure: Token usage was not extracted from trajectory.');
+      process.exit(1);
+    }
+    console.log('✅ Success: Trajectory model and token usage extracted accurately.');
+    process.exit(0);
   } catch (err) {
     console.error('❌ An error occurred during the smoke test:', err);
     process.exit(1);


### PR DESCRIPTION
The previously hardcoded proto fields were brittle and resulted in failing to get the tools/guides used and the model in the latest nightly run (because the proto changed/did not have the same fields in those values?):

<img width="181" height="69" alt="image" src="https://github.com/user-attachments/assets/e28910ab-70ef-41e5-8938-fdb8c8a30295" />

Updated to search for the data within the trajectory instead of harcoding. Validated with `jetski-cli-smoke` test and by regenerating the evals on the failed nightly run:

<img width="214" height="61" alt="image" src="https://github.com/user-attachments/assets/995ae164-4c04-4867-ac59-c43682c6da14" />

Also discovered that the Jetski CLI agent runner does not support the `--model` flag anymore. So removing and will set in the Jetski CLI settings before running evals.