### PR TITLE
fix(ci): grant App token access to modern-web-guidance and handle publish errors

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
           app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
+          repositories: ${{ github.event.repository.name }},modern-web-guidance
           permission-contents: write
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/serving/skills-cli/publish-skills.ts
+++ b/serving/skills-cli/publish-skills.ts
@@ -81,13 +81,25 @@ async function publishToDistributionRepo(publishCliDir: string, newVersion: stri
   console.log(`Creating GitHub release v${newVersion} on GoogleChrome/modern-web-guidance...`);
   console.log(`\nPublishing new dist/skills-cli/ to GoogleChrome/modern-web-guidance (main branch)...`);
 
-  await ghpages.publish(publishCliDir, {
-    branch: 'main',
-    repo: 'git@github.com:GoogleChrome/modern-web-guidance.git',
-    dotfiles: true,
-    message: `Release v${newVersion}`,
-    tag: `v${newVersion}`,
-    src: GH_PUBLISH_PATTERNS,
+  await new Promise<void>((resolve, reject) => {
+    ghpages.publish(
+      publishCliDir,
+      {
+        branch: 'main',
+        repo: 'git@github.com:GoogleChrome/modern-web-guidance.git',
+        dotfiles: true,
+        message: `Release v${newVersion}`,
+        tag: `v${newVersion}`,
+        src: GH_PUBLISH_PATTERNS,
+      },
+      (err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      },
+    );
   });
 
   // TODO: not working. Think we need a GH API key from the modern-web-guidance repo.


### PR DESCRIPTION
### Problem
The automated Publish workflow (such as [Publish Run #31428072379](https://github.com/GoogleChrome/modern-web-guidance-src/actions/runs/31428072379)) completed with a green checkmark, but the downstream repository [`GoogleChrome/modern-web-guidance`](https://github.com/GoogleChrome/modern-web-guidance) was not updated and remained stuck at `v0.0.179`.

### Root Cause
1. In #1181, `actions/create-github-app-token` in `.github/workflows/publish.yml` was configured with `repositories: ${{ github.event.repository.name }}` (`modern-web-guidance-src`), restricting the GitHub App installation token from having write permissions to `GoogleChrome/modern-web-guidance`.
2. In `serving/skills-cli/publish-skills.ts`, `ghpages.publish` was awaited directly without a callback. `gh-pages` swallowed the underlying git authentication/push error and resolved the returned Promise cleanly, causing the publish script to log success and pass CI despite the push failing.

### Changes
1. **`.github/workflows/publish.yml`**: Added `modern-web-guidance` to the App token `repositories` parameter (`repositories: ${{ github.event.repository.name }},modern-web-guidance`).
2. **`serving/skills-cli/publish-skills.ts`**: Wrapped `ghpages.publish` in an explicit Promise that checks the error callback so any future git push or authentication errors fail the step and surface in CI logs.