### PR TITLE
Create a registry for origin trial features

### DIFF
--- a/features/origin-trials.json
+++ b/features/origin-trials.json
@@ -1,23 +1,11 @@
 {
   "canvas-html": {
-    "chromestatus_url": "https://chromestatus.com/feature/5172548013916160",
-    "milestones": {
-      "chrome_first": 148,
-      "chrome_last": 154
-    }
+    "chromestatus_url": "https://chromestatus.com/feature/5172548013916160"
   },
   "declarative-webmcp": {
-    "chromestatus_url": "https://chromestatus.com/feature/5117755740913664",
-    "milestones": {
-      "chrome_first": 149,
-      "chrome_last": 156
-    }
+    "chromestatus_url": "https://chromestatus.com/feature/5117755740913664"
   },
   "document-modelcontext": {
-    "chromestatus_url": "https://chromestatus.com/feature/5117755740913664",
-    "milestones": {
-      "chrome_first": 149,
-      "chrome_last": 156
-    }
+    "chromestatus_url": "https://chromestatus.com/feature/5117755740913664"
   }
 }

--- a/features/origin-trials.json
+++ b/features/origin-trials.json
@@ -1,0 +1,23 @@
+{
+  "canvas-html": {
+    "chromestatus_url": "https://chromestatus.com/feature/5172548013916160",
+    "milestones": {
+      "chrome_first": 148,
+      "chrome_last": 154
+    }
+  },
+  "declarative-webmcp": {
+    "chromestatus_url": "https://chromestatus.com/feature/5117755740913664",
+    "milestones": {
+      "chrome_first": 149,
+      "chrome_last": 156
+    }
+  },
+  "document-modelcontext": {
+    "chromestatus_url": "https://chromestatus.com/feature/5117755740913664",
+    "milestones": {
+      "chrome_first": 149,
+      "chrome_last": 156
+    }
+  }
+}

--- a/guides/validate-after-web-feature-update.ts
+++ b/guides/validate-after-web-feature-update.ts
@@ -2,7 +2,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { features } from 'web-features';
-import { scanAllGuides, scanDisciplineSkills } from '../lib/guide-validation.ts';
+import { scanAllGuides, scanDisciplineSkills, getOriginTrialsRegistry } from '../lib/guide-validation.ts';
+import { resolveFeatureId } from '../serving/lib/baseline.ts';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -187,10 +188,57 @@ if (changedRegularFeatures.length > 0) {
   }
 }
 
+// 5. Check for graduated Origin Trial features (features in features/origin-trials.json that now have browser support)
+interface GraduatedOriginTrial {
+  featureId: string;
+  supportedBrowsers: string[];
+  locations: string[];
+}
+
+const originTrials = getOriginTrialsRegistry();
+const graduatedOriginTrials: GraduatedOriginTrial[] = [];
+for (const featureId of Object.keys(originTrials)) {
+  const resolvedIds = resolveFeatureId(featureId);
+  const supportedBrowsers: string[] = [];
+  for (const id of resolvedIds) {
+    const f = (features as Record<string, any>)[id];
+    if (f?.status?.support) {
+      for (const [browser, version] of Object.entries(f.status.support)) {
+        if (version && version !== '-') {
+          supportedBrowsers.push(`${browser} ${version}`);
+        }
+      }
+    }
+  }
+  if (supportedBrowsers.length > 0) {
+    const locations = Array.from(featureToLocations.get(featureId) || []);
+    graduatedOriginTrials.push({
+      featureId,
+      supportedBrowsers,
+      locations,
+    });
+    hasError = true;
+  }
+}
+
+if (graduatedOriginTrials.length > 0) {
+  console.log('🎓 Graduated Origin Trial feature IDs detected:');
+  for (const item of graduatedOriginTrials) {
+    console.log(`  - "${item.featureId}" now has browser support (${item.supportedBrowsers.join(', ')})`);
+    console.log('    ↳ Remove from features/origin-trials.json');
+    if (item.locations.length > 0) {
+      console.log('    ↳ Referenced in:');
+      for (const loc of item.locations) {
+        console.log(`      • ${loc}`);
+      }
+    }
+  }
+}
+
 // Write structured Markdown comment body to GITHUB_OUTPUT if any items were flagged
