### PR TITLE
Auto-assign ATLs to use case issues based on category

### DIFF
--- a/guides/atl-triage.test.ts
+++ b/guides/atl-triage.test.ts
@@ -144,6 +144,20 @@ Web Feature ID: user-action-pseudos
     const result = handleIssue(123, [], description, mockConfig);
     assert.deepStrictEqual(result, ['user-action-reviewer']);
   });
+  it('assigns the category ATL if the issue is a use case under that category', () => {
+    const description = `Use case subdir: [guides/css-layout/some-use-case](https://github.com/...)`;
+    const result = handleIssue(123, [], description, mockConfig);
+    assert.deepStrictEqual(result, ['malchata']);
+  });
+
+  it('assigns both the category ATL and feature override ATL for use case issues', () => {
+    const description = `
+Use case subdir: [guides/css-layout/some-use-case](https://github.com/...)
+Affected web-feature IDs: [canvas-html](...)
+`;
+    const result = handleIssue(123, [], description, mockConfig);
+    assert.deepStrictEqual(result.sort(), ['malchata', 'override-issue-reviewer'].sort());
+  });
 });
 
 describe('handlePR', () => {
@@ -169,10 +183,10 @@ describe('handlePR', () => {
     ];
 
     const result = handlePR(456, 'some-contributor', mockConfig, mockFiles);
-    // 'deliver-optimized-decorative-images' resolves to 'override-pr-reviewer' (via feature 'image-set' override)
+    // 'deliver-optimized-decorative-images' resolves to 'override-pr-reviewer' (via feature 'image-set' override) + 'rviscomi', 'paulirish' (default performance)
     // 'carousel-slide-effects' resolves to 'philipwalton' (default motion)
     // 'grid-layout' resolves to 'malchata' (default css-layout)
-    assert.deepStrictEqual(result.sort(), ['override-pr-reviewer', 'philipwalton', 'malchata'].sort());
+    assert.deepStrictEqual(result.sort(), ['override-pr-reviewer', 'rviscomi', 'paulirish', 'philipwalton', 'malchata'].sort());
   });
 
   it('does not request review from the PR author', () => {
@@ -181,9 +195,9 @@ describe('handlePR', () => {
       'guides/motion/carousel-slide-effects/expectations.md'
     ];
 
-    // Author is override-pr-reviewer, so only philipwalton should be requested
+    // Author is override-pr-reviewer, so only rviscomi, paulirish, and philipwalton should be requested
     const result = handlePR(456, 'override-pr-reviewer', mockConfig, mockFiles);
-    assert.deepStrictEqual(result.sort(), ['philipwalton'].sort());
+    assert.deepStrictEqual(result.sort(), ['rviscomi', 'paulirish', 'philipwalton'].sort());
   });
 
   it('returns empty array when no content files are touched', () => {
@@ -208,7 +222,9 @@ describe('handlePR', () => {
         // Return active requested / reviewed ATLs with mixed case to test case-insensitivity
         return JSON.stringify({
           reviewRequests: [
-            { login: 'Override-Pr-Reviewer' }
+            { login: 'Override-Pr-Reviewer' },
+            { login: 'rviscomi' },
+            { login: 'paulirish' }
           ],
           reviews: [
             { author: { login: 'PhilipWalton' }, state: 'APPROVED' }
@@ -222,8 +238,8 @@ describe('handlePR', () => {
     });
 
     try {
-      // both 'override-pr-reviewer' (via feature 'image-set' override) and 'philipwalton' (default motion)
-      // are resolved, but they are excluded because they are in reviewRequests/reviews.
+      // 'override-pr-reviewer' (via feature 'image-set' override), 'rviscomi', 'paulirish' (default performance),
+      // and 'philipwalton' (default motion) are resolved, but they are excluded because they are in reviewRequests/reviews.
       // So no additional review request is made.
       const result = handlePR(456, 'some-contributor', mockConfig);
       assert.deepStrictEqual(result, []);

--- a/guides/atl-triage.ts
+++ b/guides/atl-triage.ts
@@ -90,36 +90,48 @@ function getFeatureIdsFromGuide(guidePath: string): string[] {
   }
 }
 
-export function resolveAtl(category: string, featureIds: string[], atlConfig: AtlConfig): string | string[] {
-  let resolvedValue = atlConfig.default[category];
+export function resolveAtl(category: string, featureIds: string[], atlConfig: AtlConfig): string[] {
+  const resolved = new Set<string>();
+
+  // Add category default ATL
+  const categoryDefault = atlConfig.default[category];
+  if (categoryDefault) {
+    if (Array.isArray(categoryDefault)) {
+      categoryDefault.forEach(a => resolved.add(a));
+    } else {
+      resolved.add(categoryDefault);
+    }
+  }
 
   if (featureIds && featureIds.length > 0) {
-    let foundOverride = false;
     // Check specific feature ID overrides
     for (const fid of featureIds) {
       if (atlConfig.web_features[fid]) {
-        resolvedValue = atlConfig.web_features[fid];
-        foundOverride = true;
-        break;
+        const override = atlConfig.web_features[fid];
+        if (Array.isArray(override)) {
+          override.forEach(a => resolved.add(a));
+        } else {
+          resolved.add(override);
+        }
       }
     }
     // Check feature group overrides
-    if (!foundOverride) {
-      for (const fid of featureIds) {
-        const groups = featureGroups[fid] || [];
-        for (const group of groups) {
-          if (atlConfig.web_features_groups[group]) {
-            resolvedValue = atlConfig.web_features_groups[group];
-            foundOverride = true;
-            break;
+    for (const fid of featureIds) {
+      const groups = featureGroups[fid] || [];
+      for (const group of groups) {
+        if (atlConfig.web_features_groups[group]) {
+          const override = atlConfig.web_features_groups[group];
+          if (Array.isArray(override)) {
+            override.forEach(a => resolved.add(a));
+          } else {
+            resolved.add(override);
           }
         }
-        if (foundOverride) break;
       }
     }
   }
 
-  return resolvedValue;
+  return Array.from(resolved);
 }
 
 export function getAtlsFromDescription(description: string, atlConfig: AtlConfig): string[] {
@@ -208,6 +220,17 @@ export function handleIssue(issueNumber: number, labels: string[], issueDescript
   if (descriptionAtls.length > 0) {
     console.log(`Found ATLs from description: ${descriptionAtls.join(', ')}`);
     descriptionAtls.forEach(a => assignedAtls.add(a));
+  }
+
+  // 3. Check issue description for use case category
+  const categoryMatch = issueDescription.match(/Use case subdir:\s*\[guides\/([^/\]]+)/i);
+  if (categoryMatch) {
+    const category = categoryMatch[1].trim().toLowerCase();
+    if (atlConfig.default[category]) {
+      const atls = Array.isArray(atlConfig.default[category]) ? atlConfig.default[category] : [atlConfig.default[category]];
+      console.log(`Found category "${category}" from use case subdir in description. ATL: ${atls.join(', ')}`);
+      atls.forEach(a => assignedAtls.add(a));
+    }
   }
 
   if (assignedAtls.size === 0) {


### PR DESCRIPTION
If a use case is under a category with an ATL, its corresponding issue should automatically be assigned to that ATL along with any other finer-grained ATLs for things like specific web features or groups.