### PR TITLE
build: decouple README generation from distribution build

### DIFF
--- a/serving/skills-cli/build-dist.ts
+++ b/serving/skills-cli/build-dist.ts
@@ -7,14 +7,11 @@ import { config } from "../../lib/skills-config.ts";
 import { rootDir } from "../../lib/paths.ts";
 import { processGuides } from "../scripts/build-guides.ts";
 import { replaceMacros } from "../lib/macros.ts";
-import { updateReadmeWithFeaturesAndUseCases } from "./build-readme.ts";
 
 const SERVING_DIR = path.join(rootDir, "serving");
 const ROOT_DIST_DIR = path.join(rootDir, "dist");
 
 interface BuildResult {
-  featuresCount: number;
-  useCasesCount: number;
   skillsCount: number;
   skillNames: string[];
 }
@@ -168,8 +165,6 @@ async function main(opts: { publishRoot: string, version?: string}): Promise<Bui
     fs.cpSync(path.join(SERVING_DIR, "skills-cli/template"), publishRoot, { recursive: true });
     fs.copyFileSync(path.join(rootDir, "LICENSE"), path.join(publishRoot, "LICENSE"));
 
-
-
     if (version) {
       updateVersionsInDir(publishRoot, version);
     }
@@ -280,10 +275,9 @@ async function main(opts: { publishRoot: string, version?: string}): Promise<Bui
     }
 
     const { skillsCount, skillNames } = processSkills(publishRoot);
-    const { featuresCount, useCasesCount } = updateReadmeWithFeaturesAndUseCases(publishRoot);
 
     console.log(`\nSuccess! standalone distribution generated in ${publishRoot}`);
-    return { featuresCount, useCasesCount, skillsCount, skillNames };
+    return { skillsCount, skillNames };
   } finally {
     if (fs.existsSync(lockFilePath)) {
       fs.unlinkSync(lockFilePath);

--- a/serving/skills-cli/publish-skills.ts
+++ b/serving/skills-cli/publish-skills.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { execSync } from 'node:child_process';
 import ghpages from 'gh-pages';
 import { buildDist } from './build-dist.ts';
+import { updateReadmeWithFeaturesAndUseCases } from './build-readme.ts';
 import { fileURLToPath } from 'node:url';
 import { minimatch } from 'minimatch';
 
@@ -145,10 +146,8 @@ async function main() {
     newVersion = incrementVersion(newVersion);
   }
 
-  const result = await validate(newVersion);
+  const { skillsCount, skillNames } = await validate(newVersion);
   const publishCliDir = path.join(DIST_DIR, "skills-cli");
-
-  const { featuresCount, useCasesCount, skillsCount, skillNames } = result;
 
   if (isDryRun) {
     const files = await fs.readdir(publishCliDir, {recursive: true, withFileTypes: true});
@@ -167,17 +166,15 @@ async function main() {
 
     console.log(`\n[Dry Run] Skipping GitHub publishing. Would push:\n - ${filteredFiles.join('\n - ')}`);
     console.log(`\n[Dry Run] ✅ Successfully verified v${newVersion} build pipeline offline!`);
-
-    console.log(`\n[Dry Run] Summary:`);
-    console.log(` - Use cases: ${useCasesCount}`);
-    console.log(` - Features: ${featuresCount}`);
-    console.log(` - Skills: ${skillsCount} (${skillNames.join(', ')})`);
+    console.log(`\n[Dry Run] Skills: ${skillsCount} (${skillNames.join(', ')})`);
 
     console.log(`\n💡 Tip: Run thorough pre-flight verification with FULL=1 to include heavy agent tests:`);
     console.log(`   env FULL=1 TEST_REPORTER=spec pnpm test`);
   } else {
     console.log(`\n💡 Tip: Run thorough pre-flight verification with FULL=1 to include heavy agent tests:`);
     console.log(`   env FULL=1 TEST_REPORTER=spec pnpm test`);
+
+    const { featuresCount, useCasesCount } = updateReadmeWithFeaturesAndUseCases(publishCliDir);
 
     const releaseNotes = `### Summary
 - Use cases: ${useCasesCount}

--- a/serving/skills-cli/test-dist.test.ts
+++ b/serving/skills-cli/test-dist.test.ts
@@ -114,18 +114,18 @@ test('Manifest source paths resolve relative to dist directory', async () => {
   await assert.doesNotReject(fs.access(resolvedVsCodePath), `VS Code skill path ${vscodePath} must resolve to an existing SKILL.md`);
 });
 
-test('README dynamic Skill Coverage content', async () => {
+test('README template and dynamic Skill Coverage content', async () => {
   const readmeRaw = await fs.readFile(path.join(STAGING_DIR, 'README.md'), 'utf8');
+  assert.ok(readmeRaw.includes('Modern Web Guidance'), 'README should contain title');
   
-  // Verify it contains the new headers and format
-  assert.ok(readmeRaw.includes('#### The full list'), 'README should contain the Skill Coverage header');
-  assert.ok(readmeRaw.includes('modern web features'), 'README should contain the feature count summary text');
-  assert.ok(readmeRaw.includes('<details>'), 'README should contain collapsible details tags');
-  assert.ok(readmeRaw.includes('<h3>'), 'README should contain category h3 headings');
-  
-  // Quick sanity check that at least one feature name format works out, e.g. explorer links
-  assert.match(readmeRaw, /https:\/\/web-platform-dx\.github\.io\/web-features-explorer\/features\//, 'README should contain links to Web Features Explorer');
-  assert.match(readmeRaw, /https:\/\/github\.com\/GoogleChrome\/modern-web-guidance\/blob\/main\/skills\/modern-web-guidance\/guides\//, 'README should contain GitHub blob links for use cases');
+  // When dynamic coverage is injected (e.g. during publish-skills validation), verify its format
+  if (readmeRaw.includes('#### The full list')) {
+    assert.ok(readmeRaw.includes('modern web features'), 'README should contain the feature count summary text');
+    assert.ok(readmeRaw.includes('<details>'), 'README should contain collapsible details tags');
+    assert.ok(readmeRaw.includes('<h3>'), 'README should contain category h3 headings');
+    assert.match(readmeRaw, /https:\/\/web-platform-dx\.github\.io\/web-features-explorer\/features\//, 'README should contain links to Web Features Explorer');
+    assert.match(readmeRaw, /https:\/\/github\.com\/GoogleChrome\/modern-web-guidance\/blob\/main\/skills\/modern-web-guidance\/guides\//, 'README should contain GitHub blob links for use cases');
+  }
 });
 
 test('modern-web CLI search and retrieve', async () => {


### PR DESCRIPTION
### Summary

Currently when adding or updating guides in a PR, `pnpm build` and `preflight` invoke `build-dist.ts`, which unconditionally mutated the root `README.md` file during the build step. This caused the CI check `git add -A && git diff --cached --exit-code` to fail on PRs unless authors manually committed the built README changes.

### Changes
1. **`serving/skills-cli/build-dist.ts`**: Removed the `updateReadmeWithFeaturesAndUseCases` call from `buildDist` so builds only compile vectors/guides, standalone skills, and esbuild binaries.
2. **`serving/skills-cli/publish-skills.ts`**: Moved the call to `updateReadmeWithFeaturesAndUseCases(publishCliDir)` directly into the release publishing step (`!isDryRun`), ensuring documentation is automatically updated during the weekly CI release workflow.
3. **`serving/skills-cli/test-dist.test.ts`**: Verified that tests check the template README in dist and only validate dynamic coverage when present.