### PR TITLE
restore wildcard CODEOWNERS but deferring content to atl-triage

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,18 +1,18 @@
 # Default owners for implementation and infra
 * @paulirish @micahjo7
 
-# Critical infra & workflow files
-.github/ @paulirish @micahjo7
-package.json @paulirish @micahjo7
-pnpm-lock.yaml @paulirish @micahjo7
-pnpm-workspace.yaml @paulirish @micahjo7
-
 # Blanket ownerless overrides for content (rely entirely on atl-triage bot instead)
 guides/
 features/
 
-# CODEOWNERS config (requires core infra + Rick's approval)
+# CODEOWNERS config
 CODEOWNERS @paulirish @rviscomi @micahjo7
+
+# Critical infra & workflow files (redundant but the explicitness is nice)
+.github/ @paulirish @micahjo7
+package.json @paulirish @micahjo7
+pnpm-lock.yaml @paulirish @micahjo7
+pnpm-workspace.yaml @paulirish @micahjo7
 
 # Eval files
 **/grader.ts @paulirish @micahjo7

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,18 @@
+# Default owners for implementation and infra
+* @paulirish @micahjo7
+
+# Critical infra & workflow files
+.github/ @paulirish @micahjo7
+package.json @paulirish @micahjo7
+pnpm-lock.yaml @paulirish @micahjo7
+pnpm-workspace.yaml @paulirish @micahjo7
+
+# Blanket ownerless overrides for content (rely entirely on atl-triage bot instead)
+guides/
+features/
+
+# CODEOWNERS config (requires core infra + Rick's approval)
+CODEOWNERS @paulirish @rviscomi @micahjo7
 
 # Eval files
 **/grader.ts @paulirish @micahjo7


### PR DESCRIPTION
Follow-up to #1206. Restores wildcard codeowners for infra while maintaining ownerless status for guide content.

### Context
The changes in #1206 removed the wildcard `*` owner rule. As a result, infrastructure files (including GitHub Actions workflows, project dependencies, and core libraries) currently have no codeowners. 

 Without codeowner coverage:

    * Any collaborator with write access can approve and merge changes to GitHub Action workflows,
  dependency files, or build configurations. 

While I can explicitly add some of those critical things (and I did)... We can also satisfy **both** multi-party approval AND the atl-triage pipeline..... using [this ownerless line trick](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#:~:text=as%20its%20owners%20are%20left%20empty).  

Therefore `guides/` and `features/` are set as ownerless. Content PRs will continue to route reviewer requests dynamically via the `atl-triage` bot. yay.




----


Furthermore, the **Require review from Code Owners** setting is disabled in the repository's `main` branch ruleset. (And has been since day 10.  So currently, the `CODEOWNERS` file only functions as a reviewer assignment mechanism. It does not act as a approval gate.  (Rick, remember that Thomas-merged PR that caught your eye? That was this.)

So.. I'd like to propose we turn this  on. Because I think generally we've all expected that that setting has been on ...  

Of course, 100% happy to revise this if something's not working well for us ...
