### PR TITLE
Link to guides and features in release notes

### DIFF
--- a/serving/skills-cli/generate-release-notes.test.ts
+++ b/serving/skills-cli/generate-release-notes.test.ts
@@ -96,6 +96,7 @@ test('parseBaselineUpdateFromPatch extracts feature name and status rank', () =>
 +Baseline status for Masks: Widely available.
 `;
   const infoWidely = parseBaselineUpdateFromPatch('complex-shapes', patchWidely);
+  assert.ok(infoWidely);
   assert.strictEqual(infoWidely.featureName, 'Masks');
   assert.strictEqual(infoWidely.statusRank, 1);
   assert.ok(infoWidely.statusDescription.includes('Widely available'));
@@ -106,6 +107,7 @@ test('parseBaselineUpdateFromPatch extracts feature name and status rank', () =>
 +Baseline status for field-sizing: Newly available.
 `;
   const infoNewly = parseBaselineUpdateFromPatch('form-fields-automatically-fit-contents', patchNewly);
+  assert.ok(infoNewly);
   assert.strictEqual(infoNewly.featureName, 'field-sizing');
   assert.strictEqual(infoNewly.statusRank, 2);
   assert.ok(infoNewly.statusDescription.includes('Newly available'));
@@ -612,6 +614,7 @@ test('parseBaselineUpdateFromPatch extracts feature name from patch context line
 +Supported by: Chrome 120, Firefox 135.
 `;
   const info = parseBaselineUpdateFromPatch('complex-shapes', patchWithContext);
+  assert.ok(info);
   assert.strictEqual(info.featureName, 'Masks');
   assert.strictEqual(info.featureId, 'masks');
   assert.ok(info.statusDescription.includes('Firefox 135'));

--- a/serving/skills-cli/generate-release-notes.test.ts
+++ b/serving/skills-cli/generate-release-notes.test.ts
@@ -13,6 +13,11 @@ import {
   classifyChanges,
   getGuideDescription,
   getUniqueGuideNames,
+  getGuidePathInDistribution,
+  getGuideGithubUrl,
+  formatGuideBoldLink,
+  formatGuideCodeLink,
+  linkifyGuideBullets,
   parseMarkdownBullets,
   isPatchOnlyVersionBump,
   isJsonOnlyVersionBump,
@@ -141,9 +146,10 @@ test('buildBaselineBullets sorts entries strictly: Widely -> Newly -> Limited an
   // First should be Rank 1 (:has() and CSS Masks sorted alphabetically)
   assert.ok(bullets[0].includes(':has() selector'));
   assert.ok(bullets[1].includes('CSS Masks'));
-  assert.ok(bullets[1].includes('across 2 guides (`complex-shapes`, `shaped-cutouts`)'));
+  assert.ok(bullets[1].includes('across 2 guides ([`complex-shapes`](https://github.com/GoogleChrome/modern-web-guidance/blob/main/skills/modern-web-guidance/guides/visual-design/complex-shapes.md), [`shaped-cutouts`](https://github.com/GoogleChrome/modern-web-guidance/blob/main/skills/modern-web-guidance/guides/visual-design/shaped-cutouts.md))'));
   // Second group is Rank 2 (field-sizing)
   assert.ok(bullets[2].includes('field-sizing'));
+  assert.ok(bullets[2].includes('[`form-fields-automatically-fit-contents`](https://github.com/GoogleChrome/modern-web-guidance/blob/main/skills/modern-web-guidance/guides/forms/form-fields-automatically-fit-contents.md)'));
   // Third group is Rank 3 (Language Detection)
   assert.ok(bullets[3].includes('Language Detection'));
 });
@@ -304,8 +310,8 @@ test('generateFallbackReleaseNotes formats guide, baseline, and ecosystem update
   const notes = generateFallbackReleaseNotes('v0.1.0', '0.1.1', evalSummary, changedFiles, baselineUpdates);
 
   assert.ok(notes.includes('# Release Notes: `v0.1.1`'));
-  assert.ok(notes.includes('## 🔄 Updated Guides\n\n* **size-aware-styling**: Updates and improvements to web platform guidance.'));
-  assert.ok(notes.includes('## 🌐 Browser Support Updates\n\n* **CSS Masks**: Now **Baseline Widely available** in `complex-shapes`.'));
+  assert.ok(notes.includes('## 🔄 Updated Guides\n\n* **[size-aware-styling](https://github.com/GoogleChrome/modern-web-guidance/blob/v0.1.1/skills/modern-web-guidance/guides/css/size-aware-styling.md)**: Updates and improvements to web platform guidance.'));
+  assert.ok(notes.includes('## 🌐 Browser Support Updates\n\n* **CSS Masks**: Now **Baseline Widely available** in [`complex-shapes`](https://github.com/GoogleChrome/modern-web-guidance/blob/v0.1.1/skills/modern-web-guidance/guides/visual-design/complex-shapes.md).'));
   assert.ok(notes.includes('## 🔌 Plugins\n\n* **.grok-plugin/marketplace.json**: Updates to agent plugin configuration.'));
 });
 
@@ -486,5 +492,89 @@ test('all changed guide files are categorized into added, modified, removed, or 
       `Expected guide file '${file}' (${guideName}) in changedFiles to be in a category`
     );
   }
+});
+
+test('getGuidePathInDistribution and getGuideGithubUrl resolve correct paths and GitHub URLs', () => {
+  // 1. Regular guide in guides/<category>/<name>
+  const translatorPath = getGuidePathInDistribution('translator');
+  assert.strictEqual(translatorPath, 'skills/modern-web-guidance/guides/built-in-ai/translator.md');
+  assert.strictEqual(
+    getGuideGithubUrl('translator'),
+    'https://github.com/GoogleChrome/modern-web-guidance/blob/main/skills/modern-web-guidance/guides/built-in-ai/translator.md'
+  );
+  assert.strictEqual(
+    getGuideGithubUrl('translator', 'v0.0.185'),
+    'https://github.com/GoogleChrome/modern-web-guidance/blob/v0.0.185/skills/modern-web-guidance/guides/built-in-ai/translator.md'
+  );
+  assert.strictEqual(
+    getGuideGithubUrl('translator', '0.0.185'),
+    'https://github.com/GoogleChrome/modern-web-guidance/blob/v0.0.185/skills/modern-web-guidance/guides/built-in-ai/translator.md'
+  );
+
+  const siblingPath = getGuidePathInDistribution('dynamic-sibling-styling');
+  assert.strictEqual(siblingPath, 'skills/modern-web-guidance/guides/css/dynamic-sibling-styling.md');
+  assert.strictEqual(
+    getGuideGithubUrl('dynamic-sibling-styling', 'v0.0.185'),
+    'https://github.com/GoogleChrome/modern-web-guidance/blob/v0.0.185/skills/modern-web-guidance/guides/css/dynamic-sibling-styling.md'
+  );
+
+  // 2. Standalone skills
+  assert.strictEqual(getGuidePathInDistribution('chrome-extensions'), 'skills/chrome-extensions/SKILL.md');
+  assert.strictEqual(getGuidePathInDistribution('chrome-extensions-skill'), 'skills/chrome-extensions/SKILL.md');
+  assert.strictEqual(
+    getGuideGithubUrl('chrome-extensions', 'v0.0.185'),
+    'https://github.com/GoogleChrome/modern-web-guidance/blob/v0.0.185/skills/chrome-extensions/SKILL.md'
+  );
+
+  assert.strictEqual(getGuidePathInDistribution('modern-web-guidance'), 'skills/modern-web-guidance/SKILL.md');
+  assert.strictEqual(getGuidePathInDistribution('modern-web-guidance-skill'), 'skills/modern-web-guidance/SKILL.md');
+
+  // 3. Unknown guide returns undefined
+  assert.strictEqual(getGuidePathInDistribution('non-existent-guide-xyz'), undefined);
+  assert.strictEqual(getGuideGithubUrl('non-existent-guide-xyz'), undefined);
+});
+
+test('formatGuideBoldLink and formatGuideCodeLink format links when guide exists and fallback when absent', () => {
+  // Existing guide
+  assert.strictEqual(
+    formatGuideBoldLink('translator', 'v0.0.185'),
+    '**[translator](https://github.com/GoogleChrome/modern-web-guidance/blob/v0.0.185/skills/modern-web-guidance/guides/built-in-ai/translator.md)**'
+  );
+  assert.strictEqual(
+    formatGuideCodeLink('translator', 'v0.0.185'),
+    '[`translator`](https://github.com/GoogleChrome/modern-web-guidance/blob/v0.0.185/skills/modern-web-guidance/guides/built-in-ai/translator.md)'
+  );
+
+  // Non-existent guide
+  assert.strictEqual(formatGuideBoldLink('unknown-guide'), '**unknown-guide**');
+  assert.strictEqual(formatGuideCodeLink('unknown-guide'), '`unknown-guide`');
+});
+
+test('linkifyGuideBullets correctly links guide names in bullet points without double-linking', () => {
+  const originalBullets = [
+    '* **translator**: Updated to require accessing the API exclusively via the global `Translator` interface (deprecating `window.ai.translator`), clarified the 4 availability states (`available`, `downloadable`, `downloading`, `unavailable`), and added guidance on download progress monitoring and user gesture requirements.',
+    '* Introduced **[state-aware-sticky-headers](https://github.com/GoogleChrome/modern-web-guidance/blob/v0.0.185/skills/modern-web-guidance/guides/ui-atoms/state-aware-sticky-headers.md)** detailing how to build UI headers that react to scroll changes.',
+    '* Added `size-aware-styling` guidance for responsive container styling.',
+  ];
+
+  const linkedBullets = linkifyGuideBullets(originalBullets, ['translator', 'state-aware-sticky-headers', 'size-aware-styling'], 'v0.0.185');
+
+  // 1. Unlinked bold guide name is linked directly
+  assert.strictEqual(
+    linkedBullets[0],
+    '* **[translator](https://github.com/GoogleChrome/modern-web-guidance/blob/v0.0.185/skills/modern-web-guidance/guides/built-in-ai/translator.md)**: Updated to require accessing the API exclusively via the global `Translator` interface (deprecating `window.ai.translator`), clarified the 4 availability states (`available`, `downloadable`, `downloading`, `unavailable`), and added guidance on download progress monitoring and user gesture requirements.'
+  );
+
+  // 2. Already linked bullet remains intact (no double-linking)
+  assert.strictEqual(
+    linkedBullets[1],
+    '* Introduced **[state-aware-sticky-headers](https://github.com/GoogleChrome/modern-web-guidance/blob/v0.0.185/skills/modern-web-guidance/guides/ui-atoms/state-aware-sticky-headers.md)** detailing how to build UI headers that react to scroll changes.'
+  );
+
+  // 3. Code-formatted guide identifier is linked
+  assert.strictEqual(
+    linkedBullets[2],
+    '* Added [`size-aware-styling`](https://github.com/GoogleChrome/modern-web-guidance/blob/v0.0.185/skills/modern-web-guidance/guides/css/size-aware-styling.md) guidance for responsive container styling.'
+  );
 });
 

--- a/serving/skills-cli/generate-release-notes.test.ts
+++ b/serving/skills-cli/generate-release-notes.test.ts
@@ -623,7 +623,15 @@ test('resolveWebFeatureId, getWebStatusUrl, and formatWebFeatureBoldLink correct
   assert.strictEqual(resolveWebFeatureId(':has()'), 'has');
   assert.strictEqual(getWebStatusUrl(':has()'), 'https://webstatus.dev/features/has');
 
-  // 2. Unknown feature fallback
+  // 2. Exact feature display names that differ from feature IDs
+  assert.strictEqual(resolveWebFeatureId('overflow'), 'overflow-shorthand');
+  assert.strictEqual(resolveWebFeatureId('Overflow media queries'), 'overflow');
+  assert.strictEqual(resolveWebFeatureId('lang'), 'lang-attr');
+  assert.strictEqual(resolveWebFeatureId(':lang()'), 'lang');
+  assert.strictEqual(resolveWebFeatureId('Selection'), 'selection-api');
+  assert.strictEqual(resolveWebFeatureId('::selection'), 'selection');
+
+  // 3. Unknown feature fallback
   assert.strictEqual(resolveWebFeatureId('unknown-feature-xyz'), undefined);
   assert.strictEqual(getWebStatusUrl('unknown-feature-xyz'), undefined);
   assert.strictEqual(formatWebFeatureBoldLink('unknown-feature-xyz'), '**unknown-feature-xyz**');

--- a/serving/skills-cli/generate-release-notes.test.ts
+++ b/serving/skills-cli/generate-release-notes.test.ts
@@ -8,6 +8,7 @@ import {
   buildReleaseNotesMarkdown,
   buildBaselineBullets,
   parseBaselineUpdateFromPatch,
+  parseBaselineUpdatesFromPatch,
   isPatchOnlyBaselineUpdate,
   stripBaselineLinesFromPatch,
   classifyChanges,
@@ -17,6 +18,9 @@ import {
   getGuideGithubUrl,
   formatGuideBoldLink,
   formatGuideCodeLink,
+  resolveWebFeatureId,
+  getWebStatusUrl,
+  formatWebFeatureBoldLink,
   linkifyGuideBullets,
   parseMarkdownBullets,
   isPatchOnlyVersionBump,
@@ -92,7 +96,7 @@ test('parseBaselineUpdateFromPatch extracts feature name and status rank', () =>
 +Baseline status for Masks: Widely available.
 `;
   const infoWidely = parseBaselineUpdateFromPatch('complex-shapes', patchWidely);
-  assert.strictEqual(infoWidely.featureName, 'CSS Masks');
+  assert.strictEqual(infoWidely.featureName, 'Masks');
   assert.strictEqual(infoWidely.statusRank, 1);
   assert.ok(infoWidely.statusDescription.includes('Widely available'));
 
@@ -110,19 +114,19 @@ test('parseBaselineUpdateFromPatch extracts feature name and status rank', () =>
 test('buildBaselineBullets sorts entries strictly: Widely -> Newly -> Limited and groups guides', () => {
   const updates: BaselineUpdateInfo[] = [
     {
-      featureName: 'Language Detection',
+      featureName: 'Language detector',
       statusRank: 3,
       statusDescription: 'Added **Edge 148** support',
       guideName: 'language-detection',
     },
     {
-      featureName: 'CSS Masks',
+      featureName: 'Masks',
       statusRank: 1,
       statusDescription: 'Now **Baseline Widely available**',
       guideName: 'complex-shapes',
     },
     {
-      featureName: 'CSS Masks',
+      featureName: 'Masks',
       statusRank: 1,
       statusDescription: 'Now **Baseline Widely available**',
       guideName: 'shaped-cutouts',
@@ -134,7 +138,7 @@ test('buildBaselineBullets sorts entries strictly: Widely -> Newly -> Limited an
       guideName: 'form-fields-automatically-fit-contents',
     },
     {
-      featureName: ':has() selector',
+      featureName: ':has()',
       statusRank: 1,
       statusDescription: 'Now **Baseline Widely available**',
       guideName: 'child-state-based-styling',
@@ -143,15 +147,15 @@ test('buildBaselineBullets sorts entries strictly: Widely -> Newly -> Limited an
 
   const bullets = buildBaselineBullets(updates);
   assert.strictEqual(bullets.length, 4);
-  // First should be Rank 1 (:has() and CSS Masks sorted alphabetically)
-  assert.ok(bullets[0].includes(':has() selector'));
-  assert.ok(bullets[1].includes('CSS Masks'));
+  // First should be Rank 1 (:has() and Masks sorted alphabetically)
+  assert.ok(bullets[0].includes('**[:has()](https://webstatus.dev/features/has)**'));
+  assert.ok(bullets[1].includes('**[Masks](https://webstatus.dev/features/masks)**'));
   assert.ok(bullets[1].includes('across 2 guides ([`complex-shapes`](https://github.com/GoogleChrome/modern-web-guidance/blob/main/skills/modern-web-guidance/guides/visual-design/complex-shapes.md), [`shaped-cutouts`](https://github.com/GoogleChrome/modern-web-guidance/blob/main/skills/modern-web-guidance/guides/visual-design/shaped-cutouts.md))'));
   // Second group is Rank 2 (field-sizing)
-  assert.ok(bullets[2].includes('field-sizing'));
+  assert.ok(bullets[2].includes('**[field-sizing](https://webstatus.dev/features/field-sizing)**'));
   assert.ok(bullets[2].includes('[`form-fields-automatically-fit-contents`](https://github.com/GoogleChrome/modern-web-guidance/blob/main/skills/modern-web-guidance/guides/forms/form-fields-automatically-fit-contents.md)'));
-  // Third group is Rank 3 (Language Detection)
-  assert.ok(bullets[3].includes('Language Detection'));
+  // Third group is Rank 3 (Language detector)
+  assert.ok(bullets[3].includes('**[Language detector](https://webstatus.dev/features/languagedetector)**'));
 });
 
 test('isJsonOnlyVersionBump correctly compares JSON objects on disk ignoring version', () => {
@@ -300,7 +304,7 @@ test('generateFallbackReleaseNotes formats guide, baseline, and ecosystem update
   const evalSummary: EvalSummaryItem[] = [];
   const baselineUpdates: BaselineUpdateInfo[] = [
     {
-      featureName: 'CSS Masks',
+      featureName: 'Masks',
       statusRank: 1,
       statusDescription: 'Now **Baseline Widely available**',
       guideName: 'complex-shapes',
@@ -311,7 +315,7 @@ test('generateFallbackReleaseNotes formats guide, baseline, and ecosystem update
 
   assert.ok(notes.includes('# Release Notes: `v0.1.1`'));
   assert.ok(notes.includes('## 🔄 Updated Guides\n\n* **[size-aware-styling](https://github.com/GoogleChrome/modern-web-guidance/blob/v0.1.1/skills/modern-web-guidance/guides/css/size-aware-styling.md)**: Updates and improvements to web platform guidance.'));
-  assert.ok(notes.includes('## 🌐 Browser Support Updates\n\n* **CSS Masks**: Now **Baseline Widely available** in [`complex-shapes`](https://github.com/GoogleChrome/modern-web-guidance/blob/v0.1.1/skills/modern-web-guidance/guides/visual-design/complex-shapes.md).'));
+  assert.ok(notes.includes('## 🌐 Browser Support Updates\n\n* **[Masks](https://webstatus.dev/features/masks)**: Now **Baseline Widely available** in [`complex-shapes`](https://github.com/GoogleChrome/modern-web-guidance/blob/v0.1.1/skills/modern-web-guidance/guides/visual-design/complex-shapes.md).'));
   assert.ok(notes.includes('## 🔌 Plugins\n\n* **.grok-plugin/marketplace.json**: Updates to agent plugin configuration.'));
 });
 
@@ -389,7 +393,7 @@ test('classifyChanges correctly classifies added, modified, baseline, plugin, re
 
   // 5. Baseline updates (includes both standalone baseline guide and dual-update guide)
   assert.strictEqual(result.baselineUpdates.length, 2);
-  assert.strictEqual(result.baselineUpdates[0].featureName, 'CSS Masks');
+  assert.strictEqual(result.baselineUpdates[0].featureName, 'Masks');
   assert.strictEqual(result.baselineUpdates[0].statusRank, 1);
   assert.strictEqual(result.baselineUpdates[1].featureName, 'linear() easing');
   assert.strictEqual(result.baselineUpdates[1].statusRank, 1);
@@ -576,5 +580,71 @@ test('linkifyGuideBullets correctly links guide names in bullet points without d
     linkedBullets[2],
     '* Added [`size-aware-styling`](https://github.com/GoogleChrome/modern-web-guidance/blob/v0.0.185/skills/modern-web-guidance/guides/css/size-aware-styling.md) guidance for responsive container styling.'
   );
+});
+
+test('resolveWebFeatureId, getWebStatusUrl, and formatWebFeatureBoldLink correctly link to webstatus.dev', () => {
+  // 1. Direct ID or canonical name resolution
+  assert.strictEqual(resolveWebFeatureId('sibling-count() and sibling-index()'), 'sibling-count');
+  assert.strictEqual(getWebStatusUrl('sibling-count() and sibling-index()'), 'https://webstatus.dev/features/sibling-count');
+  assert.strictEqual(
+    formatWebFeatureBoldLink('sibling-count() and sibling-index()'),
+    '**[sibling-count() and sibling-index()](https://webstatus.dev/features/sibling-count)**'
+  );
+  assert.strictEqual(resolveWebFeatureId('field-sizing'), 'field-sizing');
+  assert.strictEqual(resolveWebFeatureId('Masks'), 'masks');
+  assert.strictEqual(getWebStatusUrl('Masks'), 'https://webstatus.dev/features/masks');
+  assert.strictEqual(formatWebFeatureBoldLink('Masks'), '**[Masks](https://webstatus.dev/features/masks)**');
+
+  assert.strictEqual(resolveWebFeatureId(':has()'), 'has');
+  assert.strictEqual(getWebStatusUrl(':has()'), 'https://webstatus.dev/features/has');
+
+  // 2. Unknown feature fallback
+  assert.strictEqual(resolveWebFeatureId('unknown-feature-xyz'), undefined);
+  assert.strictEqual(getWebStatusUrl('unknown-feature-xyz'), undefined);
+  assert.strictEqual(formatWebFeatureBoldLink('unknown-feature-xyz'), '**unknown-feature-xyz**');
+});
+
+test('parseBaselineUpdateFromPatch extracts feature name from patch context lines', () => {
+  const patchWithContext = `
+@@ -50,3 +50,3 @@
+ Baseline status for Masks: Limited availability.
+-Supported by: Chrome 120.
++Supported by: Chrome 120, Firefox 135.
+`;
+  const info = parseBaselineUpdateFromPatch('complex-shapes', patchWithContext);
+  assert.strictEqual(info.featureName, 'Masks');
+  assert.strictEqual(info.featureId, 'masks');
+  assert.ok(info.statusDescription.includes('Firefox 135'));
+});
+
+test('parseBaselineUpdatesFromPatch extracts multiple feature updates from multi-hunk patches', () => {
+  const multiHunkPatch = `
+@@ -20,6 +20,6 @@
+ Baseline status for Masks: Limited availability.
+-Supported by: Chrome 120.
++Supported by: Chrome 120, Firefox 135.
+@@ -80,6 +80,6 @@
+ Baseline status for :has(): Limited availability.
+-Supported by: Safari 17.
++Supported by: Safari 17, Firefox 135.
+`;
+  const updates = parseBaselineUpdatesFromPatch('multi-feature-guide', multiHunkPatch);
+  assert.strictEqual(updates.length, 2);
+  assert.strictEqual(updates[0].featureName, 'Masks');
+  assert.strictEqual(updates[0].featureId, 'masks');
+  assert.ok(updates[0].statusDescription.includes('Firefox 135'));
+
+  assert.strictEqual(updates[1].featureName, ':has()');
+  assert.strictEqual(updates[1].featureId, 'has');
+  assert.ok(updates[1].statusDescription.includes('Firefox 135'));
+
+  // 3. Patch without any extractable feature name is omitted
+  const unidentifiablePatch = `
+@@ -10,2 +10,2 @@
+-Some unrelated line
++Some other line
+`;
+  assert.strictEqual(parseBaselineUpdateFromPatch('unrelated-guide', unidentifiablePatch), null);
+  assert.deepStrictEqual(parseBaselineUpdatesFromPatch('unrelated-guide', unidentifiablePatch), []);
 });
 

--- a/serving/skills-cli/generate-release-notes.test.ts
+++ b/serving/skills-cli/generate-release-notes.test.ts
@@ -65,6 +65,16 @@ test('isPatchOnlyBaselineUpdate correctly identifies baseline-only patches', () 
 `;
   assert.strictEqual(isPatchOnlyBaselineUpdate(baselinePatch), true);
 
+  const limitedBaselinePatch = `
+@@ -54,4 +54,4 @@
+ ### Fallback strategies
+  popover="hint" has limited availability.
+-Supported by: Chrome 133 (Feb 2025), Edge 133 (Feb 2025), and Firefox 149 (Mar 2026).
++Supported by: Chrome 151, Edge 151, and Firefox 153 (Jul 2026).
+  Unsupported in: Safari.
+`;
+  assert.strictEqual(isPatchOnlyBaselineUpdate(limitedBaselinePatch), true);
+
   const substantivePatch = `
 @@ -10,6 +10,8 @@
  ## Overview
@@ -87,6 +97,19 @@ test('stripBaselineLinesFromPatch filters out baseline status lines while retain
   assert.ok(stripped.includes('+Here is some new substantive guidance about masks.'));
   assert.ok(stripped.includes('+Always specify a fallback.'));
   assert.ok(!stripped.includes('Baseline status for Masks'));
+
+  const mixedLimitedPatch = `
+@@ -1,6 +1,8 @@
+ ## Overview
++Here is some new substantive guidance about tooltips.
+-popover="hint" has limited availability.
++popover="hint" has limited availability.
++Always specify a fallback.
+`;
+  const strippedLimited = stripBaselineLinesFromPatch(mixedLimitedPatch);
+  assert.ok(strippedLimited.includes('+Here is some new substantive guidance about tooltips.'));
+  assert.ok(strippedLimited.includes('+Always specify a fallback.'));
+  assert.ok(!strippedLimited.includes('has limited availability'));
 });
 
 test('parseBaselineUpdateFromPatch extracts feature name and status rank', () => {
@@ -103,7 +126,7 @@ test('parseBaselineUpdateFromPatch extracts feature name and status rank', () =>
 
   const patchNewly = `
 @@ -10,7 +10,7 @@
--Baseline status for field-sizing: Limited availability.
+-field-sizing has limited availability.
 +Baseline status for field-sizing: Newly available.
 `;
   const infoNewly = parseBaselineUpdateFromPatch('form-fields-automatically-fit-contents', patchNewly);
@@ -606,10 +629,10 @@ test('resolveWebFeatureId, getWebStatusUrl, and formatWebFeatureBoldLink correct
   assert.strictEqual(formatWebFeatureBoldLink('unknown-feature-xyz'), '**unknown-feature-xyz**');
 });
 
-test('parseBaselineUpdateFromPatch extracts feature name from patch context lines', () => {
+test('parseBaselineUpdateFromPatch extracts feature name from patch context lines and handles version updates', () => {
   const patchWithContext = `
 @@ -50,3 +50,3 @@
- Baseline status for Masks: Limited availability.
+ Masks has limited availability.
 -Supported by: Chrome 120.
 +Supported by: Chrome 120, Firefox 135.
 `;
@@ -617,17 +640,77 @@ test('parseBaselineUpdateFromPatch extracts feature name from patch context line
   assert.ok(info);
   assert.strictEqual(info.featureName, 'Masks');
   assert.strictEqual(info.featureId, 'masks');
-  assert.ok(info.statusDescription.includes('Firefox 135'));
+  assert.strictEqual(info.statusDescription, 'Added **Firefox 135** support');
+
+  // Version revision for existing browsers (e.g. v0.0.183 -> v0.0.184 popover="hint" case)
+  const patchVersionUpdate = `
+@@ -127,3 +127,3 @@
+ popover="hint" has limited availability.
+-Supported by: Chrome 133 (Feb 2025), Edge 133 (Feb 2025), and Firefox 149 (Mar 2026).
++Supported by: Chrome 151, Edge 151, and Firefox 153 (Jul 2026).
+`;
+  const infoVersion = parseBaselineUpdateFromPatch('interest-triggered-tooltips', patchVersionUpdate);
+  assert.ok(infoVersion);
+  assert.strictEqual(infoVersion.featureName, 'popover="hint"');
+  assert.strictEqual(infoVersion.statusDescription, 'Updated supported browser versions for **Chrome, Edge, and Firefox**');
+
+  // Safari iOS support handling
+  const patchSafariIOS = `
+@@ -50,3 +50,3 @@
+ WebGPU has limited availability.
+-Supported by: Chrome 113.
++Supported by: Chrome 113, Safari 18, and Safari iOS 18.3 (Jan 2025).
+`;
+  const infoIOS = parseBaselineUpdateFromPatch('gpu-compute', patchSafariIOS);
+  assert.ok(infoIOS);
+  assert.strictEqual(infoIOS.statusDescription, 'Added **Safari 18 and Safari iOS 18.3** support');
+
+  // Engine removal handling (v0.0.174 -> v0.0.175 LanguageModel case)
+  const patchRemoval = `
+@@ -170,3 +170,3 @@
+ LanguageModel has limited availability.
+-Supported by: Chrome 148 (May 2026) and Edge 148 (May 2026).
++Supported by: Chrome 148 (May 2026).
+`;
+  const infoRemoval = parseBaselineUpdateFromPatch('language-model', patchRemoval);
+  assert.ok(infoRemoval);
+  assert.strictEqual(infoRemoval.featureName, 'LanguageModel');
+  assert.strictEqual(infoRemoval.statusDescription, 'Removed **Edge** support');
+
+  // Multiple changes (add + remove + version update)
+  const patchMulti = `
+@@ -10,3 +10,3 @@
+ test-feature has limited availability.
+-Supported by: Chrome 123 and Firefox 100.
++Supported by: Chrome 150 and Edge 150.
+`;
+  const infoMulti = parseBaselineUpdateFromPatch('test-guide', patchMulti);
+  assert.ok(infoMulti);
+  assert.strictEqual(
+    infoMulti.statusDescription,
+    'Added **Edge 150** support, removed **Firefox** support, and updated supported browser version for **Chrome**'
+  );
+
+  // Mobile-to-desktop consolidation (iOS/Android expanded to full support)
+  const patchConsolidation = `
+@@ -10,3 +10,3 @@
+ test-feature has limited availability.
+-Supported by: Chrome 120 and Safari iOS 18.3.
++Supported by: Chrome 120 and Safari 18.3.
+`;
+  const infoConsolidation = parseBaselineUpdateFromPatch('test-guide', patchConsolidation);
+  assert.ok(infoConsolidation);
+  assert.strictEqual(infoConsolidation.statusDescription, 'Added **Safari 18.3** support');
 });
 
 test('parseBaselineUpdatesFromPatch extracts multiple feature updates from multi-hunk patches', () => {
   const multiHunkPatch = `
 @@ -20,6 +20,6 @@
- Baseline status for Masks: Limited availability.
+ Masks has limited availability.
 -Supported by: Chrome 120.
 +Supported by: Chrome 120, Firefox 135.
 @@ -80,6 +80,6 @@
- Baseline status for :has(): Limited availability.
+ :has() has limited availability.
 -Supported by: Safari 17.
 +Supported by: Safari 17, Firefox 135.
 `;
@@ -635,11 +718,11 @@ test('parseBaselineUpdatesFromPatch extracts multiple feature updates from multi
   assert.strictEqual(updates.length, 2);
   assert.strictEqual(updates[0].featureName, 'Masks');
   assert.strictEqual(updates[0].featureId, 'masks');
-  assert.ok(updates[0].statusDescription.includes('Firefox 135'));
+  assert.strictEqual(updates[0].statusDescription, 'Added **Firefox 135** support');
 
   assert.strictEqual(updates[1].featureName, ':has()');
   assert.strictEqual(updates[1].featureId, 'has');
-  assert.ok(updates[1].statusDescription.includes('Firefox 135'));
+  assert.strictEqual(updates[1].statusDescription, 'Added **Firefox 135** support');
 
   // 3. Patch without any extractable feature name is omitted
   const unidentifiablePatch = `

--- a/serving/skills-cli/generate-release-notes.ts
+++ b/serving/skills-cli/generate-release-notes.ts
@@ -102,7 +102,6 @@ export async function generateReleaseNotes(opts: ReleaseNotesOptions): Promise<s
       guideNames: addedGuideNames,
       apiKey,
       model,
-      ref: targetTag,
     });
     if (generatedNewBullets) {
       newGuideBullets = linkifyGuideBullets(generatedNewBullets, addedGuideNames, targetTag);
@@ -125,7 +124,6 @@ export async function generateReleaseNotes(opts: ReleaseNotesOptions): Promise<s
       guideNames: modifiedGuideNames,
       apiKey,
       model,
-      ref: targetTag,
     });
     if (generatedUpdatedBullets) {
       updatedGuideBullets = linkifyGuideBullets(generatedUpdatedBullets, modifiedGuideNames, targetTag);

--- a/serving/skills-cli/generate-release-notes.ts
+++ b/serving/skills-cli/generate-release-notes.ts
@@ -16,11 +16,13 @@ import {
   isPluginFile,
   getExactDistributionDiff,
   getConsumerFacingDiff,
+  formatGuideBoldLink,
 } from './release-notes-diff.ts';
 import {
   buildBaselineBullets,
   buildReleaseNotesMarkdown,
   generateFallbackReleaseNotes,
+  linkifyGuideBullets,
 } from './release-notes-markdown.ts';
 import {
   generateNewGuideSummariesWithGemini,
@@ -64,8 +66,9 @@ export async function generateReleaseNotes(opts: ReleaseNotesOptions): Promise<s
       ? getExactDistributionDiff(previousTag, publishCliDir)
       : getConsumerFacingDiff(previousTag, target);
 
+  const targetTag = newVersion.startsWith('v') ? newVersion : `v${newVersion}`;
   const pluginFiles = changedFiles.filter(isPluginFile);
-  const baselineBullets = buildBaselineBullets(baselineUpdates);
+  const baselineBullets = buildBaselineBullets(baselineUpdates, targetTag);
 
   if (!apiKey) {
     if (
@@ -99,16 +102,18 @@ export async function generateReleaseNotes(opts: ReleaseNotesOptions): Promise<s
       guideNames: addedGuideNames,
       apiKey,
       model,
+      ref: targetTag,
     });
     if (generatedNewBullets) {
-      newGuideBullets = generatedNewBullets;
+      newGuideBullets = linkifyGuideBullets(generatedNewBullets, addedGuideNames, targetTag);
     } else {
       console.log('Falling back to default new guide release notes generator...');
       newGuideBullets = addedGuideNames.map(g => {
         const desc = guideDescriptions[g];
+        const link = formatGuideBoldLink(g, targetTag);
         return desc
-          ? `* **${g}**: ${desc}`
-          : `* **${g}**: Introduced new web platform guidance.`;
+          ? `* ${link}: ${desc}`
+          : `* ${link}: Introduced new web platform guidance.`;
       });
     }
   }
@@ -120,20 +125,21 @@ export async function generateReleaseNotes(opts: ReleaseNotesOptions): Promise<s
       guideNames: modifiedGuideNames,
       apiKey,
       model,
+      ref: targetTag,
     });
     if (generatedUpdatedBullets) {
-      updatedGuideBullets = generatedUpdatedBullets;
+      updatedGuideBullets = linkifyGuideBullets(generatedUpdatedBullets, modifiedGuideNames, targetTag);
     } else {
       console.log('Falling back to default updated guide release notes generator...');
       updatedGuideBullets = modifiedGuideNames.map(
-        g => `* **${g}**: Updates and improvements to web platform guidance.`
+        g => `* ${formatGuideBoldLink(g, targetTag)}: Updates and improvements to web platform guidance.`
       );
     }
   }
 
   for (const rename of renamedGuides) {
     if (!modifiedGuideNames.includes(rename.newName)) {
-      updatedGuideBullets.push(`* Renamed **${rename.oldName}** to **${rename.newName}**.`);
+      updatedGuideBullets.push(`* Renamed **${rename.oldName}** to ${formatGuideBoldLink(rename.newName, targetTag)}.`);
     }
   }
 

--- a/serving/skills-cli/release-notes-diff.ts
+++ b/serving/skills-cli/release-notes-diff.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { execSync } from 'node:child_process';
 import matter from 'gray-matter';
 import { minimatch } from 'minimatch';
+import { features } from 'web-features';
 import { rootDir } from '../../lib/paths.ts';
 export interface EvalSummaryItem {
   testId?: string;
@@ -21,6 +22,7 @@ export interface EvalSummaryItem {
 
 export interface BaselineUpdateInfo {
   featureName: string;
+  featureId?: string;
   statusRank: number; // 1: Widely, 2: Newly, 3: Limited
   statusDescription: string;
   guideName: string;
@@ -182,15 +184,15 @@ export function stripBaselineLinesFromPatch(patch?: string): string {
 }
 
 /**
- * Extracts structured Baseline / browser support update info from a patch.
+ * Extracts structured Baseline / browser support update info from a single hunk or patch block.
  */
-export function parseBaselineUpdateFromPatch(guideName: string, patch: string): BaselineUpdateInfo {
-  const addedLines = patch
+export function parseBaselineUpdateFromHunk(guideName: string, hunk: string): BaselineUpdateInfo | null {
+  const addedLines = hunk
     .split('\n')
     .filter(l => l.startsWith('+') && !l.startsWith('+++'))
     .map(l => l.slice(1).trim());
 
-  const removedLines = patch
+  const removedLines = hunk
     .split('\n')
     .filter(l => l.startsWith('-') && !l.startsWith('---'))
     .map(l => l.slice(1).trim());
@@ -199,6 +201,7 @@ export function parseBaselineUpdateFromPatch(guideName: string, patch: string): 
   let statusRank = 3;
   let statusDescription = 'Updated browser engine support';
 
+  // 1. Check added lines for a status transition
   for (const line of addedLines) {
     const match = line.match(/Baseline status for\s+(.+?):\s*(Widely available|Newly available|Limited availability)/i);
     if (match) {
@@ -218,10 +221,17 @@ export function parseBaselineUpdateFromPatch(guideName: string, patch: string): 
     }
   }
 
-  if (featureName.toLowerCase() === 'masks') {
-    featureName = 'CSS Masks';
-  } else if (!featureName) {
-    featureName = guideName;
+  // 2. If status line didn't change (e.g. engine update in Limited status), extract featureName from hunk context
+  if (!featureName) {
+    const match = hunk.match(/Baseline status for\s+(.+?):/i);
+    if (match) {
+      featureName = match[1].trim();
+    }
+  }
+
+  // If the feature name cannot be extracted, omit this update
+  if (!featureName) {
+    return null;
   }
 
   if (statusRank === 3) {
@@ -237,12 +247,36 @@ export function parseBaselineUpdateFromPatch(guideName: string, patch: string): 
     }
   }
 
+  const featureId = resolveWebFeatureId(featureName);
+
   return {
     featureName,
+    featureId,
     statusRank,
     statusDescription,
     guideName,
   };
+}
+
+/**
+ * Extracts all Baseline / browser support update infos from a patch (supporting multi-hunk diffs).
+ */
+export function parseBaselineUpdatesFromPatch(guideName: string, patch: string): BaselineUpdateInfo[] {
+  const hunks = patch.split(/(?=@@ -\d+)/g).filter(h => h.trim());
+  const updates: BaselineUpdateInfo[] = [];
+  for (const hunk of hunks) {
+    if (hasBaselineUpdateInPatch(hunk)) {
+      const update = parseBaselineUpdateFromHunk(guideName, hunk);
+      if (update) {
+        updates.push(update);
+      }
+    }
+  }
+  return updates;
+}
+
+export function parseBaselineUpdateFromPatch(guideName: string, patch: string): BaselineUpdateInfo | null {
+  return parseBaselineUpdatesFromPatch(guideName, patch)[0] || null;
 }
 
 /**
@@ -383,6 +417,40 @@ export function formatGuideBoldLink(guideName: string, ref = 'main'): string {
   return url ? `**[${guideName}](${url})**` : `**${guideName}**`;
 }
 
+// Lookup mapping lowercase feature IDs and display names to canonical feature IDs
+const featureNameToIdMap = new Map<string, string>();
+for (const [id, f] of Object.entries(features)) {
+  featureNameToIdMap.set(id.toLowerCase(), id);
+  if (f.name) {
+    featureNameToIdMap.set(f.name.toLowerCase(), id);
+  }
+}
+
+/**
+ * Resolves the canonical web-features featureId from a feature name.
+ */
+export function resolveWebFeatureId(featureName: string): string | undefined {
+  return featureNameToIdMap.get(featureName.toLowerCase());
+}
+
+/**
+ * Returns the webstatus.dev feature URL if a feature ID is resolved.
+ */
+export function getWebStatusUrl(featureName: string): string | undefined {
+  const featureId = resolveWebFeatureId(featureName);
+  return featureId ? `https://webstatus.dev/features/${featureId}` : undefined;
+}
+
+/**
+ * Formats a web feature name as a markdown bold link to webstatus.dev if resolved, or plain bold if not.
+ */
+export function formatWebFeatureBoldLink(featureName: string, featureId?: string): string {
+  const resolvedId = featureId || resolveWebFeatureId(featureName);
+  return resolvedId
+    ? `**[${featureName}](https://webstatus.dev/features/${resolvedId})**`
+    : `**${featureName}**`;
+}
+
 /**
  * Formats a guide name as a markdown code link if a URL is resolved, or plain code if not.
  */
@@ -431,7 +499,7 @@ export function classifyChanges(records: RawChangeRecord[]): ClassifiedChanges {
         changedFiles.push(relPath);
         if (patch) {
           if (hasBaselineUpdateInPatch(patch)) {
-            baselineUpdates.push(parseBaselineUpdateFromPatch(guideName, patch));
+            baselineUpdates.push(...parseBaselineUpdatesFromPatch(guideName, patch));
           }
           if (!isPatchOnlyBaselineUpdate(patch)) {
             const renameNote = oldGuideName !== guideName
@@ -453,7 +521,7 @@ export function classifyChanges(records: RawChangeRecord[]): ClassifiedChanges {
         changedFiles.push(relPath);
       } else if (patch) {
         if (hasBaselineUpdateInPatch(patch)) {
-          baselineUpdates.push(parseBaselineUpdateFromPatch(guideName, patch));
+          baselineUpdates.push(...parseBaselineUpdatesFromPatch(guideName, patch));
         }
         if (!isPatchOnlyBaselineUpdate(patch)) {
           const substantivePatch = stripBaselineLinesFromPatch(patch);

--- a/serving/skills-cli/release-notes-diff.ts
+++ b/serving/skills-cli/release-notes-diff.ts
@@ -183,6 +183,24 @@ export function stripBaselineLinesFromPatch(patch?: string): string {
   return filtered.join('\n');
 }
 
+function formatList(items: string[]): string {
+  if (items.length <= 1) return items[0] || '';
+  if (items.length === 2) return `${items[0]} and ${items[1]}`;
+  return `${items.slice(0, -1).join(', ')}, and ${items[items.length - 1]}`;
+}
+
+function parseEngineMap(line?: string): Map<string, { raw: string; name: string; version: string }> {
+  if (!line) return new Map();
+  const regex = /(Chrome|Firefox|Safari(?:\s+iOS)?|Edge)\s+(\d+(?:\.\d+)?)/gi;
+  const map = new Map<string, { raw: string; name: string; version: string }>();
+  let m: RegExpExecArray | null;
+  while ((m = regex.exec(line)) !== null) {
+    const key = m[1].toLowerCase().replace(/\s+/g, '_');
+    map.set(key, { raw: m[0], name: m[1], version: m[2] });
+  }
+  return map;
+}
+
 /**
  * Extracts structured Baseline / browser support update info from a single hunk or patch block.
  */
@@ -203,7 +221,7 @@ export function parseBaselineUpdateFromHunk(guideName: string, hunk: string): Ba
 
   // 1. Check added lines for a status transition
   for (const line of addedLines) {
-    const match = line.match(/Baseline status for\s+(.+?):\s*(Widely available|Newly available|Limited availability)/i);
+    const match = line.match(/Baseline status for\s+(.+?):\s*(Widely available|Newly available)/i);
     if (match) {
       featureName = match[1].trim();
       const status = match[2].trim().toLowerCase();
@@ -213,9 +231,6 @@ export function parseBaselineUpdateFromHunk(guideName: string, hunk: string): Ba
       } else if (status.includes('newly')) {
         statusRank = 2;
         statusDescription = 'Now **Baseline Newly available**';
-      } else if (status.includes('limited')) {
-        statusRank = 3;
-        statusDescription = 'Updated Baseline status (**Limited availability**)';
       }
       break;
     }
@@ -223,9 +238,9 @@ export function parseBaselineUpdateFromHunk(guideName: string, hunk: string): Ba
 
   // 2. If status line didn't change (e.g. engine update in Limited status), extract featureName from hunk context
   if (!featureName) {
-    const match = hunk.match(/Baseline status for\s+(.+?):/i);
+    const match = hunk.match(/(?:Baseline status for\s+(.+?):|(.+?)\s+has limited availability)/i);
     if (match) {
-      featureName = match[1].trim();
+      featureName = (match[1] || match[2]).trim();
     }
   }
 
@@ -238,11 +253,49 @@ export function parseBaselineUpdateFromHunk(guideName: string, hunk: string): Ba
     const addedSupported = addedLines.find(l => l.includes('Supported by:'));
     const removedSupported = removedLines.find(l => l.includes('Supported by:'));
     if (addedSupported) {
-      const addedEngines: string[] = addedSupported.match(/(Chrome|Firefox|Safari|Edge)\s+\d+(\.\d+)?/gi) || [];
-      const removedEngines: string[] = removedSupported?.match(/(Chrome|Firefox|Safari|Edge)\s+\d+(\.\d+)?/gi) || [];
-      const newEngines = addedEngines.filter(e => !removedEngines.includes(e));
-      if (newEngines.length > 0) {
-        statusDescription = `Added **${newEngines.join(', ')}** support`;
+      const addedMap = parseEngineMap(addedSupported);
+      const removedMap = parseEngineMap(removedSupported);
+
+      const brandNew: string[] = [];
+      const removedEngines: string[] = [];
+      const versionUpdated: string[] = [];
+
+      for (const [key, info] of addedMap.entries()) {
+        if (!removedMap.has(key)) {
+          brandNew.push(info.raw);
+        } else if (removedMap.get(key)!.version !== info.version) {
+          versionUpdated.push(info.name);
+        }
+      }
+
+      for (const [key, info] of removedMap.entries()) {
+        if (!addedMap.has(key)) {
+          // If a mobile-specific variant (e.g. safari_ios, chrome_android, firefox_android)
+          // is omitted because the desktop base engine is now supported, it was consolidated into full support.
+          const baseKey = key.replace(/_(?:ios|android)$/, '');
+          if (baseKey !== key && addedMap.has(baseKey)) {
+            continue;
+          }
+          removedEngines.push(info.name);
+        }
+      }
+
+      const clauses: string[] = [];
+      if (brandNew.length > 0) {
+        clauses.push(`Added **${formatList(brandNew)}** support`);
+      }
+      if (removedEngines.length > 0) {
+        const verb = clauses.length > 0 ? 'removed' : 'Removed';
+        clauses.push(`${verb} **${formatList(removedEngines)}** support`);
+      }
+      if (versionUpdated.length > 0) {
+        const plural = versionUpdated.length > 1 ? 'versions' : 'version';
+        const verb = clauses.length > 0 ? 'updated' : 'Updated';
+        clauses.push(`${verb} supported browser ${plural} for **${formatList(versionUpdated)}**`);
+      }
+
+      if (clauses.length > 0) {
+        statusDescription = formatList(clauses);
       }
     }
   }

--- a/serving/skills-cli/release-notes-diff.ts
+++ b/serving/skills-cli/release-notes-diff.ts
@@ -470,20 +470,19 @@ export function formatGuideBoldLink(guideName: string, ref = 'main'): string {
   return url ? `**[${guideName}](${url})**` : `**${guideName}**`;
 }
 
-// Lookup mapping lowercase feature IDs and display names to canonical feature IDs
+// Lookup mapping feature display names to canonical web-feature IDs
 const featureNameToIdMap = new Map<string, string>();
 for (const [id, f] of Object.entries(features)) {
-  featureNameToIdMap.set(id.toLowerCase(), id);
-  if (f.name) {
-    featureNameToIdMap.set(f.name.toLowerCase(), id);
+  if (f.kind === 'feature') {
+    featureNameToIdMap.set(f.name, id);
   }
 }
 
 /**
- * Resolves the canonical web-features featureId from a feature name.
+ * Resolves the canonical web-features featureId from a feature display name.
  */
 export function resolveWebFeatureId(featureName: string): string | undefined {
-  return featureNameToIdMap.get(featureName.toLowerCase());
+  return featureNameToIdMap.get(featureName);
 }
 
 /**

--- a/serving/skills-cli/release-notes-diff.ts
+++ b/serving/skills-cli/release-notes-diff.ts
@@ -458,7 +458,7 @@ export function getGuidePathInDistribution(guideName: string): string | undefine
 export function getGuideGithubUrl(guideName: string, ref = 'main'): string | undefined {
   const relPath = getGuidePathInDistribution(guideName);
   if (!relPath) return undefined;
-  const normalizedRef = ref.startsWith('v') || ref === 'main' || ref.startsWith('refs/') ? ref : `v${ref}`;
+const normalizedRef = /^\d+\./.test(ref) ? `v${ref}` : ref;
   return `${GITHUB_REPO_URL}/blob/${normalizedRef}/${relPath}`;
 }
 

--- a/serving/skills-cli/release-notes-diff.ts
+++ b/serving/skills-cli/release-notes-diff.ts
@@ -319,12 +319,76 @@ export function getGuideDescription(relPath: string): string | undefined {
   return undefined;
 }
 
-/**
- * Extracts unique guide identifiers from changed file paths.
- */
 export function getUniqueGuideNames(changedFiles: string[]): string[] {
   const guideFiles = changedFiles.filter(isGuideFile);
   return Array.from(new Set(guideFiles.map(getGuideName)));
+}
+
+export const GITHUB_REPO_URL = 'https://github.com/GoogleChrome/modern-web-guidance';
+
+/**
+ * Resolves the relative path of a guide or skill within the published modern-web-guidance repository.
+ */
+export function getGuidePathInDistribution(guideName: string): string | undefined {
+  if (guideName.endsWith('-skill')) {
+    const skillBase = guideName.slice(0, -'-skill'.length);
+    return `skills/${skillBase}/SKILL.md`;
+  }
+
+  // Check standalone skills in skills-src
+  const skillSrcPath = path.join(rootDir, 'skills-src', guideName, 'SKILL.md');
+  if (fs.existsSync(skillSrcPath)) {
+    return `skills/${guideName}/SKILL.md`;
+  }
+
+  // Check discipline or category skills in guides/
+  const categorySkillPath = path.join(rootDir, 'guides', guideName, 'SKILL.md');
+  if (fs.existsSync(categorySkillPath)) {
+    return `skills/modern-web-guidance/SKILL.md`;
+  }
+
+  // Scan guides/ to find the category for guideName
+  const guidesRootDir = path.join(rootDir, 'guides');
+  if (fs.existsSync(guidesRootDir)) {
+    try {
+      const categories = fs.readdirSync(guidesRootDir, { withFileTypes: true });
+      for (const cat of categories) {
+        if (!cat.isDirectory() || cat.name.startsWith('.') || cat.name === 'node_modules') continue;
+        const candidateDir = path.join(guidesRootDir, cat.name, guideName);
+        if (fs.existsSync(candidateDir) && fs.existsSync(path.join(candidateDir, 'guide.md'))) {
+          return `skills/modern-web-guidance/guides/${cat.name}/${guideName}.md`;
+        }
+      }
+    } catch {}
+  }
+
+  return undefined;
+}
+
+/**
+ * Returns the direct GitHub URL for a guide or skill in GoogleChrome/modern-web-guidance.
+ */
+export function getGuideGithubUrl(guideName: string, ref = 'main'): string | undefined {
+  const relPath = getGuidePathInDistribution(guideName);
+  if (!relPath) return undefined;
+  const normalizedRef = ref.startsWith('v') || ref === 'main' || ref.startsWith('refs/') ? ref : `v${ref}`;
+  return `${GITHUB_REPO_URL}/blob/${normalizedRef}/${relPath}`;
+}
+
+/**
+ * Formats a guide name as a markdown bold link if a URL is resolved, or plain bold if not.
+ */
+export function formatGuideBoldLink(guideName: string, ref = 'main'): string {
+  const url = getGuideGithubUrl(guideName, ref);
+  return url ? `**[${guideName}](${url})**` : `**${guideName}**`;
+}
+
+/**
+ * Formats a guide name as a markdown code link if a URL is resolved, or plain code if not.
+ */
+export function formatGuideCodeLink(guideName: string, ref = 'main'): string {
+  const url = getGuideGithubUrl(guideName, ref);
+  return url ? `[\`${guideName}\`](${url})` : `\`${guideName}\``;
 }
 
 /**

--- a/serving/skills-cli/release-notes-diff.ts
+++ b/serving/skills-cli/release-notes-diff.ts
@@ -458,7 +458,7 @@ export function getGuidePathInDistribution(guideName: string): string | undefine
 export function getGuideGithubUrl(guideName: string, ref = 'main'): string | undefined {
   const relPath = getGuidePathInDistribution(guideName);
   if (!relPath) return undefined;
-const normalizedRef = /^\d+\./.test(ref) ? `v${ref}` : ref;
+  const normalizedRef = /^\d+\./.test(ref) ? `v${ref}` : ref;
   return `${GITHUB_REPO_URL}/blob/${normalizedRef}/${relPath}`;
 }
 

--- a/serving/skills-cli/release-notes-gemini.ts
+++ b/serving/skills-cli/release-notes-gemini.ts
@@ -1,4 +1,5 @@
 import { parseMarkdownBullets } from './release-notes-markdown.ts';
+import { getGuideGithubUrl } from './release-notes-diff.ts';
 
 export interface GeminiResponse {
   candidates?: Array<{
@@ -110,9 +111,10 @@ interface BuildGuideSummaryPromptOptions {
   type: 'new' | 'updated';
   guideNames: string[];
   guideDiff: string;
+  ref?: string;
 }
 
-function buildGuideSummaryPrompt({ type, guideNames, guideDiff }: BuildGuideSummaryPromptOptions): string {
+function buildGuideSummaryPrompt({ type, guideNames, guideDiff, ref = 'main' }: BuildGuideSummaryPromptOptions): string {
   const isNew = type === 'new';
   const label = isNew ? 'newly introduced guides' : 'updated guidance';
   const sectionHeader = isNew ? 'New Guides to Summarize' : 'Updated Guides to Summarize';
@@ -121,14 +123,17 @@ function buildGuideSummaryPrompt({ type, guideNames, guideDiff }: BuildGuideSumm
     ? 'what the new guide introduces and what use case or problem it solves'
     : 'key improvements, best practices, or platform evolutions added to the guide';
   const boldExample = isNew
-    ? '* Introduced a new guide for **State-Aware Sticky Headers** detailing how to build UI headers that react to scroll changes.'
-    : '* Updated the **Prompt API** guide to include best practices for session cloning and model pre-warming.';
+    ? `* Introduced a new guide for **[state-aware-sticky-headers](${getGuideGithubUrl('state-aware-sticky-headers', ref)})** detailing how to build UI headers that react to scroll changes.`
+    : `* Updated the **[translator](${getGuideGithubUrl('translator', ref)})** guide to require accessing the API exclusively via the global \`Translator\` interface.`;
   const focusDesc = isNew ? 'developer guidance and use cases' : 'developer guidance and API patterns';
 
   return `You are writing concise release note bullet points for ${label} in GoogleChrome/modern-web-guidance.
 
 ### ${sectionHeader} (${guideNames.length} total):
-${guideNames.map(g => `- ${g}`).join('\n')}
+${guideNames.map(g => {
+  const url = getGuideGithubUrl(g, ref);
+  return url ? `- ${g} (Link: ${url})` : `- ${g}`;
+}).join('\n')}
 
 ### Content Diff:
 ${guideDiff}
@@ -137,7 +142,7 @@ ${guideDiff}
 1. Output exactly ${guideNames.length} Markdown bullet points (starting with '* ' or '- '), one for each ${targetDesc}.
 2. Each bullet must describe ${contentDesc} in a single concise sentence or short paragraph.
 3. Keep each bullet point on a single line without manual line breaks.
-4. Bold the title or subject of the guide in each bullet (e.g., "${boldExample}").
+4. Bold and link the guide identifier in each bullet using Markdown link syntax (e.g., "${boldExample}").
 5. NEVER use nested sub-bullets or multiple bullet points for a single guide.
 6. Do NOT mention Baseline status or browser compatibility updates (these are tracked separately in the Browser Support section). Focus on substantive ${focusDesc}.
 7. Do NOT include headings, sections, benchmark tables, code blocks, or preamble. Output ONLY the ${guideNames.length} bullet points.`;
@@ -151,8 +156,9 @@ export async function generateNewGuideSummariesWithGemini(opts: {
   guideNames: string[];
   apiKey: string;
   model: string;
+  ref?: string;
 }): Promise<string[] | null> {
-  const { guideDiff, guideNames, apiKey, model } = opts;
+  const { guideDiff, guideNames, apiKey, model, ref = 'main' } = opts;
   if (!guideDiff.trim() || guideNames.length === 0) {
     return [];
   }
@@ -161,6 +167,7 @@ export async function generateNewGuideSummariesWithGemini(opts: {
     type: 'new',
     guideNames,
     guideDiff,
+    ref,
   });
 
   return callGeminiForBullets({
@@ -182,8 +189,9 @@ export async function generateUpdatedGuideSummariesWithGemini(opts: {
   guideNames: string[];
   apiKey: string;
   model: string;
+  ref?: string;
 }): Promise<string[] | null> {
-  const { guideDiff, guideNames, apiKey, model } = opts;
+  const { guideDiff, guideNames, apiKey, model, ref = 'main' } = opts;
   if (!guideDiff.trim() || guideNames.length === 0) {
     return [];
   }
@@ -192,6 +200,7 @@ export async function generateUpdatedGuideSummariesWithGemini(opts: {
     type: 'updated',
     guideNames,
     guideDiff,
+    ref,
   });
 
   return callGeminiForBullets({

--- a/serving/skills-cli/release-notes-gemini.ts
+++ b/serving/skills-cli/release-notes-gemini.ts
@@ -238,7 +238,7 @@ ${pluginDiff}
 
 ### Core Formatting Rules:
 1. Output concise Markdown bullet points (starting with '* ' or '- ') describing what was added or updated across the affected agent platforms, IDEs, or marketplaces.
-2. Bold the name of each agent platform, IDE, or marketplace (e.g., "* Added support for the **Grok** plugin marketplace.").
+2. Bold the specific name of each target agent platform, IDE, or marketplace (e.g., **GitHub Copilot**, **Claude Code**, **Cursor**, **Grok**, **Gemini CLI**) derived from the plugin directory or manifest, rather than the generic package name.
 3. Output at least 1 and at most ${pluginFiles.length} bullet points.
 4. Do NOT mention rote version bumps.
 5. Keep each bullet point on a single line without manual line breaks.

--- a/serving/skills-cli/release-notes-gemini.ts
+++ b/serving/skills-cli/release-notes-gemini.ts
@@ -114,7 +114,7 @@ interface BuildGuideSummaryPromptOptions {
   ref?: string;
 }
 
-function buildGuideSummaryPrompt({ type, guideNames, guideDiff, ref = 'main' }: BuildGuideSummaryPromptOptions): string {
+function buildGuideSummaryPrompt({ type, guideNames, guideDiff }: BuildGuideSummaryPromptOptions): string {
   const isNew = type === 'new';
   const label = isNew ? 'newly introduced guides' : 'updated guidance';
   const sectionHeader = isNew ? 'New Guides to Summarize' : 'Updated Guides to Summarize';
@@ -123,17 +123,14 @@ function buildGuideSummaryPrompt({ type, guideNames, guideDiff, ref = 'main' }: 
     ? 'what the new guide introduces and what use case or problem it solves'
     : 'key improvements, best practices, or platform evolutions added to the guide';
   const boldExample = isNew
-    ? `* Introduced a new guide for **[state-aware-sticky-headers](${getGuideGithubUrl('state-aware-sticky-headers', ref)})** detailing how to build UI headers that react to scroll changes.`
-    : `* Updated the **[translator](${getGuideGithubUrl('translator', ref)})** guide to require accessing the API exclusively via the global \`Translator\` interface.`;
+    ? `* Introduced a new guide for **state-aware-sticky-headers** detailing how to build UI headers that react to scroll changes.`
+    : `* Updated the **translator** guide to require accessing the API exclusively via the global \`Translator\` interface.`;
   const focusDesc = isNew ? 'developer guidance and use cases' : 'developer guidance and API patterns';
 
   return `You are writing concise release note bullet points for ${label} in GoogleChrome/modern-web-guidance.
 
 ### ${sectionHeader} (${guideNames.length} total):
-${guideNames.map(g => {
-  const url = getGuideGithubUrl(g, ref);
-  return url ? `- ${g} (Link: ${url})` : `- ${g}`;
-}).join('\n')}
+${guideNames.map(g => `- ${g}`).join('\n')}
 
 ### Content Diff:
 ${guideDiff}
@@ -142,7 +139,7 @@ ${guideDiff}
 1. Output exactly ${guideNames.length} Markdown bullet points (starting with '* ' or '- '), one for each ${targetDesc}.
 2. Each bullet must describe ${contentDesc} in a single concise sentence or short paragraph.
 3. Keep each bullet point on a single line without manual line breaks.
-4. Bold and link the guide identifier in each bullet using Markdown link syntax (e.g., "${boldExample}").
+4. Bold the guide identifier in each bullet using Markdown bold syntax (e.g., "${boldExample}").
 5. NEVER use nested sub-bullets or multiple bullet points for a single guide.
 6. Do NOT mention Baseline status or browser compatibility updates (these are tracked separately in the Browser Support section). Focus on substantive ${focusDesc}.
 7. Do NOT include headings, sections, benchmark tables, code blocks, or preamble. Output ONLY the ${guideNames.length} bullet points.`;

--- a/serving/skills-cli/release-notes-gemini.ts
+++ b/serving/skills-cli/release-notes-gemini.ts
@@ -110,7 +110,6 @@ interface BuildGuideSummaryPromptOptions {
   type: 'new' | 'updated';
   guideNames: string[];
   guideDiff: string;
-  ref?: string;
 }
 
 function buildGuideSummaryPrompt({ type, guideNames, guideDiff }: BuildGuideSummaryPromptOptions): string {
@@ -152,9 +151,8 @@ export async function generateNewGuideSummariesWithGemini(opts: {
   guideNames: string[];
   apiKey: string;
   model: string;
-  ref?: string;
 }): Promise<string[] | null> {
-  const { guideDiff, guideNames, apiKey, model, ref = 'main' } = opts;
+  const { guideDiff, guideNames, apiKey, model } = opts;
   if (!guideDiff.trim() || guideNames.length === 0) {
     return [];
   }
@@ -163,7 +161,6 @@ export async function generateNewGuideSummariesWithGemini(opts: {
     type: 'new',
     guideNames,
     guideDiff,
-    ref,
   });
 
   return callGeminiForBullets({
@@ -185,9 +182,8 @@ export async function generateUpdatedGuideSummariesWithGemini(opts: {
   guideNames: string[];
   apiKey: string;
   model: string;
-  ref?: string;
 }): Promise<string[] | null> {
-  const { guideDiff, guideNames, apiKey, model, ref = 'main' } = opts;
+  const { guideDiff, guideNames, apiKey, model } = opts;
   if (!guideDiff.trim() || guideNames.length === 0) {
     return [];
   }
@@ -196,7 +192,6 @@ export async function generateUpdatedGuideSummariesWithGemini(opts: {
     type: 'updated',
     guideNames,
     guideDiff,
-    ref,
   });
 
   return callGeminiForBullets({

--- a/serving/skills-cli/release-notes-gemini.ts
+++ b/serving/skills-cli/release-notes-gemini.ts
@@ -1,5 +1,4 @@
 import { parseMarkdownBullets } from './release-notes-markdown.ts';
-import { getGuideGithubUrl } from './release-notes-diff.ts';
 
 export interface GeminiResponse {
   candidates?: Array<{

--- a/serving/skills-cli/release-notes-markdown.ts
+++ b/serving/skills-cli/release-notes-markdown.ts
@@ -32,7 +32,7 @@ export function linkifyGuideBullets(bullets: string[], guideNames: string[], ref
       if (result.includes(`](${url})`)) continue;
 
       // Replace bold markdown: **guideName**
-      const exactBoldRegex = new RegExp(`\\*\\*${escapeRegExp(guideName)}\\*\\*`, 'gi');
+      const exactBoldRegex = new RegExp(`(?<!\\[)\\*\\*${escapeRegExp(guideName)}\\*\\*(?!\\]\\()`, 'gi');
       if (exactBoldRegex.test(result)) {
         result = result.replace(exactBoldRegex, (match) => {
           const inner = match.slice(2, -2);
@@ -42,7 +42,7 @@ export function linkifyGuideBullets(bullets: string[], guideNames: string[], ref
       }
 
       // Replace code markdown: `guideName` (case-sensitive to avoid false positives on API symbols)
-      const codeRegex = new RegExp(`\`${escapeRegExp(guideName)}\``, 'g');
+      const codeRegex = new RegExp(`(?<!\\[)\`${escapeRegExp(guideName)}\`(?!\\]\\()`, 'g');
       if (codeRegex.test(result)) {
         result = result.replace(codeRegex, (match) => {
           return `[${match}](${url})`;

--- a/serving/skills-cli/release-notes-markdown.ts
+++ b/serving/skills-cli/release-notes-markdown.ts
@@ -4,6 +4,7 @@ import {
   getGuideGithubUrl,
   formatGuideBoldLink,
   formatGuideCodeLink,
+  formatWebFeatureBoldLink,
   type BaselineUpdateInfo,
   type EvalSummaryItem,
 } from './release-notes-diff.ts';
@@ -85,13 +86,14 @@ export function parseMarkdownBullets(text: string): string[] {
  * Sorted order: Widely available (1) -> Newly available (2) -> Limited availability (3).
  */
 export function buildBaselineBullets(updates: BaselineUpdateInfo[], ref = 'main'): string[] {
-  const grouped = new Map<string, { featureName: string; statusRank: number; statusDescription: string; guides: string[] }>();
+  const grouped = new Map<string, { featureName: string; featureId?: string; statusRank: number; statusDescription: string; guides: string[] }>();
 
   for (const update of updates) {
     const key = `${update.featureName}::${update.statusRank}::${update.statusDescription}`;
     if (!grouped.has(key)) {
       grouped.set(key, {
         featureName: update.featureName,
+        featureId: update.featureId,
         statusRank: update.statusRank,
         statusDescription: update.statusDescription,
         guides: [],
@@ -112,12 +114,13 @@ export function buildBaselineBullets(updates: BaselineUpdateInfo[], ref = 'main'
 
   return entries.map(entry => {
     const uniqueGuides = Array.from(new Set(entry.guides));
+    const featureLink = formatWebFeatureBoldLink(entry.featureName, entry.featureId);
     if (uniqueGuides.length === 1) {
       const guideLink = formatGuideCodeLink(uniqueGuides[0], ref);
-      return `* **${entry.featureName}**: ${entry.statusDescription} in ${guideLink}.`;
+      return `* ${featureLink}: ${entry.statusDescription} in ${guideLink}.`;
     }
     const guidesList = uniqueGuides.map(g => formatGuideCodeLink(g, ref)).join(', ');
-    return `* **${entry.featureName}**: ${entry.statusDescription} across ${uniqueGuides.length} guides (${guidesList}).`;
+    return `* ${featureLink}: ${entry.statusDescription} across ${uniqueGuides.length} guides (${guidesList}).`;
   });
 }
 

--- a/serving/skills-cli/release-notes-markdown.ts
+++ b/serving/skills-cli/release-notes-markdown.ts
@@ -1,4 +1,5 @@
 import {
+  GITHUB_REPO_URL,
   isPluginFile,
   getUniqueGuideNames,
   getGuideGithubUrl,
@@ -196,7 +197,7 @@ export function buildReleaseNotesMarkdown(opts: BuildReleaseNotesMarkdownOptions
   }
 
   sections.push('---');
-  sections.push(`**Full Changelog**: https://github.com/GoogleChrome/modern-web-guidance/compare/${previousTag}...v${newVersion}`);
+  sections.push(`**Full Changelog**: ${GITHUB_REPO_URL}/compare/${previousTag}...v${newVersion}`);
 
   return sections.join('\n');
 }

--- a/serving/skills-cli/release-notes-markdown.ts
+++ b/serving/skills-cli/release-notes-markdown.ts
@@ -1,9 +1,55 @@
 import {
   isPluginFile,
   getUniqueGuideNames,
+  getGuideGithubUrl,
+  formatGuideBoldLink,
+  formatGuideCodeLink,
   type BaselineUpdateInfo,
   type EvalSummaryItem,
 } from './release-notes-diff.ts';
+
+function escapeRegExp(string: string): string {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Ensures that guide identifiers within bullet points are linked to their document in the modern-web-guidance repository.
+ */
+export function linkifyGuideBullets(bullets: string[], guideNames: string[], ref = 'main'): string[] {
+  return bullets.map((bullet, idx) => {
+    let result = bullet;
+    const prioritizedGuides = guideNames[idx]
+      ? [guideNames[idx], ...guideNames.filter((_, i) => i !== idx)]
+      : guideNames;
+
+    for (const guideName of prioritizedGuides) {
+      const url = getGuideGithubUrl(guideName, ref);
+      if (!url) continue;
+
+      // Skip if this URL is already linked in the bullet
+      if (result.includes(`](${url})`)) continue;
+
+      // Replace bold markdown: **guideName**
+      const exactBoldRegex = new RegExp(`\\*\\*${escapeRegExp(guideName)}\\*\\*`, 'gi');
+      if (exactBoldRegex.test(result)) {
+        result = result.replace(exactBoldRegex, (match) => {
+          const inner = match.slice(2, -2);
+          return `**[${inner}](${url})**`;
+        });
+        continue;
+      }
+
+      // Replace code markdown: `guideName` (case-sensitive to avoid false positives on API symbols)
+      const codeRegex = new RegExp(`\`${escapeRegExp(guideName)}\``, 'g');
+      if (codeRegex.test(result)) {
+        result = result.replace(codeRegex, (match) => {
+          return `[${match}](${url})`;
+        });
+      }
+    }
+    return result;
+  });
+}
 
 /**
  * Parses markdown bullet points, merging multi-line continuations into their parent bullet.
@@ -38,7 +84,7 @@ export function parseMarkdownBullets(text: string): string[] {
  * Deterministically constructs ordered bullet points for Baseline updates.
  * Sorted order: Widely available (1) -> Newly available (2) -> Limited availability (3).
  */
-export function buildBaselineBullets(updates: BaselineUpdateInfo[]): string[] {
+export function buildBaselineBullets(updates: BaselineUpdateInfo[], ref = 'main'): string[] {
   const grouped = new Map<string, { featureName: string; statusRank: number; statusDescription: string; guides: string[] }>();
 
   for (const update of updates) {
@@ -67,9 +113,10 @@ export function buildBaselineBullets(updates: BaselineUpdateInfo[]): string[] {
   return entries.map(entry => {
     const uniqueGuides = Array.from(new Set(entry.guides));
     if (uniqueGuides.length === 1) {
-      return `* **${entry.featureName}**: ${entry.statusDescription} in \`${uniqueGuides[0]}\`.`;
+      const guideLink = formatGuideCodeLink(uniqueGuides[0], ref);
+      return `* **${entry.featureName}**: ${entry.statusDescription} in ${guideLink}.`;
     }
-    const guidesList = uniqueGuides.map(g => `\`${g}\``).join(', ');
+    const guidesList = uniqueGuides.map(g => formatGuideCodeLink(g, ref)).join(', ');
     return `* **${entry.featureName}**: ${entry.statusDescription} across ${uniqueGuides.length} guides (${guidesList}).`;
   });
 }
@@ -175,6 +222,7 @@ export function generateFallbackReleaseNotes(
   const removedNames = categorized?.removedGuideNames ?? [];
   const guideDescriptions = categorized?.guideDescriptions ?? {};
 
+  const targetRef = newVersion.startsWith('v') ? newVersion : `v${newVersion}`;
   let newGuideBullets: string[] = [];
   let updatedGuideBullets: string[] = [];
   let removedGuideBullets: string[] = [];
@@ -182,19 +230,20 @@ export function generateFallbackReleaseNotes(
   if (addedNames.length > 0 || modifiedNames.length > 0 || removedNames.length > 0) {
     newGuideBullets = addedNames.map(g => {
       const desc = guideDescriptions[g];
+      const link = formatGuideBoldLink(g, targetRef);
       return desc
-        ? `* **${g}**: ${desc}`
-        : `* **${g}**: Introduced new web platform guidance.`;
+        ? `* ${link}: ${desc}`
+        : `* ${link}: Introduced new web platform guidance.`;
     });
-    updatedGuideBullets = modifiedNames.map(g => `* **${g}**: Updates and improvements to web platform guidance.`);
+    updatedGuideBullets = modifiedNames.map(g => `* ${formatGuideBoldLink(g, targetRef)}: Updates and improvements to web platform guidance.`);
     removedGuideBullets = removedNames.map(g => `* Removed the **${g}** guide.`);
   } else if (uniqueGuideNames.length > 0) {
     updatedGuideBullets = uniqueGuideNames.map(
-      guideName => `* **${guideName}**: Updates and improvements to web platform guidance.`
+      guideName => `* ${formatGuideBoldLink(guideName, targetRef)}: Updates and improvements to web platform guidance.`
     );
   }
 
-  const baselineBullets = buildBaselineBullets(baselineUpdates);
+  const baselineBullets = buildBaselineBullets(baselineUpdates, targetRef);
 
   const ecosystemBullets = pluginFiles.map(
     file => `* **${file}**: Updates to agent plugin configuration.`


### PR DESCRIPTION
Follow up to #1372 

- References to guides are now linked to the markdown source. The link goes to the MWG dist repo, version-pinned to the tag number of the release.
- References to web features are now linked to their page on webstatus.dev.

Example diff from the v0.0.185 release:

```diff
## 🔄 Updated Guides

-* Updated the **translator** guide to mandate using the global `Translator` interface instead of the deprecated `window.ai.translator` namespace, require user gestures for model downloads, and ensure identical language options are passed to both availability and creation methods.
+* Updated the **[translator](https://github.com/GoogleChrome/modern-web-guidance/blob/v0.0.185/skills/modern-web-guidance/guides/built-in-ai/translator.md)** guide to mandate using the global `Translator` interface instead of the deprecated `window.ai.translator` namespace, require user gestures for model downloads, and ensure identical language options are passed to both availability and creation methods.

## 🌐 Browser Support Updates

-* **sibling-count() and sibling-index()**: Now **Baseline Newly available** across 2 guides (`dynamic-sibling-styling`, `dynamic-sibling-animations`).
+* **[sibling-count() and sibling-index()](https://webstatus.dev/features/sibling-count)**: Now **Baseline Newly available** across 2 guides ([`dynamic-sibling-styling`](https://github.com/GoogleChrome/modern-web-guidance/blob/v0.0.185/skills/modern-web-guidance/guides/css/dynamic-sibling-styling.md), [`dynamic-sibling-animations`](https://github.com/GoogleChrome/modern-web-guidance/blob/v0.0.185/skills/modern-web-guidance/guides/ui-behaviors/dynamic-sibling-animations.md)).
```