### PR TITLE
Don't reassign an ATL who was unassigned

### DIFF
--- a/guides/atl-triage.test.ts
+++ b/guides/atl-triage.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, mock, before, after } from 'node:test';
 import assert from 'node:assert';
-import child_process from 'node:child_process';
 import {
   normalizeLabel,
   handleIssue,
   handlePR,
-  findGuidesTranscludingFeature
+  findGuidesTranscludingFeature,
+  githubApi
 } from './atl-triage.ts';
 import { getTranscludedFeatureIds, parseArguments } from '../serving/lib/macro-parsing.ts';
 import fs from 'node:fs';
@@ -156,13 +156,20 @@ describe('handleIssue', () => {
     }
   };
 
-  let execMock: any;
+  let unassignedMock: any;
+  let assigneesMock: any;
+  let addAssigneesMock: any;
+
   before(() => {
-    execMock = mock.method(child_process, 'execSync', () => '');
+    unassignedMock = mock.method(githubApi, 'getIssueUnassignedLogins', () => []);
+    assigneesMock = mock.method(githubApi, 'getIssueCurrentAssignees', () => []);
+    addAssigneesMock = mock.method(githubApi, 'addIssueAssignees', () => {});
   });
 
   after(() => {
-    execMock.mock.restore();
+    unassignedMock.mock.restore();
+    assigneesMock.mock.restore();
+    addAssigneesMock.mock.restore();
   });
 
   it('returns matched ATLs for matching labels', () => {
@@ -277,6 +284,41 @@ Affected web-feature IDs: [canvas-html](...)
     const result = handleIssue(123, [], description, mockConfig);
     assert.deepStrictEqual(result.sort(), ['malchata', 'override-issue-reviewer'].sort());
   });