-if (process.env.GITHUB_OUTPUT && (expiredTemps.length > 0 || changedRegularFeatures.length > 0)) {
+if (process.env.GITHUB_OUTPUT && (expiredTemps.length > 0 || changedRegularFeatures.length > 0 || graduatedOriginTrials.length > 0)) {
   const sections: string[] = [
-    '⚠️ **Action Required**: This automated `web-features` update introduced official feature IDs or platform record shifts (`moved` / `split`) affecting guidance in this repository.\n'
+    '⚠️ **Action Required**: This automated `web-features` update introduced official feature IDs, platform record shifts (`moved` / `split`), or graduated Origin Trials affecting guidance in this repository.\n'
   ];
 
   if (expiredTemps.length > 0) {
@@ -234,6 +282,21 @@ if (process.env.GITHUB_OUTPUT && (expiredTemps.length > 0 || changedRegularFeatu
     sections.push('');
   }
 
+  if (graduatedOriginTrials.length > 0) {
+    sections.push('### 3. Graduated Origin Trial Features');
+    for (const item of graduatedOriginTrials) {
+      sections.push(`- **🎓 \`${item.featureId}\` has graduated** with browser support: ${item.supportedBrowsers.join(', ')}`);
+      sections.push('  ↳ *Action:* Remove from `features/origin-trials.json`');
+      if (item.locations.length > 0) {
+        sections.push('  ↳ *Referenced in:*');
+        for (const loc of item.locations) {
+          sections.push(`    - \`${loc}\``);
+        }
+      }
+    }
+    sections.push('');
+  }
+
   sections.push('Before merging this PR, please resolve the items flagged above and re-run guide validation checks.');
 
   const delimiter = `EOF_${Date.now()}`;
@@ -244,6 +307,6 @@ if (process.env.GITHUB_OUTPUT && (expiredTemps.length > 0 || changedRegularFeatu
 if (hasError) {
   process.exit(1);
 } else {
-  console.log('✅ All temporary and regular feature IDs are valid and active upstream.');
+  console.log('✅ All temporary, origin trial, and regular feature IDs are valid and active upstream.');
   process.exit(0);
 }

--- a/lib/guide-validation.ts
+++ b/lib/guide-validation.ts
@@ -25,6 +25,51 @@ export interface PreparedGuide {
   featureIds: string[];
   relativeSubdir: string;
   statusName: ProjectStatus | null;
+  originTrials?: OriginTrialMetadata[];
+}
+
+export interface OriginTrialMetadata {
+  name?: string;
+  chromestatus_url?: string;
+  milestones?: {
+    chrome_first?: number;
+    chrome_last?: number;
+  };
+}
+
+const ORIGIN_TRIALS_FILE = path.join(REPO_ROOT, 'features', 'origin-trials.json');
+let cachedOriginTrials: Record<string, OriginTrialMetadata> | null = null;
+
+export function getOriginTrialsRegistry(): Record<string, OriginTrialMetadata> {
+  if (!cachedOriginTrials) {
+    if (fs.existsSync(ORIGIN_TRIALS_FILE)) {
+      try {
+        const raw = fs.readFileSync(ORIGIN_TRIALS_FILE, 'utf8');
+        cachedOriginTrials = JSON.parse(raw);
+      } catch (e) {
+        cachedOriginTrials = {};
+      }
+    } else {
+      cachedOriginTrials = {};
+    }
+  }
+  return cachedOriginTrials!;
+}
+
+export function getOriginTrialMetadata(featureId: string): OriginTrialMetadata | undefined {
+  const registry = getOriginTrialsRegistry();
+  return registry[featureId];
+}
+
+export function getGuideOriginTrials(featureIds: string[]): OriginTrialMetadata[] {
+  const registry = getOriginTrialsRegistry();
+  const found: OriginTrialMetadata[] = [];
+  for (const id of featureIds) {
+    if (registry[id]) {
+      found.push(registry[id]);
+    }
+  }
+  return found;
 }
 
 export interface GuideInventoryResult {
@@ -257,6 +302,7 @@ export function processGuideInventory(guides: GuideInventory[]): GuideInventoryR
       featureIds,
       relativeSubdir,
       statusName,
+      originTrials: getGuideOriginTrials(featureIds),
     });
   }
 

--- a/lib/guide-validation.ts
+++ b/lib/guide-validation.ts
@@ -4,7 +4,8 @@ import matter from 'gray-matter';
 import { marked } from 'marked';
 
 import { validateMacros } from '../serving/lib/macros.ts';
-import { validateFeature } from '../serving/lib/baseline.ts';
+import { validateFeature, resolveFeatureId } from '../serving/lib/baseline.ts';
+import { features } from 'web-features';
 import { rootDir, guidesDir } from './paths.ts';
 import { Agents } from '../harness/config.ts';
 
@@ -31,10 +32,6 @@ export interface PreparedGuide {
 export interface OriginTrialMetadata {
   name?: string;
   chromestatus_url?: string;
-  milestones?: {
-    chrome_first?: number;
-    chrome_last?: number;
-  };
 }
 
 const ORIGIN_TRIALS_FILE = path.join(REPO_ROOT, 'features', 'origin-trials.json');
@@ -71,6 +68,36 @@ export function getGuideOriginTrials(featureIds: string[]): OriginTrialMetadata[
   }
   return found;
 }
+
+/**
+ * Checks all features in the Origin Trials registry against the web-features package.
+ * Returns warnings for any feature that has graduated (supported by any major browser).
+ */
+export function checkOriginTrialGraduations(): string[] {
+  const registry = getOriginTrialsRegistry();
+  const warnings: string[] = [];
+  for (const featureId of Object.keys(registry)) {
+    const resolvedIds = resolveFeatureId(featureId);
+    const supportedBrowsers: string[] = [];
+    for (const id of resolvedIds) {
+      const f = (features as Record<string, any>)[id];
+      if (f?.status?.support) {
+        for (const [browser, version] of Object.entries(f.status.support)) {
+          if (version && version !== '-') {
+            supportedBrowsers.push(`${browser} ${version}`);
+          }
+        }
+      }
+    }
+    if (supportedBrowsers.length > 0) {
+      warnings.push(
+        `Graduation Alert: Origin Trial feature "${featureId}" now has browser support (${supportedBrowsers.join(', ')}). The feature must be removed from features/origin-trials.json.`
+      );
+    }
+  }
+  return warnings;
+}
+
 
 export interface GuideInventoryResult {
   errors: string[];


### PR DESCRIPTION
Depends on #1263  (trying a PR stack for the first time, let's see how it works)

Creates `features/origin-trials.json`, a registry of features that are known to still be part of an origin trial. In a future PR, we can use this registry to make sure that guides that depend on these features can be omitted from MWG by default, unless the user opts in.

I initially considered adding a `origin-trial: true` field to the guide frontmatter (hence the branch name) but I didn't like how that required maintenance across all guides that touch the OT feature. Having a registry centralizes the OT status for all features.

This also incorporates a validation check in the newly added `guides/validate-after-web-feature-update.ts` script, which flags any features that we say are part of an active origin trial, but have actually just shipped to a stable browser. This is so that we don't hold back guidance for features any longer than necessary.

This PR doesn't do any validation to make sure that the OT is still active, but that was my reasoning for including `chromestatus_url` in the OT JSON, so that it could be used in the future. Maybe we'd query the Chrome Status API to get the OT milestone window and check that against the browser release dates provided by `web-features`. We could also hardcode the final milestone in the OT JSON, but I thought there'd be a chance of it going stale (more stale than chromestatus). Maybe it's a case of YAGNI.