### PR TITLE
Setup ATL triage for new `gd dev` report PRs

### DIFF
--- a/.github/workflows/atl-triage.yml
+++ b/.github/workflows/atl-triage.yml
@@ -9,7 +9,7 @@ on:
   # switch to `pull_request_target` (read-write token) and fetch changed-file
   # contents via the API rather than the base checkout.
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, labeled]
 
 permissions:
   issues: write

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,6 +15,7 @@ pnpm-lock.yaml @paulirish @micahjo7
 pnpm-workspace.yaml @paulirish @micahjo7
 
 # Eval files
+**/targets/ @paulirish @micahjo7
 **/grader.ts @paulirish @micahjo7
 **/tasks/task.md @paulirish @micahjo7
 **/negative-demo.html @paulirish @micahjo7

--- a/guides/atl-triage.test.ts
+++ b/guides/atl-triage.test.ts
@@ -349,7 +349,7 @@ describe('handlePR', () => {
     const mockFiles = [
       'guides/performance/deliver-optimized-decorative-images/guide.md', // Has 'image-set' feature, will be overridden!
       'guides/motion/carousel-slide-effects/expectations.md',
-      'guides/css-layout/grid-layout/demo.html',
+      'guides/css-layout/grid-layout/guide.md',
       'guides/css-layout/grid-layout/other-file.json' // shouldn't trigger
     ];
 
@@ -371,18 +371,36 @@ describe('handlePR', () => {
     assert.deepStrictEqual(result.sort(), ['rviscomi', 'paulirish', 'philipwalton'].sort());
   });
 
-  it('returns empty array when no content files are touched', () => {
+  it('returns empty array when no content files are touched and gd-dev-content label is not set', () => {
     const mockFiles = [
       'guides/performance/deliver-optimized-decorative-images/grader.ts',
       'guides/performance/deliver-optimized-decorative-images/tasks/task.md',
+      'guides/performance/deliver-optimized-decorative-images/demo.html',
       'README.md'
     ];
 
-    const result = handlePR(456, 'some-contributor', mockConfig, mockFiles);
+    const result = handlePR(456, 'some-contributor', mockConfig, mockFiles, undefined, ['gd-dev-eval']);
     assert.deepStrictEqual(result, []);
   });
 
+  it('assigns corresponding ATL when gd-dev-content label is present even if only target eval files were touched', () => {
+    const mockFiles = [
+      'guides/performance/deliver-optimized-decorative-images/targets/daily-grind/grader.ts',
+      'guides/performance/deliver-optimized-decorative-images/targets/daily-grind/patches/zero-passrate.patch',
+      'guides/motion/carousel-slide-effects/targets/daily-grind/task.md'
+    ];
+
+    const result = handlePR(456, 'some-contributor', mockConfig, mockFiles, undefined, ['gd-dev-content']);
+    // 'deliver-optimized-decorative-images' has 'image-set' -> override-pr-reviewer + rviscomi, paulirish (performance)
+    // 'carousel-slide-effects' -> philipwalton (motion)
+    assert.deepStrictEqual(
+      result.sort(),
+      ['override-pr-reviewer', 'rviscomi', 'paulirish', 'philipwalton'].sort()
+    );
+  });
+
   it('filters out already requested and reviewed ATLs case-insensitively', () => {
+
     const filesMock = mock.method(githubApi, 'getPrFiles', () => [
       'guides/performance/deliver-optimized-decorative-images/guide.md',
       'guides/motion/carousel-slide-effects/expectations.md'

--- a/guides/atl-triage.ts
+++ b/guides/atl-triage.ts
@@ -10,7 +10,6 @@ import { getTranscludedFeatureIds } from '../serving/lib/macro-parsing.ts';
 // in the GitHub Actions runner, slowing down the triage job.
 export const GUIDE_FILE = 'guide.md';
 export const SKILL_FILE = 'SKILL.md';
-export const DEMO_FILE = 'demo.html';
 export const EXPECTATIONS_FILE = 'expectations.md';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -390,7 +389,8 @@ export function handlePR(
   prAuthor: string,
   atlConfig: AtlConfig,
   mockFiles?: string[],
-  guidesRootDir: string = path.join(path.resolve(__dirname, '..'), 'guides')
+  guidesRootDir: string = path.join(path.resolve(__dirname, '..'), 'guides'),
+  labels: string[] = []
 ) {
   console.log(`Triaging PR #${prNumber} by author: @${prAuthor}`);
   
@@ -408,23 +408,21 @@ export function handlePR(
 
   console.log(`PR modified ${files.length} files.`);
   
-  const contentFilenames = new Set([GUIDE_FILE, DEMO_FILE, EXPECTATIONS_FILE, SKILL_FILE]);
+  const contentFilenames = new Set([GUIDE_FILE, EXPECTATIONS_FILE, SKILL_FILE]);
+  const isContentLabelled = labels.includes('gd-dev-content');
   const matchedAtls = new Set<string>();
-
-  const REPO_ROOT = path.resolve(__dirname, '..');
 
   for (const file of files) {
     const parts = file.split(/[/\\]/);
 
-    // 1. Content files under guides/<category>/...
-    if (parts[0] === 'guides' && parts.length >= 2) {
+    // 1. Content files under guides/<category>/<guide-name>/...
+    if (parts[0] === 'guides' && parts.length >= 3) {
       const category = parts[1];
+      const guideName = parts[2];
       const filename = parts[parts.length - 1];
-
-      if (contentFilenames.has(filename)) {
-        const absolutePath = path.isAbsolute(file) ? file : path.join(REPO_ROOT, file);
-        const dir = path.dirname(absolutePath);
-        const guidePath = path.join(dir, GUIDE_FILE);
+      if (contentFilenames.has(filename) || isContentLabelled) {
+        const guideDir = path.join(guidesRootDir, category, guideName);
+        const guidePath = path.join(guideDir, GUIDE_FILE);
         const featureIds = getFeatureIdsFromGuide(guidePath);
         const atl = resolveAtl(category, featureIds, atlConfig);
         if (atl) {
@@ -523,7 +521,8 @@ export function main() {
     else if (event.pull_request) {
       const prNumber = event.pull_request.number;
       const prAuthor = event.pull_request.user.login;
-      handlePR(prNumber, prAuthor, atlConfig);
+      const prLabels = (event.pull_request.labels || []).map((l: any) => l.name);
+      handlePR(prNumber, prAuthor, atlConfig, undefined, undefined, prLabels);
     } 
     else {
       console.log('Event is neither an issue nor a pull request event. Skipping.');
@@ -534,7 +533,7 @@ export function main() {
     if (args.length < 2) {
       console.log('Usage for manual testing:');
       console.log('  node guides/atl-triage.ts issue <number> <label1> <label2> ...');
-      console.log('  node guides/atl-triage.ts pr <number> <author>');
+      console.log('  node guides/atl-triage.ts pr <number> <author> [label1] [label2] ...');
       process.exit(1);
     }
 
@@ -557,7 +556,8 @@ export function main() {
       handleIssue(number, labels, issueDescription, atlConfig);
     } else if (type === 'pr') {
       const author = args[2] || '';
-      handlePR(number, author, atlConfig);
+      const labels = args.slice(3);
+      handlePR(number, author, atlConfig, undefined, undefined, labels);
     } else {
       console.error(`Unknown type: ${type}`);
       process.exit(1);

--- a/guides/gd-dev-prompts.ts
+++ b/guides/gd-dev-prompts.ts
@@ -232,15 +232,14 @@ Diagnose each target according to its assigned flag:
 
 4. **\`LOW_GUIDED_PASS_RATE\`**:
    - The guided agent pass rate is under 90%.
-   - **Root Cause Investigation**: Review the failed assertions in \`${REPORT_FILE}\` and examine \`${GUIDE_FILE}\`, \`${EXPECTATIONS_FILE}\`, \`targets/<target>/grader.ts\`, and \`targets/<target>/task.md\` to understand why the agent fell short. Consider:
+   - **Root Cause Investigation**: Review the failed assertions in \`${REPORT_FILE}\` and examine \`${GUIDE_FILE}\`, \`${EXPECTATIONS_FILE}\`, and \`targets/<target>/grader.ts\` to understand why the agent fell short. Consider:
      - **Guidance Quality (\`${GUIDE_FILE}\`)**: Does the guide lack essential modern web practices, clear syntax examples, fallback patterns, or common pitfalls?
      - **Expectations Alignment (\`${EXPECTATIONS_FILE}\`)**: Are the must-pass expectations ambiguous, conflicting, or missing key constraints?
-     - **Grader Robustness (\`targets/<target>/grader.ts\`)**: Is the grader testing rigid implementation details, arbitrary markup, or unstated assumptions rather than outcome-based requirements?
-     - **Task Prompt Framing (\`targets/<target>/task.md\`)**: Is the prompt misleading, conflicting, or underspecified?
+     - **Grader Robustness (\`targets/<target>/grader.ts\`)**: Is the grader failing valid implementations due to brittle regex, rigid file/syntax assumptions, or over-constrained assertions rather than testing observable outcomes?
    - **Recommendation Rules (Mutually Exclusive)**:
      - **Source-of-Truth Fixes**: If \`${GUIDE_FILE}\` or \`${EXPECTATIONS_FILE}\` needs changes, recommend modifications **ONLY** to those files and **DO NOT** recommend edits to any files in \`targets/\`. Always append:
        \`*(Note: After modifying source files, delete the targets/ directory and re-run gd dev to regenerate all target artifacts)*\`
-     - **Target-Isolated Fixes**: Only recommend direct edits to \`targets/<target>/grader.ts\` or \`targets/<target>/task.md\` if \`${GUIDE_FILE}\` and \`${EXPECTATIONS_FILE}\` require **NO** changes.
+     - **Grader Fixes**: Only recommend direct edits to \`targets/<target>/grader.ts\` if \`${GUIDE_FILE}\` and \`${EXPECTATIONS_FILE}\` require **NO** changes.
 
 5. **\`HEALTHY\`**:
    - The target achieved ≥ 90% guided pass rate with all guidance tools and guides correctly consumed.


### PR DESCRIPTION
## Summary

- **CODEOWNERS**: Add `**/targets/` under `# Eval files` to ensure target capsule artifacts (`grader.ts`, `task.md`, and patches) are owned by `@paulirish` and `@micahjo7`.
- **ATL Triage**:
  - Remove `DEMO_FILE` from `contentFilenames` so deleting legacy demos during `gd dev` doesn't inadvertently trigger ATL review requests.
  - Support `gd-dev-content` label on PRs to request ATL review for the affected guide's category/features even if only target eval artifacts are touched initially.
  - Add `labeled` event trigger to `.github/workflows/atl-triage.yml`.
- **Prompts**: Refine recommendation and root cause investigation rules in `gd-dev-prompts.ts`.

## Test Plan

- `node --test guides/atl-triage.test.ts` (all 40 tests passing)
- `pnpm preflight` (build, typecheck, oxlint, and all workspace tests passing)