+
+  it('skips auto-assigning ATLs who have previously been unassigned from the issue', () => {
+    unassignedMock.mock.mockImplementation(() => ['RVISCOMI']); // Test mixed-case matching
+
+    try {
+      const result = handleIssue(123, ['category:performance'], '', mockConfig);
+      // 'rviscomi' was unassigned, so only 'paulirish' should be assigned
+      assert.deepStrictEqual(result, ['paulirish']);
+    } finally {
+      unassignedMock.mock.mockImplementation(() => []);
+    }
+  });
+
+  it('returns empty array when all candidate ATLs were previously unassigned', () => {
+    unassignedMock.mock.mockImplementation(() => ['rviscomi', 'paulirish']);
+
+    try {
+      const result = handleIssue(123, ['category:performance'], '', mockConfig);
+      assert.deepStrictEqual(result, []);
+    } finally {
+      unassignedMock.mock.mockImplementation(() => []);
+    }
+  });
+
+  it('skips ATLs who are already assigned to the issue', () => {
+    assigneesMock.mock.mockImplementation(() => ['rviscomi']);
+
+    try {
+      const result = handleIssue(123, ['category:performance'], '', mockConfig);
+      // 'rviscomi' is already assigned, so only 'paulirish' is newly assigned
+      assert.deepStrictEqual(result, ['paulirish']);
+    } finally {
+      assigneesMock.mock.mockImplementation(() => []);
+    }
+  });
 });
 
 describe('handlePR', () => {
@@ -292,6 +334,16 @@ describe('handlePR', () => {
     },
     web_features_groups: {}
   };
+
+  let addReviewersMock: any;
+
+  before(() => {
+    addReviewersMock = mock.method(githubApi, 'addPrReviewers', () => {});
+  });
+
+  after(() => {
+    addReviewersMock.mock.restore();
+  });
 
   it('requests review from matching ATLs for content files', () => {
     const mockFiles = [
@@ -331,44 +383,22 @@ describe('handlePR', () => {
   });
 
   it('filters out already requested and reviewed ATLs case-insensitively', () => {
-    // Stub execSync to return mock values
-    const execMock = mock.method(child_process, 'execSync', (command: string) => {
-      if (command.includes('--json files')) {
-        // Return files lists
-        return 'guides/performance/deliver-optimized-decorative-images/guide.md\nguides/motion/carousel-slide-effects/expectations.md\n';
-      }
-      if (command.includes('--json reviews,reviewRequests')) {
-        // Return active requested / reviewed ATLs with mixed case to test case-insensitivity
-        return JSON.stringify({
-          reviewRequests: [
-            { login: 'Override-Pr-Reviewer' },
-            { login: 'rviscomi' },
-            { login: 'paulirish' }
-          ],
-          reviews: [
-            { author: { login: 'PhilipWalton' }, state: 'APPROVED' }
-          ]
-        });
-      }
-      if (command.includes('--add-reviewer')) {
-        return '';
-      }
-      throw new Error(`Unexpected command: ${command}`);
-    });
+    const filesMock = mock.method(githubApi, 'getPrFiles', () => [
+      'guides/performance/deliver-optimized-decorative-images/guide.md',
+      'guides/motion/carousel-slide-effects/expectations.md'
+    ]);
+    const reviewStateMock = mock.method(githubApi, 'getPrReviewState', () => ({
+      reviewRequests: ['Override-Pr-Reviewer', 'rviscomi', 'paulirish'],
+      reviews: ['PhilipWalton']
+    }));
 
     try {
-      // 'override-pr-reviewer' (via feature 'image-set' override), 'rviscomi', 'paulirish' (default performance),
-      // and 'philipwalton' (default motion) are resolved, but they are excluded because they are in reviewRequests/reviews.
-      // So no additional review request is made.
       const result = handlePR(456, 'some-contributor', mockConfig);
       assert.deepStrictEqual(result, []);
-      
-      // Ensure the add-reviewer command was not run since matchedAtls is empty after exclusions
-      const calls = execMock.mock.calls;
-      const addReviewerCalled = calls.some(call => String(call.arguments[0]).includes('--add-reviewer'));
-      assert.strictEqual(addReviewerCalled, false);
+      assert.strictEqual(addReviewersMock.mock.callCount(), 0);
     } finally {
-      execMock.mock.restore();
+      filesMock.mock.restore();
+      reviewStateMock.mock.restore();
     }
   });
 

--- a/guides/atl-triage.ts
+++ b/guides/atl-triage.ts
@@ -193,7 +193,61 @@ export function getAtlsFromDescription(description: string, atlConfig: AtlConfig
   return Array.from(resolvedAtls);
 }
 
-export function handleIssue(issueNumber: number, labels: string[], issueDescription: string, atlConfig: AtlConfig) {
+export const githubApi = {
+  getIssueUnassignedLogins(issueNumber: number): string[] {
+    const eventsOutput = child_process.execSync(
+      `gh api repos/{owner}/{repo}/issues/${issueNumber}/events --paginate --jq '.[] | select(.event == "unassigned") | .assignee.login'`,
+      { encoding: 'utf8' }
+    );
+    return eventsOutput
+      .split('\n')
+      .map(l => l.trim())
+      .filter(Boolean);
+  },
+
+  getIssueCurrentAssignees(issueNumber: number): string[] {
+    const assigneesOutput = child_process.execSync(
+      `gh issue view ${issueNumber} --json assignees --jq ".assignees[].login"`,
+      { encoding: 'utf8' }
+    );
+    return assigneesOutput
+      .split('\n')
+      .map(l => l.trim())
+      .filter(Boolean);
+  },
+
+  addIssueAssignees(issueNumber: number, assignees: string[]): void {
+    child_process.execSync(`gh issue edit ${issueNumber} --add-assignee "${assignees.join(',')}"`, { stdio: 'inherit' });
+  },
+
+  getIssueBody(issueNumber: number): string {
+    return child_process.execSync(`gh issue view ${issueNumber} --json body --jq ".body"`, { encoding: 'utf8' }).trim();
+  },
+
+  getPrFiles(prNumber: number): string[] {
+    const output = child_process.execSync(`gh pr view ${prNumber} --json files --jq ".files[].path"`, { encoding: 'utf8' });
+    return output.trim().split('\n').map(f => f.trim()).filter(Boolean);
+  },
+
+  getPrReviewState(prNumber: number): { reviewRequests: string[]; reviews: string[] } {
+    const output = child_process.execSync(`gh pr view ${prNumber} --json reviews,reviewRequests`, { encoding: 'utf8' });
+    const prData = JSON.parse(output);
+    const reviewRequests = (prData.reviewRequests || []).map((r: any) => r.login).filter(Boolean);
+    const reviews = (prData.reviews || []).map((r: any) => r.author?.login).filter(Boolean);
+    return { reviewRequests, reviews };
+  },
+
+  addPrReviewers(prNumber: number, reviewers: string[]): void {
+    child_process.execSync(`gh pr edit ${prNumber} --add-reviewer "${reviewers.join(',')}"`, { stdio: 'inherit' });
+  }
+};
+
+export function handleIssue(
+  issueNumber: number,
+  labels: string[],
+  issueDescription: string,
+  atlConfig: AtlConfig
+) {
   console.log(`Triaging issue #${issueNumber} with labels: ${labels.join(', ')}`);
   
   const assignedAtls = new Set<string>();
@@ -239,15 +293,49 @@ export function handleIssue(issueNumber: number, labels: string[], issueDescript
     return [];
   }
 
-  const assignees = Array.from(assignedAtls).join(',');
-  console.log(`Assigning issue #${issueNumber} to: ${assignees}`);
+  // Check if any candidate ATLs have ever been unassigned or are already assigned to this issue
+  const unassignedLogins = new Set<string>();
+  const currentAssignees = new Set<string>();
+
   try {
-    child_process.execSync(`gh issue edit ${issueNumber} --add-assignee "${assignees}"`, { stdio: 'inherit' });
+    const unassigned = githubApi.getIssueUnassignedLogins(issueNumber);
+    unassigned.forEach(l => unassignedLogins.add(l.toLowerCase()));
+  } catch (err) {
+    console.warn(`Failed to fetch event history for issue #${issueNumber}:`, err);
+  }
+
+  try {
+    const assignees = githubApi.getIssueCurrentAssignees(issueNumber);
+    assignees.forEach(l => currentAssignees.add(l.toLowerCase()));
+  } catch (err) {
+    console.warn(`Failed to fetch current assignees for issue #${issueNumber}:`, err);
+  }
+
+  for (const atl of Array.from(assignedAtls)) {
+    const lowerAtl = atl.toLowerCase();
+    if (unassignedLogins.has(lowerAtl)) {
+      console.log(`Skipping ATL @${atl} for issue #${issueNumber} because they were previously unassigned.`);
+      assignedAtls.delete(atl);
+    } else if (currentAssignees.has(lowerAtl)) {
+      console.log(`ATL @${atl} is already assigned to issue #${issueNumber}.`);
+      assignedAtls.delete(atl);
+    }
+  }
+
+  if (assignedAtls.size === 0) {
+    console.log('No new ATLs to assign to this issue.');
+    return [];
+  }
+
+  const assignees = Array.from(assignedAtls);
+  console.log(`Assigning issue #${issueNumber} to: ${assignees.join(',')}`);
+  try {
+    githubApi.addIssueAssignees(issueNumber, assignees);
     console.log('Successfully assigned issue.');
   } catch (err) {
     console.error(`Failed to assign issue #${issueNumber}:`, err);
   }
-  return Array.from(assignedAtls);
+  return assignees;
 }
 
 export interface TranscludedGuide {
@@ -311,8 +399,7 @@ export function handlePR(
     files = mockFiles;
   } else {
     try {
-      const output = child_process.execSync(`gh pr view ${prNumber} --json files --jq ".files[].path"`, { encoding: 'utf8' });
-      files = output.trim().split('\n').map(f => f.trim()).filter(Boolean);
+      files = githubApi.getPrFiles(prNumber);
     } catch (err) {
       console.error(`Failed to fetch files for PR #${prNumber}:`, err);
       return [];
@@ -383,13 +470,8 @@ export function handlePR(
 
   if (!mockFiles) {
     try {
-      const output = child_process.execSync(`gh pr view ${prNumber} --json reviews,reviewRequests`, { encoding: 'utf8' });
-      const prData = JSON.parse(output);
-      
-      const existingRequested = (prData.reviewRequests || []).map((r: any) => r.login).filter(Boolean);
-      const existingReviewed = (prData.reviews || []).map((r: any) => r.author?.login).filter(Boolean);
-      
-      excludeLogins.push(...existingRequested, ...existingReviewed);
+      const prData = githubApi.getPrReviewState(prNumber);
+      excludeLogins.push(...prData.reviewRequests, ...prData.reviews);
     } catch (err) {
       console.error(`Failed to fetch existing review state for PR #${prNumber}:`, err);
     }
@@ -409,17 +491,17 @@ export function handlePR(
     return [];
   }
 
-  const reviewers = Array.from(matchedAtls).join(',');
-  console.log(`Requesting review on PR #${prNumber} from: ${reviewers}`);
+  const reviewers = Array.from(matchedAtls);
+  console.log(`Requesting review on PR #${prNumber} from: ${reviewers.join(',')}`);
   if (!mockFiles) {
     try {
-      child_process.execSync(`gh pr edit ${prNumber} --add-reviewer "${reviewers}"`, { stdio: 'inherit' });
+      githubApi.addPrReviewers(prNumber, reviewers);
       console.log('Successfully requested reviews.');
     } catch (err) {
       console.error(`Failed to request reviews for PR #${prNumber}:`, err);
     }
   }
-  return Array.from(matchedAtls);
+  return reviewers;
 }
 
 export function main() {
@@ -468,7 +550,7 @@ export function main() {
       const labels = args.slice(2);
       let issueDescription = '';
       try {
-        issueDescription = child_process.execSync(`gh issue view ${number} --json body --jq ".body"`, { encoding: 'utf8' }).trim();
+        issueDescription = githubApi.getIssueBody(number);
       } catch (err) {
         console.warn(`Failed to fetch issue body for issue #${number}:`, err);
       }


### PR DESCRIPTION
If an ATL gets auto-assigned to an issue or PR, they should be able to remove their assignment without it automatically getting reassigned.

This change takes assignment removals into consideration before adding an ATL. Also cleaned up some weird tests.

cc @bramus 