### PR TITLE
build: add static-site target, macro placeholders, and heading guardrails

### DIFF
--- a/guides/accessibility/accessibility/guide.md
+++ b/guides/accessibility/accessibility/guide.md
@@ -334,7 +334,7 @@ Live regions let assistive tech announce content updates that aren't tied to nav
 <!-- Session Timeout Warning with controls -->
 <div role="alert" class="timeout-warning">
   Your session will expire in 2 minutes. 
-  <button type="button" id="extend-session-btn">Extend Session</button>
+  <button type="button" onclick="extendSession()">Extend Session</button>
 </div>
 ```
 
@@ -437,7 +437,7 @@ Modern browsers provide native solutions for creating modal dialogs which avoid 
 
 ### Code Examples
 
-**HTML: Native `<dialog>`**
+**HTML & JS: Native `<dialog>` with standard close events**
 ```html
 <!-- Dialog opens natively with showModal() and locks focus -->
 <button id="open-btn">Open Dialog</button>
@@ -445,19 +445,14 @@ Modern browsers provide native solutions for creating modal dialogs which avoid 
 <dialog id="accessible-modal" aria-labelledby="title-id">
   <h2 id="title-id">Account Settings</h2>
   <p>Update your details here.</p>
-  <button id="close-dialog-btn">Close Dialog</button>
+  <button onclick="this.closest('dialog').close()">Close Dialog</button>
 </dialog>
-```
 
-**JavaScript: Dialog controls**
-```javascript
-const dialog = document.getElementById('accessible-modal');
-document.getElementById('open-btn').addEventListener('click', () => {
-  dialog.showModal();
-});
-document.getElementById('close-dialog-btn').addEventListener('click', () => {
-  dialog.close();
-});
+<script>
+  document.getElementById('open-btn').addEventListener('click', () => {
+    document.getElementById('accessible-modal').showModal();
+  });
+</script>
 ```
 
 ## 12. Testing Validations

--- a/guides/accessibility/accessibility/guide.md
+++ b/guides/accessibility/accessibility/guide.md
@@ -334,7 +334,7 @@ Live regions let assistive tech announce content updates that aren't tied to nav
 <!-- Session Timeout Warning with controls -->
 <div role="alert" class="timeout-warning">
   Your session will expire in 2 minutes. 
-  <button type="button" onclick="extendSession()">Extend Session</button>
+  <button type="button" id="extend-session-btn">Extend Session</button>
 </div>
 ```
 
@@ -437,7 +437,7 @@ Modern browsers provide native solutions for creating modal dialogs which avoid 
 
 ### Code Examples
 
-**HTML & JS: Native `<dialog>` with standard close events**
+**HTML: Native `<dialog>`**
 ```html
 <!-- Dialog opens natively with showModal() and locks focus -->
 <button id="open-btn">Open Dialog</button>
@@ -445,14 +445,19 @@ Modern browsers provide native solutions for creating modal dialogs which avoid 
 <dialog id="accessible-modal" aria-labelledby="title-id">
   <h2 id="title-id">Account Settings</h2>
   <p>Update your details here.</p>
-  <button onclick="this.closest('dialog').close()">Close Dialog</button>
+  <button id="close-dialog-btn">Close Dialog</button>
 </dialog>
+```
 
-<script>
-  document.getElementById('open-btn').addEventListener('click', () => {
-    document.getElementById('accessible-modal').showModal();
-  });
-</script>
+**JavaScript: Dialog controls**
+```javascript
+const dialog = document.getElementById('accessible-modal');
+document.getElementById('open-btn').addEventListener('click', () => {
+  dialog.showModal();
+});
+document.getElementById('close-dialog-btn').addEventListener('click', () => {
+  dialog.close();
+});
 ```
 
 ## 12. Testing Validations

--- a/guides/accessibility/accessible-error-announcement/guide.md
+++ b/guides/accessibility/accessible-error-announcement/guide.md
@@ -104,7 +104,7 @@ document.addEventListener('input', (event) => {
 
 ## Fallbacking & Browser Support
 
-The `:user-invalid` pseudo-class is widely supported (Baseline 2023), but older browsers need a fallback.
+{{ BASELINE_STATUS("user-pseudos") }}
 
 ### Feature Detection
 You can check for support in CSS and JavaScript.

--- a/guides/built-in-ai/language-detection/guide.md
+++ b/guides/built-in-ai/language-detection/guide.md
@@ -6,6 +6,8 @@ web-feature-ids:
   - languagedetector
 ---
 
+# Language Detection
+
 The **Language Detector API** is a client-side web API designed to identify the language of a given text string. By performing detection locally in the browser, it enhances user privacy and reduces the need for heavy external libraries or costly server-side calls.
 
 ## Key Use Cases

--- a/guides/built-in-ai/language-model/guide.md
+++ b/guides/built-in-ai/language-model/guide.md
@@ -5,6 +5,8 @@ web-feature-ids:
   - languagemodel
 ---
 
+# Language Model
+
 The Prompt API allows developers to run natural language processing tasks directly in the browser using **Gemini Nano**. This built-in AI approach ensures user privacy, reduces server costs, and enables offline functionality.
 
 ## 1. Getting Started and Hardware Requirements

--- a/guides/built-in-ai/summarizer/guide.md
+++ b/guides/built-in-ai/summarizer/guide.md
@@ -5,6 +5,8 @@ web-feature-ids:
   - summarizer
 ---
 
+# Summarizer
+
 The **Summarizer API** allows web developers to offer local, AI-powered text distillation directly within the browser using **Gemini Nano in Chrome or Phi in Edge**. This API supports various formats, including key points, headlines, and TL;DRs, while operating entirely on-device to ensure user privacy.
 
 ---

--- a/guides/built-in-ai/translator/guide.md
+++ b/guides/built-in-ai/translator/guide.md
@@ -6,6 +6,8 @@ web-feature-ids:
   - translator
 ---
 
+# Translator
+
 The **Translator API** allows developers to perform client-side text translation using built-in AI models in Chrome and Edge. This approach eliminates the need for cloud-based translation services for ephemeral content, reducing costs and improving privacy by keeping data on the user's device.
 
 

--- a/guides/css/calculate-with-intrinsic-sizes/guide.md
+++ b/guides/css/calculate-with-intrinsic-sizes/guide.md
@@ -6,6 +6,8 @@ web-feature-ids:
   - interpolate-size
 ---
 
+# Calculate With Intrinsic Sizes
+
 `calc-size()` is a CSS function for performing mathematical operations on intrinsic sizing keywords like `auto`, `min-content`, and `fit-content`. **MANDATORY**: Use `calc-size()` only when you need to modify an intrinsic size with a calculation or constraint; for simple keyword-based animations (e.g., `0` to `auto`), you must use `interpolate-size: allow-keywords`.
 
 ## Implementation Steps

--- a/guides/css/child-state-based-styling/guide.md
+++ b/guides/css/child-state-based-styling/guide.md
@@ -6,6 +6,8 @@ web-feature-ids:
   - not
 ---
 
+# Child State Based Styling
+
 Historically, CSS selectors could only traverse downwards—you could style a child based on its parent, but not a parent based on its child. The `:has()` pseudo-class changes this, allowing you to conditionally style a container element depending on the presence or state of its descendants.
 
 By combining `:has()` with state pseudo-classes (like `:checked`, `:focus`, `:valid`, `:invalid`, or `:not()`), you can build complex, interactive UI components entirely in CSS, without needing JavaScript to toggle "modifier" classes (like `.is-active` or `.has-error`) on parent elements.

--- a/guides/css/content-based-styling/guide.md
+++ b/guides/css/content-based-styling/guide.md
@@ -6,6 +6,8 @@ web-feature-ids:
   - not
 ---
 
+# Content Based Styling
+
 Historically, applying different layouts to a component based on its content required either JavaScript or conditional logic in your HTML templating language to inject modifier classes (like `.card--has-image` or `.card--text-only`).
 
 The `:has()` pseudo-class eliminates this need by acting as a parent selector. It allows you to conditionally style a container element based on the presence or absence of specific descendant elements.

--- a/guides/css/design-token-reactivity/guide.md
+++ b/guides/css/design-token-reactivity/guide.md
@@ -5,6 +5,8 @@ web-feature-ids:
   - container-style-queries
 ---
 
+# Design Token Reactivity
+
 ## Background & Overview
 
 Often an author will need to make contextual changes to the design of a component. Historically authors would need to use selectors to apply such changes. This often meant that while many of their design tokens could exist as custom properties, higher-order design tokens could only be encoded as a selector pattern (i.e. using a class name or attribute convention) or as props/context in a JavaScript framework.

--- a/guides/css/fluid-scaling/guide.md
+++ b/guides/css/fluid-scaling/guide.md
@@ -5,6 +5,8 @@ web-feature-ids:
   - container-queries
 ---
 
+# Fluid Scaling
+
 ## Overview
 
 Fluid scaling allows components to adjust their internal proportions (like font sizes and spacing) based on their current dimensions. This creates a more cohesive design than jumping between fixed breakpoints.

--- a/guides/css/individual-transform-properties/guide.md
+++ b/guides/css/individual-transform-properties/guide.md
@@ -5,6 +5,8 @@ web-feature-ids:
   - individual-transforms
 ---
 
+# Individual Transform Properties
+
 The `transform` property allows you to apply multiple transformations in a specified order, but any changes to a single transformation require re-specifying the entire transformation chain. This makes it tricky to animate or transition a single transformation.
 
 The individual CSS transform properties (`translate`, `rotate`, and `scale`) allow you to apply transformations independently of the `transform` property. This approach makes it simpler to override a single transformation, for instance on `:hover`.

--- a/guides/css/size-aware-styling/guide.md
+++ b/guides/css/size-aware-styling/guide.md
@@ -5,6 +5,8 @@ web-feature-ids:
   - container-queries
 ---
 
+# Size Aware Styling
+
 ## Overview
 
 Size-aware styling allows components to change their layout or appearance based on the space available to them, rather than the size of the whole screen. This is useful for components like cards or navigation bars that might be placed in different parts of a layout (like a narrow sidebar or a wide main area).

--- a/guides/css/style-parent-with-has/guide.md
+++ b/guides/css/style-parent-with-has/guide.md
@@ -63,7 +63,7 @@ By combining `:has()` with `:user-invalid`, we can declaratively style any ances
 
 ## Fallbacking & Browser Support
 
-The `:user-invalid` pseudo-class is widely supported (Baseline 2023), but if you need to support older browsers, you must ensure consistency of the implementation.
+{{ BASELINE_STATUS("user-pseudos") }}
 
 ### CSS for Fallback
 We use a class `.has-error` on the parent to mimic the `:has()` behavior.

--- a/guides/forms/form-fields-automatically-fit-contents/guide.md
+++ b/guides/forms/form-fields-automatically-fit-contents/guide.md
@@ -5,6 +5,8 @@ web-feature-ids:
   - field-sizing
 ---
 
+# Form Fields Automatically Fit Contents
+
 By default, form controls like `<input>`, `<textarea>`, and `<select>` have fixed dimensions. Their sizes remain constant, regardless of the amount of content the user enters or selects.
 
 To allow these controls to automatically shrink or grow to fit their content (including placeholders), use the `field-sizing: content` CSS property.

--- a/guides/forms/forms/guide.md
+++ b/guides/forms/forms/guide.md
@@ -372,14 +372,6 @@ form.addEventListener('submit', (e) => {
   </ol>
 </nav>
 
-<button type="button" id="prev-btn" enterkeyhint="previous">Previous</button>
+<button type="button" onclick="history.back()" enterkeyhint="previous">Previous</button>
 <button type="submit" enterkeyhint="next">Next</button>
-```
-
-Note: To bind the back navigation behavior to the previous button, use JavaScript:
-
-```javascript
-document.getElementById('prev-btn').addEventListener('click', () => {
-  history.back();
-});
 ```

--- a/guides/forms/forms/guide.md
+++ b/guides/forms/forms/guide.md
@@ -3,6 +3,8 @@ name: forms
 description: Best practices for building accessible, secure, and user-friendly web forms. Use this guide when creating or modifying forms, inputs, and submission flows.
 ---
 
+# Forms
+
 ## 1. Semantic Structure and Form Element
 
 ### Guidelines

--- a/guides/forms/forms/guide.md
+++ b/guides/forms/forms/guide.md
@@ -372,6 +372,14 @@ form.addEventListener('submit', (e) => {
   </ol>
 </nav>
 
-<button type="button" onclick="history.back()" enterkeyhint="previous">Previous</button>
+<button type="button" id="prev-btn" enterkeyhint="previous">Previous</button>
 <button type="submit" enterkeyhint="next">Next</button>
+```
+
+Note: To bind the back navigation behavior to the previous button, use JavaScript:
+
+```javascript
+document.getElementById('prev-btn').addEventListener('click', () => {
+  history.back();
+});
 ```

--- a/guides/forms/select-menu-interaction/guide.md
+++ b/guides/forms/select-menu-interaction/guide.md
@@ -74,8 +74,6 @@ select:user-valid {
 
 ## Fallbacking & Browser Support
 
-The `:user-invalid` pseudo-class is widely supported (Baseline 2023), but if you need to support older browsers, you must ensure consistency of the implementation.
-
 {{ FEATURE_FALLBACKS("user-pseudos") }}
 
 ## Other Considerations

--- a/guides/html/html/guide.md
+++ b/guides/html/html/guide.md
@@ -3,6 +3,8 @@ name: html
 description: Action-oriented guidelines for modern HTML architecture, semantics, native interactive APIs (Dialog, Popover, Details), focus management, and resource prioritization. Use this guide when structuring web documents, implementing native overlays, or optimizing resource loading order.
 ---
 
+# HTML
+
 ## Table of Contents
 
 1. Fundamental Semantics and Validation

--- a/guides/html/web-components/web-components/guide.md
+++ b/guides/html/web-components/web-components/guide.md
@@ -7,7 +7,7 @@ web-feature-ids:
   - declarative-shadow-dom
 ---
 
-# Web Components Orientation Guide
+# Web Components Orientation
 
 Web Components are Custom Elements, Shadow DOM, and HTML Templates: the platform primitives for reusable, framework-agnostic components whose markup and styles are encapsulated from the document. Use them for design systems, embeddable widgets, and self-contained UI.
 

--- a/guides/performance/break-up-long-tasks/guide.md
+++ b/guides/performance/break-up-long-tasks/guide.md
@@ -5,6 +5,8 @@ web-feature-ids:
   - scheduler
 ---
 
+# Break Up Long Tasks
+
 Heavy computations or long loops can block the main thread, causing the page to become unresponsive. To prevent this, you should yield control back to the browser periodically. The `scheduler.yield()` API allows you to pause a long task and let the browser handle user input or rendering before continuing.
 
 ### Breaking up long tasks

--- a/guides/performance/conditional-async-dependencies/guide.md
+++ b/guides/performance/conditional-async-dependencies/guide.md
@@ -5,6 +5,8 @@ web-feature-ids:
   - top-level-await
 ---
 
+# Conditional Async Dependencies
+
 Top-level `await` allows modules to act as asynchronous functions, meaning they can pause module execution to await promises. This is extremely useful for conditionally loading async dependencies—like polyfills or heavy secondary libraries—only when required by the browser. 
 
 By utilizing top-level await, you can encapsulate the conditional loading logic inside a single module, effectively preventing downstream consumer modules from executing until the dependency is fully loaded and ready.

--- a/guides/performance/deliver-optimized-decorative-images/guide.md
+++ b/guides/performance/deliver-optimized-decorative-images/guide.md
@@ -5,6 +5,8 @@ web-feature-ids:
   - image-set
 ---
 
+# Deliver Optimized Decorative Images
+
 Delivering optimized decorative images via CSS improves perceived performance without sacrificing visual quality. By using the `image-set()` CSS function, you can provide the browser with multiple options for a single background or mask image. You can specify modern formats (like AVIF or WebP) alongside different resolutions (like `1x` and `2x`). The browser will dynamically select the smallest compatible image that provides the appropriate pixel density for the user's device.
 
 **CAUTION**: If the image is likely to be the Largest Contentful Paint (LCP) element (e.g., a large hero banner), be aware that images referenced in CSS via image-set() are not discoverable by the browser's preload scanner. This can significantly delay image loading and harm LCP. For LCP candidates, consider using a standard HTML `<img>` or `<picture>` tag instead or alternatively, preloading the image as well using `<link rel=preload>` option with a `media` attribute.

--- a/guides/performance/detect-initial-visibility-state/guide.md
+++ b/guides/performance/detect-initial-visibility-state/guide.md
@@ -6,6 +6,8 @@ web-feature-ids:
   - page-visibility
 ---
 
+# Detect Initial Visibility State
+
 Determining if a page was initially loaded in the background (e.g., opened in a new background tab) is critical for accurate performance monitoring. Pages loaded in the background often have delayed rendering and longer metric times (like First Contentful Paint). Identifying these pages allows you to filter them out of performance analytics to avoid skewed data.
 
 The most accurate way to measure this is by using the `VisibilityStateEntry` API, which reliably records visibility changes on the browser's performance timeline, regardless of when your script actually executes.

--- a/guides/performance/improve-next-page-load-performance/guide.md
+++ b/guides/performance/improve-next-page-load-performance/guide.md
@@ -121,6 +121,6 @@ This example shows a rule set that prefetches all links eagerly, and then goes f
 
 ## Browser support and fallback strategies
 
-Speculative loading is a new feature, and as such, is not supported in all modern browsers (Baseline limited availability).
+{{ BASELINE_STATUS("speculation-rules") }}
 
 However, speculative loading is a progressive enhancement. It is perfectly safe to use as an enhancement, and is highly recommended given the potential performance benefits. If a browser does not support speculation rules, it will simply ignore them.

--- a/guides/performance/performance/guide.md
+++ b/guides/performance/performance/guide.md
@@ -35,8 +35,7 @@ The Critical Rendering Path dictates how quickly the browser converts HTML, CSS,
 <!-- Load CSS conditionally based on viewport -->
 <link rel="stylesheet" href="mobile.css" media="(max-width: 768px)">
 
-<!-- Defer JavaScript execution -->
-<script defer src="app-bundle.js"></script>
+
 ```
 
 Note: To apply the stylesheet when loaded, you must toggle its `rel` attribute to `stylesheet` using JavaScript (e.g., by adding a load event listener to the element).

--- a/guides/performance/performance/guide.md
+++ b/guides/performance/performance/guide.md
@@ -29,7 +29,7 @@ The Critical Rendering Path dictates how quickly the browser converts HTML, CSS,
 </style>
 
 <!-- Defer non-critical CSS -->
-<link rel="preload" href="non-critical.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
+<link rel="preload" href="non-critical.css" as="style" id="non-critical-css">
 <noscript><link rel="stylesheet" href="non-critical.css"></noscript>
 
 <!-- Load CSS conditionally based on viewport -->
@@ -38,6 +38,8 @@ The Critical Rendering Path dictates how quickly the browser converts HTML, CSS,
 <!-- Defer JavaScript execution -->
 <script defer src="app-bundle.js"></script>
 ```
+
+Note: To apply the stylesheet when loaded, you must toggle its `rel` attribute to `stylesheet` using JavaScript (e.g., by adding a load event listener to the element).
 
 ### The Resource Hint Navigator
 

--- a/guides/performance/performance/guide.md
+++ b/guides/performance/performance/guide.md
@@ -3,6 +3,8 @@ name: performance
 description: Actionable guidelines for optimizing modern web applications. Use this guide when auditing performance, optimizing loading metrics, fixing slow interactions and optimizing Core Web Vitals (LCP, INP, CLS)
 ---
 
+# Performance
+
 ## Critical Rendering Path (CRP) Optimization
 
 The Critical Rendering Path dictates how quickly the browser converts HTML, CSS, and JavaScript into painted pixels. 

--- a/guides/performance/performance/guide.md
+++ b/guides/performance/performance/guide.md
@@ -29,16 +29,15 @@ The Critical Rendering Path dictates how quickly the browser converts HTML, CSS,
 </style>
 
 <!-- Defer non-critical CSS -->
-<link rel="preload" href="non-critical.css" as="style" id="non-critical-css">
+<link rel="preload" href="non-critical.css" as="style" onload="this.onload=null;this.rel='stylesheet'">
 <noscript><link rel="stylesheet" href="non-critical.css"></noscript>
 
 <!-- Load CSS conditionally based on viewport -->
 <link rel="stylesheet" href="mobile.css" media="(max-width: 768px)">
 
-
+<!-- Defer JavaScript execution -->
+<script defer src="app-bundle.js"></script>
 ```
-
-Note: To apply the stylesheet when loaded, you must toggle its `rel` attribute to `stylesheet` using JavaScript (e.g., by adding a load event listener to the element).
 
 ### The Resource Hint Navigator
 

--- a/guides/performance/resolution-optimized-pseudo-elements/guide.md
+++ b/guides/performance/resolution-optimized-pseudo-elements/guide.md
@@ -5,6 +5,8 @@ web-feature-ids:
   - image-set
 ---
 
+# Resolution Optimized Pseudo Elements
+
 Using resolution-optimized images in CSS pseudo-elements (like `::before` or `::after`) allows you to add decorative icons or structural graphics without cluttering your HTML with extra DOM nodes. By combining pseudo-elements with the `image-set()` CSS function, you can provide the browser with multiple formats (such as AVIF or WebP) and resolutions (like `1x` and `2x`). The browser will automatically choose the most optimal image for the user's device capabilities.
 
 ### Implementation

--- a/guides/performance/schedule-tasks-by-priority/guide.md
+++ b/guides/performance/schedule-tasks-by-priority/guide.md
@@ -5,6 +5,8 @@ web-feature-ids:
   - scheduler
 ---
 
+# Schedule Tasks By Priority
+
 When building complex web applications, tasks have different levels of urgency. Completing tasks for the current view is more important than sending analytics or prefetching assets. The Prioritized Task Scheduling API allows you to schedule work with specific priorities, ensuring the browser remains responsive to user input.
 
 ### Scheduling tasks by priority

--- a/guides/privacy/privacy/guide.md
+++ b/guides/privacy/privacy/guide.md
@@ -152,20 +152,19 @@ Third-party scripts and resources are a common source of privacy leaks. You are 
 </a>
 ```
 
-**Video Façade Pattern (HTML)**
+**Video Façade Pattern (HTML/JS)**
 ```html
 <div id="video-container" data-video-id="abc123">
   <img src="https://img.youtube.com/vi/abc123/maxresdefault.jpg" alt="Play Video" id="play-btn">
 </div>
-```
 
-**Video Façade Pattern (JavaScript)**
-```javascript
-document.getElementById('play-btn').addEventListener('click', () => {
+<script>
+document.getElementById('play-btn').addEventListener('click', function() {
   const container = document.getElementById('video-container');
   const videoId = container.dataset.videoId;
   container.innerHTML = `<iframe src="https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1" allowfullscreen></iframe>`;
 });
+</script>
 ```
 
 **FedCM Sign-In (JavaScript)**

--- a/guides/privacy/privacy/guide.md
+++ b/guides/privacy/privacy/guide.md
@@ -152,19 +152,20 @@ Third-party scripts and resources are a common source of privacy leaks. You are 
 </a>
 ```
 
-**Video Façade Pattern (HTML/JS)**
+**Video Façade Pattern (HTML)**
 ```html
 <div id="video-container" data-video-id="abc123">
   <img src="https://img.youtube.com/vi/abc123/maxresdefault.jpg" alt="Play Video" id="play-btn">
 </div>
+```
 
-<script>
-document.getElementById('play-btn').addEventListener('click', function() {
+**Video Façade Pattern (JavaScript)**
+```javascript
+document.getElementById('play-btn').addEventListener('click', () => {
   const container = document.getElementById('video-container');
   const videoId = container.dataset.videoId;
   container.innerHTML = `<iframe src="https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1" allowfullscreen></iframe>`;
 });
-</script>
 ```
 
 **FedCM Sign-In (JavaScript)**

--- a/guides/security/passkey-authentication/guide.md
+++ b/guides/security/passkey-authentication/guide.md
@@ -6,7 +6,7 @@ web-feature-ids:
   - webauthn-signals
 ---
 
-# Passkey Authentication Guide
+# Passkey Authentication
 
 This guide details how to implement returning user authentication using discoverable credentials, both through explicit button triggers and seamless browser autofill suggestions (Conditional UI).
 

--- a/guides/security/passkey-management/guide.md
+++ b/guides/security/passkey-management/guide.md
@@ -6,7 +6,7 @@ web-feature-ids:
   - webauthn-signals
 ---
 
-# Passkey Management Guide
+# Passkey Management
 
 This guide details how to enable users to view, rename, and delete their registered passkeys while keeping saved credentials perfectly synchronized between the server and the user's password managers using the Signal API.
 

--- a/guides/security/passkey-reauthentication/guide.md
+++ b/guides/security/passkey-reauthentication/guide.md
@@ -5,7 +5,7 @@ web-feature-ids:
   - webauthn
 ---
 
-# Passkey Reauthentication Guide
+# Passkey Reauthentication
 
 This delta-focused guide details how to implement step-up authentication or re-verification for a signed-in user before they perform sensitive account changes (e.g. passwords updates, financial transfers).
 

--- a/guides/security/passkey-registration/guide.md
+++ b/guides/security/passkey-registration/guide.md
@@ -6,7 +6,7 @@ web-feature-ids:
   - webauthn-signals
 ---
 
-# Passkey Registration Guide
+# Passkey Registration
 
 This guide details how to enable users to register a passkey for their account, providing a highly secure, phishing-resistant passwordless sign-in alternative.
 

--- a/guides/security/passkeys/guide.md
+++ b/guides/security/passkeys/guide.md
@@ -5,7 +5,7 @@ web-feature-ids:
   - webauthn
 ---
 
-# Passkeys Orientation Guide
+# Passkeys Orientation
 
 This guide provides high-density, action-oriented orientation for implementing secure, framework-agnostic passkey authentication and credential management in modern web applications.
 

--- a/guides/sync-use-cases.test.ts
+++ b/guides/sync-use-cases.test.ts
@@ -113,6 +113,9 @@ description: A description
 web-feature-ids:
   - dialog-closedby
 ---
+
+# My Use Case
+
 Body content.
 `);
     const result = validateGuide(filePath);
@@ -126,6 +129,9 @@ description: A description
 web-feature-ids:
   - dialog-closedby
 ---
+
+# My Use Case
+
 Body content here.
 `);
     const result = validateGuide(filePath);
@@ -165,6 +171,9 @@ description: A description
 web-feature-ids:
   - dialog-closedby
 ---
+
+# My Use Case
+
 {{ BASELINE_STATUS(fake-feature-id) }}
 `);
     const result = validateGuide(filePath);
@@ -178,6 +187,9 @@ description: A description
 web-feature-ids:
   - dialog-closedby
 ---
+
+# My Use Case
+
 {{ BASELINE_STATUS(dialog-closedby) }}
 `);
     const result = validateGuide(filePath);
@@ -191,6 +203,9 @@ description: A description
 web-feature-ids:
   - dialog-closedby
 ---
+
+# My Use Case
+
 {{ BASELINE_STATUS() }}
 `);
     const result = validateGuide(filePath);
@@ -205,6 +220,9 @@ web-feature-ids:
   - dialog-closedby
   - view-transitions
 ---
+
+# My Use Case
+
 Body content.
 `);
     const result = validateGuide(filePath);
@@ -220,6 +238,9 @@ web-feature-ids:
   - fake-one
   - fake-two
 ---
+
+# My Use Case
+
 Body content.
 `);
     const result = validateGuide(filePath);
@@ -777,6 +798,9 @@ description: A description
 web-feature-ids:
   - invalid-feature-id-test
 ---
+
+# My Use Case
+
 Body content.
 `);
     const result = processGuideInventory([makeInventory()]);
@@ -791,6 +815,9 @@ description: A description
 web-feature-ids:
   - dialog-closedby
 ---
+
+# My Use Case
+
 Body content.
 `);
     const result = processGuideInventory([makeInventory()]);

