### PR TITLE
Sign infra bot commits from @google.com email

### DIFF
--- a/.github/workflows/update-web-features.yml
+++ b/.github/workflows/update-web-features.yml
@@ -97,6 +97,8 @@ jobs:
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v7.0.5
         with:
           token: ${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}
+          author: "Modern Web Guidance Bot <modern-web-guidance-bot@google.com>"
+          committer: "Modern Web Guidance Bot <modern-web-guidance-bot@google.com>"
           commit-message: "chore(deps): bump web-features package"
           title: "chore(deps): bump web-features package"
           body: |


### PR DESCRIPTION
Related https://github.com/GoogleChrome/modern-web-guidance-src/pull/1271

This is needed so that the CLA check doesn't fail when the bot opens PRs