### PR TITLE
feat(guides): enforce character and line limit with baseline snapshot

### DIFF
--- a/guides/guides-integrity.test.ts
+++ b/guides/guides-integrity.test.ts
@@ -41,7 +41,7 @@ describe('Guides Validation (Single Source of Truth)', () => {
 
     it(`validates ${relativeDir}`, () => {
       const result = processGuideInventory([guide]);
-      
+
       if (result.hasError) {
         assert.fail(`Validation errors found in ${relativeDir}:\n${result.errors.join('\n')}`);
       }
@@ -173,6 +173,77 @@ describe('Guides Validation (Single Source of Truth)', () => {
           assert.fail(`Feature snippet file "features/${file}" uses unregistered feature ID: ${res.errorMessage}`);
         }
       }
+    }
+  });
+
+  // This test enforces character and line limits based on the minimum allowed character and line limits of the current Guidance agent harnesses
+  // AGY CLI Character limit: 8,192 Characters
+  // Codex Cli line limit: 256 lines
+  it('enforces character limits on guides', () => {
+    const MAX_RECOMMENDED_CHARS = 8192; // AGY's terminal stdout limit
+    const MAX_RECOMMENDED_LINES = 256; // Codex Cli line limit
+    const baselinePath = path.join(REPO_ROOT, 'guides/oversized-guides-baseline.json');
+    interface BaselineEntry {
+      chars?: number;
+      lines?: number;
+    }
+    let baseline: Record<string, BaselineEntry | number | string> = {};
+    if (fs.existsSync(baselinePath)) {
+      try {
+        baseline = JSON.parse(fs.readFileSync(baselinePath, 'utf8'));
+      } catch (e) {
+        assert.fail(`Failed to parse guides/oversized-guides-baseline.json: ${e}`);
+      }
+    }
+
+    const errors: string[] = [];
+    const cleanupHints: string[] = [];
+
+    for (const guide of guides) {
+      const guidePath = path.join(guide.dir, 'guide.md');
+      if (!fs.existsSync(guidePath)) continue;
+
+      const rel = path.relative(REPO_ROOT, guidePath).replace(/\\/g, '/');
+      const content = fs.readFileSync(guidePath, 'utf8');
+      const currentLength = content.length;
+      const currentLines = content.split(/\r?\n/).length;
+
+      const exceedsChars = currentLength > MAX_RECOMMENDED_CHARS;
+      const exceedsLines = currentLines > MAX_RECOMMENDED_LINES;
+
+      if (exceedsChars || exceedsLines) {
+        if (rel in baseline) {
+          const entry = baseline[rel];
+          const maxAllowedChars = typeof entry === 'number'
+            ? entry
+            : (typeof entry === 'object' && entry !== null ? (entry.chars ?? MAX_RECOMMENDED_CHARS) : MAX_RECOMMENDED_CHARS);
+          const maxAllowedLines = typeof entry === 'number'
+            ? MAX_RECOMMENDED_LINES
+            : (typeof entry === 'object' && entry !== null ? (entry.lines ?? MAX_RECOMMENDED_LINES) : MAX_RECOMMENDED_LINES);
+
+          if (currentLength > maxAllowedChars) {
+            errors.push(`Guide "${rel}" grew beyond its character budget: ${currentLength} chars (max allowed: ${maxAllowedChars}).`);
+          }
+          if (currentLines > maxAllowedLines) {
+            errors.push(`Guide "${rel}" grew beyond its line count budget: ${currentLines} lines (max allowed: ${maxAllowedLines}).`);
+          }
+        } else {
+          const reasons: string[] = [];
+          if (exceedsChars) reasons.push(`${currentLength} chars > ${MAX_RECOMMENDED_CHARS}`);
+          if (exceedsLines) reasons.push(`${currentLines} lines > ${MAX_RECOMMENDED_LINES}`);
+          errors.push(`New or unbudgeted oversized guide "${rel}" (${reasons.join(', ')}). Please trim the guide or record it in guides/oversized-guides-baseline.json.`);
+        }
+      } else if (rel in baseline) {
+        cleanupHints.push(`"${rel}" is now ${currentLength} chars and ${currentLines} lines (<= ${MAX_RECOMMENDED_CHARS} chars, <= ${MAX_RECOMMENDED_LINES} lines)`);
+      }
+    }
+
+    if (cleanupHints.length > 0) {
+      console.warn(`\nInfo: The following guides are below limit (${MAX_RECOMMENDED_CHARS} chars, ${MAX_RECOMMENDED_LINES} lines) and can be removed from guides/oversized-guides-baseline.json:\n` + cleanupHints.map(h => `   - ${h}`).join('\n'));
+    }
+
+    if (errors.length > 0) {
+      assert.fail(`Guide character/line limit enforcement failed:\n${errors.map(e => `   - ${e}`).join('\n')}`);
     }
   });
 });

