### PR TITLE
feat(guides): integrate cssomnom for static CSS AST checks in gd dev

### DIFF
--- a/guides/gd-dev-prompts.test.ts
+++ b/guides/gd-dev-prompts.test.ts
@@ -1,5 +1,8 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
   buildSolutionPrompt,
   buildZeroPassratePrompt,
@@ -8,6 +11,9 @@ import {
   buildDevReportPrompt,
 } from './gd-dev-prompts.ts';
 import { Agents } from '../harness/config.ts';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 test('buildSolutionPrompt includes instructions and paths', () => {
   const prompt = buildSolutionPrompt({
@@ -47,11 +53,15 @@ test('buildTargetGraderPrompt includes Option B scoping rules', () => {
     templateFile: 'template.grader.ts',
   });
   assert.ok(prompt.includes('getTargetFiles'));
+  assert.ok(prompt.includes('getCssStyleSheet'));
+  assert.ok(prompt.includes('CSSOMNom'));
   assert.ok(prompt.includes('Static Analysis First'));
   assert.ok(prompt.includes('daily-grind'));
   assert.ok(prompt.includes('Jetski CLI Solution'));
   assert.ok(prompt.includes('Claude Code Solution'));
   assert.ok(prompt.includes('Codex CLI Solution'));
+  assert.ok(prompt.includes('Utility CSS Flexibility'));
+  assert.ok(prompt.includes('npx oxlint'));
 });
 
 test('buildTargetGraderPrompt formats failure context correctly when provided', () => {
@@ -106,4 +116,23 @@ test('buildDevReportPrompt creates comprehensive diagnostic prompt with flags an
   assert.ok(prompt.includes('Evaluation Results'));
   assert.ok(prompt.includes('Diagnostic Analysis & Actionable Recommendations'));
   assert.ok(prompt.includes('ROOT-CAUSE DIAGNOSIS RULES'));
+});
+
+test('all reference files and type definitions referenced in grader generation exist on disk', () => {
+  const requiredSandboxFiles = [
+    path.resolve(__dirname, 'template.grader.ts'),
+    path.resolve(__dirname, 'test-fixture.ts'),
+    path.resolve(__dirname, 'parser-pattern-library.test.ts'),
+    path.resolve(__dirname, 'playwright-pattern-library.grader.ts'),
+    path.resolve(__dirname, 'node_modules', 'ts-morph', 'lib', 'ts-morph.d.ts'),
+    path.resolve(__dirname, 'node_modules', 'linkedom', 'types', 'index.d.ts'),
+    path.resolve(__dirname, 'node_modules', 'cssomnom', 'dist', 'CSSOM.d.ts'),
+  ];
+
+  for (const filePath of requiredSandboxFiles) {
+    assert.ok(
+      fs.existsSync(filePath),
+      `Required grader reference file must exist on disk: ${filePath}`
+    );
+  }
 });

--- a/guides/gd-dev-prompts.ts
+++ b/guides/gd-dev-prompts.ts
@@ -69,12 +69,10 @@ export interface GraderPromptOptions {
   playwrightPatternLibraryPath?: string;
   tsMorphDtsPath?: string;
   linkedomDtsPath?: string;
+  cssomnomDtsPath?: string;
   failureContext?: string;
 }
 
-// TODO: Future CSSOMNom OSPO integration
-// When the cssomnom package is published to npm and installed in guides/package.json,
-// update Rule 2 (Assertion Hierarchy) in buildTargetGraderPrompt and the CSS test example in template.grader.ts to use CSSOMNom AST verification instead of regex.
 export function buildTargetGraderPrompt(opts: GraderPromptOptions): string {
   const contextBlock = opts.failureContext
     ? `### ⚠️ PREVIOUS FAILURE CONTEXT
@@ -118,29 +116,35 @@ ${solutionList}
 # VERIFICATION & SCOPING RULES
 
 ## 1. Strictly Follow the Boilerplate Template
-Base your grader's imports, workspace setup, helper function usage, and test structure on \`${opts.templateFile}\`. Use the template's helpers (\`getTargetFiles\`, \`extractAllCss\`, \`getJsProject\`, \`getHtmlDocuments\`) to dynamically locate and analyze modified code across standalone files and embedded template tags. Never hardcode file paths.
+Base your grader's imports, workspace setup, helper function usage, and test structure on \`${opts.templateFile}\`. Use the template's helpers (\`getTargetFiles\`, \`getCssStyleSheet\`, \`getJsProject\`, \`getHtmlDocuments\`) to dynamically locate and analyze modified code across standalone files and embedded template tags. Never hardcode file paths.
 
 ## 2. Assertion Hierarchy
-- **Static Analysis First**: Prioritize static analysis over browser execution for structural assertions.
+- **Static Analysis First**: Prioritize static AST analysis over browser execution for structural assertions. Always avoid regex on HTML, CSS, and JavaScript files.
+  - Use **Linkedom** for HTML structure and DOM querying (\`getHtmlDocuments\`).
+  - Use **CSSOMNom** for CSS rules, at-rules (@media, @supports, @container, @view-transition), and declarations (\`getCssStyleSheet\`).
+  - Use **ts-morph** for JavaScript/TypeScript syntax, AST analysis, and function/variable querying (\`getJsProject\`).
 - **Browser Checks Only When Necessary**: Only write browser-based Playwright E2E tests when strictly necessary (for requirements that cannot be verified statically, such as runtime click events or dynamic state updates). Omit browser test blocks entirely if static checks are sufficient.
 - **Reference Examples & API Definitions**: Before writing tests, use your file-viewing tools to inspect these reference pattern libraries and API type definitions for implementation patterns:
   - **Test Fixture Helper Signatures (Reference Only)**: [test-fixture.reference.ts](file://${opts.testFixtureReferencePath})
-  - **Static Analysis Patterns (Linkedom, ts-morph)**: [parser-pattern-library.test.ts](file://${opts.parserPatternLibraryPath})
+  - **Static Analysis Patterns (Linkedom, CSSOMNom, ts-morph)**: [parser-pattern-library.test.ts](file://${opts.parserPatternLibraryPath})
   - **Browser Analysis Patterns (Playwright)**: [playwright-pattern-library.grader.ts](file://${opts.playwrightPatternLibraryPath})
   - **TS Morph Type Definitions**: [ts-morph.d.ts](file://${opts.tsMorphDtsPath})
-  - **Linkedom Type Definitions**: [index.d.ts](file://${opts.linkedomDtsPath})
+  - **Linkedom Type Definitions**: [linkedom.d.ts](file://${opts.linkedomDtsPath})
+  - **CSSOMNom Type Definitions**: [cssomnom.d.ts](file://${opts.cssomnomDtsPath})
 
 ## 3. Granular Assertions: Single Assertion per Test
 Write only one assertion per \`test('...', ...)\` block across both static and browser tests. Do not combine multiple assertions into a single test block. This ensures precise, unambiguous error reporting during calibration if a test fails.
 
 ## 4. Precision & Matching Rules
 - **Outcome-Based Assertions**: Verify structural and functional requirements in static checks rather than forcing a single narrow implementation when valid alternatives exist.
+- **Utility CSS Flexibility**: In apps using utility-first CSS frameworks (e.g., Tailwind), accept either standard CSS declarations (\`getCssStyleSheet\`) or equivalent utility classes on elements in template markup (\`getHtmlDocuments\`).
 - **Flexible Pattern Matching**: Avoid exact-string equality for dynamic names or classes. Use loose matches, inclusion checks, and word boundaries (e.g., \`/\\bname\\b/\`) to avoid substring false positives.
 - **No Swallowed Errors**: Do not wrap assertions in generic try/catch blocks that swallow exceptions.
 
 ## 5. Dependencies & Sandbox Constraints
-Do not install any npm packages or execute application dev/build commands (like astro build or vite build) in your workspace. However, you MUST verify that your generated grader code compiles cleanly. Run this command in your workspace to check for TypeScript compilation/syntax errors and fix them before ending your turn:
-\`npx tsc --noEmit --skipLibCheck --target esnext --module nodenext --moduleResolution nodenext --allowImportingTsExtensions --esModuleInterop grader.ts\`
+Do not install any npm packages or execute application dev/build commands (like astro build or vite build) in your workspace. However, you MUST verify that your generated grader code compiles cleanly and passes linting. Run these verification commands in your workspace and fix any errors before ending your turn:
+1. \`npx tsc --noEmit --skipLibCheck --target esnext --module nodenext --moduleResolution nodenext --allowImportingTsExtensions --esModuleInterop grader.ts\`
+2. \`npx oxlint grader.ts\`
 
 # INSTRUCTION
 When writing files, you MUST use your built-in structured file editing tools (e.g., write_file or replace). Do not use shell commands (like cat, echo, or heredocs <<) to create files in the terminal.`;
@@ -236,7 +240,7 @@ Diagnose each target according to its assigned flag:
    - **Root Cause Investigation**: Review the failed assertions in \`${REPORT_FILE}\` and examine \`${GUIDE_FILE}\`, \`${EXPECTATIONS_FILE}\`, and \`targets/<target>/grader.ts\` to understand why the agent fell short. Consider:
      - **Guidance Quality (\`${GUIDE_FILE}\`)**: Does the guide lack essential modern web practices, clear syntax examples, fallback patterns, or common pitfalls?
      - **Expectations Alignment (\`${EXPECTATIONS_FILE}\`)**: Are the must-pass expectations ambiguous, conflicting, or missing key constraints?
-     - **Grader Robustness (\`targets/<target>/grader.ts\`)**: Is the grader failing valid implementations due to brittle regex, rigid file/syntax assumptions, or over-constrained assertions rather than testing observable outcomes?
+     - **Grader Robustness (\`targets/<target>/grader.ts\`)**: Is the grader failing valid implementations due to overly rigid syntax checks, hardcoded selectors/names, or fragile AST queries?
      - **Miscellaneous Issues**: Any other issues discovered.
    - **Recommendation Rules**:
      - **Source-of-Truth Fixes**: If \`${GUIDE_FILE}\` or \`${EXPECTATIONS_FILE}\` needs changes, recommend modifications **ONLY** to those files and **DO NOT** recommend edits to any files in \`targets/\`. Always append:

--- a/guides/grader-gen.ts
+++ b/guides/grader-gen.ts
@@ -82,6 +82,10 @@ export async function generateTargetGrader(guideDirAbs: string, baseApp: string,
       path.resolve(repoRoot, 'guides', 'node_modules', 'linkedom', 'types', 'index.d.ts'),
       path.join(workDir, 'linkedom.d.ts')
     );
+    fs.copyFileSync(
+      path.resolve(repoRoot, 'guides', 'node_modules', 'cssomnom', 'dist', 'CSSOM.d.ts'),
+      path.join(workDir, 'cssomnom.d.ts')
+    );
 
     const sourcePatches = path.join(guideDirAbs, TARGETS_DIR, baseApp, PATCHES_DIR);
     if (fs.existsSync(sourcePatches)) {
@@ -108,6 +112,7 @@ export async function generateTargetGrader(guideDirAbs: string, baseApp: string,
       playwrightPatternLibraryPath: path.join(workDir, 'playwright-pattern-library.grader.ts'),
       tsMorphDtsPath: path.join(workDir, 'ts-morph.d.ts'),
       linkedomDtsPath: path.join(workDir, 'linkedom.d.ts'),
+      cssomnomDtsPath: path.join(workDir, 'cssomnom.d.ts'),
       failureContext,
     });
 

--- a/guides/package.json
+++ b/guides/package.json
@@ -9,6 +9,7 @@
   "devDependencies": {
     "@octokit/rest": "^22.0.1",
     "@playwright/test": "^1.58.2",
+    "cssomnom": "^0.1.4",
     "gray-matter": "^4.0.3",
     "linkedom": "^0.18.12",
     "marked": "^18.0.3",

--- a/guides/parser-pattern-library.test.ts
+++ b/guides/parser-pattern-library.test.ts
@@ -2,10 +2,11 @@ import { test, describe } from 'node:test';
 import assert from 'node:assert';
 import { parseHTML } from 'linkedom';
 import { Project, SyntaxKind } from 'ts-morph';
+import { parse, getCascadedStyle, CSSMediaRule, CSSViewTransitionRule, CSSStyleRule, CSSSupportsRule, CSSContainerRule } from 'cssomnom';
 
 describe('Parser Pattern Library (Best Practices)', () => {
   
-  test('Pattern 1: Static DOM Analysis with Linkedom (Avoid Regex on HTML)', () => {
+  test('Pattern 1: Static DOM Analysis with Linkedom', () => {
     const html = `
       <form>
         <label for="email">Email</label>
@@ -25,28 +26,92 @@ describe('Parser Pattern Library (Best Practices)', () => {
     assert.strictEqual(label.textContent, 'Email');
   });
 
-  test('Pattern 2: Static CSS Analysis with Regex (TODO: Update to CSSOMNom once enabled)', () => {
+  test('Pattern 2: Static CSS & Utility Analysis (cssomnom + Linkedom)', () => {
     const css = `
       @media (prefers-reduced-motion: no-preference) {
         @view-transition {
           navigation: auto;
         }
       }
+
+      @supports (anchor-name: --my-anchor) {
+        .tooltip {
+          position-anchor: --my-anchor;
+          inset-area: block-end;
+        }
+      }
+
+      @container (min-width: 400px) {
+        .card {
+          display: flex;
+          color: blue;
+        }
+      }
+
+      .card {
+        view-transition-name: card-item;
+        contain: layout;
+        display: block;
+      }
     `;
     
-    // Normalize whitespace for easier matching
-    const cleanCss = css.replace(/\s+/g, ' ');
+    const stylesheet = parse(css);
+    const rules = Array.from(stylesheet.cssRules);
+
+    // 1. Verify @media rule and nested @view-transition rule
+    const mediaRule = rules.find((r): r is CSSMediaRule => r instanceof CSSMediaRule && r.conditionText.includes('no-preference'));
+    assert.ok(mediaRule, 'Should find media rule with prefers-reduced-motion: no-preference');
     
-    // Verify @view-transition is defined and navigation is auto
-    const hasViewTransition = /@view-transition\s*\{[^}]*\bnavigation\s*:\s*auto\b[^}]*\}/.test(cleanCss);
-    assert.ok(hasViewTransition);
-    
-    // Verify wrapped in no-preference media query
-    const hasNoPreferenceMedia = /@media\s*\([^)]*\bno-preference\b[^)]*\)\s*\{[^{}]*@view-transition/.test(cleanCss);
-    assert.ok(hasNoPreferenceMedia);
+    const viewTransitionRule = Array.from(mediaRule.cssRules).find((r): r is CSSViewTransitionRule => r instanceof CSSViewTransitionRule);
+    assert.ok(viewTransitionRule, 'Should find @view-transition rule nested inside media query');
+    assert.strictEqual(viewTransitionRule.navigation, 'auto');
+
+    // 2. Verify @supports rule and nested declarations
+    const supportsRule = rules.find((r): r is CSSSupportsRule => r instanceof CSSSupportsRule && r.conditionText.includes('anchor-name'));
+    assert.ok(supportsRule, 'Should find @supports rule for anchor-name');
+    const tooltipRule = Array.from(supportsRule.cssRules).find((r): r is CSSStyleRule => r instanceof CSSStyleRule && r.selectorText === '.tooltip');
+    assert.ok(tooltipRule, 'Should find .tooltip rule inside @supports');
+    assert.strictEqual(tooltipRule.style.getPropertyValue('position-anchor'), '--my-anchor');
+
+    // 3. Verify @container rule
+    const containerRule = rules.find((r): r is CSSContainerRule => r instanceof CSSContainerRule && r.conditionText.includes('min-width: 400px'));
+    assert.ok(containerRule, 'Should find @container rule');
+
+    // 4. Verify style rules and declarations
+    const cardRule = rules.find((r): r is CSSStyleRule => r instanceof CSSStyleRule && r.selectorText === '.card');
+    assert.ok(cardRule, 'Should find .card style rule');
+    assert.strictEqual(cardRule.style.getPropertyValue('view-transition-name'), 'card-item');
+    assert.strictEqual(cardRule.style.getPropertyValue('contain'), 'layout');
+
+    // 5. Utility CSS flexibility: Accept either standard CSS declarations or template utility classes
+    const { document } = parseHTML('<div class="@container card @md:flex-row">Item</div>');
+    const hasContainer = rules.some(r => r instanceof CSSStyleRule && /\b(inline-size|size)\b/.test(r.style.getPropertyValue('container-type')))
+      || Boolean(document.querySelector('[class*="@container"]'));
+    assert.strictEqual(hasContainer, true);
   });
 
-  test('Pattern 3: Handling Advanced Selectors supported by Linkedom (:has)', () => {
+  test('Pattern 3: Static Cascade & Selector Resolution (cssomnom + Linkedom)', () => {
+    const html = `
+      <div class="card highlight">Item</div>
+    `;
+    const css = `
+      .card { color: red; display: block; }
+      .card.highlight { color: blue; }
+    `;
+
+    const { document } = parseHTML(html);
+    const cardEl = document.querySelector('.card');
+    assert.ok(cardEl);
+
+    const stylesheet = parse(css);
+    const cascaded = getCascadedStyle(cardEl, Array.from(stylesheet.cssRules));
+
+    // getCascadedStyle computes the winning cascade declaration without a browser
+    assert.strictEqual(cascaded.getPropertyValue('color'), 'rgb(0, 0, 255)');
+    assert.strictEqual(cascaded.getPropertyValue('display'), 'block');
+  });
+
+  test('Pattern 4: Handling Advanced Selectors with Linkedom (:has)', () => {
     const html = `
       <div class="container">
         <p class="child">Hello</p>
@@ -63,7 +128,7 @@ describe('Parser Pattern Library (Best Practices)', () => {
     assert.strictEqual(matched.length, 1);
   });
 
-  test('Pattern 4: Static JS Analysis with ts-morph (Avoid Regex on JS)', () => {
+  test('Pattern 5: Static JS Analysis with ts-morph', () => {
     const html = `
       <script>
         function handleInteraction() {
@@ -82,7 +147,7 @@ describe('Parser Pattern Library (Best Practices)', () => {
     assert.strictEqual(functionDecls[0].getName(), 'handleInteraction');
   });
 
-  test('Pattern 5: Advanced JS Analysis with ts-morph (Feature Detection)', () => {
+  test('Pattern 6: Advanced JS Analysis with ts-morph (Feature Detection)', () => {
     const html = `
       <script>
         if ('onbeforematch' in HTMLElement.prototype) {

--- a/guides/template.grader.ts
+++ b/guides/template.grader.ts
@@ -2,38 +2,52 @@ import {
   test,
   expect,
   getTargetFiles,
-  extractAllCss,
+  getCssStyleSheet,
   getJsProject,
   getHtmlDocuments,
 } from '../../../../test-fixture.ts';
 
-// NOTE: Add imports from ts-morph or linkedom as needed:
+// NOTE: Add imports from ts-morph, linkedom, or cssomnom as needed:
 // e.g. import { SyntaxKind, type Project } from 'ts-morph';
 // e.g. import type { Document } from 'linkedom';
+// e.g. import { getCascadedStyle, CSSStyleRule, type CSSStyleSheet } from 'cssomnom';
 
 const targetFiles: string[] = getTargetFiles(import.meta.url);
 
 test.describe('<guide-name> Target Grader', () => {
 
   // --- STATIC ASSERTIONS (FAST) ---
-  // Use static assertions to query DOM structure, attributes, and JavaScript syntax on the host.
+  // Use static assertions to query DOM structure, attributes, CSS rules, and JavaScript syntax on the host.
   // These run instantly and are far more robust for structural verification than starting a browser.
   
-  test('HTML structure satisfies guide requirements (linkedom)', () => {
+  test('Example test containing HTML checks (linkedom)', () => {
     // EXAMPLE: DOM parsing using linkedom across HTML & component templates:
     // const docs: Array<{ file: string; document: Document }> = getHtmlDocuments(targetFiles);
     // const targetEl = docs.map(d => d.document.querySelector('.target-element')).find(Boolean);
     // expect(targetEl).not.toBeUndefined();
   });
 
-  // TODO: Future CSSOMNom OSPO integration - update this CSS test example to use CSSOMNom AST parsing when cssomnom is enabled.
-  test('CSS styles satisfy guide requirements (Regex)', () => {
-    // EXAMPLE: Static CSS checks across stylesheets, <style> tags, and inline styles:
-    // const cleanCss: string = extractAllCss(targetFiles);
-    // expect(cleanCss).toMatch(/your-css-pattern/i);
+  test('Example test containing CSS checks (cssomnom)', () => {
+    // EXAMPLE 1: Static CSS AST parsing across stylesheets, <style> tags, and inline styles:
+    // const stylesheet: CSSStyleSheet = getCssStyleSheet(targetFiles);
+    // const rules = Array.from(stylesheet.cssRules);
+    // const targetRule = rules.find((r): r is CSSStyleRule => r instanceof CSSStyleRule && r.selectorText === '.target-element');
+    //
+    // For utility-first apps (Tailwind), accept either CSS rules or template utility classes:
+    // const docs: Array<{ file: string; document: Document }> = getHtmlDocuments(targetFiles);
+    // const hasDisplay = targetRule?.style.getPropertyValue('display') === 'flex'
+    //   || docs.some(d => Boolean(d.document.querySelector('.flex, [class*="flex"]')));
+    // expect(hasDisplay).toBe(true);
+    //
+    // EXAMPLE 2: Resolving cascaded styles against a Linkedom element without a browser:
+    // const targetEl = docs.map(d => d.document.querySelector('.target-element')).find(Boolean);
+    // if (targetEl) {
+    //   const cascaded = getCascadedStyle(targetEl, rules);
+    //   expect(cascaded.getPropertyValue('display')).toBe('flex');
+    // }
   });
 
-  test('JavaScript source satisfies guide requirements (ts-morph)', () => {
+  test('Example test containing JS checks (ts-morph)', () => {
     // EXAMPLE: JavaScript AST parsing using ts-morph across JS/TS files and <script> tags:
     // const project: Project = getJsProject(targetFiles);
     // const functionDecls = project.getSourceFiles().flatMap(sf =>
@@ -54,13 +68,13 @@ test.describe('<guide-name> Target Grader', () => {
     });
 
     // EXAMPLE 1: Checking computed styles
-    // test('target element has correct computed color', async ({ page }) => {
+    // test('Example browser test containing computed style check', async ({ page }) => {
     //   const color = await page.$eval('.target', el => window.getComputedStyle(el).color);
     //   expect(color).toBe('rgb(255, 0, 0)');
     // });
 
     // EXAMPLE 2: Layout / Position checks using getBoundingClientRect
-    // test('element B is positioned below element A', async ({ page }) => {
+    // test('Example browser test containing layout check', async ({ page }) => {
     //   const pos = await page.evaluate(() => {
     //     const a = document.getElementById('a')!.getBoundingClientRect();
     //     const b = document.getElementById('b')!.getBoundingClientRect();

--- a/guides/test-fixture.test.ts
+++ b/guides/test-fixture.test.ts
@@ -1,0 +1,108 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { getCssStyleSheet, getHtmlDocuments, getJsProject } from './test-fixture.ts';
+import { CSSStyleRule } from 'cssomnom';
+import { SyntaxKind } from 'ts-morph';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+describe('test-fixture helpers', () => {
+
+  test('getCssStyleSheet extracts and parses CSS from .css, .html <style>, and inline styles', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fixture-css-test-'));
+    try {
+      const cssFile = path.join(tempDir, 'style.css');
+      fs.writeFileSync(cssFile, '.card { display: flex; color: red; }', 'utf8');
+
+      const htmlFile = path.join(tempDir, 'index.html');
+      fs.writeFileSync(
+        htmlFile,
+        '<html><head><style>.header { font-weight: bold; }</style></head><body><div class="box" style="position-anchor: --my-anchor; opacity: 1;"></div></body></html>',
+        'utf8'
+      );
+
+      const tsFile = path.join(tempDir, 'component.ts');
+      fs.writeFileSync(tsFile, 'const template = `<style>.footer { margin-top: 10px; }</style>`;', 'utf8');
+
+      const stylesheet = getCssStyleSheet([cssFile, htmlFile, tsFile]);
+      assert.ok(stylesheet, 'Should return a CSSStyleSheet');
+
+      const rules = Array.from(stylesheet.cssRules);
+
+      // Check .css rule
+      const cardRule = rules.find((r): r is CSSStyleRule => r instanceof CSSStyleRule && r.selectorText === '.card');
+      assert.ok(cardRule, 'Should find .card rule');
+      assert.strictEqual(cardRule.style.getPropertyValue('display'), 'flex');
+      assert.strictEqual(cardRule.style.getPropertyValue('color'), 'red');
+
+      // Check HTML <style> rule
+      const headerRule = rules.find((r): r is CSSStyleRule => r instanceof CSSStyleRule && r.selectorText === '.header');
+      assert.ok(headerRule, 'Should find .header rule from HTML <style>');
+      assert.strictEqual(headerRule.style.getPropertyValue('font-weight'), 'bold');
+
+      // Check HTML inline style rule
+      const inlineRule = rules.find((r): r is CSSStyleRule => r instanceof CSSStyleRule && r.selectorText === '[style]');
+      assert.ok(inlineRule, 'Should find inline style rule');
+      assert.strictEqual(inlineRule.style.getPropertyValue('position-anchor'), '--my-anchor');
+      assert.strictEqual(inlineRule.style.getPropertyValue('opacity'), '1');
+
+      // Check TS embedded <style> rule
+      const footerRule = rules.find((r): r is CSSStyleRule => r instanceof CSSStyleRule && r.selectorText === '.footer');
+      assert.ok(footerRule, 'Should find .footer rule from TS file');
+      assert.strictEqual(footerRule.style.getPropertyValue('margin-top'), '10px');
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test('getCssStyleSheet handles empty file lists gracefully', () => {
+    const stylesheet = getCssStyleSheet([]);
+    assert.ok(stylesheet);
+    assert.strictEqual(stylesheet.cssRules.length, 0);
+  });
+
+  test('getHtmlDocuments parses HTML files into Linkedom documents', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fixture-html-test-'));
+    try {
+      const htmlFile = path.join(tempDir, 'index.html');
+      fs.writeFileSync(htmlFile, '<div id="main" class="container"><p>Hello</p></div>', 'utf8');
+
+      const docs = getHtmlDocuments([htmlFile]);
+      assert.strictEqual(docs.length, 1);
+      assert.strictEqual(docs[0].file, htmlFile);
+
+      const pEl = docs[0].document.querySelector('.container p');
+      assert.ok(pEl);
+      assert.strictEqual(pEl.textContent, 'Hello');
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test('getJsProject populates ts-morph Project from .ts and <script> tags', () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fixture-js-test-'));
+    try {
+      const tsFile = path.join(tempDir, 'logic.ts');
+      fs.writeFileSync(tsFile, 'export function calculateTotal(a: number, b: number): number { return a + b; }', 'utf8');
+
+      const htmlFile = path.join(tempDir, 'index.html');
+      fs.writeFileSync(htmlFile, '<script>function inlineHelper() { return 42; }</script>', 'utf8');
+
+      const project = getJsProject([tsFile, htmlFile]);
+      const sourceFiles = project.getSourceFiles();
+      assert.ok(sourceFiles.length >= 2);
+
+      const functionDecls = sourceFiles.flatMap(sf => sf.getDescendantsOfKind(SyntaxKind.FunctionDeclaration));
+      const funcNames = functionDecls.map(fn => fn.getName());
+      assert.ok(funcNames.includes('calculateTotal'));
+      assert.ok(funcNames.includes('inlineHelper'));
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/guides/test-fixture.ts
+++ b/guides/test-fixture.ts
@@ -6,6 +6,7 @@ import * as net from 'net';
 import { fileURLToPath } from 'url';
 import { parseHTML } from 'linkedom';
 import { Project } from 'ts-morph';
+import { parse, CSSStyleSheet } from 'cssomnom';
 import { extractTargetFilesFromPatch } from '../lib/patch-utils.ts';
 
 export { expect } from '@playwright/test';
@@ -150,7 +151,11 @@ const HTML_EXTS = /\.(html|htm|astro)$/i;
 const CSS_EXTS = /\.css$/i;
 const JS_EXTS = /\.(js|ts|tsx|jsx)$/i;
 
-export function extractAllCss(files: string[]): string {
+/**
+ * Parses all CSS across standalone stylesheets (.css), HTML/Astro <style> tags,
+ * and inline styles into a CSSOMNom CSSStyleSheet object.
+ */
+export function getCssStyleSheet(files: string[]): CSSStyleSheet {
   const cssBlocks: string[] = [];
   for (const file of files) {
     if (!fs.existsSync(file) || fs.statSync(file).isDirectory()) continue;
@@ -166,11 +171,15 @@ export function extractAllCss(files: string[]): string {
         });
         document.querySelectorAll('[style]').forEach((el: any) => {
           const inlineStyle = el.getAttribute('style');
-          if (inlineStyle) cssBlocks.push(inlineStyle);
+          if (inlineStyle) cssBlocks.push(`[style] { ${inlineStyle} }`);
         });
       } catch {
         const styleMatches = content.match(/<style[^>]*>([\s\S]*?)<\/style>/gi);
-        if (styleMatches) cssBlocks.push(...styleMatches);
+        if (styleMatches) {
+          for (const match of styleMatches) {
+            cssBlocks.push(match.replace(/^<style[^>]*>/i, '').replace(/<\/style>$/i, ''));
+          }
+        }
       }
     } else if (JS_EXTS.test(file)) {
       const styleMatches = content.match(/<style[^>]*>([\s\S]*?)<\/style>/gi);
@@ -181,7 +190,7 @@ export function extractAllCss(files: string[]): string {
       }
     }
   }
-  return cssBlocks.join('\n').replace(/\s+/g, ' ');
+  return parse(cssBlocks.join('\n'));
 }
 
 export function populateJsProject(project: Project, files: string[]): void {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.58.2
+      cssomnom:
+        specifier: ^0.1.4
+        version: 0.1.4
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
@@ -1676,6 +1679,10 @@ packages:
 
   cssom@0.5.0:
     resolution: {integrity: sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==}
+
+  cssomnom@0.1.4:
+    resolution: {integrity: sha512-TlHXKwGFR4sUrMaJusJqXnRqHfH6pOCGFcz7+2cIEhgCr7THEElrbs0EkOG8e3ZdNOdtF+M6JIczViXNEFvq6A==}
+    engines: {node: '>=24.11.0'}
 
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
@@ -4870,6 +4877,8 @@ snapshots:
   css-what@8.0.0: {}
 
   cssom@0.5.0: {}
+
+  cssomnom@0.1.4: {}
 
   data-uri-to-buffer@4.0.1: {}
 


### PR DESCRIPTION
## Summary
Integrates [`cssomnom`](https://github.com/GoogleChromeLabs/cssomnom) into the `gd dev` toolchain for robust, static CSS AST parsing without needing a browser or fragile regex matching.

### Key Changes
- **`test-fixture.ts`**: Implements `getCssStyleSheet(targetFiles)` to extract and parse CSS rules from stylesheets, `<style>` tags, and inline `style` attributes into a typed `CSSStyleSheet` AST.
- **Grader Generation Prompts**: Updates `buildTargetGraderPrompt` to guide LLMs in using `getCssStyleSheet` for CSS assertions and includes **Utility CSS Flexibility** rules (accepting either standard CSS declarations via `cssomnom` or template utility classes like Tailwind via `linkedom`).
- **Pattern Library & Boilerplate**: Updates `parser-pattern-library.test.ts` (Pattern 2) and `template.grader.ts` with recipes for querying rules (`@container`, `@supports`, `@media`, declarations) and multi-paradigm utility class handling.
- Also adds a lint check command to the agent along with the existing typecheck command
- **Tests**: Adds full unit test coverage in `test-fixture.test.ts` and `gd-dev-prompts.test.ts`.

## Verification
- Example generation posted in https://github.com/GoogleChrome/modern-web-guidance-src/pull/1350 (this resolved previous issues with this PR being unable to generate graders that checked Tailwind CSS)
- `pnpm preflight` passed with 0 errors across all workspace packages.
- Verified in `gd dev` runs where both `daily-grind` and `devtools-times` target graders calibrated on Attempt 1.