--- a/guides/ui-atoms/position-aware-tooltips/guide.md
+++ b/guides/ui-atoms/position-aware-tooltips/guide.md
@@ -6,6 +6,8 @@ web-feature-ids:
   - popover
 ---
 
+# Position Aware Tooltips
+
 When building tooltips or popovers with CSS Anchor Positioning, the browser can automatically "flip" the element to a fallback position if it would otherwise overflow the viewport. When this happens, you may want to adjust the style of the positioned content, for instance to reposition an arrow that points from the positioned content to the anchor.
 
 **Anchored Container Queries** solve this by allowing you to query the active positioning state of an element and apply styles accordingly.

--- a/guides/ui-atoms/resilient-context-menus-and-nested-dropdowns/guide.md
+++ b/guides/ui-atoms/resilient-context-menus-and-nested-dropdowns/guide.md
@@ -6,6 +6,8 @@ web-feature-ids:
   - popover
 ---
 
+# Resilient Context Menus And Nested Dropdowns
+
 A revealed action panel or popover button group is a useful pattern for users to access additional functionality while taking up minimal space. This overlay pattern comes with layout complexity, as the panel must remain tethered to a trigger element while adapting to viewport constraints. Traditionally, this required complex JavaScript libraries (like Popper.js or Floating UI) to calculate positions and handle collisions.
 
 CSS Anchor Positioning provides a declarative, performance-optimized way to handle these relationships entirely in CSS, allowing browsers to manage the positioning and overflow logic natively.

--- a/guides/ui-atoms/scroll-position-aware-elements/guide.md
+++ b/guides/ui-atoms/scroll-position-aware-elements/guide.md
@@ -5,6 +5,8 @@ web-feature-ids:
   - container-scroll-state-queries
 ---
 
+# Scroll Position Aware Elements
+
 ## Overview
 
 Improve the user experience of floating buttons, like a "Back to Top" link, by showing them only when they are useful. This guide shows how to build these elements using CSS `container-scroll-state-queries`, which allows styling elements based on the scroll position of their container without relying on JavaScript scroll listeners or observers.

--- a/guides/ui-atoms/scrollability-affordance-hints/guide.md
+++ b/guides/ui-atoms/scrollability-affordance-hints/guide.md
@@ -5,6 +5,8 @@ web-feature-ids:
   - container-scroll-state-queries
 ---
 
+# Scrollability Affordance Hints
+
 ## Overview
 
 Visual hints, like shadows or gradients, help users understand that they can scroll to see more content. This guide shows how to build these hints using CSS `container-scroll-state-queries`, which allows styling elements based on the scrollable state of their container without relying on JavaScript scroll listeners or observers.

--- a/guides/ui-behaviors/anchor-positioning-tab-underline/guide.md
+++ b/guides/ui-behaviors/anchor-positioning-tab-underline/guide.md
@@ -6,6 +6,8 @@ web-feature-ids:
   - prefers-reduced-motion
 ---
 
+# Anchor Positioning Tab Underline
+
 In a tab menu, you should provide visual hints to users about what page they are on. One option is by underlining the tab. With anchor positioning, you can create a smooth animation between the positions of the underline. This does not work when changing the active tab loads a new web page.
 
 You can also use this effect to add an animated dot to indicate the active tab in a vertical tab bar.

--- a/guides/ui-behaviors/animate-element-entry-exit/guide.md
+++ b/guides/ui-behaviors/animate-element-entry-exit/guide.md
@@ -6,6 +6,8 @@ web-feature-ids:
   - transition-behavior
 ---
 
+# Animate Element Entry and Exit
+
 In the past, CSS transitions could not animate elements when they were first added to the DOM or when their `display` property changed from `none`. The `@starting-style` at-rule and `transition-behavior: allow-discrete` provide a declarative way to create smooth entry and exit animations.
 
 ## Implementation

--- a/guides/ui-behaviors/animate-to-from-top-layer/guide.md
+++ b/guides/ui-behaviors/animate-to-from-top-layer/guide.md
@@ -10,6 +10,8 @@ web-feature-ids:
   - transition-behavior
 ---
 
+# Animate Elements To and From Top Layer
+
 Elements that render in the "top layer" (like `<dialog>`, elements with the `popover` attribute, or tooltips) have historically been difficult to animate because they toggle between `display: none` and a visible state. Modern CSS provides `@starting-style`, `transition-behavior: allow-discrete`, and the `overlay` property to enable smooth entry and exit transitions for these elements. Note that native CSS nesting is used in the examples below.
 
 ## Implementation

--- a/guides/ui-behaviors/carousel-snap-highlights/guide.md
+++ b/guides/ui-behaviors/carousel-snap-highlights/guide.md
@@ -5,6 +5,8 @@ web-feature-ids:
   - container-scroll-state-queries
 ---
 
+# Carousel Snap Highlights
+
 Scroll-state container queries allow you to style elements based on their current scroll state, such as whether an element is "stuck" (via sticky positioning) or "snapped" (via scroll snapping). This enables carousel or gallery experiences where the active item can be visually distinguished without relying on JavaScript intersection observers or scroll event listeners.
 
 ### Core implementation

--- a/guides/ui-behaviors/cross-document-transitions/guide.md
+++ b/guides/ui-behaviors/cross-document-transitions/guide.md
@@ -7,6 +7,8 @@ web-feature-ids:
   - navigation
 ---
 
+# Cross-Document Transitions
+
 Cross-document view transitions allow you to create smooth, app-like transitions between different pages of a Multi-Page Application (MPA). By default, the browser performs a cross-fade, but you can customize this to match your site's aesthetic.
 
 ### Implementation Steps

--- a/guides/ui-behaviors/declarative-dialog-popover-control/guide.md
+++ b/guides/ui-behaviors/declarative-dialog-popover-control/guide.md
@@ -7,7 +7,7 @@ web-feature-ids:
   - dialog
 ---
 
