### PR TITLE
feat(guides): Add file redirection instructions for large retrieve outputs to modern-web-guidance skill

### DIFF
--- a/guides/modern-web-guidance/SKILL.md
+++ b/guides/modern-web-guidance/SKILL.md
@@ -75,6 +75,13 @@ Once you have a relevant `id` from the search results, call this script using th
 npx -y modern-web-guidance@latest retrieve "<id>"
 ```
 
+> **Handling Large Output / Truncation**:
+> Guides contain complete code samples and browser fallbacks that may exceed terminal output limits. If the output is truncated, redirect to a temporary file and read it with your file viewing tool:
+> ```sh
+> npx -y modern-web-guidance@latest retrieve "<id>" > .temp-guide.md
+> ```
+> Read the complete file before generating code, and delete the temporary file when finished.
+
 **Example Output**:
 `The markdown content of the guide describing implementation steps...`
 


### PR DESCRIPTION
This commit updates the modern-web-guidance skill instructions to guide AI agents on handling large retrieval responses that might exceed terminal output limits. It advises agents to redirect the output to a temporary file (such as .temp-guide.md) so they can read the full guide and its fallback rules completely before generating code.

<img width="1020" height="851" alt="Screenshot 2026-08-26 at 12 40 09 AM" src="https://github.com/user-attachments/assets/2c72f3f6-cfcc-4055-9fc6-7f60111a6591" />
