### PR TITLE
fix(harness,eval-view): sanitize experimental model routing paths and fix word-wrap hyphens

### DIFF
--- a/eval-view/landing.js
+++ b/eval-view/landing.js
@@ -553,7 +553,7 @@ function renderSuites() {
                 </td>
                 <td>${getAgentBadge(testInfo.agent)}${escapeHtml(testInfo.agent)}</td>
                 <td>${servingDisplayNames[testInfo.serving] || testInfo.serving}</td>
-                <td style="font-size: 0.85rem; color: var(--text-secondary); word-break: break-word; width: 120px;">${escapeHtml(testInfo.model).replaceAll('-', '-&shy;')}</td>
+                <td style="font-size: 0.85rem; color: var(--text-secondary); word-break: break-word; width: 120px;">${escapeHtml(testInfo.model).replaceAll('-', '-<wbr>')}</td>
                 <td style="font-weight: 600;">${taskCount} ${maxRuns > 1 ? `<span style="color: var(--text-secondary); font-size: 0.8rem; font-weight: 400;">×${maxRuns}</span>` : ''}</td>
                 <td class="uplift-cell" data-compound-key="${compoundKey}" style="width: 200px; padding: 0; vertical-align: middle; position: relative; z-index: 2;">
                     <a href="${localLink}" style="display: block; color: inherit; text-decoration: none; padding: 10px 15px;">

--- a/harness/agents/jetski-cli-agent.ts
+++ b/harness/agents/jetski-cli-agent.ts
@@ -292,7 +292,7 @@ export function parseJetskiCliSession(dirPath: string): TrajectorySummary {
           // Look for Gemini model name patterns across string fields in the Protobuf message
           const modelCandidate = strings.find(s => /^gemini/i.test(s));
           if (modelCandidate) {
-            modelName = modelCandidate;
+            modelName = modelCandidate.split('|')[0].trim();
             break;
           }
         }

--- a/harness/tests/trajectory-parsing.test.ts
+++ b/harness/tests/trajectory-parsing.test.ts
@@ -472,3 +472,33 @@ test('collectCodex metrics from modern custom_tool_call trajectory file', async 
     removeTempDir(tempDir);
   }
 });
+
+test('parseJetskiCliSession sanitizes pipe-delimited experimental model names', () => {
+  const tempDir = createTempDir();
+  try {
+    const dbPath = path.join(tempDir, 'session-pipe-model.db');
+    const db = new DatabaseSync(dbPath);
+    db.exec(`
+      CREATE TABLE steps (idx INTEGER, step_type INTEGER, status INTEGER, metadata BLOB, step_payload BLOB);
+      CREATE TABLE gen_metadata (idx INTEGER, data BLOB);
+    `);
+
+    const rawModelString = 'gemini-3.7-flash-medium|experimental-routing-path/checkpoint/1';
+    const modelInner = encodeField(19, 2, Buffer.from(rawModelString));
+    const genDataProto = encodeField(1, 2, modelInner);
+
+    const insertGen = db.prepare('INSERT INTO gen_metadata (idx, data) VALUES (?, ?)');
+    insertGen.run(1, genDataProto);
+    db.close();
+
+    const parsed = parseJetskiCliSession(tempDir);
+    assert.strictEqual(parsed.model, 'gemini-3.7-flash-medium');
+
+    writeTrajectorySummary(tempDir, parsed);
+    const model = extractModelFromResults(tempDir, Agents.JETSKI_CLI);
+    assert.strictEqual(model, 'gemini-3.7-flash-medium');
+  } finally {
+    removeTempDir(tempDir);
+  }
+});
+


### PR DESCRIPTION
## Summary

This PR addresses two related issues with model name extraction and display:

1. **Experimental model routing path sanitization**:
   In nightly run `nightly-2026-08-26_17-00-02-jetski_cli`, Jetski CLI generation metadata recorded an internal composite model string:
   `gemini-3.7-flash-medium|andwise-agy-fa...`
   This caused the experimental submodel path to appear on the dashboard.
   - Updated `parseJetskiCliSession()` in `harness/agents/jetski-cli-agent.ts` to strip pipe-delimited experimental routing paths (`.split('|')[0].trim()`), establishing a single source of truth for model extraction.
   - Added a unit test in `harness/tests/trajectory-parsing.test.ts` verifying pipe-delimited model sanitization using a placeholder path.
   *(Note: The remote evaluation results in GCS and `suites.gen.json` for that run have already been reconciled).*

2. **Dashboard soft-hyphen double dash fix**:
   In `eval-view/landing.js`, `.replaceAll('-', '-&shy;')` placed a soft hyphen `&shy;` immediately after every literal hyphen `-`. When a model name wrapped onto two lines (e.g. `gemini-3.7-flash-medium`), the browser rendered the literal hyphen plus the soft-hyphen generated hyphen, displaying as `gemini-3.7-flash--` / `medium`.
   - Replaced `-&shy;` with `-<wbr>` to provide clean word-break opportunities without injecting duplicate hyphen glyphs on line wrap.

Before:
<img width="133" height="42" alt="Screenshot 2026-08-26 at 4 05 02 PM" src="https://github.com/user-attachments/assets/1f6050d0-a387-41f3-bbe9-086f67ccea09" />

After:
<img width="121" height="43" alt="Screenshot 2026-08-26 at 4 50 07 PM" src="https://github.com/user-attachments/assets/84498f6b-18d2-418a-9ee0-909d2baf7382" />

## Verification
- `pnpm run preflight` (Build, typecheck, lint, and all workspace tests pass)
- `pnpm --filter eval-view run test:e2e` (Playwright E2E dashboard tests pass)