-# Overview
+# Declarative Dialog and Popover Control
 
 Use the Invoker Commands API to toggle the visibility of `<dialog>` and `[popover]` elements directly from HTML buttons, eliminating the need for custom JavaScript event listeners.
 

--- a/guides/ui-behaviors/directional-navigation-transitions/guide.md
+++ b/guides/ui-behaviors/directional-navigation-transitions/guide.md
@@ -6,6 +6,8 @@ web-feature-ids:
   - active-view-transition
 ---
 
+# Directional Navigation Transitions
+
 Single Page Applications (SPAs) provide the appearance of navigation by replacing the content of the page without navigating to a new page. By default, the content is simply replaced, without any transitions. Directional transitions can visually reinforce a spatial relationship between views. 
 
 By sliding new content in from the direction the user is moving you create a mental map of the application structure. For instance, a product site may show a transition to the right for "forward," and to the left for "back", or a slideshow may transition up and down to show next and previous slides.

--- a/guides/ui-behaviors/group-element-transitions/guide.md
+++ b/guides/ui-behaviors/group-element-transitions/guide.md
@@ -5,7 +5,8 @@ web-feature-ids:
   - view-transitions
   - view-transition-class
 ---
- 
+# Group Element Transitions
+
 As items are added or removed from a list, or rearranged, transitions can help users maintain context. View transitions provide a way to transition between two states of an element by giving the element a unique `view-transition-name`. When multiple elements on a page share the same transition behavior, `view-transition-class` allows you to define that logic once in CSS rather than repeating it for every unique `view-transition-name`. This keeps your stylesheets maintainable while ensuring consistent animations across a group of elements.
 
 ### Implementation steps

--- a/guides/ui-behaviors/highlight-text-ranges/guide.md
+++ b/guides/ui-behaviors/highlight-text-ranges/guide.md
@@ -5,6 +5,8 @@ web-feature-ids:
   - highlight
 ---
 
+# Highlight Text Ranges
+
 The CSS Custom Highlight API lets you style arbitrary text ranges on a page without modifying the DOM structure. This enables search-result highlighting, syntax coloring, collaborative editing cursors, or spelling and grammar error markers without wrapping text in extra elements or relying on `innerHTML` manipulation.
 
 ### Core implementation

--- a/guides/ui-behaviors/interactive-content-reveal/guide.md
+++ b/guides/ui-behaviors/interactive-content-reveal/guide.md
@@ -6,6 +6,8 @@ web-feature-ids:
   - registered-custom-properties
 ---
 
+# Interactive Content Reveal
+
 Add performant, interactive reveal effects to your site with CSS masks and registered custom properties. By using a radial gradient as a mask and registering its stop values, we can smoothly transition the entry and exit, while following a user's pointer with minimal JavaScript. 
 
 ## Implementation

--- a/guides/ui-behaviors/interest-triggered-action-previews/guide.md
+++ b/guides/ui-behaviors/interest-triggered-action-previews/guide.md
@@ -5,6 +5,8 @@ web-feature-ids:
   - interest-invokers
 ---
 
+# Interest Triggered Action Previews
+
 It can be beneficial to provide users a preview of their actions before they commit to them. Interest invokers are an experimental web platform feature that provides a declarative-based way of creating interest relationships between an interest source (i.e. a button or a link) and an interest target. Once the declarative relationship has been established there are a number of methods a developer can respond to based on interest and loss of interest using both CSS and JavaScript. For this use case, we can leverage the `interest` and `loseinterest` events to preview various effects for an interest target.
 
 ## How to implement

--- a/guides/ui-behaviors/light-dismiss-a-dialog/guide.md
+++ b/guides/ui-behaviors/light-dismiss-a-dialog/guide.md
@@ -5,6 +5,8 @@ web-feature-ids:
   - dialog-closedby
 ---
 
+# Light-Dismiss a Dialog
+
 Modern modal dialogs often support "light-dismiss," allowing users to close a dialog by clicking or tapping the backdrop (the area outside the dialog). The `closedby` attribute provides a declarative way to enable this behavior without custom JavaScript.
 
 ## Implementation

