### PR TITLE
fix(harness): refine evaluation token calculation, clean up agent invocation naming, and unify Agents enum

### DIFF
--- a/bin/gd.ts
+++ b/bin/gd.ts
@@ -278,8 +278,8 @@ async function main() {
 
       const mergedSuiteConfig = await resolveSuiteConfig(values.config as string | undefined);
 
-      const { runAgent } = await import('../harness/run_suite.ts');
-      await runAgent(tmpl, prompt, mergedSuiteConfig);
+      const { runSingleTask } = await import('../harness/run_suite.ts');
+      await runSingleTask(tmpl, prompt, mergedSuiteConfig);
       break;
     }
 

--- a/guides/dev-guide.test.ts
+++ b/guides/dev-guide.test.ts
@@ -76,11 +76,11 @@ Agent test results:
   });
 });
 
-test('setupIsolatedWorkDir conditionally copies credentials based on GD_DEV_USE_JETSKI', async (t) => {
+test('setupGuideDevWorkDir conditionally copies credentials based on GD_DEV_USE_JETSKI', async (t) => {
   const fs = await import('node:fs');
   const path = await import('node:path');
   const os = await import('node:os');
-  const { setupIsolatedWorkDir } = await import('./lib/utils.ts');
+  const { setupGuideDevWorkDir } = await import('./lib/utils.ts');
   const { cleanupIsolatedHome } = await import('../harness/lib/agent-shared.ts');
 
   const originalHome = process.env.HOME;
@@ -115,7 +115,7 @@ test('setupIsolatedWorkDir conditionally copies credentials based on GD_DEV_USE_
   // 1. Without GD_DEV_USE_JETSKI (Gemini CLI mode)
   delete process.env.GD_DEV_USE_JETSKI;
   delete process.env.JETSKI_DIR;
-  const geminiWorkDir = setupIsolatedWorkDir('test-dev-gemini');
+  const geminiWorkDir = setupGuideDevWorkDir('test-dev-gemini');
   const geminiTempHome = path.dirname(geminiWorkDir);
   
   assert.ok(fs.existsSync(path.join(geminiTempHome, '.gemini', 'oauth_creds.json')), 'Gemini credentials should be copied');
@@ -129,7 +129,7 @@ test('setupIsolatedWorkDir conditionally copies credentials based on GD_DEV_USE_
 
   // 2. With GD_DEV_USE_JETSKI=1 (Jetski CLI mode)
   process.env.GD_DEV_USE_JETSKI = '1';
-  const jetskiWorkDir = setupIsolatedWorkDir('test-dev-jetski');
+  const jetskiWorkDir = setupGuideDevWorkDir('test-dev-jetski');
   const jetskiTempHome = path.dirname(jetskiWorkDir);
 
   assert.strictEqual(fs.existsSync(path.join(jetskiTempHome, '.gemini', 'oauth_creds.json')), false, 'Gemini credentials should not be copied');

--- a/guides/dev-guide.ts
+++ b/guides/dev-guide.ts
@@ -1,13 +1,13 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { rootDir, baseAppsDir } from '../lib/paths.ts';
+import { rootDir } from '../lib/paths.ts';
 import { testGrader, runPlaywright, type CalibrationResult } from './run-grader.ts';
 import { generateTargetGrader } from './grader-gen.ts';
 import { spawnAsync } from '../harness/lib/agent-shared.ts';
 import { defaultSuiteConfig, Serving, Agents, type SuiteConfig } from '../harness/config.ts';
 import { collectGuidesUsed } from '../harness/lib/guidance_validation.ts';
-import { setupGuideDevWorkDir, runAgent, stageBaseAppWorkspace } from './lib/utils.ts';
+import { setupGuideDevWorkDir, runAgent, copyBaseAppToWorkspace } from './lib/utils.ts';
 import {
   buildSolutionPrompt,
   buildZeroPassratePrompt,
@@ -191,10 +191,7 @@ async function generateTargetPatch(guideDirAbs: string, baseApp: string, patchTy
   const agent = patchType === 'zero-passrate' ? getDefaultSolutionAgent() : patchType;
   const workDir = setupGuideDevWorkDir(`${baseApp}-${patchType}`, undefined, agent);
   try {
-    fs.cpSync(path.join(baseAppsDir, baseApp), workDir, {
-      recursive: true,
-      filter: (src) => !src.includes('node_modules')
-    });
+    await copyBaseAppToWorkspace(baseApp, workDir);
 
     fs.copyFileSync(path.join(guideDirAbs, GUIDE_FILE), path.join(workDir, GUIDE_FILE));
     fs.copyFileSync(path.join(guideDirAbs, EXPECTATIONS_FILE), path.join(workDir, EXPECTATIONS_FILE));
@@ -229,10 +226,7 @@ async function generateTargetTask(guideDirAbs: string, baseApp: string): Promise
   try {
     fs.copyFileSync(path.join(guideDirAbs, GUIDE_FILE), path.join(workDir, GUIDE_FILE));
     fs.copyFileSync(path.join(guideDirAbs, EXPECTATIONS_FILE), path.join(workDir, EXPECTATIONS_FILE));
-    const sourceBaseAppDir = path.join(baseAppsDir, baseApp);
-    if (fs.existsSync(sourceBaseAppDir)) {
-      await fs.promises.cp(sourceBaseAppDir, workDir, { recursive: true });
-    }
+    await copyBaseAppToWorkspace(baseApp, workDir);
 
     const prompt = buildTargetTaskPrompt({
       guideFile: GUIDE_FILE,
@@ -314,21 +308,18 @@ async function runAgentTest(targetDir: string, guideName: string, guidedOnly = f
 
       // 1. Grade base app (with zero-passrate baseline applied)
       const zeroPassratePatch = path.join(targetsDir, baseApp, ZERO_PASSRATE_PATCH_FILE);
-
-      const { workDir: stagingDir, cleanup } = stageBaseAppWorkspace(baseApp, zeroPassratePatch, `pre-grade-${baseApp}`);
-      try {
-        process.env.PATCH_FILE = path.resolve(zeroPassratePatch);
-        const preResults = await gradeOutput(stagingDir, targetGraderPath, path.join(targetDir, 'test-app-results', baseApp, 'pre-grade-report'));
-        if (preResults) results['pre'] = preResults;
-      } finally {
-        delete process.env.PATCH_FILE;
-        cleanup();
-      }
+      const preResults = await gradeOutput(
+        targetsDir,
+        targetGraderPath,
+        path.join(targetDir, 'test-app-results', baseApp, 'pre-grade-report'),
+        zeroPassratePatch
+      );
+      if (preResults) results['pre'] = preResults;
 
       // 2. Run agent suite
       const { runSuite } = await import('../harness/run_suite.ts');
       const testOutputDir = path.join(targetDir, 'test-app-results', baseApp);
-      const agentOverride = process.env.GD_DEV_USE_JETSKI === '1' ? Agents.JETSKI_CLI : undefined;
+      const agent = getDefaultSolutionAgent();
       await runSuite({
         name: `${guideName}-${baseApp}`,
         outputDir: testOutputDir,
@@ -338,7 +329,7 @@ async function runAgentTest(targetDir: string, guideName: string, guidedOnly = f
         guidedOnly,
         suiteConfig: {
           ...suiteConfig,
-          ...(agentOverride ? { agent: agentOverride } : {}),
+          agent,
         },
       });
 
@@ -347,11 +338,13 @@ async function runAgentTest(targetDir: string, guideName: string, guidedOnly = f
       for (const runType of runTypes) {
         const resultDir = path.join(testOutputDir, '1', guideName, baseApp, runType);
         if (!fs.existsSync(resultDir)) continue;
-
+        const patchFile = path.join(resultDir, 'agent.patch');
         const gradeResults = await gradeOutput(
           resultDir,
           targetGraderPath,
-          path.join(resultDir, 'grade-report')
+          path.join(resultDir, 'grade-report'),
+          patchFile,
+          zeroPassratePatch
         );
         if (gradeResults) results[runType] = gradeResults;
       }
@@ -361,22 +354,28 @@ async function runAgentTest(targetDir: string, guideName: string, guidedOnly = f
       if (fs.existsSync(guidedDir)) {
         const suiteConfig = defaultSuiteConfig;
         const servingMode = suiteConfig.serving as any;
-        const activeAgent = agentOverride || suiteConfig.agent;
+        const activeAgent = agent;
         const usage = await collectGuidesUsed(guidedDir, servingMode, activeAgent);
         guidesConsumed = [...new Set([...usage.retrievedGuides, ...usage.fileReadGuides])];
       }
 
-      printTestComparison(results, guidesConsumed);
+      printTestComparison(results, guidesConsumed, baseApp);
     })
   );
 }
 
-async function gradeOutput(appDir: string, graderPath: string, outputDir: string): Promise<{ passed: number; total: number } | null> {
+async function gradeOutput(
+  appDir: string,
+  graderPath: string,
+  outputDir: string,
+  patchFile?: string,
+  zeroPassrateFile?: string
+): Promise<{ passed: number; total: number } | null> {
   const label = path.basename(path.dirname(outputDir));
   console.log(cYellow(`\nGrading ${label}...`));
 
   try {
-    const gradeResults = await runPlaywright(appDir, graderPath, outputDir, 'pipe');
+    const gradeResults = await runPlaywright(appDir, graderPath, outputDir, 'pipe', patchFile, zeroPassrateFile);
     const passed = gradeResults.stats?.expected || 0;
     const failed = gradeResults.stats?.unexpected || 0;
     const total = passed + failed;
@@ -393,7 +392,8 @@ async function gradeOutput(appDir: string, graderPath: string, outputDir: string
 
 export function printTestComparison(
   results: Record<string, { passed: number; total: number }>,
-  guidesConsumed?: string[]
+  guidesConsumed: string[] | undefined,
+  baseApp: string
 ): void {
   const total = results.pre?.total || results.guided?.total || results.unguided?.total || 0;
   if (total === 0) return;
@@ -404,7 +404,7 @@ export function printTestComparison(
     return `  ${label.padEnd(pad)} ${r.passed}/${r.total} checks passed (${pct}%)`;
   };
 
-  console.log(cBold(`\nAgent test results:`));
+  console.log(cBold(`\nAgent test results (${baseApp}):`));
   console.log(fmt('Base app (zero-passrate):', results.pre, 25));
   console.log(fmt('Unguided:', results.unguided, 25));
   console.log(fmt('Guided:', results.guided, 25));

--- a/guides/dev-guide.ts
+++ b/guides/dev-guide.ts
@@ -7,7 +7,7 @@ import { generateTargetGrader } from './grader-gen.ts';
 import { spawnAsync } from '../harness/lib/agent-shared.ts';
 import { defaultSuiteConfig, Serving, Agents, type SuiteConfig } from '../harness/config.ts';
 import { collectGuidesUsed } from '../harness/lib/guidance_validation.ts';
-import { setupIsolatedWorkDir, runAgentForModel, stageBaseAppWorkspace, type AgentName } from './lib/utils.ts';
+import { setupGuideDevWorkDir, runAgent, stageBaseAppWorkspace } from './lib/utils.ts';
 import {
   buildSolutionPrompt,
   buildZeroPassratePrompt,
@@ -182,14 +182,14 @@ export async function devGuide(targetDirRaw: string, options: DevGuideOptions = 
 
   // Summary
   const defaultAgent = getDefaultSolutionAgent();
-  printSummary(targetDir, currentInv, { success: overallSuccess, solutions: { [defaultAgent]: { passed: 0, failed: 0, failingTests: [] }, claude: { passed: 0, failed: 0, failingTests: [] }, codex: { passed: 0, failed: 0, failingTests: [] } }, zeroPassrate: { passed: 0, failed: 0, passingTests: [] } }, 1);
+  printSummary(targetDir, currentInv, { success: overallSuccess, solutions: { [defaultAgent]: { passed: 0, failed: 0, failingTests: [] }, [Agents.CLAUDE_CODE]: { passed: 0, failed: 0, failingTests: [] }, [Agents.CODEX_CLI]: { passed: 0, failed: 0, failingTests: [] } }, zeroPassrate: { passed: 0, failed: 0, passingTests: [] } }, 1);
 
   return overallSuccess;
 }
 
 async function generateTargetPatch(guideDirAbs: string, baseApp: string, patchType: SolutionAgent | 'zero-passrate'): Promise<void> {
-  const agent: AgentName = patchType === 'zero-passrate' ? getDefaultSolutionAgent() : patchType;
-  const workDir = setupIsolatedWorkDir(`gd-gen-${baseApp}-${patchType}`, undefined, agent);
+  const agent = patchType === 'zero-passrate' ? getDefaultSolutionAgent() : patchType;
+  const workDir = setupGuideDevWorkDir(`${baseApp}-${patchType}`, undefined, agent);
   try {
     fs.cpSync(path.join(baseAppsDir, baseApp), workDir, {
       recursive: true,
@@ -206,7 +206,7 @@ async function generateTargetPatch(guideDirAbs: string, baseApp: string, patchTy
       ? buildZeroPassratePrompt({ guideFile: GUIDE_FILE, expectationsFile: EXPECTATIONS_FILE, workDir })
       : buildSolutionPrompt({ guideFile: GUIDE_FILE, expectationsFile: EXPECTATIONS_FILE, workDir });
 
-    await runAgentForModel(agent, prompt, workDir);
+    await runAgent(agent, prompt, workDir);
 
     const patchRelFile = patchType === 'zero-passrate' ? ZERO_PASSRATE_PATCH_FILE : SOLUTION_PATCH_FILES[patchType];
     const destPatch = path.join(guideDirAbs, TARGETS_DIR, baseApp, patchRelFile);
@@ -225,7 +225,7 @@ async function generateTargetPatch(guideDirAbs: string, baseApp: string, patchTy
 }
 
 async function generateTargetTask(guideDirAbs: string, baseApp: string): Promise<void> {
-  const workDir = setupIsolatedWorkDir(`gd-gen-${baseApp}-task`);
+  const workDir = setupGuideDevWorkDir(`${baseApp}-task`);
   try {
     fs.copyFileSync(path.join(guideDirAbs, GUIDE_FILE), path.join(workDir, GUIDE_FILE));
     fs.copyFileSync(path.join(guideDirAbs, EXPECTATIONS_FILE), path.join(workDir, EXPECTATIONS_FILE));
@@ -240,7 +240,7 @@ async function generateTargetTask(guideDirAbs: string, baseApp: string): Promise
       baseApp,
     });
 
-    await runAgentForModel(getDefaultSolutionAgent(), prompt, workDir);
+    await runAgent(getDefaultSolutionAgent(), prompt, workDir);
 
     const generatedTask = path.join(workDir, TASK_FILE);
     if (fs.existsSync(generatedTask)) {
@@ -314,11 +314,10 @@ async function runAgentTest(targetDir: string, guideName: string, guidedOnly = f
 
       // 1. Grade base app (with zero-passrate baseline applied)
       const zeroPassratePatch = path.join(targetsDir, baseApp, ZERO_PASSRATE_PATCH_FILE);
-      const patchToApply = fs.existsSync(zeroPassratePatch) ? zeroPassratePatch : undefined;
 
-      const { workDir: stagingDir, cleanup } = stageBaseAppWorkspace(baseApp, patchToApply, `gd-pre-grade-${baseApp}`);
+      const { workDir: stagingDir, cleanup } = stageBaseAppWorkspace(baseApp, zeroPassratePatch, `pre-grade-${baseApp}`);
       try {
-        if (patchToApply) process.env.PATCH_FILE = path.resolve(patchToApply);
+        process.env.PATCH_FILE = path.resolve(zeroPassratePatch);
         const preResults = await gradeOutput(stagingDir, targetGraderPath, path.join(targetDir, 'test-app-results', baseApp, 'pre-grade-report'));
         if (preResults) results['pre'] = preResults;
       } finally {

--- a/guides/feedback-handler.ts
+++ b/guides/feedback-handler.ts
@@ -11,7 +11,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import fs from 'node:fs';
-import { runCommand, runAgentForModel, escapeLeftAngleBracket } from './lib/utils.ts';
+import { runCommand, runAgent, escapeLeftAngleBracket } from './lib/utils.ts';
 import { parsePassRates, type PassRates } from './lib/utils.ts';
 import { getDefaultSolutionAgent } from '../lib/guide-validation.ts';
 
@@ -106,7 +106,7 @@ Note: \`reviewThreads\` contains inline comments and their resolution status. \`
 Output your response as a clear markdown summary and TODO list.
 `;
 
-  const synthesis = await runAgentForModel(getDefaultSolutionAgent(), plannerPrompt, undefined, { captureOutput: true });
+  const synthesis = await runAgent(getDefaultSolutionAgent(), plannerPrompt, undefined, { captureOutput: true });
   console.log('\n--- Synthesis & Plan ---');
   console.log(synthesis);
   console.log('------------------------\n');
@@ -145,7 +145,7 @@ Focus on the source files. Do not run \`gd dev\` or try to calibrate the grader,
 Use your file editing tools to make the changes.
 `;
   try {
-    const response = await runAgentForModel(getDefaultSolutionAgent(), fixerPrompt, undefined, { captureOutput: true });
+    const response = await runAgent(getDefaultSolutionAgent(), fixerPrompt, undefined, { captureOutput: true });
     console.log('✅ Fixes applied to source files');
     return response;
   } catch (err) {

--- a/guides/gd-dev-prompts.test.ts
+++ b/guides/gd-dev-prompts.test.ts
@@ -6,6 +6,7 @@ import {
   buildTargetGraderPrompt,
   buildTargetTaskPrompt,
 } from './gd-dev-prompts.ts';
+import { Agents } from '../harness/config.ts';
 
 test('buildSolutionPrompt includes instructions and paths', () => {
   const prompt = buildSolutionPrompt({
@@ -35,9 +36,9 @@ test('buildTargetGraderPrompt includes Option B scoping rules', () => {
     guideFile: 'guide.md',
     expectationsFile: 'expectations.md',
     solutionPatchFiles: {
-      jetski: 'patches/jetski-solution.patch',
-      claude: 'patches/claude-solution.patch',
-      codex: 'patches/codex-solution.patch',
+      [Agents.JETSKI_CLI]: 'patches/jetski-solution.patch',
+      [Agents.CLAUDE_CODE]: 'patches/claude-solution.patch',
+      [Agents.CODEX_CLI]: 'patches/codex-solution.patch',
     },
     zeroPassratePatchFile: 'patches/zero-passrate.patch',
     graderFile: 'grader.ts',
@@ -57,9 +58,9 @@ test('buildTargetGraderPrompt formats failure context correctly when provided', 
     guideFile: 'guide.md',
     expectationsFile: 'expectations.md',
     solutionPatchFiles: {
-      jetski: 'patches/jetski-solution.patch',
-      claude: 'patches/claude-solution.patch',
-      codex: 'patches/codex-solution.patch',
+      [Agents.JETSKI_CLI]: 'patches/jetski-solution.patch',
+      [Agents.CLAUDE_CODE]: 'patches/claude-solution.patch',
+      [Agents.CODEX_CLI]: 'patches/codex-solution.patch',
     },
     zeroPassratePatchFile: 'patches/zero-passrate.patch',
     graderFile: 'grader.ts',

--- a/guides/gd-dev-prompts.ts
+++ b/guides/gd-dev-prompts.ts
@@ -6,7 +6,8 @@
  * type-safe parameter interpolation.
  */
 
-import type { SolutionAgent } from '../lib/guide-validation.ts';
+import { type SolutionAgent } from '../lib/guide-validation.ts';
+import { Agents } from '../harness/config.ts';
 
 export interface PatchPromptOptions {
   guideFile: string;
@@ -86,10 +87,10 @@ Analyze this failure and modify the existing grader file to fix these assertions
     : '';
 
   const agentLabels: Record<SolutionAgent, string> = {
-    gemini: 'Gemini CLI',
-    jetski: 'Jetski CLI',
-    claude: 'Claude Code',
-    codex: 'Codex CLI',
+    [Agents.GEMINI_CLI]: 'Gemini CLI',
+    [Agents.JETSKI_CLI]: 'Jetski CLI',
+    [Agents.CLAUDE_CODE]: 'Claude Code',
+    [Agents.CODEX_CLI]: 'Codex CLI',
   };
 
   const solutionList = Object.entries(opts.solutionPatchFiles)

--- a/guides/grader-gen.ts
+++ b/guides/grader-gen.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { baseAppsDir } from '../lib/paths.ts';
-import { setupIsolatedWorkDir, runAgentForModel } from './lib/utils.ts';
+import { setupGuideDevWorkDir, runAgent } from './lib/utils.ts';
 import { buildTargetGraderPrompt } from './gd-dev-prompts.ts';
 import {
   GUIDE_FILE,
@@ -25,7 +25,7 @@ export async function generateTargetGrader(guideDirAbs: string, baseApp: string,
   const relativeGuidePath = path.relative(repoRoot, guideDirAbs);
   const relativeWorkSubdir = path.join(relativeGuidePath, 'targets', baseApp);
 
-  const workDir = setupIsolatedWorkDir(`gd-gen-${baseApp}-grader`, relativeWorkSubdir);
+  const workDir = setupGuideDevWorkDir(`${baseApp}-grader`, relativeWorkSubdir);
   try {
     fs.cpSync(path.join(baseAppsDir, baseApp), workDir, {
       recursive: true,
@@ -96,7 +96,7 @@ export async function generateTargetGrader(guideDirAbs: string, baseApp: string,
       failureContext,
     });
 
-    await runAgentForModel(getDefaultSolutionAgent(), prompt, workDir);
+    await runAgent(getDefaultSolutionAgent(), prompt, workDir);
 
     const generatedGrader = path.join(workDir, GRADER_FILE);
     if (fs.existsSync(generatedGrader)) {

--- a/guides/grader-gen.ts
+++ b/guides/grader-gen.ts
@@ -36,23 +36,35 @@ export async function generateTargetGrader(guideDirAbs: string, baseApp: string,
 
     const tempHome = path.resolve(workDir, '../../../../..'); // workDir is tempHome/guides/cat/guide/targets/app
     
-    // Copy patch-utils.ts to tempHome/lib/patch-utils.ts
-    const srcLibDir = path.resolve(repoRoot, 'lib');
+    // =========================================================================
+    // 1. RUNTIME EXECUTION DEPENDENCIES (in tempHome)
+    // Required so grader.ts runtime import `../../../../test-fixture.ts` and
+    // test-fixture.ts import `../lib/patch-utils.ts` resolve during Playwright execution.
+    // =========================================================================
     fs.mkdirSync(path.join(tempHome, 'lib'), { recursive: true });
     fs.copyFileSync(
-      path.join(srcLibDir, 'patch-utils.ts'),
+      path.resolve(repoRoot, 'lib', 'patch-utils.ts'),
       path.join(tempHome, 'lib', 'patch-utils.ts')
     );
-
-    // Copy template.grader.ts, test-fixture.ts, and pattern libraries to tempHome/guides/
     fs.mkdirSync(path.join(tempHome, 'guides'), { recursive: true });
+    fs.copyFileSync(
+      path.resolve(repoRoot, 'guides', 'test-fixture.ts'),
+      path.join(tempHome, 'guides', 'test-fixture.ts')
+    );
+
+    // =========================================================================
+    // 2. AGENT SANDBOX VIEWING & EDITING DEPENDENCIES (in workDir)
+    // All reference files, pattern libraries, API definitions, and patches must live
+    // directly inside `workDir` so the CLI agent's `read_file` tool can access them
+    // without triggering sandbox "Path not in workspace" security errors.
+    // =========================================================================
     fs.copyFileSync(
       path.resolve(repoRoot, 'guides', 'template.grader.ts'),
       path.join(workDir, 'template.grader.ts')
     );
     fs.copyFileSync(
       path.resolve(repoRoot, 'guides', 'test-fixture.ts'),
-      path.join(tempHome, 'guides', 'test-fixture.ts')
+      path.join(workDir, 'test-fixture.ts')
     );
     fs.copyFileSync(
       path.resolve(repoRoot, 'guides', 'parser-pattern-library.test.ts'),
@@ -62,17 +74,19 @@ export async function generateTargetGrader(guideDirAbs: string, baseApp: string,
       path.resolve(repoRoot, 'guides', 'playwright-pattern-library.grader.ts'),
       path.join(workDir, 'playwright-pattern-library.grader.ts')
     );
+    fs.copyFileSync(
+      path.resolve(repoRoot, 'guides', 'node_modules', 'ts-morph', 'lib', 'ts-morph.d.ts'),
+      path.join(workDir, 'ts-morph.d.ts')
+    );
+    fs.copyFileSync(
+      path.resolve(repoRoot, 'guides', 'node_modules', 'linkedom', 'types', 'index.d.ts'),
+      path.join(workDir, 'linkedom.d.ts')
+    );
 
     const sourcePatches = path.join(guideDirAbs, TARGETS_DIR, baseApp, PATCHES_DIR);
     if (fs.existsSync(sourcePatches)) {
       fs.cpSync(sourcePatches, path.join(workDir, PATCHES_DIR), { recursive: true });
     }
-
-    const parserPatternsPath = path.join(workDir, 'parser-pattern-library.test.ts');
-    const playwrightPatternsPath = path.join(workDir, 'playwright-pattern-library.grader.ts');
-
-    const tsMorphDts = path.join(repoRoot, 'guides', 'node_modules/ts-morph/lib/ts-morph.d.ts');
-    const linkedomDts = path.join(repoRoot, 'guides', 'node_modules/linkedom/types/index.d.ts');
 
     const targetDir = path.join(guideDirAbs, TARGETS_DIR, baseApp);
     const activeAgents = getActiveSolutionAgents(targetDir);
@@ -89,10 +103,10 @@ export async function generateTargetGrader(guideDirAbs: string, baseApp: string,
       graderFile: GRADER_FILE,
       baseApp,
       templateFile: 'template.grader.ts',
-      parserPatternLibraryPath: parserPatternsPath,
-      playwrightPatternLibraryPath: playwrightPatternsPath,
-      tsMorphDtsPath: tsMorphDts,
-      linkedomDtsPath: linkedomDts,
+      parserPatternLibraryPath: path.join(workDir, 'parser-pattern-library.test.ts'),
+      playwrightPatternLibraryPath: path.join(workDir, 'playwright-pattern-library.grader.ts'),
+      tsMorphDtsPath: path.join(workDir, 'ts-morph.d.ts'),
+      linkedomDtsPath: path.join(workDir, 'linkedom.d.ts'),
       failureContext,
     });
 

--- a/guides/lib/utils.ts
+++ b/guides/lib/utils.ts
@@ -10,17 +10,16 @@ import {
   spawnAsync,
   setupAgentCredentials,
   getAgentCommandAndArgs,
-  type AgentName,
 } from '../../harness/lib/agent-shared.ts';
-
-export { setupAgentCredentials, getAgentCommandAndArgs, type AgentName };
+import { Agents } from '../../harness/config.ts';
 
 export function stageBaseAppWorkspace(
   baseApp: string,
-  patchFile?: string,
-  prefix: string = 'grade-run',
+  patchFile: string,
+  suffix: string,
   zeroPassrateFile?: string
 ): { workDir: string; cleanup: () => void } {
+  const prefix = suffix.startsWith('gd-') ? suffix : `gd-${suffix}`;
   const tempHome = createIsolatedHome(prefix);
   const workDir = path.join(tempHome, baseApp);
   fs.mkdirSync(workDir, { recursive: true });
@@ -58,7 +57,7 @@ export async function runCommand(command: string, args: string[], cwd?: string, 
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
       cwd,
-      env: env || { ...process.env },
+      env,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
 
@@ -81,8 +80,8 @@ export async function runCommand(command: string, args: string[], cwd?: string, 
   });
 }
 
-export async function runAgentForModel(
-  agent: AgentName,
+export async function runAgent(
+  agent: Agents,
   prompt: string,
   workDir?: string,
   options: { captureOutput?: boolean } = {}
@@ -108,13 +107,13 @@ export async function runAgentForModel(
   return '';
 }
 
-export function setupIsolatedWorkDir(prefix: string, relativeWorkSubdir?: string, agent?: AgentName): string {
-  const tempHome = createIsolatedHome(prefix);
+export function setupGuideDevWorkDir(suffix: string, relativeWorkSubdir?: string, agent?: Agents): string {
+  const tempHome = createIsolatedHome(`gd-gen-${suffix}`);
   const workDir = relativeWorkSubdir ? path.join(tempHome, relativeWorkSubdir) : path.join(tempHome, 'work');
   fs.mkdirSync(workDir, { recursive: true });
 
   const geminiDest = path.join(tempHome, '.gemini');
-  const effectiveAgent: AgentName = agent ?? (process.env.GD_DEV_USE_JETSKI === '1' ? 'jetski' : 'gemini');
+  const effectiveAgent: Agents = agent ?? (process.env.GD_DEV_USE_JETSKI === '1' ? Agents.JETSKI_CLI : Agents.GEMINI_CLI);
   setupAgentCredentials(effectiveAgent, tempHome);
 
   createTrustedFolders(geminiDest, [tempHome]);

--- a/guides/lib/utils.ts
+++ b/guides/lib/utils.ts
@@ -2,10 +2,8 @@ import { spawn } from 'node:child_process';
 import path from 'node:path';
 import fs from 'node:fs';
 import { rootDir, baseAppsDir } from '../../lib/paths.ts';
-import { applyPatchSync } from '../../lib/patch-utils.ts';
 import {
   createIsolatedHome,
-  cleanupIsolatedHome,
   createTrustedFolders,
   spawnAsync,
   setupAgentCredentials,
@@ -13,45 +11,18 @@ import {
 } from '../../harness/lib/agent-shared.ts';
 import { Agents } from '../../harness/config.ts';
 
-export function stageBaseAppWorkspace(
-  baseApp: string,
-  patchFile: string,
-  suffix: string,
-  zeroPassrateFile?: string
-): { workDir: string; cleanup: () => void } {
-  const prefix = suffix.startsWith('gd-') ? suffix : `gd-${suffix}`;
-  const tempHome = createIsolatedHome(prefix);
-  const workDir = path.join(tempHome, baseApp);
-  fs.mkdirSync(workDir, { recursive: true });
-
+export async function copyBaseAppToWorkspace(baseApp: string, destDir: string): Promise<void> {
   const refBaseAppDir = path.join(baseAppsDir, baseApp);
-  if (fs.existsSync(refBaseAppDir)) {
-    fs.cpSync(refBaseAppDir, workDir, {
-      recursive: true,
-      filter: (src) => !src.includes('/dist') && !src.includes('/.astro'),
-    });
+  if (!fs.existsSync(refBaseAppDir)) {
+    console.warn(`Source base app not found at ${refBaseAppDir}`);
+    return;
   }
-
-  if (zeroPassrateFile && fs.existsSync(zeroPassrateFile)) {
-    if (fs.readFileSync(zeroPassrateFile, 'utf8').trim().length > 0) {
-      applyPatchSync(workDir, zeroPassrateFile);
-    }
-  }
-
-  if (patchFile && fs.existsSync(patchFile)) {
-    if (fs.readFileSync(patchFile, 'utf8').trim().length > 0) {
-      applyPatchSync(workDir, patchFile);
-    }
-  }
-
-  const cleanup = () => {
-    try {
-      cleanupIsolatedHome(tempHome);
-    } catch (e) {}
-  };
-
-  return { workDir, cleanup };
+  await fs.promises.cp(refBaseAppDir, destDir, {
+    recursive: true,
+    filter: (src) => !src.includes('/dist') && !src.includes('/.astro') && !src.includes('node_modules'),
+  });
 }
+
 
 export async function runCommand(command: string, args: string[], cwd?: string, env?: NodeJS.ProcessEnv): Promise<string> {
   return new Promise((resolve, reject) => {

--- a/guides/run-grader.ts
+++ b/guides/run-grader.ts
@@ -279,7 +279,7 @@ export async function testTargetGrader(guideDirAbs: string, baseApp: string): Pr
     const solPatchFile = SOLUTION_PATCH_FILES[agent];
     const solutionPatch = path.join(targetDir, solPatchFile);
     const solutionOutDir = path.join(targetDir, 'grade-report', `solution-${agent}`);
-    const { workDir: goldenSandbox, cleanup: cleanupGolden } = stageBaseAppWorkspace(baseApp, solutionPatch, `gd-cal-${baseApp}-${agent}`);
+    const { workDir: goldenSandbox, cleanup: cleanupGolden } = stageBaseAppWorkspace(baseApp, solutionPatch, `cal-${baseApp}-${agent}`);
     let unexpected = 0;
     try {
       console.log(cYellow(`\nRunning against ${baseApp} with ${solPatchFile} (${agent})... (Expecting 100% pass)`));
@@ -326,7 +326,7 @@ export async function testTargetGrader(guideDirAbs: string, baseApp: string): Pr
   let zeroPassrateStatus = '';
   let zeroPassrateFailed = false;
   const zeroPassrateTask = (async () => {
-    const { workDir: zeroPassrateSandbox, cleanup: cleanupZeroPassrate } = stageBaseAppWorkspace(baseApp, zeroPassratePatch, `gd-cal-${baseApp}-zp`);
+    const { workDir: zeroPassrateSandbox, cleanup: cleanupZeroPassrate } = stageBaseAppWorkspace(baseApp, zeroPassratePatch, `cal-${baseApp}-zp`);
     let passed = 0;
     try {
       console.log(cYellow(`Running against ${baseApp} with ${ZERO_PASSRATE_PATCH_FILE}... (Expecting 100% fail)`));

--- a/guides/run-grader.ts
+++ b/guides/run-grader.ts
@@ -8,7 +8,9 @@ import { fileURLToPath } from 'node:url';
 import { guidesDir } from '../lib/paths.ts';
 import { cRed, cYellow, cCyan } from '../lib/colors.ts';
 import { TARGETS_DIR, getActiveSolutionAgents, SOLUTION_PATCH_FILES, type SolutionAgent, ZERO_PASSRATE_PATCH_FILE, GRADER_FILE, getSupportedBaseApps } from '../lib/guide-validation.ts';
-import { stageBaseAppWorkspace } from './lib/utils.ts';
+import { copyBaseAppToWorkspace } from './lib/utils.ts';
+import { createIsolatedHome, cleanupIsolatedHome } from '../harness/lib/agent-shared.ts';
+import { applyPatchSync } from '../lib/patch-utils.ts';
 
 export interface PlaywrightOptions {
   targetPathAbs: string;
@@ -18,6 +20,28 @@ export interface PlaywrightOptions {
   jsonOutputName?: string;
   patchFile?: string;
   stdio?: 'inherit' | 'ignore' | 'pipe';
+}
+
+async function stageGradingWorkspace(
+  baseApp: string,
+  patchFile: string,
+  zeroPassrateFile?: string
+): Promise<{ workDir: string; cleanup: () => void }> {
+  const tempHome = createIsolatedHome('grade-run');
+  const workDir = path.join(tempHome, baseApp);
+
+  await copyBaseAppToWorkspace(baseApp, workDir);
+
+  for (const file of [zeroPassrateFile, patchFile]) {
+    if (file && fs.existsSync(file) && fs.readFileSync(file, 'utf8').trim()) {
+      applyPatchSync(workDir, file);
+    }
+  }
+
+  return {
+    workDir,
+    cleanup: () => { try { cleanupIsolatedHome(tempHome); } catch {} }
+  };
 }
 
 export function executePlaywright(opts: PlaywrightOptions): ChildProcess {
@@ -59,26 +83,19 @@ export async function runPlaywright(
   targetPathAbs: string,
   graderPath: string,
   htmlOutputDir: string,
-  stdio: 'inherit' | 'ignore' | 'pipe' = 'inherit'
+  stdio: 'inherit' | 'ignore' | 'pipe' = 'inherit',
+  patchFile?: string,
+  zeroPassrateFile?: string
 ): Promise<any> {
   const tmpJson = path.join(os.tmpdir(), `pw-results-${Date.now()}-${Math.random().toString(36).substring(7)}.json`);
 
   const isDir = fs.existsSync(targetPathAbs) && fs.statSync(targetPathAbs).isDirectory();
-  const appDir = isDir ? targetPathAbs : path.dirname(targetPathAbs);
-  const agentPatch = path.join(appDir, 'agent.patch');
   let effectiveTargetPath = targetPathAbs;
   let cleanupGradingDir: (() => void) | null = null;
 
-  const hasPatch = fs.existsSync(agentPatch);
-  if (hasPatch) {
-    const targetsMatch = graderPath.match(/targets[/\\]([^/\\]+)/);
-    if (!targetsMatch) {
-      throw new Error(`Could not determine target baseApp from grader path: ${graderPath}`);
-    }
-    const baseApp = targetsMatch[1];
-    const zeroPassratePatch = path.join(path.dirname(graderPath), ZERO_PASSRATE_PATCH_FILE);
-    const zeroPassrateFile = fs.existsSync(zeroPassratePatch) ? zeroPassratePatch : undefined;
-    const { workDir: tempGradingDir, cleanup } = stageBaseAppWorkspace(baseApp, agentPatch, 'grade-run', zeroPassrateFile);
+  if (patchFile) {
+    const baseApp = path.basename(path.dirname(graderPath));
+    const { workDir: tempGradingDir, cleanup } = await stageGradingWorkspace(baseApp, patchFile, zeroPassrateFile);
     cleanupGradingDir = cleanup;
     effectiveTargetPath = isDir ? tempGradingDir : path.join(tempGradingDir, path.basename(targetPathAbs));
   }
@@ -91,7 +108,7 @@ export async function runPlaywright(
       reporters: ['json', 'html'],
       htmlOutputDir,
       jsonOutputName: tmpJson,
-      patchFile: hasPatch ? agentPatch : process.env.PATCH_FILE,
+      patchFile: patchFile,
       stdio: stdio === 'ignore' ? 'pipe' : stdio
     });
 
@@ -103,7 +120,7 @@ export async function runPlaywright(
 
     await once(child, 'close');
 
-    const effectiveAppDir = fs.existsSync(effectiveTargetPath) && fs.statSync(effectiveTargetPath).isDirectory() ? effectiveTargetPath : path.dirname(effectiveTargetPath);
+    const effectiveAppDir = isDir ? effectiveTargetPath : path.dirname(effectiveTargetPath);
     const testResultsDir = path.join(effectiveAppDir, 'test-results');
     await fs.promises.rm(testResultsDir, { recursive: true, force: true }).catch(() => {});
 
@@ -126,15 +143,14 @@ async function runPlaywrightCalibration(
   graderPath: string,
   outDir: string,
   patchFile: string,
-  result: CalibrationResult
+  result: CalibrationResult,
+  zeroPassrateFile?: string
 ): Promise<any> {
-  process.env.PATCH_FILE = patchFile;
-  const results = await runPlaywright(targetPathAbs, graderPath, outDir, 'ignore')
+  const results = await runPlaywright(targetPathAbs, graderPath, outDir, 'ignore', patchFile, zeroPassrateFile)
     .catch(err => {
       result.errorDetails = `Dev server crashed or failed to run against ${path.basename(patchFile)}: ${err.message}`;
       return null;
     });
-  delete process.env.PATCH_FILE;
 
   if (!results) {
     return null;
@@ -279,87 +295,69 @@ export async function testTargetGrader(guideDirAbs: string, baseApp: string): Pr
     const solPatchFile = SOLUTION_PATCH_FILES[agent];
     const solutionPatch = path.join(targetDir, solPatchFile);
     const solutionOutDir = path.join(targetDir, 'grade-report', `solution-${agent}`);
-    const { workDir: goldenSandbox, cleanup: cleanupGolden } = stageBaseAppWorkspace(baseApp, solutionPatch, `cal-${baseApp}-${agent}`);
     let unexpected = 0;
-    try {
-      console.log(cYellow(`\nRunning against ${baseApp} with ${solPatchFile} (${agent})... (Expecting 100% pass)`));
-      const solutionResults = await runPlaywrightCalibration(goldenSandbox, graderPath, solutionOutDir, solutionPatch, result);
+    console.log(cYellow(`\nRunning against ${baseApp} with ${solPatchFile} (${agent})... (Expecting 100% pass)`));
+    const solutionResults = await runPlaywrightCalibration(targetDir, graderPath, solutionOutDir, solutionPatch, result);
 
-      if (!solutionResults) {
-        allSolutionsPassed = false;
-        solutionStatus[agent] = `❌ FAILED (Dev server crashed or compile error)`;
-        solutionErrors.push(`[${solPatchFile}] Dev server crashed or compile error: ${result.errorDetails || 'Unknown error'}`);
-        return;
-      }
+    if (!solutionResults) {
+      allSolutionsPassed = false;
+      solutionStatus[agent] = `❌ FAILED (Dev server crashed or compile error)`;
+      solutionErrors.push(`[${solPatchFile}] Dev server crashed or compile error: ${result.errorDetails || 'Unknown error'}`);
+      return;
+    }
 
-      unexpected = solutionResults.stats?.unexpected || 0;
-      const expected = solutionResults.stats?.expected || 0;
-      if (!result.solutions[agent]) {
-        result.solutions[agent] = { passed: 0, failed: 0, failingTests: [] };
-      }
-      result.solutions[agent]!.passed = expected;
-      result.solutions[agent]!.failed = unexpected;
+    unexpected = solutionResults.stats?.unexpected || 0;
+    const expected = solutionResults.stats?.expected || 0;
+    if (!result.solutions[agent]) {
+      result.solutions[agent] = { passed: 0, failed: 0, failingTests: [] };
+    }
+    result.solutions[agent]!.passed = expected;
+    result.solutions[agent]!.failed = unexpected;
 
-      if (expected === 0 && unexpected === 0) {
-        allSolutionsPassed = false;
-        solutionStatus[agent] = `❌ FAILED (No tests were run)`;
-        solutionErrors.push(`[${solPatchFile}] No tests were run.`);
-      } else if (unexpected > 0) {
-        allSolutionsPassed = false;
-        solutionStatus[agent] = `❌ FAILED (${expected} passed, ${unexpected} failed)`;
-        result.solutions[agent]!.failingTests = solutionResults.suites?.flatMap((s: PlaywrightSuite) => collectSpecs(s, false)) || [];
-        const pwErrors = collectPlaywrightErrors(solutionResults);
-        solutionErrors.push(`[${solPatchFile}] failed ${unexpected} tests:\n\n${pwErrors}`);
-        solutionResults.suites?.forEach((suite: PlaywrightSuite) => printFailingSpecs(suite));
-      } else {
-        solutionStatus[agent] = `✅ PASSED (${expected}/${expected} passed)`;
-      }
-    } finally {
-      if (unexpected > 0) {
-        console.log(cYellow(`⚠️ Calibration failed for ${agent}. Keeping golden sandbox directory for debugging: ${goldenSandbox}`));
-      } else {
-        cleanupGolden();
-      }
+    if (expected === 0 && unexpected === 0) {
+      allSolutionsPassed = false;
+      solutionStatus[agent] = `❌ FAILED (No tests were run)`;
+      solutionErrors.push(`[${solPatchFile}] No tests were run.`);
+    } else if (unexpected > 0) {
+      allSolutionsPassed = false;
+      solutionStatus[agent] = `❌ FAILED (${expected} passed, ${unexpected} failed)`;
+      result.solutions[agent]!.failingTests = solutionResults.suites?.flatMap((s: PlaywrightSuite) => collectSpecs(s, false)) || [];
+      const pwErrors = collectPlaywrightErrors(solutionResults);
+      solutionErrors.push(`[${solPatchFile}] failed ${unexpected} tests:\n\n${pwErrors}`);
+      solutionResults.suites?.forEach((suite: PlaywrightSuite) => printFailingSpecs(suite));
+    } else {
+      solutionStatus[agent] = `✅ PASSED (${expected}/${expected} passed)`;
     }
   });
 
   let zeroPassrateStatus = '';
   let zeroPassrateFailed = false;
   const zeroPassrateTask = (async () => {
-    const { workDir: zeroPassrateSandbox, cleanup: cleanupZeroPassrate } = stageBaseAppWorkspace(baseApp, zeroPassratePatch, `cal-${baseApp}-zp`);
     let passed = 0;
-    try {
-      console.log(cYellow(`Running against ${baseApp} with ${ZERO_PASSRATE_PATCH_FILE}... (Expecting 100% fail)`));
-      const zeroPassrateResults = await runPlaywrightCalibration(zeroPassrateSandbox, graderPath, zeroPassrateOutDir, zeroPassratePatch, result);
+    console.log(cYellow(`Running against ${baseApp} with ${ZERO_PASSRATE_PATCH_FILE}... (Expecting 100% fail)`));
+    const zeroPassrateResults = await runPlaywrightCalibration(targetDir, graderPath, zeroPassrateOutDir, zeroPassratePatch, result);
 
-      if (!zeroPassrateResults) {
-        zeroPassrateFailed = true;
-        zeroPassrateStatus = `❌ FAILED (Dev server crashed or compile error)`;
-        return;
-      }
+    if (!zeroPassrateResults) {
+      zeroPassrateFailed = true;
+      zeroPassrateStatus = `❌ FAILED (Dev server crashed or compile error)`;
+      return;
+    }
 
-      passed = zeroPassrateResults.stats?.expected || 0;
-      const failed = zeroPassrateResults.stats?.unexpected || 0;
-      result.zeroPassrate.passed = passed;
-      result.zeroPassrate.failed = failed;
+    passed = zeroPassrateResults.stats?.expected || 0;
+    const failed = zeroPassrateResults.stats?.unexpected || 0;
+    result.zeroPassrate.passed = passed;
+    result.zeroPassrate.failed = failed;
 
-      if (passed === 0 && failed === 0) {
-        zeroPassrateFailed = true;
-        zeroPassrateStatus = `❌ FAILED (No tests were run for ${ZERO_PASSRATE_PATCH_FILE})`;
-      } else if (passed > 0) {
-        zeroPassrateFailed = true;
-        result.zeroPassrate.passingTests = zeroPassrateResults.suites?.flatMap((s: PlaywrightSuite) => collectSpecs(s, true)) || [];
-        zeroPassrateStatus = `❌ FAILED ([${ZERO_PASSRATE_PATCH_FILE}] incorrectly passed ${passed} tests:\n\n${collectPlaywrightErrors(zeroPassrateResults)})`;
-        zeroPassrateResults.suites?.forEach((suite: PlaywrightSuite) => printPassingSpecs(suite));
-      } else {
-        zeroPassrateStatus = `✅ PASSED (0 tests passed, as expected for anti-pattern)`;
-      }
-    } finally {
-      if (passed > 0) {
-        console.log(cYellow(`⚠️ Calibration failed. Keeping zero-passrate sandbox directory for debugging: ${zeroPassrateSandbox}`));
-      } else {
-        cleanupZeroPassrate();
-      }
+    if (passed === 0 && failed === 0) {
+      zeroPassrateFailed = true;
+      zeroPassrateStatus = `❌ FAILED (No tests were run for ${ZERO_PASSRATE_PATCH_FILE})`;
+    } else if (passed > 0) {
+      zeroPassrateFailed = true;
+      result.zeroPassrate.passingTests = zeroPassrateResults.suites?.flatMap((s: PlaywrightSuite) => collectSpecs(s, true)) || [];
+      zeroPassrateStatus = `❌ FAILED ([${ZERO_PASSRATE_PATCH_FILE}] incorrectly passed ${passed} tests:\n\n${collectPlaywrightErrors(zeroPassrateResults)})`;
+      zeroPassrateResults.suites?.forEach((suite: PlaywrightSuite) => printPassingSpecs(suite));
+    } else {
+      zeroPassrateStatus = `✅ PASSED (0 tests passed, as expected for anti-pattern)`;
     }
   })();
 

--- a/harness/agents/claude-code-agent.ts
+++ b/harness/agents/claude-code-agent.ts
@@ -1,8 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { getSuiteConfig, createIsolatedHome, cleanupIsolatedHome, parseAgentArgs, updateMcpConfig, createWorkDir, copySkills, watchLogFile, runCliAgentCommand, parseJsonlFile, copyFileIfExists, type GuideUsage } from '../lib/agent-shared.ts';
-import config, { Agents, Serving } from '../config.ts';
+import { cleanupIsolatedHome, parseAgentArgs, watchLogFile, runCliAgentCommand, parseJsonlFile, copyFileIfExists, setupIsolatedWorkDir, type GuideUsage } from '../lib/agent-shared.ts';
+import config, { Agents } from '../config.ts';
 import { MODERN_WEB_LOG_FILE } from '../../constants.ts';
 import { generateClaudeTrajectoryHtml } from '../lib/claude-trajectory-viewer.ts';
 
@@ -31,42 +31,6 @@ const TRAJECTORY_GLOB = '*.jsonl';
 
 function getSessionFiles(dir: string, recursive = false): string[] {
   return fs.globSync(recursive ? `**/${TRAJECTORY_GLOB}` : TRAJECTORY_GLOB, { cwd: dir });
-}
-
-
-// Usage: node claude-code-agent.ts <prompt> <runType> <targetDir> <templateDir>
-/**
- * Sets up an isolated HOME and work directory to ensure test isolation.
- * @returns {string} The path to the temporary work directory.
- */
-function setupIsolatedWorkDir(templateDir: string, runType: string, targetDir?: string): string {
-  const tempHome = createIsolatedHome('ghh-claude', targetDir);
-  const workDir = createWorkDir(templateDir, tempHome, runType);
-
-  setupClaudeCodeCredentials(tempHome);
-
-  // Set environment variables
-  process.env.HOME = tempHome;
-
-  // Add CLAUDE context and MCP servers for guided runs
-  if (runType === 'guided') {
-    const suiteConfig = getSuiteConfig();
-    const approach = suiteConfig.serving;
-
-    if (approach === Serving.SKILLS_CLI || approach === Serving.SKILLS) {
-      copySkills(tempHome, Agents.CLAUDE_CODE, approach === Serving.SKILLS_CLI, suiteConfig.skillsToEnable);
-    } else if (approach === Serving.MCP) {
-      updateMcpConfig(
-        path.join(tempHome, '.claude.json'),
-        suiteConfig.mcpServersToEnable,
-        config.environment.modernWebServerPath,
-        config.environment.mcpApiKey,
-        Agents.CLAUDE_CODE
-      );
-    }
-  }
-
-  return workDir;
 }
 
 function exportClaudeCodeTrajectories(workDir: string, targetDir: string): void {
@@ -126,7 +90,7 @@ function exportClaudeCodeTrajectories(workDir: string, targetDir: string): void 
  */
 async function run() {
   const { userPrompt, runType, targetDir, templateDir } = parseAgentArgs('claude-code-agent.ts');
-  const workDir = setupIsolatedWorkDir(templateDir, runType, targetDir);
+  const workDir = setupIsolatedWorkDir(Agents.CLAUDE_CODE, templateDir, runType, targetDir);
 
   if (!workDir || !fs.existsSync(workDir)) {
     throw new Error(`Failed to initialize working directory: ${workDir}`);

--- a/harness/agents/codex-cli-agent.ts
+++ b/harness/agents/codex-cli-agent.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { getSuiteConfig, createIsolatedHome, cleanupIsolatedHome, parseAgentArgs, createWorkDir, copySkills, updateMcpConfig, watchLogFile, runCliAgentCommand, parseJsonlFile, type GuideUsage } from '../lib/agent-shared.ts';
+import { cleanupIsolatedHome, parseAgentArgs, watchLogFile, runCliAgentCommand, parseJsonlFile, setupIsolatedWorkDir, type GuideUsage } from '../lib/agent-shared.ts';
 import config, { Agents, Serving } from '../config.ts';
 import { MODERN_WEB_LOG_FILE } from '../../constants.ts';
 import { generateCodexTrajectoryHtml } from '../lib/codex-trajectory-viewer.ts';
@@ -34,39 +34,6 @@ const TRAJECTORY_GLOB = 'session-*.jsonl';
 
 function getSessionFiles(dir: string, recursive = false): string[] {
   return fs.globSync(recursive ? `**/${TRAJECTORY_GLOB}` : TRAJECTORY_GLOB, { cwd: dir });
-}
-
-// Usage: node codex-cli-agent.ts <prompt> <runType> <targetDir> <templateDir>
-/**
- * Sets up an isolated HOME and work directory to ensure test isolation.
- * @returns {string} The path to the temporary work directory.
- */
-function setupIsolatedWorkDir(templateDir: string, runType: string, targetDir?: string): string {
-  const tempHome = createIsolatedHome('ghh-codex', targetDir);
-  const workDir = createWorkDir(templateDir, tempHome, runType);
-
-  setupCodexCliCredentials(tempHome);
-
-  process.env.HOME = tempHome;
-
-  if (runType === 'guided') {
-    const suiteConfig = getSuiteConfig();
-    const approach = suiteConfig.serving;
-
-    if (approach === Serving.SKILLS_CLI || approach === Serving.SKILLS) {
-      copySkills(tempHome, Agents.CODEX_CLI, approach === Serving.SKILLS_CLI, suiteConfig.skillsToEnable);
-    } else if (approach === Serving.MCP) {
-      updateMcpConfig(
-        path.join(tempHome, '.codex', 'config.toml'),
-        suiteConfig.mcpServersToEnable,
-        config.environment.modernWebServerPath,
-        config.environment.mcpApiKey,
-        Agents.CODEX_CLI
-      );
-    }
-  }
-
-  return workDir;
 }
 
 function exportCodexTrajectories(workDir: string, targetDir: string): void {
@@ -113,7 +80,7 @@ function exportCodexTrajectories(workDir: string, targetDir: string): void {
 
 async function run() {
   const { userPrompt, runType, targetDir, templateDir } = parseAgentArgs('codex-cli-agent.ts');
-  const workDir = setupIsolatedWorkDir(templateDir, runType, targetDir);
+  const workDir = setupIsolatedWorkDir(Agents.CODEX_CLI, templateDir, runType, targetDir);
 
   if (!workDir || !fs.existsSync(workDir)) {
     throw new Error(`Failed to initialize working directory: ${workDir}`);

--- a/harness/agents/gemini-cli-agent.ts
+++ b/harness/agents/gemini-cli-agent.ts
@@ -1,8 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import config, { Agents, Serving } from '../config.ts';
-import { getSuiteConfig, updateMcpConfig, createIsolatedHome, cleanupIsolatedHome, copyFileIfExists, parseAgentArgs, createWorkDir, copySkills, watchLogFile, exportTrajectories, runCliAgentCommand, parseJsonlFile, type GuideUsage } from '../lib/agent-shared.ts';
+import config, { Agents } from '../config.ts';
+import { cleanupIsolatedHome, copyFileIfExists, parseAgentArgs, watchLogFile, exportTrajectories, runCliAgentCommand, parseJsonlFile, setupIsolatedWorkDir, type GuideUsage } from '../lib/agent-shared.ts';
 import type { ConversationRecord } from '@google/gemini-cli-core';
 import { MODERN_WEB_LOG_FILE } from '../../constants.ts';
 
@@ -40,47 +40,12 @@ function getSessionFiles(dir: string, recursive = false): string[] {
   return fs.globSync(recursive ? `**/${TRAJECTORY_GLOB}` : TRAJECTORY_GLOB, { cwd: dir });
 }
 
-// Usage: node gemini-cli-agent.ts <prompt> <runType> <targetDir> <templateDir>
-/**
- * Sets up an isolated HOME and work directory to ensure test isolation.
- * @returns {string} The path to the temporary work directory.
- */
-function setupIsolatedWorkDir(templateDir: string, runType: string, targetDir?: string): string {
-  const tempHome = createIsolatedHome('ghh-gemini', targetDir);
-  const workDir = createWorkDir(templateDir, tempHome, runType);
-
-  const geminiDest = setupGeminiCliCredentials(tempHome);
-
-  // Set environment variables
-  process.env.HOME = tempHome;
-
-  // Add GEMINI context and MCP servers for guided runs
-  if (runType === 'guided') {
-    const suiteConfig = getSuiteConfig();
-    const approach = suiteConfig.serving;
-
-    if (approach === Serving.SKILLS_CLI || approach === Serving.SKILLS) {
-      copySkills(tempHome, Agents.GEMINI_CLI, approach === Serving.SKILLS_CLI, suiteConfig.skillsToEnable);
-    } else if (approach === Serving.MCP) {
-      updateMcpConfig(
-        path.join(geminiDest, 'settings.json'),
-        suiteConfig.mcpServersToEnable,
-        config.environment.modernWebServerPath,
-        config.environment.mcpApiKey,
-        Agents.GEMINI_CLI
-      );
-    }
-  }
-
-  return workDir;
-}
-
 /**
  * Executes the Gemini CLI command and captures output.
  */
 async function run() {
   const { userPrompt, runType, targetDir, templateDir } = parseAgentArgs('gemini-cli-agent.ts');
-  const workDir = setupIsolatedWorkDir(templateDir, runType, targetDir);
+  const workDir = setupIsolatedWorkDir(Agents.GEMINI_CLI, templateDir, runType, targetDir);
 
   if (!workDir || !fs.existsSync(workDir)) {
     throw new Error(`Failed to initialize working directory: ${workDir}`);

--- a/harness/agents/jetski-cli-agent.ts
+++ b/harness/agents/jetski-cli-agent.ts
@@ -30,7 +30,12 @@ export function setupJetskiCliCredentials(tempHome: string): string {
 
 export function getJetskiCliCommandAndArgs(prompt: string): { command: string; commandArgs: string[] } {
   const command = config.environment.jetskiCliBin;
-  const commandArgs = ['-p', prompt, '--dangerously-skip-permissions'];
+  const model = process.env.JETSKI_MODEL;
+  const commandArgs = [
+    '-p', prompt,
+    '--dangerously-skip-permissions',
+    ...(model ? ['--model', model] : [])
+  ];
   return { command, commandArgs };
 }
 

--- a/harness/agents/jetski-cli-agent.ts
+++ b/harness/agents/jetski-cli-agent.ts
@@ -2,8 +2,8 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { DatabaseSync } from 'node:sqlite';
-import config, { Agents, Serving } from '../config.ts';
-import { getSuiteConfig, updateMcpConfig, createIsolatedHome, cleanupIsolatedHome, parseAgentArgs, createWorkDir, copySkills, watchLogFile, exportTrajectories, runCliAgentCommand, createTrustedFolders, copyFileIfExists, type GuideUsage } from '../lib/agent-shared.ts';
+import config, { Agents } from '../config.ts';
+import { cleanupIsolatedHome, parseAgentArgs, watchLogFile, exportTrajectories, runCliAgentCommand, createTrustedFolders, copyFileIfExists, setupIsolatedWorkDir, type GuideUsage } from '../lib/agent-shared.ts';
 import { MODERN_WEB_LOG_FILE } from '../../constants.ts';
 
 export function setupJetskiCliCredentials(tempHome: string): string {
@@ -63,47 +63,12 @@ export function readTrajectorySummary(dir: string): TrajectorySummary | null {
   return null;
 }
 
-// Usage: node jetski-cli-agent.ts <prompt> <runType> <targetDir> <templateDir>
-/**
- * Sets up an isolated HOME and work directory to ensure test isolation.
- * @returns {string} The path to the temporary work directory.
- */
-function setupIsolatedWorkDir(templateDir: string, runType: string, targetDir?: string): string {
-  const tempHome = createIsolatedHome('ghh-jetski-cli', targetDir);
-  const workDir = createWorkDir(templateDir, tempHome, runType);
-
-  const jetskiDest = setupJetskiCliCredentials(tempHome);
-
-  // Set environment variables
-  process.env.HOME = tempHome;
-
-  // Add GEMINI context and MCP servers for guided runs
-  if (runType === 'guided') {
-    const suiteConfig = getSuiteConfig();
-    const approach = suiteConfig.serving;
-
-    if (approach === Serving.SKILLS_CLI || approach === Serving.SKILLS) {
-      copySkills(tempHome, Agents.JETSKI_CLI, approach === Serving.SKILLS_CLI, suiteConfig.skillsToEnable);
-    } else if (approach === Serving.MCP) {
-      updateMcpConfig(
-        path.join(jetskiDest, 'mcp_config.json'),
-        suiteConfig.mcpServersToEnable,
-        config.environment.modernWebServerPath,
-        config.environment.mcpApiKey,
-        Agents.JETSKI_CLI
-      );
-    }
-  }
-
-  return workDir;
-}
-
 /**
  * Executes the Jetski CLI command and captures output.
  */
 async function run() {
   const { userPrompt, runType, targetDir, templateDir } = parseAgentArgs('jetski-cli-agent.ts');
-  const workDir = setupIsolatedWorkDir(templateDir, runType, targetDir);
+  const workDir = setupIsolatedWorkDir(Agents.JETSKI_CLI, templateDir, runType, targetDir);
 
   if (!workDir || !fs.existsSync(workDir)) {
     throw new Error(`Failed to initialize working directory: ${workDir}`);
@@ -246,8 +211,7 @@ export function parseJetskiCliSession(dirPath: string): TrajectorySummary {
   const fileReadGuides: string[] = [];
   const toolsUsed: string[] = [];
   let modelName = 'unknown';
-  let totalInput = 0;
-  let totalOutput = 0;
+  let totalTokens = 0;
   let totalCached = 0;
   let hasTokens = false;
 
@@ -257,6 +221,11 @@ export function parseJetskiCliSession(dirPath: string): TrajectorySummary {
     try {
       const db = new DatabaseSync(fullPath, { readOnly: true });
       const rows = db.prepare('SELECT step_type, metadata, step_payload FROM steps').all() as Array<{ step_type?: number; metadata?: Uint8Array; step_payload?: Uint8Array }>;
+      let fileInput = 0;
+      let fileLastCached = 0;
+      let fileOutput = 0;
+      let fileHasTokens = false;
+
       for (const row of rows) {
         // Decode Protobuf step_payload for tool executions
         if (row.step_payload) {
@@ -289,32 +258,28 @@ export function parseJetskiCliSession(dirPath: string): TrajectorySummary {
           }
         }
 
-        // Protobuf token extraction from metadata (schema-agnostic across tags)
+        // Protobuf token extraction from metadata (field 9 stores Gemini UsageMetadata)
         if (row.metadata) {
           const proto = parseProtobuf(Buffer.from(row.metadata));
-          const visited = new Set<any>();
-          const extractTokensFromNode = (node: any) => {
-            if (!node || typeof node !== 'object' || visited.has(node)) return;
-            visited.add(node);
-            if (Array.isArray(node)) {
-              for (const item of node) extractTokensFromNode(item);
-              return;
-            }
-            const input = (node[2] && typeof node[2][0] === 'number') ? node[2][0] : 0;
-            const output = (node[3] && typeof node[3][0] === 'number') ? node[3][0] : 0;
-            const cached = (node[5] && typeof node[5][0] === 'number') ? node[5][0] : 0;
+          const usageNode = proto[9]?.[0];
+          if (usageNode && typeof usageNode === 'object') {
+            const input = (usageNode[2] && typeof usageNode[2][0] === 'number') ? usageNode[2][0] : 0;
+            const output = (usageNode[3] && typeof usageNode[3][0] === 'number') ? usageNode[3][0] : 0;
+            const cached = (usageNode[5] && typeof usageNode[5][0] === 'number') ? usageNode[5][0] : 0;
             if (input > 0 || output > 0 || cached > 0) {
-              totalInput += input;
-              totalOutput += output;
-              totalCached += cached;
-              hasTokens = true;
+              fileInput += input;
+              fileLastCached = Math.max(fileLastCached, cached);
+              fileOutput += output;
+              fileHasTokens = true;
             }
-            for (const key of Object.keys(node)) {
-              extractTokensFromNode(node[key]);
-            }
-          };
-          extractTokensFromNode(proto);
+          }
         }
+      }
+
+      if (fileHasTokens) {
+        totalTokens += (fileInput + fileLastCached + fileOutput);
+        totalCached += fileLastCached;
+        hasTokens = true;
       }
 
       // Extract model name from gen_metadata by scanning string values
@@ -336,10 +301,6 @@ export function parseJetskiCliSession(dirPath: string): TrajectorySummary {
       db.close();
     } catch {}
   }
-
-  const totalTokens = (hasTokens && totalInput > 0 && totalOutput === 0 && totalCached > 0 && totalInput >= totalCached) 
-    ? totalInput 
-    : totalInput + totalOutput + totalCached;
 
   return {
     retrievedGuides: [...new Set(retrievedGuides)],

--- a/harness/agents/pi-agent.ts
+++ b/harness/agents/pi-agent.ts
@@ -3,26 +3,20 @@ import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
-import config, { Agents, Serving } from '../config.ts';
-import { getSuiteConfig, createIsolatedHome, cleanupIsolatedHome, copyFileIfExists, parseAgentArgs, createWorkDir, copySkills, watchLogFile, exportTrajectories, runCliAgentCommand } from '../lib/agent-shared.ts';
+import config, { Agents } from '../config.ts';
+import { cleanupIsolatedHome, copyFileIfExists, parseAgentArgs, watchLogFile, exportTrajectories, runCliAgentCommand, parseJsonlFile, setupIsolatedWorkDir, type GuideUsage } from '../lib/agent-shared.ts';
 
 import { MODERN_WEB_LOG_FILE } from '../../constants.ts';
 
 const TRAJECTORY_GLOB = '*.jsonl';
 
-function getSessionFiles(dir: string): string[] {
-  return fs.globSync(TRAJECTORY_GLOB, { cwd: dir });
+function getSessionFiles(dir: string, recursive = false): string[] {
+  if (!fs.existsSync(dir)) return [];
+  const pattern = recursive ? `**/${TRAJECTORY_GLOB}` : TRAJECTORY_GLOB;
+  return fs.globSync(pattern, { cwd: dir });
 }
 
-// Usage: node pi-agent.ts <prompt> <runType> <targetDir> <templateDir>
-/**
- * Sets up an isolated HOME and work directory to ensure test isolation.
- * @returns {string} The path to the temporary work directory.
- */
-function setupIsolatedWorkDir(templateDir: string, runType: string, targetDir?: string): string {
-  const tempHome = createIsolatedHome('ghh-pi', targetDir);
-  const workDir = createWorkDir(templateDir, tempHome, runType);
-
+export function setupPiCredentials(tempHome: string): void {
   const piSource = path.join(os.homedir(), '.pi');
   const piDest = path.join(tempHome, '.pi');
   const piDestAgent = path.join(piDest, 'agent');
@@ -42,32 +36,27 @@ function setupIsolatedWorkDir(templateDir: string, runType: string, targetDir?: 
     copyFileIfExists(src, path.join(piDestAgent, file));
   }
 
-  // Set environment variables
-  process.env.HOME = tempHome;
-  process.env.PI_CODING_AGENT_DIR = path.join(tempHome, '.pi', 'agent');
+  process.env.PI_CODING_AGENT_DIR = piDestAgent;
+}
 
-  // Add context and resources for guided runs
-  if (runType === 'guided') {
-    const suiteConfig = getSuiteConfig();
-    const approach = suiteConfig.serving;
+export function getPiCommandAndArgs(prompt: string, extraArgs: string[] = []): { command: string; commandArgs: string[] } {
+  const command = config.environment.piBin || 'pi';
+  const piModel = process.env.PI_MODEL || process.env.PROMPT_MODEL;
+  const modelArg = piModel ? ['--model', piModel] : [];
 
-    if (approach === Serving.SKILLS_CLI || approach === Serving.SKILLS) {
-      copySkills(tempHome, Agents.CLAUDE_CODE, approach === Serving.SKILLS_CLI, suiteConfig.skillsToEnable);
-      // Pi uses .agents/skills/ directory structure
-      const skillsSrc = path.join(tempHome, '.claude', 'skills');
-      const skillsDest = path.join(tempHome, '.agents', 'skills');
-      if (fs.existsSync(skillsSrc)) {
-        fs.mkdirSync(skillsDest, { recursive: true });
-        fs.cpSync(skillsSrc, skillsDest, { recursive: true });
-      }
-    } else if (approach === Serving.MCP) {
-      // Pi doesn't have native MCP support per documentation
-      // "No MCP. Build CLI tools with READMEs (see Skills), or build an extension"
-      console.warn('Warning: MCP serving mode is not natively supported by Pi. Consider using SKILLS_CLI mode instead.');
-    }
-  }
+  // Allow overriding --no-session via env var for trajectory testing
+  const noSession = process.env.PI_NO_SESSION !== 'false';
+  const sessionArgs = noSession ? ['--no-session'] : [];
 
-  return workDir;
+  const commandArgs = [
+    '-p', // print mode: non-interactive, process and exit
+    ...sessionArgs, // ephemeral mode: don't save session (unless disabled)
+    '--offline', // disable network operations for update checks
+    ...modelArg,
+    ...extraArgs,
+    prompt
+  ];
+  return { command, commandArgs };
 }
 
 /**
@@ -75,7 +64,7 @@ function setupIsolatedWorkDir(templateDir: string, runType: string, targetDir?: 
  */
 async function run() {
   const { userPrompt, runType, targetDir, templateDir } = parseAgentArgs('pi-agent.ts');
-  const workDir = setupIsolatedWorkDir(templateDir, runType, targetDir);
+  const workDir = setupIsolatedWorkDir(Agents.PI, templateDir, runType, targetDir);
 
   if (!workDir || !fs.existsSync(workDir)) {
     throw new Error(`Failed to initialize working directory: ${workDir}`);
@@ -84,26 +73,7 @@ async function run() {
   try {
     console.log(`Starting Pi agent in ${workDir}`);
 
-    const command = config.environment.piBin || 'pi';
-    
-    // Determine model from environment or suite config
-    let modelArg: string[] = [];
-    const piModel = process.env.PI_MODEL || process.env.PROMPT_MODEL;
-    if (piModel) {
-      modelArg = ['--model', piModel];
-    }
-
-    // Allow overriding --no-session via env var for trajectory testing
-    const noSession = process.env.PI_NO_SESSION !== 'false';
-    const sessionArgs = noSession ? ['--no-session'] : [];
-
-    const commandArgs = [
-      '-p', // print mode: non-interactive, process and exit
-      ...sessionArgs, // ephemeral mode: don't save session (unless disabled)
-      '--offline', // disable network operations for update checks
-      ...modelArg,
-      userPrompt
-    ];
+    const { command, commandArgs } = getPiCommandAndArgs(userPrompt);
 
     console.log(`Executing: ${command} ${commandArgs.join(' ')}`);
 
@@ -140,35 +110,28 @@ async function run() {
 }
 
 export function extractPiModel(resultsDir: string): string {
-  const sessionFiles = getSessionFiles(resultsDir);
+  const sessionFiles = getSessionFiles(resultsDir, true);
   if (sessionFiles.length === 0) return 'unknown';
 
   const counts: Record<string, number> = {};
   for (const file of sessionFiles) {
     const sessionPath = path.join(resultsDir, file);
     try {
-      const content = fs.readFileSync(sessionPath, 'utf8');
-      const lines = content.split('\n').filter(line => line.trim());
-      
-      for (const line of lines) {
-        try {
-          const msg = JSON.parse(line);
-          let model: string | undefined;
-          if (msg.type === 'message' && msg.message?.model) {
-            model = msg.message.model;
-          } else if (msg.type === 'model_change' && msg.modelId) {
-            model = msg.modelId;
-          }
-          // Fallback for older formats
-          if (!model && msg.metadata?.model) {
-            model = msg.metadata.model;
-          }
+      const items = parseJsonlFile(sessionPath);
+      for (const msg of items) {
+        let model: string | undefined;
+        if (msg.type === 'message' && msg.message?.model) {
+          model = msg.message.model;
+        } else if (msg.type === 'model_change' && msg.modelId) {
+          model = msg.modelId;
+        }
+        // Fallback for older formats
+        if (!model && msg.metadata?.model) {
+          model = msg.metadata.model;
+        }
 
-          if (model) {
-            counts[model] = (counts[model] || 0) + 1;
-          }
-        } catch {
-          // Ignore parse errors
+        if (model) {
+          counts[model] = (counts[model] || 0) + 1;
         }
       }
     } catch (e) {
@@ -187,26 +150,19 @@ export function extractPiTokenUsage(dir: string): { total: number; cached: numbe
   let cached = 0;
   let hasData = false;
   try {
-    const sessionFiles = getSessionFiles(dir);
+    const sessionFiles = getSessionFiles(dir, true);
     for (const file of sessionFiles) {
       try {
         const sessionPath = path.join(dir, file);
-        const content = fs.readFileSync(sessionPath, 'utf8');
-        const lines = content.split('\n').filter(line => line.trim());
-        
-        for (const line of lines) {
-          try {
-            const msg = JSON.parse(line);
-            const usage = msg.message?.usage || msg.metadata?.usage || msg.usage;
-            if (usage) {
-              total += usage.totalTokens || 0;
-              if (usage.cacheRead !== undefined) {
-                cached += usage.cacheRead;
-              }
-              hasData = true;
+        const items = parseJsonlFile(sessionPath);
+        for (const msg of items) {
+          const usage = msg.message?.usage || msg.metadata?.usage || msg.usage;
+          if (usage) {
+            total += usage.totalTokens || 0;
+            if (usage.cacheRead !== undefined) {
+              cached += usage.cacheRead;
             }
-          } catch {
-            // Ignore parse errors
+            hasData = true;
           }
         }
       } catch {
@@ -222,17 +178,13 @@ export function extractPiTokenUsage(dir: string): { total: number; cached: numbe
 export function collectPiToolsFromTrajectory(dir: string): string[] {
   const toolsUsed: string[] = [];
   const sessionFiles = getSessionFiles(dir);
-  const firstSession = sessionFiles[0];
-  if (!firstSession) return toolsUsed;
+  if (sessionFiles.length === 0) return toolsUsed;
 
-  try {
-    const sessionPath = path.join(dir, firstSession);
-    const content = fs.readFileSync(sessionPath, 'utf8');
-    const lines = content.split('\n').filter(line => line.trim());
-    
-    for (const line of lines) {
-      try {
-        const msg = JSON.parse(line);
+  for (const file of sessionFiles) {
+    try {
+      const sessionPath = path.join(dir, file);
+      const items = parseJsonlFile(sessionPath);
+      for (const msg of items) {
         const assistantMsg = msg.type === 'message' ? msg.message : msg;
         
         if (assistantMsg?.role === 'assistant') {
@@ -255,19 +207,17 @@ export function collectPiToolsFromTrajectory(dir: string): string[] {
             }
           }
         }
-      } catch {
-        // Ignore parse errors
       }
+    } catch (e) {
+      console.error(`Failed to collect tools used for Pi:`, e);
     }
-  } catch (e) {
-    console.error(`Failed to collect tools used for Pi:`, e);
   }
 
   return Array.from(new Set(toolsUsed));
 }
 
 
-export function collectPiGuidesFromTrajectory(dirPath: string, _serving: string): Promise<{ retrievedGuides: string[]; fileReadGuides: string[] }> {
+export async function collectPiGuidesFromTrajectory(dirPath: string, _serving: string): Promise<GuideUsage> {
   const retrievedGuides: string[] = [];
   const fileReadGuides: string[] = [];
   try {
@@ -275,59 +225,53 @@ export function collectPiGuidesFromTrajectory(dirPath: string, _serving: string)
 
     for (const file of sessionFiles) {
       const sessionPath = path.join(dirPath, file);
-      const content = fs.readFileSync(sessionPath, 'utf8');
-      const lines = content.split('\n').filter(line => line.trim());
+      const items = parseJsonlFile(sessionPath);
 
-      for (const line of lines) {
-        try {
-          const entry = JSON.parse(line);
-          const assistantMsg = entry.type === 'message' ? entry.message : entry;
+      for (const entry of items) {
+        const assistantMsg = entry.type === 'message' ? entry.message : entry;
 
-          if (assistantMsg?.role === 'assistant') {
-            const toolCalls = assistantMsg.content?.filter((c: any) => c.type === 'toolCall') || [];
-            if (assistantMsg.tool_calls) {
-              toolCalls.push(...assistantMsg.tool_calls);
-            }
+        if (assistantMsg?.role === 'assistant') {
+          const toolCalls = assistantMsg.content?.filter((c: any) => c.type === 'toolCall') || [];
+          if (assistantMsg.tool_calls) {
+            toolCalls.push(...assistantMsg.tool_calls);
+          }
 
-            for (const contentItem of toolCalls) {
-              const args = contentItem.arguments || {};
-              const toolName = contentItem.function?.name || contentItem.name;
+          for (const contentItem of toolCalls) {
+            const args = contentItem.arguments || {};
+            const toolName = contentItem.function?.name || contentItem.name;
 
-              // Check for read tool accessing skill files
-              if (toolName === 'read' && (args.path || args.file_path)) {
-                  const filePath = (args.path || args.file_path) as string;
-                  if (filePath.includes('/skills/') || filePath.includes('.agents/skills/')) {
-                    // Match guide.md files in guides/{category}/{guide-name}/guide.md structure
-                    const match = filePath.match(/\/skills\/[^/]+\/guides\/[^/]+\/([^/]+)\/guide\.md$/) ||
-                                  // Match .md files in references/{category}/{guide-name}.md structure  
-                                  filePath.match(/\/skills\/[^/]+\/references\/[^/]+\/([^/]+)\.md$/) ||
-                                  // Fallback: match {guide-name}.md in any skills subdirectory (but not guide.md itself)
-                                  filePath.match(/\/skills\/[^/]+\/(?:[^/]+\/)*([^/]+)\.md$/);
-                    if (match && match[1] !== 'guide') {
-                      fileReadGuides.push(match[1]);
-                    }
-                  }
-                } else if (toolName === 'bash' && args.command) {
-                  const command = args.command as string;
-                  const match = command.match(/(?:--)?retrieve\s+["']?([^"'\s]+)["']?/);
-                  if (match) {
-                    retrievedGuides.push(...match[1].split(',').map(s => s.trim()));
+            // Check for read tool accessing skill files
+            if (toolName === 'read' && (args.path || args.file_path)) {
+                const filePath = (args.path || args.file_path) as string;
+                if (filePath.includes('/skills/') || filePath.includes('.agents/skills/')) {
+                  // Match guide.md files in guides/{category}/{guide-name}/guide.md structure
+                  const match = filePath.match(/\/skills\/[^/]+\/guides\/[^/]+\/([^/]+)\/guide\.md$/) ||
+                                // Match .md files in references/{category}/{guide-name}.md structure  
+                                filePath.match(/\/skills\/[^/]+\/references\/[^/]+\/([^/]+)\.md$/) ||
+                                // Fallback: match {guide-name}.md in any skills subdirectory (but not guide.md itself)
+                                filePath.match(/\/skills\/[^/]+\/(?:[^/]+\/)*([^/]+)\.md$/);
+                  if (match && match[1] !== 'guide') {
+                    fileReadGuides.push(match[1]);
                   }
                 }
-            }
+              } else if (toolName === 'bash' && args.command) {
+                const command = args.command as string;
+                const match = command.match(/(?:--)?retrieve\s+["']?([^"'\s]+)["']?/);
+                if (match) {
+                  retrievedGuides.push(...match[1].split(',').map((s: string) => s.trim()));
+                }
+              }
           }
-        } catch {
-          // Ignore parse errors
         }
       }
     }
   } catch (e) {
     console.error(`Error reading session files in ${dirPath}:`, e);
   }
-  return Promise.resolve({
+  return {
     retrievedGuides: [...new Set(retrievedGuides)],
     fileReadGuides: [...new Set(fileReadGuides)]
-  });
+  };
 }
 
 const isMain = process.argv[1] === fileURLToPath(import.meta.url);

--- a/harness/config.ts
+++ b/harness/config.ts
@@ -22,6 +22,8 @@ export const Agents = {
   PI: 'pi'
 } as const;
 
+export type Agents = typeof Agents[keyof typeof Agents];
+
 export const Serving = {
   SKILLS_CLI: 'skills_cli',
   SKILLS: 'skills',

--- a/harness/lib/agent-shared.ts
+++ b/harness/lib/agent-shared.ts
@@ -531,6 +531,13 @@ export function copyResultsToTarget(workDir: string, targetDir: string, subPath:
     const sourceDir = path.join(workDir, subPath);
     try {
       execSync(`cp -R "${sourceDir}/." "${targetDir}/"`);
+      // Remove .git and node_modules directories if present
+      for (const dirName of ['.git', 'node_modules']) {
+        const dirPath = path.join(targetDir, dirName);
+        if (fs.existsSync(dirPath)) {
+          fs.rmSync(dirPath, { recursive: true, force: true });
+        }
+      }
       console.log(`Copied results from ${sourceDir} to: ${targetDir}`);
     } catch (e) {
       console.warn(`Failed to copy results from ${sourceDir} to ${targetDir}: ${e}`);

--- a/harness/lib/agent-shared.ts
+++ b/harness/lib/agent-shared.ts
@@ -1,53 +1,72 @@
 import fs from 'fs';
 import path from 'path';
 import { execSync, spawn, type SpawnOptions } from 'child_process';
-import { Agents } from '../config.ts';
+import { Agents, Serving, type SuiteConfig } from '../config.ts';
 import { classifyGuide, scanAllGuides } from '../../lib/guide-validation.ts';
 import { rootDir, guidesDir } from '../../lib/paths.ts';
 import { capturePatchFromGit, initGitRepo } from '../../lib/patch-utils.ts';
 
-import { type SuiteConfig } from '../config.ts';
 import { setupGeminiCliCredentials, getGeminiCliCommandAndArgs } from '../agents/gemini-cli-agent.ts';
 import { setupJetskiCliCredentials, getJetskiCliCommandAndArgs } from '../agents/jetski-cli-agent.ts';
 import { setupClaudeCodeCredentials, getClaudeCodeCommandAndArgs } from '../agents/claude-code-agent.ts';
 import { setupCodexCliCredentials, getCodexCliCommandAndArgs } from '../agents/codex-cli-agent.ts';
+import { setupPiCredentials, getPiCommandAndArgs } from '../agents/pi-agent.ts';
 
-export {
-  setupGeminiCliCredentials,
-  getGeminiCliCommandAndArgs,
-  setupJetskiCliCredentials,
-  getJetskiCliCommandAndArgs,
-  setupClaudeCodeCredentials,
-  getClaudeCodeCommandAndArgs,
-  setupCodexCliCredentials,
-  getCodexCliCommandAndArgs,
-};
-
-export type AgentName = 'gemini' | 'jetski' | 'claude' | 'codex';
-
-export function setupAgentCredentials(agent: AgentName, tempHome: string): void {
-  if (agent === 'jetski') {
+export function setupAgentCredentials(agent: Agents, tempHome: string): void {
+  if (agent === Agents.JETSKI || agent === Agents.JETSKI_CLI) {
     setupJetskiCliCredentials(tempHome);
-  } else if (agent === 'gemini') {
+  } else if (agent === Agents.GEMINI_CLI) {
     setupGeminiCliCredentials(tempHome);
-  } else if (agent === 'claude') {
+  } else if (agent === Agents.CLAUDE_CODE) {
     setupClaudeCodeCredentials(tempHome);
-  } else if (agent === 'codex') {
+  } else if (agent === Agents.CODEX_CLI) {
     setupCodexCliCredentials(tempHome);
+  } else if (agent === Agents.PI) {
+    setupPiCredentials(tempHome);
   }
 }
 
-export function getAgentCommandAndArgs(agent: AgentName, prompt: string): { command: string; commandArgs: string[] } {
+export function getAgentCommandAndArgs(agent: Agents, prompt: string): { command: string; commandArgs: string[] } {
   switch (agent) {
-    case 'jetski':
+    case Agents.JETSKI:
+    case Agents.JETSKI_CLI:
       return getJetskiCliCommandAndArgs(prompt);
-    case 'gemini':
+    case Agents.GEMINI_CLI:
       return getGeminiCliCommandAndArgs(prompt);
-    case 'claude':
+    case Agents.CLAUDE_CODE:
       return getClaudeCodeCommandAndArgs(prompt);
-    case 'codex':
+    case Agents.CODEX_CLI:
       return getCodexCliCommandAndArgs(prompt);
+    case Agents.PI:
+      return getPiCommandAndArgs(prompt);
+    default:
+      throw new Error(`Unsupported agent: ${agent}`);
   }
+}
+
+export function setupIsolatedWorkDir(
+  agent: Agents,
+  templateDir: string,
+  runType: string,
+  targetDir?: string
+): string {
+  const tempHome = createIsolatedHome(`ghh-${agent}`, targetDir);
+  const workDir = createWorkDir(templateDir, tempHome, runType);
+
+  setupAgentCredentials(agent, tempHome);
+  process.env.HOME = tempHome;
+
+  if (runType === 'guided') {
+    const suiteConfig = getSuiteConfig();
+    copySkills(
+      tempHome,
+      agent,
+      suiteConfig.serving === Serving.SKILLS_CLI,
+      suiteConfig.skillsToEnable
+    );
+  }
+
+  return workDir;
 }
 
 export interface GuideUsage {
@@ -326,13 +345,13 @@ export function updateMcpConfig(
  * @param agent The agent type
  * @returns True if successful, false otherwise
  */
-export function copySkills(homeDir: string, agent: string, cli: boolean, skillsToEnable: string[] = ['modern-web-guidance']): boolean {
+export function copySkills(homeDir: string, agent: Agents, cli: boolean, skillsToEnable: string[] = ['modern-web-guidance']): boolean {
   const guidesSource = guidesDir;
 
   let destDir = '';
   if (agent === Agents.CLAUDE_CODE) {
     destDir = path.join(homeDir, '.claude', 'skills');
-  } else if (agent === Agents.CODEX_CLI) {
+  } else if (agent === Agents.CODEX_CLI || agent === Agents.PI) {
     destDir = path.join(homeDir, '.agents', 'skills');
   } else if (agent === Agents.JETSKI || agent === Agents.JETSKI_CLI) {
     destDir = path.join(homeDir, '.gemini', 'jetski', 'skills');

--- a/harness/lib/agent-shared.ts
+++ b/harness/lib/agent-shared.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { execSync, spawn, type SpawnOptions } from 'child_process';
 import { Agents, Serving, type SuiteConfig } from '../config.ts';
-import { classifyGuide, scanAllGuides } from '../../lib/guide-validation.ts';
+import { classifyGuide, scanAllGuides, ZERO_PASSRATE_PATCH_FILE } from '../../lib/guide-validation.ts';
 import { rootDir, guidesDir } from '../../lib/paths.ts';
 import { capturePatchFromGit, initGitRepo } from '../../lib/patch-utils.ts';
 
@@ -829,17 +829,23 @@ export function getGraderScriptContent(
   const targetFile = path.join(targetDir, 'index.html');
   const gradeReportDir = path.join(targetDir, 'grade-report');
   const graderResults = path.join(targetDir, `${guideName}_results.json`);
+  const agentPatch = path.join(targetDir, 'agent.patch');
+  const zeroPassratePatch = path.join(path.dirname(graderPath), ZERO_PASSRATE_PATCH_FILE);
 
   return `import fs from 'fs';
 import { runPlaywright } from ${JSON.stringify(runGraderModulePath)};
 
 async function run() {
   try {
+    const patchFile = fs.existsSync(${JSON.stringify(agentPatch)}) ? ${JSON.stringify(agentPatch)} : undefined;
+    const zeroPassrateFile = fs.existsSync(${JSON.stringify(zeroPassratePatch)}) ? ${JSON.stringify(zeroPassratePatch)} : undefined;
     const json = await runPlaywright(
       ${JSON.stringify(targetFile)},
       ${JSON.stringify(graderPath)},
       ${JSON.stringify(gradeReportDir)},
-      'inherit'
+      'inherit',
+      patchFile,
+      zeroPassrateFile
     );
     fs.writeFileSync(${JSON.stringify(graderResults)}, JSON.stringify(json, null, 2));
   } catch (err) {

--- a/harness/run_suite.ts
+++ b/harness/run_suite.ts
@@ -8,6 +8,7 @@ import { harnessDir, baseAppsDir, resultsDir } from '../lib/paths.ts';
 import { getTaskMap, ZERO_PASSRATE_PATCH_FILE, type TaskInfo } from '../lib/guide-validation.ts';
 import { applyPatchSync, initGitRepo } from '../lib/patch-utils.ts';
 import { getGraderScriptContent } from './lib/agent-shared.ts';
+import { copyBaseAppToWorkspace } from '../guides/lib/utils.ts';
 
 const RUN_TYPES = ['guided', 'unguided'];
 
@@ -351,15 +352,11 @@ export async function setupWorkspaceBaseApp(taskInfo: TaskInfo, runDir: string, 
   }
 
   const refBaseAppDir = path.join(baseAppsDir, taskInfo.baseApp);
-  if (fs.existsSync(refBaseAppDir)) {
-    fs.cpSync(refBaseAppDir, workspaceBaseAppDir, {
-      recursive: true,
-      filter: (src) => !src.includes('/dist') && !src.includes('/.astro'),
-    });
-  } else {
+  if (!fs.existsSync(refBaseAppDir)) {
     console.warn(`Source base app not found at ${refBaseAppDir}`);
     return null;
   }
+  await copyBaseAppToWorkspace(taskInfo.baseApp, workspaceBaseAppDir);
   const pkgJsonPath = path.join(workspaceBaseAppDir, 'package.json');
   if (fs.existsSync(pkgJsonPath)) {
     const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));

--- a/harness/run_suite.ts
+++ b/harness/run_suite.ts
@@ -17,7 +17,7 @@ let logStream: fs.WriteStream | null = null;
 
 const COMMON_APPEND_PROMPT = `\n\nDon't bother doing any manual verification in a browser. If images are needed, prefer using some stock photos from the web rather than generating them with Nano Banana.`;
 
-export async function runAgent(templateDirRaw: string, promptContentRaw: string, providedSuiteConfig?: SuiteConfig) {
+export async function runSingleTask(templateDirRaw: string, promptContentRaw: string, providedSuiteConfig?: SuiteConfig) {
   const suiteConfig = providedSuiteConfig || defaultSuiteConfig;
   const agent = suiteConfig.agent;
   let templateDir = templateDirRaw;

--- a/harness/tests/run-agent.test.ts
+++ b/harness/tests/run-agent.test.ts
@@ -4,10 +4,10 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import config from '../config.ts';
-import { runAgentForModel } from '../../guides/lib/utils.ts';
+import { runAgent } from '../../guides/lib/utils.ts';
 import { getDefaultSolutionAgent } from '../../lib/guide-validation.ts';
 
-describe('runAgentForModel routing and argument building', () => {
+describe('runAgent routing and argument building', () => {
   let tempDir: string;
   let mockCliPath: string;
   let originalGeminiCli: string;
@@ -53,7 +53,7 @@ echo "mock-cli ran with args: $@"
   test('should invoke Gemini CLI by default with --yolo', async () => {
     delete process.env.GD_DEV_USE_JETSKI;
     
-    const output = await runAgentForModel(getDefaultSolutionAgent(), 'hello world', tempDir, { captureOutput: true });
+    const output = await runAgent(getDefaultSolutionAgent(), 'hello world', tempDir, { captureOutput: true });
     assert.ok(output.includes('mock-cli ran with args: -p hello world --yolo'));
   });
 
@@ -61,7 +61,7 @@ echo "mock-cli ran with args: $@"
     process.env.GD_DEV_USE_JETSKI = '1';
 
     try {
-      const output = await runAgentForModel(getDefaultSolutionAgent(), 'hello world', tempDir, { captureOutput: true });
+      const output = await runAgent(getDefaultSolutionAgent(), 'hello world', tempDir, { captureOutput: true });
       assert.ok(output.includes('mock-cli ran with args: -p hello world'));
       assert.ok(!output.includes('--yolo'));
     } finally {

--- a/harness/tests/trajectory-parsing.test.ts
+++ b/harness/tests/trajectory-parsing.test.ts
@@ -62,8 +62,8 @@ test('collectJetski metrics from trajectory files', async () => {
     ]);
     const metadataProto = encodeField(9, 2, statsInner);
 
-    // 3. gen_metadata with tag 1 -> tag 21 ("Gemini 3.5 Flash")
-    const modelInner = encodeField(21, 2, Buffer.from('Gemini 3.5 Flash'));
+    // 3. gen_metadata with tag 1 -> tag 21 ("gemini-3.6-flash")
+    const modelInner = encodeField(21, 2, Buffer.from('gemini-3.6-flash'));
     const genDataProto = encodeField(1, 2, modelInner);
 
     const insertStep = db.prepare('INSERT INTO steps (idx, step_type, status, metadata, step_payload) VALUES (?, ?, ?, ?, ?)');
@@ -81,8 +81,8 @@ test('collectJetski metrics from trajectory files', async () => {
     assert.deepStrictEqual(parsed.retrievedGuides, ['validate-input-after-interaction', 'required-field-feedback']);
     assert.deepStrictEqual(parsed.fileReadGuides, ['required-field-feedback']);
     assert.deepStrictEqual(parsed.toolsUsed, ['modern-web-guidance']);
-    assert.strictEqual(parsed.model, 'Gemini 3.5 Flash');
-    assert.deepStrictEqual(parsed.tokenUsage, { total: 1500, cached: 400 });
+    assert.strictEqual(parsed.model, 'gemini-3.6-flash');
+    assert.deepStrictEqual(parsed.tokenUsage, { total: 1900, cached: 400 });
 
     // 2. Write summary file as done by the agent run() lifecycle
     writeTrajectorySummary(tempDir, parsed);
@@ -96,10 +96,10 @@ test('collectJetski metrics from trajectory files', async () => {
     assert.deepStrictEqual(tools, ['modern-web-guidance']);
 
     const model = extractModelFromResults(tempDir, Agents.JETSKI_CLI);
-    assert.strictEqual(model, 'Gemini 3.5 Flash');
+    assert.strictEqual(model, 'gemini-3.6-flash');
 
     const tokens = extractTokenUsageFromResults(tempDir, Agents.JETSKI_CLI);
-    assert.deepStrictEqual(tokens, { total: 1500, cached: 400 });
+    assert.deepStrictEqual(tokens, { total: 1900, cached: 400 });
   } finally {
     removeTempDir(tempDir);
   }

--- a/lib/guide-validation.ts
+++ b/lib/guide-validation.ts
@@ -3,10 +3,10 @@ import path from 'node:path';
 import matter from 'gray-matter';
 import { marked } from 'marked';
 
-// Import shared utilities (using relative paths from guides/)
 import { validateMacros } from '../serving/lib/macros.ts';
 import { validateFeature } from '../serving/lib/baseline.ts';
 import { rootDir, guidesDir } from './paths.ts';
+import { Agents } from '../harness/config.ts';
 
 const REPO_ROOT = rootDir;
 
@@ -285,29 +285,29 @@ export function getSupportedBaseApps(): string[] {
 
 export const TARGETS_DIR = 'targets';
 export const PATCHES_DIR = 'patches';
-export const ALL_SOLUTION_AGENTS = ['gemini', 'jetski', 'claude', 'codex'] as const;
-export type SolutionAgent = (typeof ALL_SOLUTION_AGENTS)[number];
 
-export function getDefaultSolutionAgent(): 'gemini' | 'jetski' {
-  return process.env.GD_DEV_USE_JETSKI === '1' ? 'jetski' : 'gemini';
+export type SolutionAgent =
+  | typeof Agents.GEMINI_CLI
+  | typeof Agents.JETSKI_CLI
+  | typeof Agents.CLAUDE_CODE
+  | typeof Agents.CODEX_CLI;
+
+export function getDefaultSolutionAgent(): SolutionAgent {
+  return process.env.GD_DEV_USE_JETSKI === '1' ? Agents.JETSKI_CLI : Agents.GEMINI_CLI;
 }
 
 export function getActiveSolutionAgents(targetDir?: string): SolutionAgent[] {
-  const defaultAgent = getDefaultSolutionAgent();
-  if (!targetDir || !fs.existsSync(targetDir)) {
-    return [defaultAgent, 'claude', 'codex'];
-  }
-  const hasGemini = fs.existsSync(path.join(targetDir, SOLUTION_PATCH_FILES.gemini));
-  const hasJetski = fs.existsSync(path.join(targetDir, SOLUTION_PATCH_FILES.jetski));
-  const primary: SolutionAgent = hasGemini ? 'gemini' : (hasJetski ? 'jetski' : defaultAgent);
-  return [primary, 'claude', 'codex'];
+  const hasGemini = Boolean(targetDir && fs.existsSync(path.join(targetDir, SOLUTION_PATCH_FILES[Agents.GEMINI_CLI])));
+  const hasJetski = Boolean(targetDir && fs.existsSync(path.join(targetDir, SOLUTION_PATCH_FILES[Agents.JETSKI_CLI])));
+  const primary: SolutionAgent = hasGemini ? Agents.GEMINI_CLI : (hasJetski ? Agents.JETSKI_CLI : getDefaultSolutionAgent());
+  return [primary, Agents.CLAUDE_CODE, Agents.CODEX_CLI];
 }
 
 export const SOLUTION_PATCH_FILES: Record<SolutionAgent, string> = {
-  gemini: path.join(PATCHES_DIR, 'gemini-solution.patch'),
-  jetski: path.join(PATCHES_DIR, 'jetski-solution.patch'),
-  claude: path.join(PATCHES_DIR, 'claude-solution.patch'),
-  codex: path.join(PATCHES_DIR, 'codex-solution.patch'),
+  [Agents.GEMINI_CLI]: path.join(PATCHES_DIR, 'gemini-solution.patch'),
+  [Agents.JETSKI_CLI]: path.join(PATCHES_DIR, 'jetski-solution.patch'),
+  [Agents.CLAUDE_CODE]: path.join(PATCHES_DIR, 'claude-solution.patch'),
+  [Agents.CODEX_CLI]: path.join(PATCHES_DIR, 'codex-solution.patch'),
 };
 export const ZERO_PASSRATE_PATCH_FILE = path.join(PATCHES_DIR, 'zero-passrate.patch');
 
@@ -516,15 +516,15 @@ export function inventoryGuide(dir: string, options?: { useTargetEvals?: boolean
       const targetDir = path.join(targetsDir, baseApp);
       const exists = fs.existsSync(targetDir) && fs.statSync(targetDir).isDirectory();
       const hasPrimarySolution =
-        fs.existsSync(path.join(targetDir, SOLUTION_PATCH_FILES.gemini)) ||
-        fs.existsSync(path.join(targetDir, SOLUTION_PATCH_FILES.jetski));
+        fs.existsSync(path.join(targetDir, SOLUTION_PATCH_FILES[Agents.GEMINI_CLI])) ||
+        fs.existsSync(path.join(targetDir, SOLUTION_PATCH_FILES[Agents.JETSKI_CLI]));
       const appInv: TargetInventory = {
         name: baseApp,
         dir: targetDir,
         hasSolution: exists &&
           hasPrimarySolution &&
-          fs.existsSync(path.join(targetDir, SOLUTION_PATCH_FILES.claude)) &&
-          fs.existsSync(path.join(targetDir, SOLUTION_PATCH_FILES.codex)),
+          fs.existsSync(path.join(targetDir, SOLUTION_PATCH_FILES[Agents.CLAUDE_CODE])) &&
+          fs.existsSync(path.join(targetDir, SOLUTION_PATCH_FILES[Agents.CODEX_CLI])),
         hasZeroPassrate: exists && fs.existsSync(path.join(targetDir, ZERO_PASSRATE_PATCH_FILE)),
         hasGrader: exists && fs.existsSync(path.join(targetDir, GRADER_FILE)),
         hasTask: exists && fs.existsSync(path.join(targetDir, TASK_FILE)),

--- a/nightly/run_agent.sh
+++ b/nightly/run_agent.sh
@@ -164,8 +164,8 @@ cleanup() {
   if [ "${NIGHTLY_GUIDANCE_RUN:-0}" = "1" ]; then
     printf "%b\n\n----------------------------------------\n\n" "$body" >> "${SUMMARY_FILE:-$SCRIPT_DIR/${PREFIX}_summary.txt}"
     
-    # Delete the local results to save disk space in nightly runs
-    if [ -d "${REPO_ROOT}/harness/results/${SUITE_ID}" ]; then
+    # Delete the local results to save disk space in nightly runs only if upload succeeded
+    if [ "$UPLOAD_EXIT_CODE" -eq 0 ] && [ -d "${REPO_ROOT}/harness/results/${SUITE_ID}" ]; then
       echo "Deleting ${PREFIX} local results directory ${SUITE_ID} to save disk space..."
       rm -rf "${REPO_ROOT}/harness/results/${SUITE_ID}"
     fi


### PR DESCRIPTION
## Summary of Changes

### 1. **Pi Agent Refactoring (`harness/agents/pi-agent.ts`)**
- Refactored `pi-agent.ts` trajectory collection and summary functions to align with the structure and conventions of the other CLI agent modules (`gemini`, `jetski`, `claude`, `codex`).

### 2. **Evaluation Token Calculation Fix (`jetski-cli-agent.ts`)**
- Fixed the token calculation logic in `jetski-cli-agent.ts`, which was previously reporting inaccurate token counts.

### 3. **Function Naming & Collision Resolution**
- Renamed `runAgentForModel` to **`runAgent`** in `guides/lib/utils.ts` to reflect LLM tool execution for guide development tasks.
- Renamed `runAgent` in `harness/run_suite.ts` (used by `gd run` in `bin/gd.ts`) to **`runSingleTask`** to eliminate naming collisions across `guides/` and `harness/`.

### 4. **Enum & Domain Typing Standardization**
- Replaced loose string literals (`'gemini'`, `'jetski'`, etc.) with canonical `Agents` enum constants (`Agents.GEMINI_CLI`, etc.).
- Defined `SolutionAgent` in `lib/guide-validation.ts` strictly typed to the 4 reference models maintaining golden `.patch` files.

### 5. **Nightly Script Disk Protection (`nightly/run_agent.sh`)**
- Added `if [ "$UPLOAD_EXIT_CODE" -eq 0 ]` so local evaluation run directories are deleted to save disk space **only if GCS upload succeeded**.

### 6. **Grading Workspace Isolation in `/tmp` (`guides/run-grader.ts`, `harness/lib/agent-shared.ts`)**
- Refactored `runPlaywright()` to automatically stage target base apps and apply diffs (`agent.patch`, `zero-passrate.patch`, `solution-*.patch`) inside isolated temporary workspaces (`/tmp/grade-run-*`).
- Eliminates test file collisions, sandbox leaks, and target-based eval failures where Playwright previously ran against unpatched workspaces.
- Inlined sandbox staging and cleanup lifecycle into `run-grader.ts`, removing redundant helper exports from `guides/lib/utils.ts`.

### 7. **Evaluation Result Sanitization (`harness/run_suite.ts`)**
- Sanitized workspace copying for base apps and results collection to exclude unnecessary `.git` and `node_modules` directories from evaluation output bundles.