### PR TITLE
fix(harness): support custom_tool_call in Codex trajectory extraction

### DIFF
--- a/harness/agents/codex-cli-agent.ts
+++ b/harness/agents/codex-cli-agent.ts
@@ -56,17 +56,7 @@ function exportCodexTrajectories(workDir: string, targetDir: string): void {
     fs.copyFileSync(src, path.join(targetDir, rawDestName));
 
     // 2. Read and parse JSONL
-    const logContent = fs.readFileSync(src, 'utf8');
-    const jsonLines = logContent.split(/\r?\n/).filter(Boolean);
-
-    const logData = jsonLines.map(line => {
-      try {
-        return JSON.parse(line);
-      } catch (e) {
-        console.error("Failed to parse JSONL line:", e);
-        return { error: "Failed to parse line", raw: line };
-      }
-    });
+    const logData = parseJsonlFile(src);
 
     // 3. Generate and save the HTML viewer
     const htmlContent = generateCodexTrajectoryHtml(logData);
@@ -121,6 +111,66 @@ async function run() {
   }
 }
 
+function unescapeString(raw: string, quote: string): string {
+  if (quote === '"') {
+    try {
+      return JSON.parse(`"${raw}"`);
+    } catch {
+      return raw.replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+    }
+  } else if (quote === "'") {
+    return raw.replace(/\\'/g, "'").replace(/\\\\/g, '\\');
+  } else if (quote === '`') {
+    return raw.replace(/\\`/g, '`').replace(/\\\\/g, '\\');
+  }
+  return raw;
+}
+
+export function extractCommandsFromCodexItem(obj: any): string[] {
+  const commands: string[] = [];
+  const payload = obj?.payload || obj;
+  if (!payload) return commands;
+
+  const itemType = payload.type || obj?.type;
+  if (itemType !== 'function_call' && itemType !== 'custom_tool_call') {
+    return commands;
+  }
+
+  const raw = payload.input ?? payload.arguments ?? obj.input ?? obj.arguments;
+  if (!raw) return commands;
+
+  if (typeof raw === 'object') {
+    if (typeof raw.cmd === 'string') commands.push(raw.cmd);
+    else if (typeof raw.command === 'string') commands.push(raw.command);
+    return commands;
+  }
+
+  if (typeof raw === 'string') {
+    try {
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === 'object') {
+        if (typeof parsed.cmd === 'string') return [parsed.cmd];
+        if (typeof parsed.command === 'string') return [parsed.command];
+      }
+    } catch {
+      // Not direct JSON
+    }
+
+    const cmdRegex = /["']?(?:cmd|command)["']?\s*:\s*(["'`])((?:\\.|(?!\1).)*)\1/g;
+    let found = false;
+    for (const match of raw.matchAll(cmdRegex)) {
+      commands.push(unescapeString(match[2], match[1]));
+      found = true;
+    }
+
+    if (!found && itemType === 'function_call' && raw.trim()) {
+      commands.push(raw);
+    }
+  }
+
+  return commands;
+}
+
 export async function collectCodexGuidesFromTrajectory(dirPath: string, serving: string): Promise<GuideUsage> {
   const retrievedGuides: string[] = [];
   const fileReadGuides: string[] = [];
@@ -128,25 +178,18 @@ export async function collectCodexGuidesFromTrajectory(dirPath: string, serving:
   for (const file of getSessionFiles(dirPath)) {
     const items = parseJsonlFile(path.join(dirPath, file));
     for (const obj of items) {
-      const functionCall = obj.type === 'function_call' ? obj : (obj.payload?.type === 'function_call' ? obj.payload : null);
-      if (functionCall?.name === 'exec_command' && functionCall.arguments) {
-        try {
-          const args = typeof functionCall.arguments === 'string' ? JSON.parse(functionCall.arguments) : functionCall.arguments;
-          const command = args.cmd || '';
-
-          if (serving === Serving.SKILLS_CLI && command.includes('modern-web') && (command.includes('retrieve') || command.includes('--retrieve'))) {
-            const match = command.match(/(?:--)?retrieve\s+["']?([^"'\s]+)["']?/);
-            if (match) {
-              retrievedGuides.push(...match[1].split(',').map((s: string) => s.trim()));
-            }
-          } else if (serving === Serving.SKILLS && command.includes('.agents/skills/') && command.includes('guide.md')) {
-            const match = command.match(/\.agents\/skills\/[^/]+\/([^/]+)\/guide\.md/);
-            if (match) {
-              retrievedGuides.push(match[1]);
-            }
+      const commands = extractCommandsFromCodexItem(obj);
+      for (const command of commands) {
+        if (serving === Serving.SKILLS_CLI && command.includes('modern-web') && (command.includes('retrieve') || command.includes('--retrieve'))) {
+          const match = command.match(/(?:--)?retrieve\s+["']?([^"'\s]+)["']?/);
+          if (match) {
+            retrievedGuides.push(...match[1].split(',').map((s: string) => s.trim()));
           }
-        } catch {
-          // Ignore
+        } else if (serving === Serving.SKILLS && command.includes('.agents/skills/') && command.includes('guide.md')) {
+          const match = command.match(/\.agents\/skills\/[^/]+\/([^/]+)\/guide\.md/);
+          if (match) {
+            fileReadGuides.push(match[1]);
+          }
         }
       }
     }
@@ -207,19 +250,13 @@ export function collectCodexToolsFromTrajectory(dir: string): string[] {
   for (const file of sessionFiles) {
     const items = parseJsonlFile(path.join(dir, file));
     for (const obj of items) {
-      const functionCall = obj.type === 'function_call' ? obj : (obj.payload?.type === 'function_call' ? obj.payload : null);
-      if (functionCall?.name === 'exec_command' && functionCall.arguments) {
-        try {
-          const args = typeof functionCall.arguments === 'string' ? JSON.parse(functionCall.arguments) : functionCall.arguments;
-          const command = args.cmd || '';
-          if (command.includes('/skills/') && command.includes('SKILL.md')) {
-            const match = command.match(/\.agents\/skills\/([^/]+)\/SKILL\.md/);
-            if (match) {
-              toolsUsed.push(match[1]);
-            }
+      const commands = extractCommandsFromCodexItem(obj);
+      for (const command of commands) {
+        if (command.includes('.agents/skills/') && command.includes('SKILL.md')) {
+          const match = command.match(/\.agents\/skills\/([^/]+)\/SKILL\.md/);
+          if (match) {
+            toolsUsed.push(match[1]);
           }
-        } catch {
-          // Ignore
         }
       }
     }

--- a/harness/lib/codex-trajectory-viewer.ts
+++ b/harness/lib/codex-trajectory-viewer.ts
@@ -116,7 +116,7 @@ export function generateCodexTrajectoryHtml(logData: any[]): string {
   html += "              contentHtml = '<div class=\"thought\"><b>Reasoning Process:</b><br/>' + escapeHtml(p.content || '[Reasoning]') + '</div>';\n";
   html += '          } else if (p.type === "function_call" || p.type === "custom_tool_call") {\n';
   html += '              role = "assistant";\n';
-  html += '              contentHtml = renderTool(p.name, p.arguments, p.call_id);\n';
+  html += '              contentHtml = renderTool(p.name, p.arguments || p.input, p.call_id);\n';
   html += '          } else if (p.type === "function_call_output" || p.type === "custom_tool_call_output") {\n';
   html += '              role = "system";\n';
   html += '              const errorClass = p.is_error ? " error" : "";\n';

--- a/harness/tests/trajectory-parsing.test.ts
+++ b/harness/tests/trajectory-parsing.test.ts
@@ -6,6 +6,7 @@ import os from 'os';
 import { DatabaseSync } from 'node:sqlite';
 import { collectGeminiGuidesFromTrajectory, collectGeminiToolsFromTrajectory } from '../agents/gemini-cli-agent.ts';
 import { collectClaudeGuidesFromTrajectory, collectClaudeToolsFromTrajectory } from '../agents/claude-code-agent.ts';
+import { collectCodexGuidesFromTrajectory, collectCodexToolsFromTrajectory, extractCommandsFromCodexItem, extractCodexCliModel, extractCodexCliTokenUsage } from '../agents/codex-cli-agent.ts';
 import { collectJetskiCliGuidesFromTrajectory, collectJetskiCliToolsFromTrajectory, writeTrajectorySummary, readTrajectorySummary, parseJetskiCliSession } from '../agents/jetski-cli-agent.ts';
 import { collectGuidesUsed, collectGuidanceToolsUsed } from '../lib/guidance_validation.ts';
 import { extractModelFromResults, extractTokenUsageFromResults } from '../lib/collection.ts';
@@ -289,6 +290,146 @@ test('trajectory_summary.json generation and priority read', async () => {
 
     const tokenUsage = extractTokenUsageFromResults(tempDir, Agents.JETSKI_CLI);
     assert.deepStrictEqual(tokenUsage, { total: 500, cached: 200 });
+  } finally {
+    removeTempDir(tempDir);
+  }
+});
+
+test('extractCommandsFromCodexItem handles quotes, backticks, escapes, and parentheses', () => {
+  // 1. JSON object in function_call
+  const cmd1 = extractCommandsFromCodexItem({
+    type: 'function_call',
+    arguments: JSON.stringify({ cmd: 'echo "hello"' })
+  });
+  assert.deepStrictEqual(cmd1, ['echo "hello"']);
+
+  // 2. Custom tool call with double quotes, escapes, and parentheses (e.g. subshell)
+  const cmd2 = extractCommandsFromCodexItem({
+    type: 'custom_tool_call',
+    input: 'const r = await tools.exec_command({"cmd":"echo $(which node) && (true || false)"}); text(r.output);'
+  });
+  assert.deepStrictEqual(cmd2, ['echo $(which node) && (true || false)']);
+
+  // 3. Custom tool call with single quotes
+  const cmd3 = extractCommandsFromCodexItem({
+    payload: {
+      type: 'custom_tool_call',
+      input: "const r = await tools.exec_command({cmd: 'cat index.html && find . ( -name \\'*.ts\\' )'});"
+    }
+  });
+  assert.deepStrictEqual(cmd3, ["cat index.html && find . ( -name '*.ts' )"]);
+
+  // 4. Custom tool call with backticks
+  const cmd4 = extractCommandsFromCodexItem({
+    payload: {
+      type: 'custom_tool_call',
+      input: 'const r = await tools.exec_command({cmd: `ls -la`});'
+    }
+  });
+  assert.deepStrictEqual(cmd4, ['ls -la']);
+});
+
+test('collectCodex metrics from legacy function_call trajectory file', async () => {
+  const tempDir = createTempDir();
+  try {
+    const lines = [
+      JSON.stringify({
+        type: 'function_call',
+        name: 'exec_command',
+        arguments: JSON.stringify({ cmd: "sed -n '1,220p' /tmp/env/.agents/skills/modern-web-guidance/SKILL.md" })
+      }),
+      JSON.stringify({
+        type: 'function_call',
+        name: 'exec_command',
+        arguments: JSON.stringify({ cmd: 'npx -y modern-web-guidance@latest retrieve "visually-texture-content,complex-shapes"' })
+      }),
+      JSON.stringify({
+        type: 'function_call',
+        name: 'exec_command',
+        arguments: JSON.stringify({ cmd: 'cat /tmp/env/.agents/skills/css/size-aware-styling/guide.md' })
+      })
+    ];
+
+    fs.writeFileSync(path.join(tempDir, 'session-123.jsonl'), lines.join('\n'));
+
+    const guides = await collectCodexGuidesFromTrajectory(tempDir, Serving.SKILLS_CLI);
+    assert.deepStrictEqual(guides.retrievedGuides, ['visually-texture-content', 'complex-shapes']);
+    assert.deepStrictEqual(guides.fileReadGuides, []);
+
+    const skillGuides = await collectCodexGuidesFromTrajectory(tempDir, Serving.SKILLS);
+    assert.deepStrictEqual(skillGuides.fileReadGuides, ['size-aware-styling']);
+
+    const tools = collectCodexToolsFromTrajectory(tempDir);
+    assert.deepStrictEqual(tools, ['modern-web-guidance']);
+  } finally {
+    removeTempDir(tempDir);
+  }
+});
+
+test('collectCodex metrics from modern custom_tool_call trajectory file', async () => {
+  const tempDir = createTempDir();
+  try {
+    const lines = [
+      JSON.stringify({
+        type: 'response_item',
+        payload: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          input: 'const r = await tools.exec_command({"cmd":"sed -n \'1,240p\' /tmp/test/.agents/skills/modern-web-guidance/SKILL.md","workdir":"/tmp/test"}); text(r.output);'
+        }
+      }),
+      JSON.stringify({
+        type: 'response_item',
+        payload: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          input: 'const r = await tools.exec_command({"cmd":"npx -y modern-web-guidance@latest retrieve \\"validate-input-after-interaction,accessible-error-announcement\\"","workdir":"/tmp/test"}); text(r.output);'
+        }
+      }),
+      JSON.stringify({
+        type: 'response_item',
+        payload: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          input: 'const r = await tools.exec_command({"cmd":"cat /tmp/test/.agents/skills/forms/validate-input-after-interaction/guide.md"}); text(r.output);'
+        }
+      }),
+      JSON.stringify({
+        type: 'turn_context',
+        payload: {
+          model: 'gpt-5.6-sol'
+        }
+      }),
+      JSON.stringify({
+        type: 'event_msg',
+        payload: {
+          type: 'token_count',
+          info: {
+            total_token_usage: {
+              total_tokens: 1500,
+              cached_input_tokens: 400
+            }
+          }
+        }
+      })
+    ];
+
+    fs.writeFileSync(path.join(tempDir, 'session-456.jsonl'), lines.join('\n'));
+
+    const guides = await collectCodexGuidesFromTrajectory(tempDir, Serving.SKILLS_CLI);
+    assert.deepStrictEqual(guides.retrievedGuides, ['validate-input-after-interaction', 'accessible-error-announcement']);
+
+    const skillGuides = await collectCodexGuidesFromTrajectory(tempDir, Serving.SKILLS);
+    assert.deepStrictEqual(skillGuides.fileReadGuides, ['validate-input-after-interaction']);
+
+    const tools = collectCodexToolsFromTrajectory(tempDir);
+    assert.deepStrictEqual(tools, ['modern-web-guidance']);
+
+    const model = extractCodexCliModel(tempDir);
+    assert.strictEqual(model, 'gpt-5.6-sol');
+
+    const tokenUsage = extractCodexCliTokenUsage(tempDir);
+    assert.deepStrictEqual(tokenUsage, { total: 1500, cached: 400 });
   } finally {
     removeTempDir(tempDir);
   }


### PR DESCRIPTION
## Description

Fixes an issue where tool activation and guide retrieval rates were reported as 0% for newer Codex CLI nightly runs (such as those using `gpt-5.6-sol`): https://googlechrome.github.io/modern-web-guidance-src/dashboard.html?testId=nightly-2026-08-17_18-50-02-codex_cli&source=remote

### Cause
Newer Codex CLI versions emit `custom_tool_call` events with `name: "exec"` running `tools.exec_command(...)` in JavaScript, whereas previous versions emitted classic `function_call` events with `name: "exec_command"`. The previous trajectory extraction logic only searched for the classic `function_call` structure.

### Changes
1. Added `extractCommandsFromCodexItem` in `harness/agents/codex-cli-agent.ts` to extract shell commands from both classic `function_call` and modern `custom_tool_call` payloads.
2. Updated `collectCodexGuidesFromTrajectory` to properly route `guide.md` file reads into `fileReadGuides`.
3. Updated `harness/lib/codex-trajectory-viewer.ts` to support `p.arguments || p.input` when rendering tool calls in the trajectory viewer.
4. Added comprehensive test coverage in `harness/tests/trajectory-parsing.test.ts` covering quotes, backticks, escapes, subshells, guide extraction, model extraction, and token usage extraction.

### Verification
- Tested against actual GCS nightly runs:
  - `nightly-2026-08-17_18-50-02-codex_cli` (`gpt-5.6-sol`): Tool Activation: 100% (130/130), Guide Usage: 97% (126/130).
  - `nightly-2026-08-10_18-08-49-codex_cli` (`gpt-5.5`): Tool Activation: 100% (130/130), Guide Usage: 98% (127/130).
- Passed `pnpm run preflight`.