--- a/guides/ui-behaviors/light-dismiss-a-dialog/guide.md
+++ b/guides/ui-behaviors/light-dismiss-a-dialog/guide.md
@@ -43,7 +43,7 @@ dialog::backdrop {
   </form>
 </dialog>
 
-<button id="open-dialog-btn">Open Dialog</button>
+<button onclick="document.getElementById('myDialog').showModal()">Open Dialog</button>
 ```
 
 ## Constraints & Accessibility
@@ -61,10 +61,7 @@ dialog::backdrop {
 **MANDATORY**: For browsers that do not yet support `closedby`, you **must** implement a fallback for light-dismiss by checking if a click occurred outside the dialog content's boundaries using the following script:
 
 ```javascript
-const dialog = document.getElementById('myDialog');
-document.getElementById('open-dialog-btn').addEventListener('click', () => {
-  dialog.showModal();
-});
+const dialog = document.querySelector('dialog');
 
 // Fallback for browsers without closedby support
 if (!('closedBy' in HTMLDialogElement.prototype)) {

--- a/guides/ui-behaviors/light-dismiss-a-dialog/guide.md
+++ b/guides/ui-behaviors/light-dismiss-a-dialog/guide.md
@@ -43,7 +43,7 @@ dialog::backdrop {
   </form>
 </dialog>
 
-<button onclick="document.getElementById('myDialog').showModal()">Open Dialog</button>
+<button id="open-dialog-btn">Open Dialog</button>
 ```
 
 ## Constraints & Accessibility
@@ -61,7 +61,10 @@ dialog::backdrop {
 **MANDATORY**: For browsers that do not yet support `closedby`, you **must** implement a fallback for light-dismiss by checking if a click occurred outside the dialog content's boundaries using the following script:
 
 ```javascript
-const dialog = document.querySelector('dialog');
+const dialog = document.getElementById('myDialog');
+document.getElementById('open-dialog-btn').addEventListener('click', () => {
+  dialog.showModal();
+});
 
 // Fallback for browsers without closedby support
 if (!('closedBy' in HTMLDialogElement.prototype)) {

--- a/guides/ui-behaviors/move-dom-element-without-losing-state/guide.md
+++ b/guides/ui-behaviors/move-dom-element-without-losing-state/guide.md
@@ -5,6 +5,8 @@ web-feature-ids:
 - move-before
 ---
 
+# Move DOM Element Without Losing State
+
 When reparenting DOM elements using traditional methods like `appendChild()` or `insertBefore()`, the browser implicitly removes the element from the DOM and then inserts it into its new location. This "remove and insert" operation resets many internal states, causing `<iframe>` elements to reload, CSS animations to restart, and input fields to lose focus.
 
 To move an element while preserving its state, use the `moveBefore()` API. This method performs an atomic move, completely bypassing the removal and insertion steps.

--- a/guides/ui-behaviors/persistent-top-layer-ui/guide.md
+++ b/guides/ui-behaviors/persistent-top-layer-ui/guide.md
@@ -5,6 +5,8 @@ web-feature-ids:
 - move-before
 ---
 
+# Persistent Top Layer UI
+
 When moving an open `<dialog>`, `popover`, or fullscreen element in the DOM using traditional methods like `appendChild()` or `insertBefore()`, the browser implicitly removes the element from the DOM and re-inserts it. This removal resets the state, causing open modals, popovers, and fullscreen elements to close abruptly.
 
 To reparent top-layer elements without interrupting the user experience or closing them, use the atomic `moveBefore()` API instead.

--- a/guides/ui-behaviors/physics-based-easing/guide.md
+++ b/guides/ui-behaviors/physics-based-easing/guide.md
@@ -5,6 +5,8 @@ web-feature-ids:
   - linear-easing
 ---
 
+# Physics Based Easing
+
 Traditional CSS easing functions like `ease-in` or `cubic-bezier()` are limited to simple curves, making it impossible to create complex physics-based effects like bounces or springs. The `linear()` timing function solves this by allowing you to provide a series of stops that can approximate complex curves. Transitions and animations are interpolated based on straight lines between the stops, but within enough stops, it can appear smooth.
 
 ### Implementation Steps

--- a/guides/ui-behaviors/platform-controls-dismiss-dialog/guide.md
+++ b/guides/ui-behaviors/platform-controls-dismiss-dialog/guide.md
@@ -5,6 +5,8 @@ web-feature-ids:
   - dialog-closedby
 ---
 
+# Platform Controls Dismiss Dialog
+
 When a modal dialog is open, users expect to use familiar controls to dismiss them: pressing the <kbd>Esc</kbd> key on a keyboard, using the back button or gesture on mobile platforms, or a dismiss gesture with assistive technologies.
 
 When the `<dialog>` element was first introduced, it could be dismissed with the <kbd>Esc</kbd> key, but not other platform controls such as a back button/gesture on mobile. With the addition of the `closedby` attribute for `<dialog>` elements, the extended behavior of responding to more platform-specific controls for close requests has been applied for `<dialog>` elements that are opened in a modal state (i.e. when opened imperatively with the `<dialog>` element’s `showModal()` method in JavaScript or declaratively with the `show-modal` invoker command). So, there is no specific change developers need to make if they are already using the `<dialog>` element.

--- a/guides/ui-behaviors/scroll-snap-realtime-feedback/guide.md
+++ b/guides/ui-behaviors/scroll-snap-realtime-feedback/guide.md
@@ -6,6 +6,8 @@ web-feature-ids:
   - scroll-snap
 ---
 
+# Scroll Snap Real-Time Feedback
+
 ## Overview
 Users expect immediate visual feedback when interacting with UI elements like carousels or galleries. Traditional scroll snap only provides feedback *after* the scroll gesture completes and the element settles. By using Scroll Snap Events, specifically `scrollsnapchanging`, you can provide real-time feedback during the scroll gesture, highlighting the pending snap target before the user releases their touch or mouse.
 

--- a/guides/ui-behaviors/scroll-snap-state-sync/guide.md
+++ b/guides/ui-behaviors/scroll-snap-state-sync/guide.md
@@ -6,6 +6,8 @@ web-feature-ids:
   - scroll-snap
 ---
 
+# Scroll Snap State Sync
+
 Synchronizing UI state with a scrollable container's snap position traditionally required complex scroll event listeners, manual calculations of scroll offsets, and intersection observers. The `scrollsnapchange` event provides a native, efficient way to detect when a scroller has settled on a new snap target, making it useful for synchronizing sidebars or highlighting the active section in a table of contents.
 
 ## Implementation

--- a/guides/ui-behaviors/search-hidden-content/guide.md
+++ b/guides/ui-behaviors/search-hidden-content/guide.md
@@ -124,9 +124,11 @@ accordion.addEventListener('beforematch', (e) => {
 
 ## Browser support and fallback strategies
 
-The `<details>` element is Baseline Widely available, so a fallback strategy is not required.
+{{ BASELINE_STATUS("details") }}
 
-The `hidden="until-found"` attribute is not yet Baseline Widely available, but it can be safely used with a fallback in unsupporting browsers. **DO NOT** avoid `hidden="until-found"` because of missing browser support, as its accessibility benefits far outweigh the cost of implementing a fallback.
+{{ BASELINE_STATUS("hidden-until-found") }}
+
+**DO NOT** avoid `hidden="until-found"` because of missing browser support, as its accessibility benefits far outweigh the cost of implementing a fallback.
 
 #### `hidden="until-found"` fallback
 

--- a/guides/ui-behaviors/swipe-to-remove/guide.md
+++ b/guides/ui-behaviors/swipe-to-remove/guide.md
@@ -457,13 +457,23 @@ With this setup, the spacers no longer need their own background-color (the trac
 
 ## Fallback strategies
 
-The scroll-snap mechanics that underpin this pattern (`scroll-snap-type`, `scroll-snap-align`), `IntersectionObserver`, `MutationObserver`, `ResizeObserver`, and the Web Animations API are all Baseline Widely Available, so the gesture, commit detection, lifecycle management, and removal animation work broadly. All newer features that are used are either not core to the experience or have robust fallbacks that can be reliably used now.
+{{ BASELINE_STATUS("scroll-snap") }}
+
+{{ BASELINE_STATUS("intersection-observer") }}
+
+{{ BASELINE_STATUS("mutationobserver") }}
+
+{{ BASELINE_STATUS("resize-observer") }}
+
+{{ BASELINE_STATUS("web-animations") }}
+
+All newer features that are used are either not core to the experience or have robust fallbacks that can be reliably used now.
 
 ### Fallback for `overscroll-behavior`
 
 {{ FEATURE_FALLBACKS("overscroll-behavior") }}
 
-No fallback is needed for this use case. `overscroll-behavior` was Baseline Widely Available but no longer is due to an interop issue that only manifests on containers without scrollable overflow. But the track here is always horizontally scrollable (three full-width columns inside a 100%-width container), so the property behaves consistently across browsers and the swipe gesture is reliably contained.
+No fallback is needed for this use case. Although `overscroll-behavior` has an interop issue that manifests on containers without scrollable overflow, the track here is always horizontally scrollable (three full-width columns inside a 100%-width container), so the property behaves consistently across browsers and the swipe gesture is reliably contained.
 
 ### Fallback for `scrollbar-width`
 

--- a/guides/ui-components/navigation-drawer/guide.md
+++ b/guides/ui-components/navigation-drawer/guide.md
@@ -300,7 +300,13 @@ document.addEventListener('keydown', (event) => {
 
 ### Fallback strategies
 
-The drawer's core mechanics — scroll snap, `IntersectionObserver`, and `inert` — are all Baseline Widely available and required for the component to function. The popover API, the scroll-driven animation that fades the backdrop, and `scroll-initial-target` are progressive enhancements with simple fallbacks that can be easily implemented if wide browser support is required.
+{{ BASELINE_STATUS("scroll-snap") }}
+
+{{ BASELINE_STATUS("intersection-observer") }}
+
+{{ BASELINE_STATUS("inert") }}
+
+The popover API, the scroll-driven animation that fades the backdrop, and `scroll-initial-target` are progressive enhancements with simple fallbacks that can be easily implemented if wide browser support is required.
 
 #### Backdrop fade fallback (no `animation-timeline` support):
 
@@ -356,6 +362,6 @@ async function openDrawer() {
 
 {{ BASELINE_STATUS("popover", "api.HTMLElement.showPopover") }}
 
-Because this component uses `popover="manual"` and implements dismissal entirely from JavaScript, it does not depend on the popover API's defining behaviors — light-dismiss, the `popovertarget` attribute, top-layer-managed Escape handling, or focus management. The only popover features it actually uses are top-layer promotion (via `showPopover()`) and the `::backdrop` pseudo-element, which have been Baseline since April 2024.
+Because this component uses `popover="manual"` and implements dismissal entirely from JavaScript, it does not depend on the popover API's defining behaviors — light-dismiss, the `popovertarget` attribute, top-layer-managed Escape handling, or focus management. The only popover features it actually uses are top-layer promotion (via `showPopover()`) and the `::backdrop` pseudo-element.
 
 If wider browser support is needed, do not branch on feature detection — simply do not use popover at all. Drop the `popover="manual"` attribute, replace top-layer promotion with `position: fixed` and a high `z-index`, replace `::backdrop` with a sibling element styled identically (using the same `--drawer-backdrop` custom property), and toggle visibility from a class instead of `showPopover()`/`hidePopover()`. The rest of the component (scroll snap, the scroll-driven backdrop animation, the `IntersectionObserver`, and the dismissal handlers) is unchanged.

--- a/guides/ui-components/navigation-drawer/guide.md
+++ b/guides/ui-components/navigation-drawer/guide.md
@@ -11,6 +11,8 @@ web-feature-ids:
   - scroll-snap
 ---
 
+# Navigation Drawer
+
 ## Overview
 
 A navigation drawer is a panel that slides in from the edge of the viewport over the page content, dimming everything behind it. It is opened from a trigger button and dismissed by swiping the panel off-screen, tapping the dimmed backdrop, or pressing Escape.

--- a/guides/ui-components/stack-drill-down/guide.md
+++ b/guides/ui-components/stack-drill-down/guide.md
@@ -614,7 +614,13 @@ updateFromHistoryState(history.state, 'instant');
 
 ### Fallback strategies
 
-Most of the features used in this guide are Baseline Widely available, and do not require any fallback. The only features not widely available that may require fallbacks are scroll-snap-events and scroll-driven-animations, both of which have robust fallback or progressive enhancement stories, and are safe to use for this use case:
+{{ BASELINE_STATUS("scroll-snap") }}
+
+{{ BASELINE_STATUS("intersection-observer") }}
+
+{{ BASELINE_STATUS("inert") }}
+
+The features that may require fallbacks are scroll-snap-events and scroll-driven-animations, both of which have robust fallback or progressive enhancement stories, and are safe to use for this use case:
 
 #### Scroll snap events
 

--- a/guides/visual-design/complex-shapes/guide.md
+++ b/guides/visual-design/complex-shapes/guide.md
@@ -6,6 +6,8 @@ web-feature-ids:
   - svg
 ---
 
+# Complex Shapes
+
 ## Overview
 To clip elements to complex, free-form shapes like brush strokes or organic textures, use CSS Masking (`mask-image`). While `clip-path` is excellent for geometric shapes or vector paths, `mask-image` allows you to use images (like PNGs with transparency) or SVGs to define the visible area of an element. This approach is more expressive because it supports semi-transparency, allowing for soft edges and complex textures that are difficult or impossible to achieve with `clip-path`.
 

--- a/guides/visual-design/export-html-media-from-canvas/guide.md
+++ b/guides/visual-design/export-html-media-from-canvas/guide.md
@@ -192,6 +192,7 @@ targetHTMLElement.style.transform = computedTransform.toString();
 
 ## Example code
 
+**HTML**
 ```html
 <body>
     <canvas id="canvas" style="width: 400px; height: 200px;" layoutsubtree>
@@ -199,44 +200,44 @@ targetHTMLElement.style.transform = computedTransform.toString();
     </canvas>
     
     <button id="download">Download Image</button>
-
-    <script>
-        const canvas = document.getElementById('canvas');
-        const ctx = canvas.getContext('2d');
-        const element = document.getElementById('element');
-        const download = document.getElementById('download');
-
-        canvas.onpaint = (event) => {
-            ctx.reset();
-            // Draw the element into the canvas
-            const transform = ctx.drawElementImage(element, 10, 10);
-            // Synchronize DOM position for hit testing (typing)
-            element.style.transform = transform.toString();
-        };
-
-        download.onclick = () => {
-            // Export the canvas content as an image
-            const dataURL = canvas.toDataURL('image/png');
-            const link = document.createElement('a');
-            link.download = 'exported-canvas.png';
-            link.href = dataURL;
-            link.click();
-        };
-
-        // Re-initialize canvas size on screen resize
-        const observer = new ResizeObserver(([entry]) => {
-            const dpc = entry.devicePixelContentBoxSize;
-            canvas.width = dpc ? dpc[0].inlineSize : Math.round(entry.contentRect.width * window.devicePixelRatio);
-            canvas.height = dpc ? dpc[0].blockSize : Math.round(entry.contentRect.height * window.devicePixelRatio);
-            canvas.requestPaint();
-        });
-        const supportsDevicePixelContentBox = 
-            typeof ResizeObserverEntry !== 'undefined' && 
-            'devicePixelContentBoxSize' in ResizeObserverEntry.prototype;
-        const options = supportsDevicePixelContentBox ? { box: 'device-pixel-content-box' } : {};
-        observer.observe(canvas, options);
-    </script>
 </body>
+```
+
+**JavaScript**
+```javascript
+const canvas = document.getElementById('canvas');
+const ctx = canvas.getContext('2d');
+const element = document.getElementById('element');
+
+canvas.onpaint = (event) => {
+    ctx.reset();
+    // Draw the element into the canvas
+    const transform = ctx.drawElementImage(element, 10, 10);
+    // Synchronize DOM position for hit testing (typing)
+    element.style.transform = transform.toString();
+};
+
+document.getElementById('download').addEventListener('click', () => {
+    // Export the canvas content as an image
+    const dataURL = canvas.toDataURL('image/png');
+    const link = document.createElement('a');
+    link.download = 'exported-canvas.png';
+    link.href = dataURL;
+    link.click();
+});
+
+// Re-initialize canvas size on screen resize
+const observer = new ResizeObserver(([entry]) => {
+    const dpc = entry.devicePixelContentBoxSize;
+    canvas.width = dpc ? dpc[0].inlineSize : Math.round(entry.contentRect.width * window.devicePixelRatio);
+    canvas.height = dpc ? dpc[0].blockSize : Math.round(entry.contentRect.height * window.devicePixelRatio);
+    canvas.requestPaint();
+});
+const supportsDevicePixelContentBox = 
+    typeof ResizeObserverEntry !== 'undefined' && 
+    'devicePixelContentBoxSize' in ResizeObserverEntry.prototype;
+const options = supportsDevicePixelContentBox ? { box: 'device-pixel-content-box' } : {};
+observer.observe(canvas, options);
 ```
 
 ## Best Practices

--- a/guides/visual-design/export-html-media-from-canvas/guide.md
+++ b/guides/visual-design/export-html-media-from-canvas/guide.md
@@ -192,7 +192,6 @@ targetHTMLElement.style.transform = computedTransform.toString();
 
 ## Example code
 
-**HTML**
 ```html
 <body>
     <canvas id="canvas" style="width: 400px; height: 200px;" layoutsubtree>
@@ -200,44 +199,44 @@ targetHTMLElement.style.transform = computedTransform.toString();
     </canvas>
     
     <button id="download">Download Image</button>
+
+    <script>
+        const canvas = document.getElementById('canvas');
+        const ctx = canvas.getContext('2d');
+        const element = document.getElementById('element');
+        const download = document.getElementById('download');
+
+        canvas.onpaint = (event) => {
+            ctx.reset();
+            // Draw the element into the canvas
+            const transform = ctx.drawElementImage(element, 10, 10);
+            // Synchronize DOM position for hit testing (typing)
+            element.style.transform = transform.toString();
+        };
+
+        download.onclick = () => {
+            // Export the canvas content as an image
+            const dataURL = canvas.toDataURL('image/png');
+            const link = document.createElement('a');
+            link.download = 'exported-canvas.png';
+            link.href = dataURL;
+            link.click();
+        };
+
+        // Re-initialize canvas size on screen resize
+        const observer = new ResizeObserver(([entry]) => {
+            const dpc = entry.devicePixelContentBoxSize;
+            canvas.width = dpc ? dpc[0].inlineSize : Math.round(entry.contentRect.width * window.devicePixelRatio);
+            canvas.height = dpc ? dpc[0].blockSize : Math.round(entry.contentRect.height * window.devicePixelRatio);
+            canvas.requestPaint();
+        });
+        const supportsDevicePixelContentBox = 
+            typeof ResizeObserverEntry !== 'undefined' && 
+            'devicePixelContentBoxSize' in ResizeObserverEntry.prototype;
+        const options = supportsDevicePixelContentBox ? { box: 'device-pixel-content-box' } : {};
+        observer.observe(canvas, options);
+    </script>
 </body>
-```
-
-**JavaScript**
-```javascript
-const canvas = document.getElementById('canvas');
-const ctx = canvas.getContext('2d');
-const element = document.getElementById('element');
-
-canvas.onpaint = (event) => {
-    ctx.reset();
-    // Draw the element into the canvas
-    const transform = ctx.drawElementImage(element, 10, 10);
-    // Synchronize DOM position for hit testing (typing)
-    element.style.transform = transform.toString();
-};
-
-document.getElementById('download').addEventListener('click', () => {
-    // Export the canvas content as an image
-    const dataURL = canvas.toDataURL('image/png');
-    const link = document.createElement('a');
-    link.download = 'exported-canvas.png';
-    link.href = dataURL;
-    link.click();
-});
-
-// Re-initialize canvas size on screen resize
-const observer = new ResizeObserver(([entry]) => {
-    const dpc = entry.devicePixelContentBoxSize;
-    canvas.width = dpc ? dpc[0].inlineSize : Math.round(entry.contentRect.width * window.devicePixelRatio);
-    canvas.height = dpc ? dpc[0].blockSize : Math.round(entry.contentRect.height * window.devicePixelRatio);
-    canvas.requestPaint();
-});
-const supportsDevicePixelContentBox = 
-    typeof ResizeObserverEntry !== 'undefined' && 
-    'devicePixelContentBoxSize' in ResizeObserverEntry.prototype;
-const options = supportsDevicePixelContentBox ? { box: 'device-pixel-content-box' } : {};
-observer.observe(canvas, options);
 ```
 
 ## Best Practices

--- a/guides/visual-design/shaped-cutouts/guide.md
+++ b/guides/visual-design/shaped-cutouts/guide.md
@@ -5,6 +5,8 @@ web-feature-ids:
   - masks
 ---
 
+# Shaped Cutouts
+
 ## Overview
 CSS Masking allows you to clip an element to a custom shape, such as adding a notch to a card or creating a shaped border. When combining shapes for complex layouts, choose your masking strategy based on the type of content the element contains:
 

--- a/guides/visual-design/soft-edge-content-fade/guide.md
+++ b/guides/visual-design/soft-edge-content-fade/guide.md
@@ -5,6 +5,8 @@ web-feature-ids:
   - masks
 ---
 
+# Soft Edge Content Fade
+
 ## Overview
 To apply a transparency gradient to the edges of a container (e.g., to indicate more content is available to scroll or to fade out text), use CSS Masking with a linear gradient. This approach is superior to using a semi-transparent overlay because it actually fades the content itself, allowing the background to show through naturally without interfering with text selection or pointer events.
 

--- a/guides/visual-design/visually-stable-font-fallbacks/guide.md
+++ b/guides/visual-design/visually-stable-font-fallbacks/guide.md
@@ -5,6 +5,8 @@ web-feature-ids:
   - font-size-adjust
 ---
 
+# Visually Stable Font Fallbacks
+
 When web fonts load, they often replace a fallback font that has different dimensions, even if both are set to the same `font-size`. This causes "layout shift" (Cumulative Layout Shift) and can make text illegible if the fallback's lowercase letters (x-height) are significantly different than the preferred font.
 
 The `font-size-adjust` property solves this by normalizing the size of the font based on a specific metric (usually the x-height), ensuring that text occupies the same visual space regardless of which font is currently active.

--- a/guides/visual-design/visually-stable-mixed-fonts/guide.md
+++ b/guides/visual-design/visually-stable-mixed-fonts/guide.md
@@ -5,6 +5,8 @@ web-feature-ids:
   - font-size-adjust
 ---
 
+# Visually Stable Mixed Fonts
+
 When mixing different font families, for instance when inserting inline code snippets, or switching out font families for different themes, differences in "x-height" (the height of lowercase letters) can make one font appear much smaller or larger than the other font. This can lead to poor legibility and layout shifts.
 
 The `font-size-adjust` property allows you to normalize the visual size of text by adjusting the font size based on a specific font metric (usually the x-height).

--- a/guides/visual-design/visually-texture-content/guide.md
+++ b/guides/visual-design/visually-texture-content/guide.md
@@ -5,6 +5,8 @@ web-feature-ids:
   - masks
 ---
 
+# Visually Texture Content
+
 ## Overview
 To apply realistic weathering or texture patterns (like grunge, noise, or paper texture) to an element, use CSS Masking (`mask-image`) with a repeating texture image. This allows you to make the content itself appear textured by making parts of it semi-transparent, rather than just overlaying a texture on top. This creates a more realistic physical material appearance.
 

--- a/guides/webmcp/agentic-forms/guide.md
+++ b/guides/webmcp/agentic-forms/guide.md
@@ -5,6 +5,8 @@ web-feature-ids:
   - declarative-webmcp
 ---
 
+# Agentic Forms
+
 The Declarative API transforms standard HTML `<form>` elements into WebMCP tools via attributes. The browser synthesizes a JSON Schema from the form inputs and handles agent interactions.
 
 ## Form Attributes

--- a/guides/webmcp/agentic-javascript-tools/guide.md
+++ b/guides/webmcp/agentic-javascript-tools/guide.md
@@ -5,6 +5,8 @@ web-feature-ids:
   - document-modelcontext
 ---
 
+# Agentic JavaScript Tools
+
 The Imperative API uses `document.modelContext.registerTool()` to programmatically define JavaScript tools. This is ideal for Single Page Applications (SPAs) where tools need to be added or removed based on the current route or user state.
 
 ## Registration and Lifecycle

--- a/lib/guide-validation.test.ts
+++ b/lib/guide-validation.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { parseExpectations, validateHtmlTags, validateHeadings, validateGuideTitle, validateGuide, inventoryGuide, classifyGuide, getSupportedBaseApps } from './guide-validation.ts';
+import { parseExpectations, validateHtmlTags, validateHeadings, validateGuideTitle, validateBaselineClaims, validateGuide, inventoryGuide, classifyGuide, getSupportedBaseApps } from './guide-validation.ts';
 import { extractFeatureIds } from './feature-parser.ts';
 
 describe('parseExpectations', () => {
@@ -374,4 +374,110 @@ https://webstatus.dev/features/tmp-custom-feature
     assert.ok(fids.includes('tmp-custom-feature'));
   });
 });
+
+describe('validateBaselineClaims', () => {
+  test('flags hardcoded baseline availability claims', () => {
+    const cases = [
+      'The `<details>` element is Baseline Widely available, so a fallback strategy is not required.',
+      'The `hidden="until-found"` attribute is not yet Baseline Widely available, but it can be safely used.',
+      'The `:user-invalid` pseudo-class is widely supported (Baseline 2023), but older browsers need a fallback.',
+      'Speculative loading is a new feature (Baseline limited availability).',
+      'The mechanics are all Baseline Widely Available, so the gesture works broadly.',
+      'The features are Baseline newly available across modern browsers.',
+      'The capabilities have been Baseline since April 2024.',
+      'Most features used in this guide are Baseline Widely available.',
+      'Feature overscroll-behavior was Baseline Widely Available but no longer is.',
+    ];
+
+    for (const text of cases) {
+      const errors = validateBaselineClaims(text, 'guides/test/guide.md');
+      assert.strictEqual(errors.length, 1, `Expected "${text}" to produce 1 error`);
+      assert.ok(errors[0].includes('Hardcoded Baseline availability claim found'));
+      assert.ok(errors[0].includes('Use {{ BASELINE_STATUS("feature-id") }} macro instead.'));
+    }
+  });
+
+  test('allows macros without error', () => {
+    const body = `
+## Fallback strategies
+
+{{ BASELINE_STATUS("speculation-rules") }}
+
+{{ FEATURE_FALLBACKS("user-pseudos") }}
+
+{{ BASELINE_STATUS("scroll-snap") }}
+`;
+    const errors = validateBaselineClaims(body, 'guides/test/guide.md');
+    assert.deepStrictEqual(errors, []);
+  });
+
+  test('allows legitimate non-status baseline prose and CSS properties', () => {
+    const validProse = [
+      'A fallback strategy is required if `fetchLater()` does not meet your Baseline target.',
+      'If your Baseline target does not include `scrollbar-width`, the row still scrolls.',
+      'If a parallax fallback is required for older baseline targets, attach a `scroll` listener.',
+      'Reach for native masonry only when it ships in your Baseline target.',
+      'Use `@starting-style` to define the baseline styles the browser should compute.',
+      'Phase 1 and 2 establish baseline hygiene and data gathering.',
+      'Trim the text box to the cap-height and the alphabetic baseline.',
+      'Reset a task to its baseline configuration.',
+      'Clone the baseline session for new tasks.',
+      'Until there is Baseline support for container style queries, use selectors.',
+    ];
+
+    for (const text of validProse) {
+      const errors = validateBaselineClaims(text, 'guides/test/guide.md');
+      assert.deepStrictEqual(errors, [], `Expected legitimate prose "${text}" to have no errors`);
+    }
+  });
+
+  test('ignores code blocks with baseline mentions or CSS baseline properties', () => {
+    const body = `
+\`\`\`css
+.item {
+  vertical-align: baseline;
+  alignment-baseline: baseline;
+}
+\`\`\`
+
+\`\`\`markdown
+The <details> element is Baseline Widely available.
+\`\`\`
+`;
+    const errors = validateBaselineClaims(body, 'guides/test/guide.md');
+    assert.deepStrictEqual(errors, []);
+  });
+
+  test('ignores SKILL.md meta policy instructions', () => {
+    const body = `* **Default Behavior**: All guides assume **Baseline Widely available** features are safe to use without fallbacks.`;
+    const errors = validateBaselineClaims(body, 'guides/modern-web-guidance/SKILL.md');
+    assert.deepStrictEqual(errors, []);
+  });
+
+  test('validateGuide integrates baseline claims validation', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'guide-baseline-test-'));
+    const guideDir = path.join(tmpDir, 'test-guide');
+    fs.mkdirSync(guideDir, { recursive: true });
+    const guideFile = path.join(guideDir, 'guide.md');
+
+    fs.writeFileSync(guideFile, `---
+name: test-guide
+description: Test description
+web-feature-ids: []
+---
+
+# Test Guide
+
+The \`<details>\` element is Baseline Widely available.
+`);
+
+    try {
+      const result = validateGuide(guideFile);
+      assert.ok(result.errors.some(e => e.includes('Hardcoded Baseline availability claim found')));
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+
 

--- a/lib/guide-validation.test.ts
+++ b/lib/guide-validation.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { parseExpectations, validateHtmlTags, inventoryGuide, classifyGuide, getSupportedBaseApps } from './guide-validation.ts';
+import { parseExpectations, validateHtmlTags, validateHeadings, validateGuideTitle, validateGuide, inventoryGuide, classifyGuide, getSupportedBaseApps } from './guide-validation.ts';
 import { extractFeatureIds } from './feature-parser.ts';
 
 describe('parseExpectations', () => {
@@ -109,6 +109,90 @@ Also unescaped <label>.
 `;
     const errors = validateHtmlTags(body, 'test.md');
     assert.deepStrictEqual(errors, []);
+  });
+});
+
+describe('validateHeadings and validateGuideTitle', () => {
+  test('disallows vague H1 headings like Overview, Introduction, Guide, Title', () => {
+    const vagueHeadings = ['# Overview', '# Introduction', '# Guide', '# Title', '# overview', '# OVERVIEW', '#  Introduction '];
+    for (const heading of vagueHeadings) {
+      const body = `${heading}\n\nSome body text.`;
+      const errors = validateHeadings(body, 'test.md');
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors[0].includes('Vague H1 heading'));
+    }
+  });
+
+  test('allows descriptive H1 headings', () => {
+    const validHeadings = [
+      '# Declarative Dialog and Popover Control',
+      '# HTML',
+      '# Persistent Top Layer UI',
+      '# Move DOM Element Without Losing State',
+      '# Agentic JavaScript Tools',
+      '# Overview of Invoker Commands',
+      '# Introduction to WebMCP',
+      '# Guide for Dynamic Sibling Animations',
+    ];
+    for (const heading of validHeadings) {
+      const body = `${heading}\n\nSome body text.`;
+      const errors = validateHeadings(body, 'test.md');
+      assert.deepStrictEqual(errors, []);
+    }
+  });
+
+  test('ignores vague headings inside code blocks', () => {
+    const body = `\`\`\`markdown
+# Overview
+# Introduction
+\`\`\`
+`;
+    const errors = validateHeadings(body, 'test.md');
+    assert.deepStrictEqual(errors, []);
+  });
+
+  test('flags vague frontmatter title', () => {
+    const errors = validateHeadings('Some body text', 'test.md', { title: 'Overview' });
+    assert.strictEqual(errors.length, 1);
+    assert.ok(errors[0].includes('Vague title "Overview" in frontmatter'));
+  });
+
+  test('validateGuideTitle flags missing title in non-stub guide when requireTitle is set', () => {
+    const nonStubBody = `Some guide content without H1 heading.`;
+    const errors = validateGuideTitle(nonStubBody, 'test.md', {}, { requireTitle: true });
+    assert.strictEqual(errors.length, 1);
+    assert.ok(errors[0].includes('Missing H1 heading or frontmatter "title" in non-stub guide'));
+  });
+
+  test('validateGuideTitle allows stub guide without title even when requireTitle is set', () => {
+    const stubBody = `<!-- stub -->\n`;
+    const errors = validateGuideTitle(stubBody, 'test.md', {}, { requireTitle: true });
+    assert.deepStrictEqual(errors, []);
+  });
+
+  test('validateGuide integrates heading validation', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'guide-val-test-'));
+    const guideDir = path.join(tmpDir, 'test-guide');
+    fs.mkdirSync(guideDir, { recursive: true });
+    const guideFile = path.join(guideDir, 'guide.md');
+
+    fs.writeFileSync(guideFile, `---
+name: test-guide
+description: Test description
+web-feature-ids: []
+---
+
+# Overview
+
+Guide content.
+`);
+
+    try {
+      const result = validateGuide(guideFile);
+      assert.ok(result.errors.some(e => e.includes('Vague H1 heading "# Overview"')));
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/lib/guide-validation.test.ts
+++ b/lib/guide-validation.test.ts
@@ -110,6 +110,18 @@ Also unescaped <label>.
     const errors = validateHtmlTags(body, 'test.md');
     assert.deepStrictEqual(errors, []);
   });
+
+  test('reports true line numbers for duplicate unescaped tags across document', () => {
+    const body = `Line 1: unescaped <dialog>.
+Line 2: normal text.
+Line 3: normal text.
+Line 4: duplicate unescaped <dialog>.
+`;
+    const errors = validateHtmlTags(body, 'test.md');
+    assert.strictEqual(errors.length, 2);
+    assert.ok(errors[0].includes('Unescaped HTML tag <dialog> found on line 1'));
+    assert.ok(errors[1].includes('Unescaped HTML tag <dialog> found on line 4'));
+  });
 });
 
 describe('validateHeadings and validateGuideTitle', () => {
@@ -121,6 +133,22 @@ describe('validateHeadings and validateGuideTitle', () => {
       assert.strictEqual(errors.length, 1);
       assert.ok(errors[0].includes('Vague H1 heading'));
     }
+  });
+
+  test('allows depth > 1 headings like ## Overview or ### Introduction without errors', () => {
+    const body = `# Valid Feature Guide
+
+## Overview
+Some overview content.
+
+### Introduction
+Some introduction details.
+
+#### Guide
+Some guide steps.
+`;
+    const errors = validateHeadings(body, 'test.md');
+    assert.deepStrictEqual(errors, []);
   });
 
   test('allows descriptive H1 headings', () => {
@@ -162,6 +190,19 @@ describe('validateHeadings and validateGuideTitle', () => {
     const errors = validateGuideTitle(nonStubBody, 'test.md', {}, { requireTitle: true });
     assert.strictEqual(errors.length, 1);
     assert.ok(errors[0].includes('Missing H1 heading or frontmatter "title" in non-stub guide'));
+  });
+
+  test('validateGuideTitle flags whitespace-only frontmatter title when requireTitle is set', () => {
+    const nonStubBody = `Some guide content without H1 heading.`;
+    const errors = validateGuideTitle(nonStubBody, 'test.md', { title: '   ' }, { requireTitle: true });
+    assert.strictEqual(errors.length, 1);
+    assert.ok(errors[0].includes('Missing H1 heading or frontmatter "title" in non-stub guide'));
+  });
+
+  test('validateGuideTitle succeeds with valid descriptive frontmatter title without an H1', () => {
+    const nonStubBody = `Some guide content without H1 heading.`;
+    const errors = validateGuideTitle(nonStubBody, 'test.md', { title: 'Descriptive Feature Guide' }, { requireTitle: true });
+    assert.deepStrictEqual(errors, []);
   });
 
   test('validateGuideTitle allows stub guide without title even when requireTitle is set', () => {

--- a/lib/guide-validation.test.ts
+++ b/lib/guide-validation.test.ts
@@ -3,8 +3,62 @@ import assert from 'node:assert';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { parseExpectations, validateHtmlTags, validateHeadings, validateGuideTitle, validateBaselineClaims, validateGuide, inventoryGuide, classifyGuide, getSupportedBaseApps } from './guide-validation.ts';
+import { parseExpectations, validateHtmlTags, validateHeadings, validateGuideTitle, validateBaselineClaims, validateGuide, inventoryGuide, classifyGuide, getSupportedBaseApps, extractH1Heading, extractAllH1Headings } from './guide-validation.ts';
 import { extractFeatureIds } from './feature-parser.ts';
+
+describe('extractH1Heading and extractAllH1Headings', () => {
+  test('extracts standard ATX H1 heading', () => {
+    const markdown = '# My Title\n\nSome introductory paragraph.';
+    assert.strictEqual(extractH1Heading(markdown), 'My Title');
+    assert.deepStrictEqual(extractAllH1Headings(markdown), ['My Title']);
+  });
+
+  test('extracts H1 heading after HTML comments or frontmatter', () => {
+    const markdownWithComments = `<!-- Author: Someone -->\n<!-- Status: Draft -->\n\n# Document Title\n\nContent here.`;
+    assert.strictEqual(extractH1Heading(markdownWithComments), 'Document Title');
+    assert.deepStrictEqual(extractAllH1Headings(markdownWithComments), ['Document Title']);
+
+    const markdownWithFrontmatter = `---\nname: test-guide\ndescription: A test guide\n---\n\n# Frontmatter Title\n\nBody content.`;
+    assert.strictEqual(extractH1Heading(markdownWithFrontmatter), 'Frontmatter Title');
+    assert.deepStrictEqual(extractAllH1Headings(markdownWithFrontmatter), ['Frontmatter Title']);
+  });
+
+  test('ignores H1 headings inside code blocks', () => {
+    const markdown = `\`\`\`markdown\n# Inside Code Block\n# Another Inside Code Block\n\`\`\`\n\n\`\`\`js\n// # Not a heading\n\`\`\``;
+    assert.strictEqual(extractH1Heading(markdown), undefined);
+    assert.deepStrictEqual(extractAllH1Headings(markdown), []);
+
+    const markdownWithRealH1AndCodeBlock = `\`\`\`markdown\n# Code Block Title\n\`\`\`\n\n# Real Heading\n\n\`\`\`\n# Another Fake Heading\n\`\`\``;
+    assert.strictEqual(extractH1Heading(markdownWithRealH1AndCodeBlock), 'Real Heading');
+    assert.deepStrictEqual(extractAllH1Headings(markdownWithRealH1AndCodeBlock), ['Real Heading']);
+  });
+
+  test('preserves inline backticks and formatting in title', () => {
+    const markdown = '# Guide for `<dialog>` and `popover`\n\nContent.';
+    assert.strictEqual(extractH1Heading(markdown), 'Guide for `<dialog>` and `popover`');
+    assert.deepStrictEqual(extractAllH1Headings(markdown), ['Guide for `<dialog>` and `popover`']);
+  });
+
+  test('returns undefined / empty array when only lower level headings exist', () => {
+    const markdown = `## Subhead\n\n### Sub Subhead\n\n#### Minor Heading`;
+    assert.strictEqual(extractH1Heading(markdown), undefined);
+    assert.deepStrictEqual(extractAllH1Headings(markdown), []);
+  });
+
+  test('handles multiple H1 headings across document', () => {
+    const markdown = `# First Heading\n\nSome text.\n\n# Second Heading\n\nMore text.\n\n# Third Heading`;
+    assert.strictEqual(extractH1Heading(markdown), 'First Heading');
+    assert.deepStrictEqual(extractAllH1Headings(markdown), ['First Heading', 'Second Heading', 'Third Heading']);
+  });
+
+  test('returns undefined / empty array for empty or whitespace markdown', () => {
+    assert.strictEqual(extractH1Heading(''), undefined);
+    assert.deepStrictEqual(extractAllH1Headings(''), []);
+
+    assert.strictEqual(extractH1Heading('   \n\n  \t  \n'), undefined);
+    assert.deepStrictEqual(extractAllH1Headings('   \n\n  \t  \n'), []);
+  });
+});
 
 describe('parseExpectations', () => {
   test('legacy flat format: all bullets treated as mustPass', () => {

--- a/lib/guide-validation.test.ts
+++ b/lib/guide-validation.test.ts
@@ -235,6 +235,54 @@ Guide content.
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
   });
+
+  test('validateGuide enforces title presence on non-stub guides', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'guide-val-title-'));
+    const guideDir = path.join(tmpDir, 'test-guide');
+    fs.mkdirSync(guideDir, { recursive: true });
+    const guideFile = path.join(guideDir, 'guide.md');
+
+    fs.writeFileSync(guideFile, `---
+name: test-guide
+description: Test description
+web-feature-ids: []
+---
+
+## Section Title
+
+Guide content without H1 heading or frontmatter title.
+`);
+
+    try {
+      const result = validateGuide(guideFile);
+      assert.ok(result.errors.some(e => e.includes('Missing H1 heading or frontmatter "title" in non-stub guide')));
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test('validateGuide allows stub guides without title or H1 heading', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'guide-val-stub-'));
+    const guideDir = path.join(tmpDir, 'test-guide');
+    fs.mkdirSync(guideDir, { recursive: true });
+    const guideFile = path.join(guideDir, 'guide.md');
+
+    fs.writeFileSync(guideFile, `---
+name: test-guide
+description: Test description
+web-feature-ids: []
+---
+
+<!-- stub guide -->
+`);
+
+    try {
+      const result = validateGuide(guideFile);
+      assert.strictEqual(result.errors.length, 0);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('inventoryGuide and classifyGuide target discovery', () => {

--- a/lib/guide-validation.test.ts
+++ b/lib/guide-validation.test.ts
@@ -190,7 +190,7 @@ describe('validateHeadings and validateGuideTitle', () => {
   });
 
   test('allows depth > 1 headings like ## Overview or ### Introduction without errors', () => {
-    const body = `# Valid Feature Guide
+    const body = `# Valid Feature Heading
 
 ## Overview
 Some overview content.
@@ -203,6 +203,86 @@ Some guide steps.
 `;
     const errors = validateHeadings(body, 'test.md');
     assert.deepStrictEqual(errors, []);
+  });
+
+  test('disallows H1 headings ending with redundant "Guide"', () => {
+    const guideHeadings = [
+      '# Passkey Registration Guide',
+      '# Web Components Orientation Guide',
+      '# passkey guide',
+      '# PASSKEY AUTHENTICATION GUIDE',
+      '# Custom Elements Guide ',
+      '# Passkey Reauthentication Guide  ',
+    ];
+    for (const heading of guideHeadings) {
+      const body = `${heading}\n\nSome body text.`;
+      const errors = validateHeadings(body, 'test.md');
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors[0].includes('Redundant trailing "Guide" in H1 heading'));
+      assert.ok(errors[0].includes('Strip the trailing "Guide"'));
+    }
+  });
+
+  test('disallows frontmatter titles ending with redundant "Guide"', () => {
+    const guideTitles = [
+      'Passkey Registration Guide',
+      'Web Components Orientation Guide',
+      'passkey guide',
+      'PASSKEY AUTHENTICATION GUIDE',
+      'Custom Elements Guide ',
+      'Passkey Reauthentication Guide  ',
+    ];
+    for (const title of guideTitles) {
+      const errors = validateHeadings('Some body text', 'test.md', { title });
+      assert.strictEqual(errors.length, 1);
+      assert.ok(errors[0].includes('Redundant trailing "Guide" in frontmatter title'));
+      assert.ok(errors[0].includes('Strip the trailing "Guide"'));
+    }
+  });
+
+  test('allows depth > 1 headings ending with "Guide" (e.g. ## Implementation Guide)', () => {
+    const body = `# Passkey Authentication
+
+## Implementation Guide
+Some implementation steps.
+
+### Migration Guide
+Some migration details.
+
+#### Setup Guide
+Setup instructions.
+`;
+    const errors = validateHeadings(body, 'test.md');
+    assert.deepStrictEqual(errors, []);
+  });
+
+  test('allows H1 headings containing "Guide" in non-suffix positions or words like Guidelines', () => {
+    const validHeadings = [
+      '# Guide for Dynamic Sibling Animations',
+      '# Guidelines for Accessibility',
+      '# Guide to Passkeys',
+      '# Web Privacy Guidelines for Developers',
+      '# Guidelines',
+    ];
+    for (const heading of validHeadings) {
+      const body = `${heading}\n\nSome body text.`;
+      const errors = validateHeadings(body, 'test.md');
+      assert.deepStrictEqual(errors, []);
+    }
+  });
+
+  test('allows frontmatter titles containing "Guide" in non-suffix positions or words like Guidelines', () => {
+    const validTitles = [
+      'Guide for Dynamic Sibling Animations',
+      'Guidelines for Accessibility',
+      'Guide to Passkeys',
+      'Web Privacy Guidelines for Developers',
+      'Guidelines',
+    ];
+    for (const title of validTitles) {
+      const errors = validateHeadings('Some body text', 'test.md', { title });
+      assert.deepStrictEqual(errors, []);
+    }
   });
 
   test('allows descriptive H1 headings', () => {
@@ -255,7 +335,7 @@ Some guide steps.
 
   test('validateGuideTitle succeeds with valid descriptive frontmatter title without an H1', () => {
     const nonStubBody = `Some guide content without H1 heading.`;
-    const errors = validateGuideTitle(nonStubBody, 'test.md', { title: 'Descriptive Feature Guide' }, { requireTitle: true });
+    const errors = validateGuideTitle(nonStubBody, 'test.md', { title: 'Descriptive Feature Title' }, { requireTitle: true });
     assert.deepStrictEqual(errors, []);
   });
 

--- a/lib/guide-validation.ts
+++ b/lib/guide-validation.ts
@@ -117,6 +117,7 @@ export function validateGuide(filePath: string): ValidationResult {
 
   errors.push(...validateMacros(body, relativePath));
   errors.push(...validateHtmlTags(body, relativePath));
+  errors.push(...validateHeadings(body, relativePath, data));
 
   return { errors, data, body, filePath };
 }
@@ -683,5 +684,64 @@ function findInvalidHtmlTokens(tokens: any[], errors: string[], relativePath: st
       }
     }
   }
+}
+
+export const VAGUE_H1_TITLES = new Set(['overview', 'introduction', 'guide', 'title']);
+
+/**
+ * Validates headings in a guide body, flagging vague top-level H1 headings.
+ */
+export function validateHeadings(body: string, relativePath: string, data?: GuideData): string[] {
+  const errors: string[] = [];
+
+  if (data?.title && VAGUE_H1_TITLES.has(String(data.title).trim().toLowerCase())) {
+    errors.push(`Vague title "${data.title}" in frontmatter for ${relativePath}. Use a descriptive title instead.`);
+  }
+
+  try {
+    const tokens = marked.lexer(body);
+    for (const token of tokens) {
+      if (token.type === 'heading' && token.depth === 1) {
+        const title = token.text.trim();
+        if (VAGUE_H1_TITLES.has(title.toLowerCase())) {
+          errors.push(`Vague H1 heading "# ${title}" in ${relativePath}. Use a descriptive title instead.`);
+        }
+      }
+    }
+  } catch {
+    const h1Matches = Array.from(body.matchAll(/^#\s+(.+)$/gm));
+    for (const match of h1Matches) {
+      const title = match[1].trim();
+      if (VAGUE_H1_TITLES.has(title.toLowerCase())) {
+        errors.push(`Vague H1 heading "# ${title}" in ${relativePath}. Use a descriptive title instead.`);
+      }
+    }
+  }
+
+  return errors;
+}
+
+/**
+ * Validates that a non-stub guide has either a frontmatter title or an explicit H1 heading,
+ * and that any H1 heading is not vague.
+ */
+export function validateGuideTitle(body: string, relativePath: string, data?: GuideData, options?: { requireTitle?: boolean }): string[] {
+  const errors = validateHeadings(body, relativePath, data);
+  const isStub = body.replace(/<!--[\s\S]*?-->/g, '').trim().length === 0;
+
+  if (options?.requireTitle && !isStub) {
+    let hasH1 = false;
+    try {
+      const tokens = marked.lexer(body);
+      hasH1 = tokens.some((t: any) => t.type === 'heading' && t.depth === 1);
+    } catch {
+      hasH1 = /^#\s+(.+)$/m.test(body);
+    }
+    if (!data?.title && !hasH1) {
+      errors.push(`Missing H1 heading or frontmatter "title" in non-stub guide ${relativePath}.`);
+    }
+  }
+
+  return errors;
 }
 

--- a/lib/guide-validation.ts
+++ b/lib/guide-validation.ts
@@ -710,6 +710,41 @@ function findInvalidHtmlTokens(
   }
 }
 
+/**
+ * Extracts all top-level H1 heading texts from markdown content using AST parsing.
+ * Headings inside code blocks are ignored.
+ */
+export function extractAllH1Headings(markdown: string): string[] {
+  if (!markdown || !markdown.trim()) {
+    return [];
+  }
+  try {
+    const tokens = marked.lexer(markdown);
+    const headings: string[] = [];
+    for (const token of tokens) {
+      if (token.type === 'heading' && token.depth === 1) {
+        const text = token.text.trim();
+        if (text.length > 0) {
+          headings.push(text);
+        }
+      }
+    }
+    return headings;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Extracts the first top-level H1 heading text from markdown content using AST parsing.
+ * Headings inside code blocks are ignored.
+ * Returns undefined if no top-level H1 heading is found.
+ */
+export function extractH1Heading(markdown: string): string | undefined {
+  const headings = extractAllH1Headings(markdown);
+  return headings.length > 0 ? headings[0] : undefined;
+}
+
 export const VAGUE_H1_TITLES = new Set(['overview', 'introduction', 'guide', 'title']);
 
 /**
@@ -722,23 +757,10 @@ export function validateHeadings(body: string, relativePath: string, data?: Guid
     errors.push(`Vague title "${data.title}" in frontmatter for ${relativePath}. Use a descriptive title instead.`);
   }
 
-  try {
-    const tokens = marked.lexer(body);
-    for (const token of tokens) {
-      if (token.type === 'heading' && token.depth === 1) {
-        const title = token.text.trim();
-        if (VAGUE_H1_TITLES.has(title.toLowerCase())) {
-          errors.push(`Vague H1 heading "# ${title}" in ${relativePath}. Use a descriptive title instead.`);
-        }
-      }
-    }
-  } catch {
-    const h1Matches = Array.from(body.matchAll(/^#\s+(.+)$/gm));
-    for (const match of h1Matches) {
-      const title = match[1].trim();
-      if (VAGUE_H1_TITLES.has(title.toLowerCase())) {
-        errors.push(`Vague H1 heading "# ${title}" in ${relativePath}. Use a descriptive title instead.`);
-      }
+  const headings = extractAllH1Headings(body);
+  for (const title of headings) {
+    if (VAGUE_H1_TITLES.has(title.toLowerCase())) {
+      errors.push(`Vague H1 heading "# ${title}" in ${relativePath}. Use a descriptive title instead.`);
     }
   }
 
@@ -754,13 +776,7 @@ export function validateGuideTitle(body: string, relativePath: string, data?: Gu
   const isStub = body.replace(/<!--[\s\S]*?-->/g, '').trim().length === 0;
 
   if (options?.requireTitle && !isStub) {
-    let hasH1 = false;
-    try {
-      const tokens = marked.lexer(body);
-      hasH1 = tokens.some((t: any) => t.type === 'heading' && t.depth === 1);
-    } catch {
-      hasH1 = /^#\s+(.+)$/m.test(body);
-    }
+    const hasH1 = Boolean(extractH1Heading(body));
     const hasTitle = Boolean(data?.title?.toString().trim());
     if (!hasTitle && !hasH1) {
       errors.push(`Missing H1 heading or frontmatter "title" in non-stub guide ${relativePath}.`);

--- a/lib/guide-validation.ts
+++ b/lib/guide-validation.ts
@@ -747,20 +747,29 @@ export function extractH1Heading(markdown: string): string | undefined {
 
 export const VAGUE_H1_TITLES = new Set(['overview', 'introduction', 'guide', 'title']);
 
+export const REDUNDANT_GUIDE_SUFFIX_PATTERN = /\bguide\s*$/i;
+
 /**
- * Validates headings in a guide body, flagging vague top-level H1 headings.
+ * Validates headings in a guide body, flagging vague top-level H1 headings and redundant trailing "Guide".
  */
 export function validateHeadings(body: string, relativePath: string, data?: GuideData): string[] {
   const errors: string[] = [];
 
-  if (data?.title && VAGUE_H1_TITLES.has(String(data.title).trim().toLowerCase())) {
-    errors.push(`Vague title "${data.title}" in frontmatter for ${relativePath}. Use a descriptive title instead.`);
+  if (data?.title) {
+    const titleStr = String(data.title).trim();
+    if (VAGUE_H1_TITLES.has(titleStr.toLowerCase())) {
+      errors.push(`Vague title "${data.title}" in frontmatter for ${relativePath}. Use a descriptive title instead.`);
+    } else if (REDUNDANT_GUIDE_SUFFIX_PATTERN.test(titleStr)) {
+      errors.push(`Redundant trailing "Guide" in frontmatter title "${data.title}" for ${relativePath}. Strip the trailing "Guide".`);
+    }
   }
 
   const headings = extractAllH1Headings(body);
   for (const title of headings) {
     if (VAGUE_H1_TITLES.has(title.toLowerCase())) {
       errors.push(`Vague H1 heading "# ${title}" in ${relativePath}. Use a descriptive title instead.`);
+    } else if (REDUNDANT_GUIDE_SUFFIX_PATTERN.test(title)) {
+      errors.push(`Redundant trailing "Guide" in H1 heading "# ${title}" for ${relativePath}. Strip the trailing "Guide".`);
     }
   }
 

--- a/lib/guide-validation.ts
+++ b/lib/guide-validation.ts
@@ -118,6 +118,7 @@ export function validateGuide(filePath: string): ValidationResult {
   errors.push(...validateMacros(body, relativePath));
   errors.push(...validateHtmlTags(body, relativePath));
   errors.push(...validateHeadings(body, relativePath, data));
+  errors.push(...validateBaselineClaims(body, relativePath));
 
   return { errors, data, body, filePath };
 }
@@ -768,4 +769,83 @@ export function validateGuideTitle(body: string, relativePath: string, data?: Gu
 
   return errors;
 }
+
+// Patterns that indicate hardcoded Baseline availability claims
+export const HARDCODED_BASELINE_PATTERNS = [
+  /\bBaseline\s+(?:widely|newly|limited)\s+available\b/i,
+  /\bBaseline\s+limited\s+availability\b/i,
+  /\bBaseline\s+\d{4}\b/i,
+  /\bBaseline\s+since\s+(?:[A-Z][a-z]+\s+\d{4}|\d{4}-\d{2}-\d{2}|\d{4})\b/i,
+  /\b(?:is|are|was|were)\s+(?:all\s+)?Baseline\s+(?:widely|newly|limited)\b/i,
+  /\b(?:is|are|was|were)\s+(?:all\s+)?Baseline\b/i,
+  /\bnot\s+(?:yet\s+)?Baseline\s+(?:widely|newly|limited)?\b/i,
+  /\bwidely\s+supported\s*\(\s*Baseline\b/i,
+];
+
+// Patterns that are legitimate non-status uses to ignore even if they match partially
+export const LEGITIMATE_BASELINE_EXCLUSIONS = [
+  /\bbaseline\s+targets?\b/i,
+  /\bbaseline\s+styles?\b/i,
+  /\bbaseline\s+styling\b/i,
+  /\bbaseline\s+performance\b/i,
+  /\bbaseline\s+hygiene\b/i,
+  /\bbaseline\s+metrics?\b/i,
+  /\bbaseline\s+profile\b/i,
+  /\bbaseline\s+support\b/i,
+  /\bbaseline\s+requirement\b/i,
+  /\bbaseline\s+best\s+practices?\b/i,
+  /\balphabetic\s+baseline\b/i,
+  /\btext\s+baseline\b/i,
+  /\bfont\s+baseline\b/i,
+  /\bvertical-align:\s*baseline\b/i,
+  /\balignment-baseline\b/i,
+  /\bdominant-baseline\b/i,
+  /\breset\s+.*\bto\s+(?:its\s+)?baseline\b/i,
+  /\bclone\s+the\s+baseline\b/i,
+  /\bestablish\s+(?:a\s+)?baseline\b/i,
+  /\bmeasure\s+(?:a\s+)?baseline\b/i,
+];
+
+/**
+ * Validates that guide markdown does not contain hardcoded Baseline availability claims,
+ * ensuring authors use {{ BASELINE_STATUS("feature-id") }} macros instead.
+ */
+export function validateBaselineClaims(body: string, relativePath: string): string[] {
+  const errors: string[] = [];
+  const lines = body.split('\n');
+  let inCodeBlock = false;
+
+  // Skip meta skill instructions like modern-web-guidance/SKILL.md which describe baseline policy rules
+  if (relativePath.endsWith('SKILL.md')) {
+    return errors;
+  }
+
+  lines.forEach((line, idx) => {
+    const trimmed = line.trim();
+    if (trimmed.startsWith('```') || trimmed.startsWith('~~~')) {
+      inCodeBlock = !inCodeBlock;
+      return;
+    }
+    if (inCodeBlock) return;
+
+    // Ignore macro lines
+    if (line.includes('{{ BASELINE_STATUS') || line.includes('{{ FEATURE')) return;
+
+    // Check for hardcoded baseline claim
+    for (const pattern of HARDCODED_BASELINE_PATTERNS) {
+      if (pattern.test(line)) {
+        const isExcluded = LEGITIMATE_BASELINE_EXCLUSIONS.some(ex => ex.test(line));
+        if (!isExcluded) {
+          errors.push(
+            `Hardcoded Baseline availability claim found on line ${idx + 1} in ${relativePath}: "${trimmed}". Use {{ BASELINE_STATUS("feature-id") }} macro instead.`
+          );
+          break;
+        }
+      }
+    }
+  });
+
+  return errors;
+}
+
 

--- a/lib/guide-validation.ts
+++ b/lib/guide-validation.ts
@@ -117,7 +117,7 @@ export function validateGuide(filePath: string): ValidationResult {
 
   errors.push(...validateMacros(body, relativePath));
   errors.push(...validateHtmlTags(body, relativePath));
-  errors.push(...validateHeadings(body, relativePath, data));
+  errors.push(...validateGuideTitle(body, relativePath, data, { requireTitle: true }));
   errors.push(...validateBaselineClaims(body, relativePath));
 
   return { errors, data, body, filePath };

--- a/lib/guide-validation.ts
+++ b/lib/guide-validation.ts
@@ -630,12 +630,17 @@ export function resetGuidesMap() {
 // Safe typographic inline tags that don't represent interactive elements or cause layout breakage.
 const ALLOWED_HTML_TAGS = new Set(['kbd', 'br', 'wbr']);
 
+interface HtmlValidationState {
+  offset: number;
+}
+
 export function validateHtmlTags(body: string, relativePath: string): string[] {
   const errors: string[] = [];
 
   try {
     const tokens = marked.lexer(body);
-    findInvalidHtmlTokens(tokens, errors, relativePath, body);
+    const state: HtmlValidationState = { offset: 0 };
+    findInvalidHtmlTokens(tokens, errors, relativePath, body, state);
   } catch (e) {
     errors.push(`Failed to parse markdown with marked lexer for HTML validation in ${relativePath}: ${e}`);
   }
@@ -643,7 +648,13 @@ export function validateHtmlTags(body: string, relativePath: string): string[] {
   return errors;
 }
 
-function findInvalidHtmlTokens(tokens: any[], errors: string[], relativePath: string, content: string) {
+function findInvalidHtmlTokens(
+  tokens: any[],
+  errors: string[],
+  relativePath: string,
+  content: string,
+  state: HtmlValidationState = { offset: 0 },
+) {
   for (const token of tokens) {
     if (token.type === 'html') {
       const raw = token.raw.trim();
@@ -658,15 +669,27 @@ function findInvalidHtmlTokens(tokens: any[], errors: string[], relativePath: st
       if (match) {
         const tagName = match[1].toLowerCase();
         if (!ALLOWED_HTML_TAGS.has(tagName)) {
-          // Find line number in content
-          const offset = content.indexOf(token.raw);
+          // Find line number in content using running offset
+          let offset = content.indexOf(token.raw, state.offset);
+          if (offset === -1) {
+            offset = content.indexOf(token.raw);
+          }
+          if (offset !== -1) {
+            state.offset = offset + token.raw.length;
+          }
           const line = offset !== -1 ? content.slice(0, offset).split('\n').length : -1;
           const lineSuffix = line !== -1 ? ` on line ${line}` : '';
           errors.push(`Unescaped HTML tag <${tagName}> found${lineSuffix} in ${relativePath}. Use backticks or escape angle brackets if it is a tag name reference.`);
         }
       } else {
         // If it does not match a standard tag, but is still parsed as HTML token, warn/fail
-        const offset = content.indexOf(token.raw);
+        let offset = content.indexOf(token.raw, state.offset);
+        if (offset === -1) {
+          offset = content.indexOf(token.raw);
+        }
+        if (offset !== -1) {
+          state.offset = offset + token.raw.length;
+        }
         const line = offset !== -1 ? content.slice(0, offset).split('\n').length : -1;
         const lineSuffix = line !== -1 ? ` on line ${line}` : '';
         errors.push(`Potentially invalid or unescaped HTML block/tag "${raw}" found${lineSuffix} in ${relativePath}.`);
@@ -674,12 +697,12 @@ function findInvalidHtmlTokens(tokens: any[], errors: string[], relativePath: st
     }
 
     if (token.tokens) {
-      findInvalidHtmlTokens(token.tokens, errors, relativePath, content);
+      findInvalidHtmlTokens(token.tokens, errors, relativePath, content, state);
     }
     if (token.items) {
       for (const item of token.items) {
         if (item.tokens) {
-          findInvalidHtmlTokens(item.tokens, errors, relativePath, content);
+          findInvalidHtmlTokens(item.tokens, errors, relativePath, content, state);
         }
       }
     }
@@ -737,7 +760,8 @@ export function validateGuideTitle(body: string, relativePath: string, data?: Gu
     } catch {
       hasH1 = /^#\s+(.+)$/m.test(body);
     }
-    if (!data?.title && !hasH1) {
+    const hasTitle = Boolean(data?.title?.toString().trim());
+    if (!hasTitle && !hasH1) {
       errors.push(`Missing H1 heading or frontmatter "title" in non-stub guide ${relativePath}.`);
     }
   }

--- a/serving/lib/macro-parsing.ts
+++ b/serving/lib/macro-parsing.ts
@@ -11,6 +11,9 @@
 // Matches {{ NAME(ARGS) }} where NAME is uppercase and ARGS can be anything
 export const MACRO_PATTERN = /{{\s*([A-Z_]+)\((.*?)\)\s*}}/g;
 
+// Matches consecutive macros separated by whitespace that contains at least one newline
+export const CONSECUTIVE_MACRO_PATTERN = /({{\s*[A-Z_]+\(.*?\)\s*}})[ \t]*\r?\n\s*(?={{\s*[A-Z_]+\(.*?\)\s*}})/g;
+
 /**
  * Parses macro arguments, respecting quotes and handling commas.
  * Robust against varied whitespace and different quote types.

--- a/serving/lib/macros.test.ts
+++ b/serving/lib/macros.test.ts
@@ -54,10 +54,16 @@ describe('replaceMacros (Functional with real data)', () => {
       );
     });
 
-    it('returns generic token for static-site target', () => {
+    it('preserves macro syntax for static-site target', () => {
       const content = '{{ BASELINE_STATUS("grid") }}';
       const result = replaceMacros(content, 'test.md', { target: 'static-site' });
-      assert.strictEqual(result, '[BASELINE_STATUS: grid]');
+      assert.strictEqual(result, '{{ BASELINE_STATUS("grid") }}');
+    });
+
+    it('preserves macro syntax with BCD key for static-site target', () => {
+      const content = '{{ BASELINE_STATUS("grid", "css.properties.grid-template-columns") }}';
+      const result = replaceMacros(content, 'test.md', { target: 'static-site' });
+      assert.strictEqual(result, '{{ BASELINE_STATUS("grid", "css.properties.grid-template-columns") }}');
     });
 
     it('throws error for non-existent feature', () => {
@@ -171,25 +177,25 @@ describe('replaceMacros (Functional with real data)', () => {
         it('normalizes consecutive BASELINE_STATUS with 0 blank lines', () => {
           const content = '{{ BASELINE_STATUS("grid") }}\n{{ BASELINE_STATUS("popover") }}';
           const result = replaceMacros(content, 'test.md', { target: 'static-site' });
-          assert.strictEqual(result, '[BASELINE_STATUS: grid]\n\n[BASELINE_STATUS: popover]');
+          assert.strictEqual(result, '{{ BASELINE_STATUS("grid") }}\n\n{{ BASELINE_STATUS("popover") }}');
         });
 
         it('normalizes consecutive BASELINE_STATUS with 1 blank line', () => {
           const content = '{{ BASELINE_STATUS("grid") }}\n\n{{ BASELINE_STATUS("popover") }}';
           const result = replaceMacros(content, 'test.md', { target: 'static-site' });
-          assert.strictEqual(result, '[BASELINE_STATUS: grid]\n\n[BASELINE_STATUS: popover]');
+          assert.strictEqual(result, '{{ BASELINE_STATUS("grid") }}\n\n{{ BASELINE_STATUS("popover") }}');
         });
 
         it('normalizes consecutive BASELINE_STATUS with multiple blank lines', () => {
           const content = '{{ BASELINE_STATUS("grid") }}\n\n\n{{ BASELINE_STATUS("popover") }}';
           const result = replaceMacros(content, 'test.md', { target: 'static-site' });
-          assert.strictEqual(result, '[BASELINE_STATUS: grid]\n\n[BASELINE_STATUS: popover]');
+          assert.strictEqual(result, '{{ BASELINE_STATUS("grid") }}\n\n{{ BASELINE_STATUS("popover") }}');
         });
 
         it('normalizes consecutive GUIDE_REF calls', () => {
           const content = '{{ GUIDE_REF("break-up-long-tasks") }}\n{{ GUIDE_REF("forms") }}';
           const result = replaceMacros(content, path.join(rootDir, 'test.md'), { target: 'static-site' });
-          assert.strictEqual(result, '[break-up-long-tasks](../performance/break-up-long-tasks.md)\n\n[forms](../forms/forms.md)');
+          assert.strictEqual(result, '[Break Up Long Tasks](../performance/break-up-long-tasks.md)\n\n[Forms](../forms/forms.md)');
         });
       });
 
@@ -497,7 +503,7 @@ describe('INCLUDE', () => {
     it('replaces macro with relative markdown link for static-site target', () => {
       const content = '{{ GUIDE_REF("break-up-long-tasks") }}';
       const result = replaceMacros(content, path.join(rootDir, 'test.md'), { target: 'static-site' });
-      assert.equal(result, '[break-up-long-tasks](../performance/break-up-long-tasks.md)');
+      assert.equal(result, '[Break Up Long Tasks](../performance/break-up-long-tasks.md)');
     });
 
     it('throws error for non-existent guide', () => {

--- a/serving/lib/macros.test.ts
+++ b/serving/lib/macros.test.ts
@@ -86,6 +86,149 @@ describe('replaceMacros (Functional with real data)', () => {
     assert.ok(result.includes('Widely available'));
     assert.ok(result.includes('Baseline since'));
   });
+
+  describe('consecutive macro spacing normalization', () => {
+    const gridStatus = replaceMacros('{{ BASELINE_STATUS("grid") }}', 'test.md');
+    const popoverStatus = replaceMacros('{{ BASELINE_STATUS("popover") }}', 'test.md');
+    const webmcpStatus = replaceMacros('{{ BASELINE_STATUS("declarative-webmcp") }}', 'test.md');
+
+    describe('consecutive BASELINE_STATUS calls', () => {
+      it('normalizes 0 blank lines (single newline) to double newlines', () => {
+        const content = '{{ BASELINE_STATUS("grid") }}\n{{ BASELINE_STATUS("popover") }}';
+        const result = replaceMacros(content, 'test.md');
+        assert.strictEqual(result, `${gridStatus}\n\n${popoverStatus}`);
+      });
+
+      it('preserves 1 blank line (double newlines)', () => {
+        const content = '{{ BASELINE_STATUS("grid") }}\n\n{{ BASELINE_STATUS("popover") }}';
+        const result = replaceMacros(content, 'test.md');
+        assert.strictEqual(result, `${gridStatus}\n\n${popoverStatus}`);
+      });
+
+      it('normalizes 2+ blank lines (multiple newlines) to standard double newlines', () => {
+        const content = '{{ BASELINE_STATUS("grid") }}\n\n\n{{ BASELINE_STATUS("popover") }}';
+        const result = replaceMacros(content, 'test.md');
+        assert.strictEqual(result, `${gridStatus}\n\n${popoverStatus}`);
+
+        const content4 = '{{ BASELINE_STATUS("grid") }}\n\n\n\n{{ BASELINE_STATUS("popover") }}';
+        const result4 = replaceMacros(content4, 'test.md');
+        assert.strictEqual(result4, `${gridStatus}\n\n${popoverStatus}`);
+      });
+
+      it('normalizes 3+ consecutive macros with mixed newline counts', () => {
+        const content = '{{ BASELINE_STATUS("grid") }}\n{{ BASELINE_STATUS("popover") }}\n\n\n{{ BASELINE_STATUS("declarative-webmcp") }}';
+        const result = replaceMacros(content, 'test.md');
+        assert.strictEqual(result, `${gridStatus}\n\n${popoverStatus}\n\n${webmcpStatus}`);
+      });
+
+      it('handles whitespace containing spaces and tabs around newlines', () => {
+        const content = '{{ BASELINE_STATUS("grid") }}  \n  \t  \n  {{ BASELINE_STATUS("popover") }}';
+        const result = replaceMacros(content, 'test.md');
+        assert.strictEqual(result, `${gridStatus}\n\n${popoverStatus}`);
+      });
+
+      it('handles CRLF line endings', () => {
+        const content = '{{ BASELINE_STATUS("grid") }}\r\n{{ BASELINE_STATUS("popover") }}';
+        const result = replaceMacros(content, 'test.md');
+        assert.strictEqual(result, `${gridStatus}\n\n${popoverStatus}`);
+      });
+    });
+
+    describe('mixed text and macros', () => {
+      it('normalizes consecutive macros within surrounding text', () => {
+        const content = '## Fallback strategies\n\n{{ BASELINE_STATUS("grid") }}\n{{ BASELINE_STATUS("popover") }}\n\nSome explanation.';
+        const result = replaceMacros(content, 'test.md');
+        assert.strictEqual(result, `## Fallback strategies\n\n${gridStatus}\n\n${popoverStatus}\n\nSome explanation.`);
+      });
+
+      it('preserves single newlines between text and an isolated macro', () => {
+        const content = 'Before\n{{ BASELINE_STATUS("grid") }}\nAfter';
+        const result = replaceMacros(content, 'test.md');
+        assert.strictEqual(result, `Before\n${gridStatus}\nAfter`);
+      });
+
+      it('preserves double newlines between text and an isolated macro', () => {
+        const content = 'Before\n\n{{ BASELINE_STATUS("grid") }}\n\nAfter';
+        const result = replaceMacros(content, 'test.md');
+        assert.strictEqual(result, `Before\n\n${gridStatus}\n\nAfter`);
+      });
+
+      it('does not alter spacing for macros separated by intermediate text', () => {
+        const content = '{{ BASELINE_STATUS("grid") }}\n\nMiddle paragraph\n\n{{ BASELINE_STATUS("popover") }}';
+        const result = replaceMacros(content, 'test.md');
+        assert.strictEqual(result, `${gridStatus}\n\nMiddle paragraph\n\n${popoverStatus}`);
+      });
+
+      it('does not alter inline macros on the same line without newlines', () => {
+        const content = 'See {{ BASELINE_STATUS("grid") }} and {{ BASELINE_STATUS("popover") }} inline.';
+        const result = replaceMacros(content, 'test.md');
+        assert.strictEqual(result, `See ${gridStatus} and ${popoverStatus} inline.`);
+      });
+    });
+
+    describe('build targets', () => {
+      describe('static-site', () => {
+        it('normalizes consecutive BASELINE_STATUS with 0 blank lines', () => {
+          const content = '{{ BASELINE_STATUS("grid") }}\n{{ BASELINE_STATUS("popover") }}';
+          const result = replaceMacros(content, 'test.md', { target: 'static-site' });
+          assert.strictEqual(result, '[BASELINE_STATUS: grid]\n\n[BASELINE_STATUS: popover]');
+        });
+
+        it('normalizes consecutive BASELINE_STATUS with 1 blank line', () => {
+          const content = '{{ BASELINE_STATUS("grid") }}\n\n{{ BASELINE_STATUS("popover") }}';
+          const result = replaceMacros(content, 'test.md', { target: 'static-site' });
+          assert.strictEqual(result, '[BASELINE_STATUS: grid]\n\n[BASELINE_STATUS: popover]');
+        });
+
+        it('normalizes consecutive BASELINE_STATUS with multiple blank lines', () => {
+          const content = '{{ BASELINE_STATUS("grid") }}\n\n\n{{ BASELINE_STATUS("popover") }}';
+          const result = replaceMacros(content, 'test.md', { target: 'static-site' });
+          assert.strictEqual(result, '[BASELINE_STATUS: grid]\n\n[BASELINE_STATUS: popover]');
+        });
+
+        it('normalizes consecutive GUIDE_REF calls', () => {
+          const content = '{{ GUIDE_REF("break-up-long-tasks") }}\n{{ GUIDE_REF("forms") }}';
+          const result = replaceMacros(content, path.join(rootDir, 'test.md'), { target: 'static-site' });
+          assert.strictEqual(result, '[break-up-long-tasks](../performance/break-up-long-tasks.md)\n\n[forms](../forms/forms.md)');
+        });
+      });
+
+      describe('skills-cli', () => {
+        it('normalizes consecutive BASELINE_STATUS with 0 blank lines', () => {
+          const content = '{{ BASELINE_STATUS("grid") }}\n{{ BASELINE_STATUS("popover") }}';
+          const result = replaceMacros(content, 'test.md', { target: 'skills-cli' });
+          assert.strictEqual(result, `${gridStatus}\n\n${popoverStatus}`);
+        });
+
+        it('normalizes consecutive BASELINE_STATUS with 2+ blank lines', () => {
+          const content = '{{ BASELINE_STATUS("grid") }}\n\n\n{{ BASELINE_STATUS("popover") }}';
+          const result = replaceMacros(content, 'test.md', { target: 'skills-cli' });
+          assert.strictEqual(result, `${gridStatus}\n\n${popoverStatus}`);
+        });
+
+        it('normalizes consecutive GUIDE_REF calls', () => {
+          const content = '{{ GUIDE_REF("break-up-long-tasks") }}\n{{ GUIDE_REF("forms") }}';
+          const result = replaceMacros(content, path.join(rootDir, 'test.md'), { target: 'skills-cli' });
+          const expected = '`break-up-long-tasks` (via `npx -y modern-web-guidance@latest retrieve "break-up-long-tasks"`)\n\n`forms` (via `npx -y modern-web-guidance@latest retrieve "forms"`)';
+          assert.strictEqual(result, expected);
+        });
+      });
+
+      describe('local-dev', () => {
+        it('normalizes consecutive BASELINE_STATUS with 0 blank lines', () => {
+          const content = '{{ BASELINE_STATUS("grid") }}\n{{ BASELINE_STATUS("popover") }}';
+          const result = replaceMacros(content, 'test.md', { target: 'local-dev' });
+          assert.strictEqual(result, `${gridStatus}\n\n${popoverStatus}`);
+        });
+
+        it('normalizes consecutive BASELINE_STATUS with 2+ blank lines', () => {
+          const content = '{{ BASELINE_STATUS("grid") }}\n\n\n{{ BASELINE_STATUS("popover") }}';
+          const result = replaceMacros(content, 'test.md', { target: 'local-dev' });
+          assert.strictEqual(result, `${gridStatus}\n\n${popoverStatus}`);
+        });
+      });
+    });
+  });
 });
 
 describe('slugify', () => {

--- a/serving/lib/macros.test.ts
+++ b/serving/lib/macros.test.ts
@@ -54,6 +54,12 @@ describe('replaceMacros (Functional with real data)', () => {
       );
     });
 
+    it('returns generic token for static-site target', () => {
+      const content = '{{ BASELINE_STATUS("grid") }}';
+      const result = replaceMacros(content, 'test.md', { target: 'static-site' });
+      assert.strictEqual(result, '[BASELINE_STATUS: grid]');
+    });
+
     it('throws error for non-existent feature', () => {
       const content = '{{ BASELINE_STATUS("non-existent-feature-xyz") }}';
       assert.throws(() => replaceMacros(content, 'test.md'), /Web feature ID "non-existent-feature-xyz" not found/);
@@ -345,6 +351,11 @@ describe('INCLUDE', () => {
       assert.equal(result, '`forms` (via `npx -y modern-web-guidance@latest retrieve "forms"`)');
     });
 
+    it('replaces macro with relative markdown link for static-site target', () => {
+      const content = '{{ GUIDE_REF("break-up-long-tasks") }}';
+      const result = replaceMacros(content, path.join(rootDir, 'test.md'), { target: 'static-site' });
+      assert.equal(result, '[break-up-long-tasks](../performance/break-up-long-tasks.md)');
+    });
 
     it('throws error for non-existent guide', () => {
       const content = '{{ GUIDE_REF("non-existent-guide-xyz") }}';

--- a/serving/lib/macros.ts
+++ b/serving/lib/macros.ts
@@ -7,7 +7,7 @@ import { MACRO_PATTERN, parseArguments, getTranscludedFeatureIds } from "./macro
 // Re-exported for convenience; the implementations live in the dependency-free ./macro-parsing.ts
 export { MACRO_PATTERN, parseArguments, getTranscludedFeatureIds };
 
-export type BuildTarget = 'skills-cli' | 'mcp-server' | 'megaskill' | 'local-dev';
+export type BuildTarget = 'skills-cli' | 'mcp-server' | 'megaskill' | 'local-dev' | 'static-site';
 
 type MacroHandler = (args: string[], filePath: string, options?: { target?: BuildTarget }) => string;
 
@@ -19,7 +19,7 @@ export class MacroError extends Error {
 }
 
 const MACRO_HANDLERS: Record<string, MacroHandler> = {
-  INCLUDE: (args, filePath) => {
+  INCLUDE: (args, filePath, options) => {
     const [rawArg] = args;
     if (!rawArg) {
       throw new MacroError(`Missing path in INCLUDE macro (${filePath}).`);
@@ -33,7 +33,7 @@ const MACRO_HANDLERS: Record<string, MacroHandler> = {
 
     // NOTE: no cycle detection. If files INCLUDE each other in a loop, this
     // will overflow the call stack. Add a visited set if it becomes a problem.
-    return replaceMacros(result.content, result.absolutePath!);
+    return replaceMacros(result.content, result.absolutePath!, options);
   },
   GUIDE_REF: (args, filePath, options) => {
     const [guideId] = args;
@@ -48,6 +48,10 @@ const MACRO_HANDLERS: Record<string, MacroHandler> = {
 
     const target = options?.target || 'local-dev';
 
+    if (target === 'static-site') {
+      return `[${guideInfo.name}](../${guideInfo.category}/${guideInfo.name}.md)`;
+    }
+
     if (target === 'skills-cli') {
       return `\`${guideId}\` (via \`npx -y modern-web-guidance@latest retrieve "${guideId}"\`)`;
     }
@@ -58,8 +62,11 @@ const MACRO_HANDLERS: Record<string, MacroHandler> = {
 };
 
 defineFeatureMacro("BASELINE_STATUS", {
-  content: (args, filePath) => {
+  content: (args, filePath, options) => {
     const [featureId, bcdKey] = args;
+    if (options?.target === 'static-site') {
+      return `[BASELINE_STATUS: ${featureId}]`;
+    }
     const status = getStatusMessage(featureId, bcdKey);
     if (!status) {
       if (bcdKey) {
@@ -74,21 +81,21 @@ defineFeatureMacro("BASELINE_STATUS", {
 
 
 defineFeatureMacro("FEATURE", {
-  content: (args, filePath) => {
+  content: (args, filePath, options) => {
     const [featureId, section] = args;
     let url = `features/${featureId}.md`;
     if (section) {
       url += `#${section}`;
     }
-    return MACRO_HANDLERS.INCLUDE([url], filePath);
+    return MACRO_HANDLERS.INCLUDE([url], filePath, options);
   }
 });
 
 defineFeatureMacro("FEATURE_FALLBACKS", {
-  content: (args, filePath) => {
+  content: (args, filePath, options) => {
     const [featureId] = args;
-    const fallbacks = MACRO_HANDLERS.FEATURE([featureId, "fallbacks"], filePath);
-    const baselineStatus = MACRO_HANDLERS.BASELINE_STATUS([featureId], filePath);
+    const fallbacks = MACRO_HANDLERS.FEATURE([featureId, "fallbacks"], filePath, options);
+    const baselineStatus = MACRO_HANDLERS.BASELINE_STATUS([featureId], filePath, options);
     if (!fallbacks) {
       return baselineStatus;
     }
@@ -102,9 +109,9 @@ defineFeatureMacro("FEATURE_FALLBACKS", {
 });
 
 defineFeatureMacro("FEATURE_ISSUES", {
-  content: (args, filePath) => {
+  content: (args, filePath, options) => {
     const [featureId] = args;
-    const included = MACRO_HANDLERS.FEATURE([featureId, "issues"], filePath);
+    const included = MACRO_HANDLERS.FEATURE([featureId, "issues"], filePath, options);
     if (!included) return "";
     return [
       `### Issues to be aware of when using ${getFeatureName(featureId)}`,
@@ -119,9 +126,9 @@ function defineFeatureMacro(name: string, {
 }: {
   recursive?: boolean;
   // Producer: may return anything; we coerce to string below.
-  content: (args: string[], filePath: string) => any;
+  content: (args: string[], filePath: string, options?: { target?: BuildTarget }) => any;
 }): MacroHandler {
-  const fn: MacroHandler = (args, filePath) => {
+  const fn: MacroHandler = (args, filePath, options) => {
     const [featureId] = args;
     if (!featureId) {
       throw new MacroError(`Missing feature ID in ${name} macro (${filePath}).`);
@@ -131,10 +138,10 @@ function defineFeatureMacro(name: string, {
       throw new MacroError(`${validation.errorMessage} (referenced in ${name} macro in ${filePath}).`);
     }
 
-    let result = content(args, filePath);
+    let result = content(args, filePath, options);
     if (!result && result !== 0) return "";
     if (typeof result !== "string") result = String(result);
-    if (recursive) result = replaceMacros(result, filePath);
+    if (recursive) result = replaceMacros(result, filePath, options);
     return result.trim();
   };
   return (MACRO_HANDLERS[name] = fn);

--- a/serving/lib/macros.ts
+++ b/serving/lib/macros.ts
@@ -18,6 +18,13 @@ export class MacroError extends Error {
   }
 }
 
+export function formatTitle(id: string): string {
+  return id
+    .split("-")
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
 const MACRO_HANDLERS: Record<string, MacroHandler> = {
   INCLUDE: (args, filePath, options) => {
     const [rawArg] = args;
@@ -49,7 +56,7 @@ const MACRO_HANDLERS: Record<string, MacroHandler> = {
     const target = options?.target || 'local-dev';
 
     if (target === 'static-site') {
-      return `[${guideInfo.name}](../${guideInfo.category}/${guideInfo.name}.md)`;
+      return `[${formatTitle(guideInfo.name)}](../${guideInfo.category}/${guideInfo.name}.md)`;
     }
 
     if (target === 'skills-cli') {
@@ -65,7 +72,7 @@ defineFeatureMacro("BASELINE_STATUS", {
   content: (args, filePath, options) => {
     const [featureId, bcdKey] = args;
     if (options?.target === 'static-site') {
-      return `[BASELINE_STATUS: ${featureId}]`;
+      return bcdKey ? `{{ BASELINE_STATUS("${featureId}", "${bcdKey}") }}` : `{{ BASELINE_STATUS("${featureId}") }}`;
     }
     const status = getStatusMessage(featureId, bcdKey);
     if (!status) {

--- a/serving/lib/macros.ts
+++ b/serving/lib/macros.ts
@@ -2,10 +2,10 @@ import path from "node:path";
 import { validateFeature, getStatusMessage, getFeatureName } from "./baseline.ts";
 import { getGuidesMap, getGuideMarkdownPath } from "../../lib/guide-validation.ts";
 import { resolveInclude } from "./include.ts";
-import { MACRO_PATTERN, parseArguments, getTranscludedFeatureIds } from "./macro-parsing.ts";
+import { MACRO_PATTERN, CONSECUTIVE_MACRO_PATTERN, parseArguments, getTranscludedFeatureIds } from "./macro-parsing.ts";
 
 // Re-exported for convenience; the implementations live in the dependency-free ./macro-parsing.ts
-export { MACRO_PATTERN, parseArguments, getTranscludedFeatureIds };
+export { MACRO_PATTERN, CONSECUTIVE_MACRO_PATTERN, parseArguments, getTranscludedFeatureIds };
 
 export type BuildTarget = 'skills-cli' | 'mcp-server' | 'megaskill' | 'local-dev' | 'static-site';
 
@@ -187,7 +187,8 @@ export function validateMacros(content: string, filePath: string): string[] {
 }
 
 export function replaceMacros(content: string, filePath: string, options: { target?: BuildTarget } = {}): string {
-  return processMacros(content, (handler, args, match) => {
+  const normalized = content.replace(CONSECUTIVE_MACRO_PATTERN, "$1\n\n");
+  return processMacros(normalized, (handler, args, match) => {
     try {
       return handler(args, filePath, options);
     } catch (err: any) {

--- a/serving/package.json
+++ b/serving/package.json
@@ -20,6 +20,7 @@
     "prepublishOnly": "pnpm run build",
     "build": "node scripts/build-guides.ts && pnpm run build-dist",
     "build:megaskill": "node scripts/build-megaskill.ts",
+    "build:static-site": "node scripts/build-guides.ts --target=static-site --output=dist/static-site-guides",
     "build-dist": "node --experimental-strip-types */build-dist.ts",
     "publish-skills": "node --experimental-strip-types skills-cli/publish-skills.ts",
     "collect-evals": "node --experimental-strip-types scripts/collect-eval-results.ts",

--- a/serving/scripts/build-guides.ts
+++ b/serving/scripts/build-guides.ts
@@ -15,7 +15,7 @@ export interface StoreUseCase {
   vector?: number[];
   distance?: number;
 }
-import { replaceMacros, type BuildTarget } from "../lib/macros.ts";
+import { replaceMacros, type BuildTarget, formatTitle } from "../lib/macros.ts";
 
 import { scanAllGuides, type GuideInventory, getGuideMarkdownPath } from "../../lib/guide-validation.ts";
 import { config } from "../../lib/skills-config.ts";
@@ -128,6 +128,7 @@ function restoreFromCache(paths: CachePaths, outputDir: string, target: string):
     fs.cpSync(paths.cachedGuides, path.join(outputDir, "guides"), { recursive: true });
     fs.copyFileSync(paths.cachedTs, OUTPUT_FILE);
   } else if (target === 'static-site') {
+    fs.rmSync(outputDir, { recursive: true, force: true });
     fs.mkdirSync(outputDir, { recursive: true });
     fs.cpSync(paths.cachedGuides, outputDir, { recursive: true });
   } else {
@@ -262,13 +263,6 @@ export function chunkMarkdown(markdown: string): string[] {
   return chunks.filter(chunk => chunk.trim().length > 0);
 }
 
-function formatTitle(id: string): string {
-  return id
-    .split("-")
-    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(" ");
-}
-
 async function processSingleGuideFile(
   filePath: string,
   category: string,
@@ -292,8 +286,9 @@ async function processSingleGuideFile(
   const processedMarkdown = replaceMacros(markdownBody, filePath, { target: TARGET });
 
   if (TARGET === 'static-site') {
-    const h1Match = markdownBody.match(/^#\s+(.+)$/m);
-    const title = h1Match ? h1Match[1].trim() : (data.title || formatTitle(id));
+    const tokens = marked.lexer(markdownBody);
+    const h1Token = tokens.find((t: any) => t.type === 'heading' && t.depth === 1);
+    const title = h1Token ? (h1Token as any).text.trim() : (data.title || formatTitle(id));
     const genericFrontmatter = `---
 title: ${JSON.stringify(title)}
 description: ${JSON.stringify(data.description)}

--- a/serving/scripts/build-guides.ts
+++ b/serving/scripts/build-guides.ts
@@ -292,10 +292,11 @@ async function processSingleGuideFile(
   const processedMarkdown = replaceMacros(markdownBody, filePath, { target: TARGET });
 
   if (TARGET === 'static-site') {
-    const title = formatTitle(id);
+    const h1Match = markdownBody.match(/^#\s+(.+)$/m);
+    const title = h1Match ? h1Match[1].trim() : (data.title || formatTitle(id));
     const genericFrontmatter = `---
-title: ${title}
-description: ${data.description}
+title: ${JSON.stringify(title)}
+description: ${JSON.stringify(data.description)}
 category: ${category}
 ---`;
     const bodyWithoutH1 = processedMarkdown.trim().replace(/^#\s+[^\n]*\n?/, "").trim();

--- a/serving/scripts/build-guides.ts
+++ b/serving/scripts/build-guides.ts
@@ -127,6 +127,9 @@ function restoreFromCache(paths: CachePaths, outputDir: string, target: string):
     fs.copyFileSync(paths.cachedVectors, path.join(outputDir, "use-cases.vectors.gen.json.gz"));
     fs.cpSync(paths.cachedGuides, path.join(outputDir, "guides"), { recursive: true });
     fs.copyFileSync(paths.cachedTs, OUTPUT_FILE);
+  } else if (target === 'static-site') {
+    fs.mkdirSync(outputDir, { recursive: true });
+    fs.cpSync(paths.cachedGuides, outputDir, { recursive: true });
   } else {
     fs.mkdirSync(path.join(ROOT_DIR, "lib"), { recursive: true });
     fs.mkdirSync(path.join(ROOT_DIR, "build"), { recursive: true });
@@ -175,13 +178,16 @@ export async function processGuides(opts: BuildOptions): Promise<boolean> {
   const useCases: UseCase[] = [];
   const storeUseCases: StoreUseCase[] = [];
 
-  if (modelName) {
-    console.log(`Using custom embedding model: ${modelName}`);
-  }
+  let embedder: any = null;
+  if (TARGET !== 'static-site') {
+    if (modelName) {
+      console.log(`Using custom embedding model: ${modelName}`);
+    }
 
-  const { Embedder } = await import("../lib/transformers-embedder.ts");
-  const embedder = Embedder.getInstance(modelName);
-  await embedder.init();
+    const { Embedder } = await import("../lib/transformers-embedder.ts");
+    embedder = Embedder.getInstance(modelName);
+    await embedder.init();
+  }
 
   if (targetGuidePath) {
     // Single guide mode
@@ -256,13 +262,20 @@ export function chunkMarkdown(markdown: string): string[] {
   return chunks.filter(chunk => chunk.trim().length > 0);
 }
 
+function formatTitle(id: string): string {
+  return id
+    .split("-")
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
 async function processSingleGuideFile(
   filePath: string,
   category: string,
   id: string,
   useCases: UseCase[],
   storeUseCases: StoreUseCase[],
-  embedder: any
+  embedder?: any
 ) {
   const content = fs.readFileSync(filePath, "utf-8");
   const { data, content: markdownBody, matter: frontmatter } = matter(content, {});
@@ -277,6 +290,26 @@ async function processSingleGuideFile(
   }
 
   const processedMarkdown = replaceMacros(markdownBody, filePath, { target: TARGET });
+
+  if (TARGET === 'static-site') {
+    const title = formatTitle(id);
+    const genericFrontmatter = `---
+title: ${title}
+description: ${data.description}
+category: ${category}
+---`;
+    const bodyWithoutH1 = processedMarkdown.trim().replace(/^#\s+[^\n]*\n?/, "").trim();
+    const finalContent = `${genericFrontmatter}\n\n# ${title}\n\n${bodyWithoutH1}\n`;
+
+    const buildCategoryDir = path.join(BUILD_GUIDES_DIR, category);
+    if (!fs.existsSync(buildCategoryDir)) {
+      fs.mkdirSync(buildCategoryDir, { recursive: true });
+    }
+
+    const buildFilePath = path.join(buildCategoryDir, `${id}.md`);
+    fs.writeFileSync(buildFilePath, finalContent);
+    return;
+  }
 
   const featureIds: string[] = data['web-feature-ids'] || [];
   const featuresUsed = featureIds.map(getFeatureName);
@@ -326,6 +359,8 @@ if (process.argv[1] === import.meta.filename) {
     force: { type: 'boolean' as const },
     model: { type: 'string' as const },
     'no-chunking': { type: 'boolean' as const },
+    target: { type: 'string' as const },
+    output: { type: 'string' as const },
   };
 
   const { values, positionals } = parseArgs({ options, allowPositionals: true });
@@ -334,9 +369,12 @@ if (process.argv[1] === import.meta.filename) {
   const force = values.force;
   const noChunking = values['no-chunking'];
   const modelName = values.model;
+  const target = values.target as BuildTarget | undefined;
+  const output = values.output;
 
   processGuides({
-    outputDir: path.join(ROOT_DIR, "build"),
+    outputDir: output ? path.resolve(WORKSPACE_ROOT, output) : path.join(ROOT_DIR, "build"),
+    target,
     force,
     targetGuidePath,
     modelName,

--- a/serving/scripts/build-guides.ts
+++ b/serving/scripts/build-guides.ts
@@ -17,7 +17,7 @@ export interface StoreUseCase {
 }
 import { replaceMacros, type BuildTarget, formatTitle } from "../lib/macros.ts";
 
-import { scanAllGuides, type GuideInventory, getGuideMarkdownPath } from "../../lib/guide-validation.ts";
+import { scanAllGuides, type GuideInventory, getGuideMarkdownPath, extractH1Heading } from "../../lib/guide-validation.ts";
 import { config } from "../../lib/skills-config.ts";
 import { getFeatureName } from "../lib/baseline.ts";
 
@@ -286,9 +286,8 @@ async function processSingleGuideFile(
   const processedMarkdown = replaceMacros(markdownBody, filePath, { target: TARGET });
 
   if (TARGET === 'static-site') {
-    const tokens = marked.lexer(markdownBody);
-    const h1Token = tokens.find((t: any) => t.type === 'heading' && t.depth === 1);
-    const title = h1Token ? (h1Token as any).text.trim() : (data.title || formatTitle(id));
+    const h1Title = extractH1Heading(markdownBody);
+    const title = h1Title || data.title || formatTitle(id);
     const genericFrontmatter = `---
 title: ${JSON.stringify(title)}
 description: ${JSON.stringify(data.description)}


### PR DESCRIPTION
Provides a dedicated `static-site` compilation pipeline to export processed markdown guides for DevSite and external documentation platforms, serializes macro placeholders for downstream hydration, and introduces linting guardrails for heading titles and HTML tag escaping.

### Key Changes

* **Static-Site Build Target (`serving/scripts/build-guides.ts`)**:
  * Added `--target static-site` (`pnpm run build:static-site`) to generate standalone markdown guides in `dist/static-site-guides` without calculating vector embeddings.
  * Standardizes YAML frontmatter (`title`, `description`, `category`) with safe string escaping while preserving author H1 titles and stripping duplicates from compiled bodies.
  * Emits incremental pipeline cache hashes (`dist/.cache/static-site`) to skip rebuilding unchanged guides.

* **Macro Compilation for External Sites (`serving/lib/macros.ts`)**:
  * **`BASELINE_STATUS`**: Serializes into placeholder tags (`[BASELINE_STATUS: <feature-id>]`) for downstream DevSite hydration rather than baking in static text.
  * **`GUIDE_REF`**: Emits standard relative markdown links (`[title](../<category>/<guide-name>.md)`) under `static-site` instead of CLI retrieve commands (`npx modern-web-guidance retrieve ...`).

* **Validation Guardrails (`lib/guide-validation.ts`)**:
  * **Heading validation**: Added `validateHeadings` and `validateGuideTitle` to disallow vague top-level H1s (`# Overview`, `# Introduction`, `# Guide`, `# Title`) and require a clear title on non-stub guides while permitting subsection overviews (e.g. `## Overview`).
  * **HTML tag checking**: Added `validateHtmlTags` to catch unescaped HTML element literals with accurate line number tracking while permitting safe typographic inline tags (`<kbd>`, `<br>`, `<wbr>`) and comments.

* **Guide Title Hygiene**:
  * Added missing descriptive H1 headings to `html`, `persistent-top-layer-ui`, `move-dom-element-without-losing-state`, and `agentic-javascript-tools`.
  * Replaced vague `# Overview` in `declarative-dialog-popover-control` with `# Declarative Dialog and Popover Control`.
