### PR TITLE
fix(cli): keep demo.html during artifact cleanup and fix gd pr edit GraphQL error

### DIFF
--- a/guides/dev-guide.test.ts
+++ b/guides/dev-guide.test.ts
@@ -186,7 +186,7 @@ test('collectPlaywrightErrors correctly parses nested suites, deduplicates error
   assert.strictEqual(collectPlaywrightErrors({}), '');
 });
 
-test('exciseOldEvalArtifacts removes tasks folder, grader.ts, demo.html, and negative-demo.html when they exist', async (t) => {
+test('exciseOldEvalArtifacts removes tasks folder, grader.ts, and negative-demo.html when they exist while keeping demo.html', async (t) => {
   const fs = await import('node:fs');
   const path = await import('node:path');
   const os = await import('node:os');
@@ -216,10 +216,10 @@ test('exciseOldEvalArtifacts removes tasks folder, grader.ts, demo.html, and neg
   // Assert old artifacts were deleted
   assert.strictEqual(fs.existsSync(tasksDir), false, 'tasks directory should be excised');
   assert.strictEqual(fs.existsSync(path.join(tmpDir, 'grader.ts')), false, 'grader.ts should be excised');
-  assert.strictEqual(fs.existsSync(path.join(tmpDir, 'demo.html')), false, 'demo.html should be excised');
   assert.strictEqual(fs.existsSync(path.join(tmpDir, 'negative-demo.html')), false, 'negative-demo.html should be excised');
 
-  // Assert non-old artifacts remain intact
+  // Assert demo.html and non-old artifacts remain intact
+  assert.strictEqual(fs.existsSync(path.join(tmpDir, 'demo.html')), true, 'demo.html should remain intact');
   assert.strictEqual(fs.existsSync(path.join(tmpDir, 'guide.md')), true, 'guide.md should remain');
   assert.strictEqual(fs.existsSync(path.join(tmpDir, 'expectations.md')), true, 'expectations.md should remain');
 });

--- a/guides/dev-guide.ts
+++ b/guides/dev-guide.ts
@@ -88,7 +88,6 @@ export function exciseOldEvalArtifacts(guideDir: string): void {
   const oldArtifacts = [
     path.join(guideDir, 'tasks'),
     path.join(guideDir, GRADER_FILE),
-    path.join(guideDir, DEMO_FILE),
     path.join(guideDir, NEGATIVE_DEMO_FILE),
   ];
 

--- a/guides/lib/dev-pr.ts
+++ b/guides/lib/dev-pr.ts
@@ -54,10 +54,15 @@ export const devPrCli = {
     }).trim();
   },
   editPr(prNumber: number, bodyPath: string, addLabels: DevPrLabel[], removeLabels: DevPrLabel[]): void {
-    const flags: string[] = [`--body-file "${bodyPath}"`];
-    if (addLabels.length > 0) flags.push(`--add-label "${addLabels.join(',')}"`);
-    if (removeLabels.length > 0) flags.push(`--remove-label "${removeLabels.join(',')}"`);
-    execSync(`gh pr edit ${prNumber} ${flags.join(' ')}`.trim(), { stdio: 'inherit' });
+    execSync(`gh api repos/{owner}/{repo}/pulls/${prNumber} --method PATCH -F body=@"${bodyPath}"`, { stdio: 'ignore' });
+    for (const label of removeLabels) {
+      try {
+        execSync(`gh api repos/{owner}/{repo}/issues/${prNumber}/labels/${encodeURIComponent(label)} --method DELETE`, { stdio: 'ignore' });
+      } catch {}
+    }
+    if (addLabels.length > 0) {
+      execSync(`gh api repos/{owner}/{repo}/issues/${prNumber}/labels -f labels[]="${addLabels.join('" -f labels[]="')}"`, { stdio: 'ignore' });
+    }
   },
 };
 


### PR DESCRIPTION
## Summary
This PR addresses two fixes for the `gd` CLI:
1. **Retain `demo.html` in `gd dev`**: When running `gd dev`, `exciseOldEvalArtifacts` cleans up legacy artifacts (such as `tasks/`, `grader.ts`, and `negative-demo.html`). Previously, it also removed `demo.html`. This change ensures that existing `demo.html` files are retained.
2. **Reliable PR editing in `gd pr`**: Updates `devPrCli.editPr` to use `gh api` (GitHub REST API) directly rather than `gh pr edit`, avoiding `GraphQL: Projects (classic) is being deprecated` errors on environments using older GitHub CLI versions (e.g., `v2.46.0`).

## Changes
- `guides/dev-guide.ts`: Removed `DEMO_FILE` from `oldArtifacts` in `exciseOldEvalArtifacts`.
- `guides/dev-guide.test.ts`: Updated unit test to verify `demo.html` is kept while legacy eval files are excised.
- `guides/lib/dev-pr.ts`: Updated `devPrCli.editPr` to update PR body and labels directly via `gh api` REST endpoints.

## Verification
- `pnpm run preflight` passed (build, typecheck, lint, and all workspace tests across all packages).
- Unit tests in `guides/dev-guide.test.ts` and `guides/dev-pr.test.ts` pass.
- Verified `gd pr` updates existing PRs successfully via `gh api`.