--- a/guides/oversized-guides-baseline.json
+++ b/guides/oversized-guides-baseline.json
@@ -1,0 +1,132 @@
+{
+  "_comment": "Baseline snapshot of guides exceeding limits (8,192 chars or 256 lines).",
+  "_date": "2026-08-18",
+  "guides/accessibility/accessibility/guide.md": {
+    "chars": 24864,
+    "lines": 469
+  },
+  "guides/built-in-ai/language-model/guide.md": {
+    "chars": 16823,
+    "lines": 372
+  },
+  "guides/css/calculate-with-intrinsic-sizes/guide.md": {
+    "chars": 9900,
+    "lines": 201
+  },
+  "guides/css/css-layout/guide.md": {
+    "chars": 18260,
+    "lines": 305
+  },
+  "guides/css/css/guide.md": {
+    "chars": 27456,
+    "lines": 533
+  },
+  "guides/css/overflow-clipping-control/guide.md": {
+    "chars": 8318,
+    "lines": 185
+  },
+  "guides/forms/autofill-payment-form/guide.md": {
+    "chars": 8332,
+    "lines": 132
+  },
+  "guides/forms/autofill-sign-in-form/guide.md": {
+    "chars": 9874,
+    "lines": 142
+  },
+  "guides/forms/autofill-sign-up-form/guide.md": {
+    "chars": 11072,
+    "lines": 152
+  },
+  "guides/forms/brand-consistent-forms/guide.md": {
+    "chars": 8613,
+    "lines": 262
+  },
+  "guides/forms/forms/guide.md": {
+    "chars": 14269,
+    "lines": 378
+  },
+  "guides/html/html/guide.md": {
+    "chars": 18123,
+    "lines": 413
+  },
+  "guides/performance/flicker-free-client-side-ab-testing/guide.md": {
+    "chars": 8888,
+    "lines": 174
+  },
+  "guides/performance/performance/guide.md": {
+    "chars": 20075,
+    "lines": 374
+  },
+  "guides/privacy/privacy/guide.md": {
+    "chars": 11615,
+    "lines": 258
+  },
+  "guides/security/passkey-authentication/guide.md": {
+    "chars": 9608,
+    "lines": 210
+  },
+  "guides/security/passkey-management/guide.md": {
+    "chars": 9388,
+    "lines": 217
+  },
+  "guides/security/passkey-registration/guide.md": {
+    "chars": 9380,
+    "lines": 187
+  },
+  "guides/security/security/guide.md": {
+    "chars": 26000,
+    "lines": 356
+  },
+  "guides/ui-atoms/carousel-slide-effects/guide.md": {
+    "chars": 8525,
+    "lines": 194
+  },
+  "guides/ui-behaviors/consistent-cross-document-transitions/guide.md": {
+    "chars": 12424,
+    "lines": 234
+  },
+  "guides/ui-behaviors/parallax-scroll-effects/guide.md": {
+    "chars": 9187,
+    "lines": 236
+  },
+  "guides/ui-behaviors/same-document-transitions/guide.md": {
+    "chars": 8680,
+    "lines": 184
+  },
+  "guides/ui-behaviors/scrollytelling/guide.md": {
+    "chars": 8668,
+    "lines": 186
+  },
+  "guides/ui-behaviors/swipe-to-remove/guide.md": {
+    "chars": 26881,
+    "lines": 537
+  },
+  "guides/ui-components/navigation-drawer/guide.md": {
+    "chars": 15790,
+    "lines": 362
+  },
+  "guides/ui-components/stack-drill-down/guide.md": {
+    "chars": 33707,
+    "lines": 688
+  },
+  "guides/visual-design/apply-webgl-shaders/guide.md": {
+    "chars": 10310,
+    "lines": 247
+  },
+  "guides/visual-design/dark-mode/guide.md": {
+    "chars": 9485,
+    "lines": 190
+  },
+  "guides/visual-design/export-html-media-from-canvas/guide.md": {
+    "chars": 11909,
+    "lines": 263
+  },
+  "guides/visual-design/expose-canvas-content-to-browser-features/guide.md": {
+    "chars": 15245,
+    "lines": 409
+  },
+  "guides/visual-design/interactive-content-in-3d-scenes/guide.md": {
+    "chars": 14343,
+    "lines": 391
+  }
+}


### PR DESCRIPTION
Implements 8,192 character (AGY CLI) and 256 line (Codex CLI) limit enforcement in guides-integrity.test.ts to prevent guidance truncation across agent harnesses. Existing oversized guides are recorded in a oversized-guides-baseline.json baseline file to allow them at current sizes while blocking any growth or new oversized guides.