### PR TITLE
Codex plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,14 @@ grok plugin install https://github.com/GoogleChrome/modern-web-guidance --trust
 ```
 </details>
 
+<details>
+<summary><b>OpenAI Codex</b></summary>
+
+```shell
+codex plugin marketplace add GoogleChrome/modern-web-guidance
+```
+</details>
+
 ## <img src="https://github.com/GoogleChrome/modern-web-guidance/raw/main/.github/img/refresh-cw.svg" width="24" height="24" style="vertical-align: middle; margin-right: 4px;"> Updating
 
 If you installed the skill using `npx modern-web-guidance@latest install`, you can update with: `npx modern-web-guidance@latest update`.

--- a/guides/modern-web-guidance/SKILL.md
+++ b/guides/modern-web-guidance/SKILL.md
@@ -90,8 +90,8 @@ When generating or modifying code, cross-check the implementation against the re
 
 -   IMPORTANT: on Windows, using `npx` may fail. Use `npx.cmd ...` instead.
 -   Network access is required for fetching npm packages needed by the task.
--   If the `npx -y modern-web-guidance…` command hangs, you may be offline. Try running again in offline
-    mode: `npx --offline …`.
+-   If the `npx -y modern-web-guidance…` command reports a registry or network error, hangs, or produces no result, retry the same command with the environment's normal network approval. Do not treat empty output as a successful search.
+-   If the command hangs due to being offline, try running again in offline mode: `npx --offline …`.
 -   The `--skill-version` flag is used to determine if this SKILL.md is out of date. If it is, a warning
     message is logged to stderr.
 

--- a/guides/modern-web-guidance/SKILL.md
+++ b/guides/modern-web-guidance/SKILL.md
@@ -90,20 +90,19 @@ When generating or modifying code, cross-check the implementation against the re
 
 ## Using npx / pnpx
 
--   Prefer `pnpx` over `npx` if `pnpm` is available (note: `pnpx` does not use the `-y` flag).
--   When requesting tool permissions, allowlist `npx -y modern-web-guidance@latest *` specifically (or `pnpx modern-web-guidance@latest *`), never bare `npx *` or `pnpx *`.
--   IMPORTANT: on Windows, using `npx` may fail. Use `npx.cmd ...` instead.
--   Network access is required for fetching npm packages needed by the task.
--   If the `npx -y modern-web-guidance…` command reports a registry or network error, hangs, or produces no result, retry the same command with the environment's normal network approval. Do not treat empty output as a successful search.
--   If the command hangs due to being offline, try running again in offline mode: `npx --offline …`.
--   The `--skill-version` flag is used to determine if this SKILL.md is out of date. If it is, a warning
-    message is logged to stderr.
+- Prefer `pnpx` over `npx` if `pnpm` is available (note: `pnpx` does not use the `-y` flag).
+- When requesting tool permissions, allowlist `npx -y modern-web-guidance@latest *` specifically (or `pnpx modern-web-guidance@latest *`), never bare `npx *` or `pnpx *`.
+- IMPORTANT: on Windows, using `npx` may fail. Use `npx.cmd ...` instead.
+- Fetching and running `modern-web-guidance` requires outbound network access. If running in a sandboxed, permission-gated, or approval-based environment (e.g., Codex, Claude Code), **proactively request approval/allowlisting for the command with network access BEFORE executing it the first time**, avoiding sandbox network timeouts.
+- In sandboxed environments where `~/.npm` is read-only or restricted, set `NPM_CONFIG_CACHE=/tmp/npm-cache`.
+- If the command hangs due to being offline, try running again in offline mode: `npx --offline …`.
+- The `--skill-version` flag is used to determine if this SKILL.md is out of date. If it is, a warning message is logged to stderr.
 
 ## Guidelines
 
--   Always search **first** to find the most relevant guides.
--   These guides are usually framework-agnostic; adapt them correctly to your setup.
--   Do not hallucinate guides or ignore them; they represent the preferred local standard for the user's project.
+- Always search **first** to find the most relevant guides.
+- These guides are usually framework-agnostic; adapt them correctly to your setup.
+- Do not hallucinate guides or ignore them; they represent the preferred local standard for the user's project.
 
 ## Interpreting Browser Support & Fallbacks
 

--- a/serving/skills-cli/RELEASING.md
+++ b/serving/skills-cli/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing Modern Web Guidance Skills
 
-To release updates for our AI skills (Claude Code, Gemini CLI / Antigravity, VS Code, Cursor, GitHub Copilot CLI, Grok, and Kimi Code), we use an automated pipeline that bundles our source files into a lightweight distribution pack (`dist/skills-cli/`) and publishes it to `GoogleChrome/modern-web-guidance`.
+To release updates for our AI skills (Claude Code, Gemini CLI / Antigravity, VS Code, Cursor, GitHub Copilot CLI, Grok, Kimi Code, and OpenAI Codex), we use an automated pipeline that bundles our source files into a lightweight distribution pack (`dist/skills-cli/`) and publishes it to `GoogleChrome/modern-web-guidance`.
 
 ## Automated CI/CD Publishing
 

--- a/serving/skills-cli/build-dist.ts
+++ b/serving/skills-cli/build-dist.ts
@@ -82,6 +82,11 @@ function updateVersionsInDir(publishCliDir: string, newVersion: string) {
   grokMarketplaceData.plugins[0].version = newVersion;
   fs.writeFileSync(grokMarketplacePath, JSON.stringify(grokMarketplaceData, null, 2) + '\n');
 
+  // Codex Plugin
+  const codexPluginPath = path.join(publishCliDir, ".codex-plugin/plugin.json");
+  const codexPluginData = JSON.parse(fs.readFileSync(codexPluginPath, 'utf8'));
+  codexPluginData.version = newVersion;
+  fs.writeFileSync(codexPluginPath, JSON.stringify(codexPluginData, null, 2) + '\n');
 }
 
 export function processSkills(publishRoot: string) {

--- a/serving/skills-cli/build-dist.ts
+++ b/serving/skills-cli/build-dist.ts
@@ -87,6 +87,16 @@ function updateVersionsInDir(publishCliDir: string, newVersion: string) {
   const codexPluginData = JSON.parse(fs.readFileSync(codexPluginPath, 'utf8'));
   codexPluginData.version = newVersion;
   fs.writeFileSync(codexPluginPath, JSON.stringify(codexPluginData, null, 2) + '\n');
+
+  // Codex Marketplace
+  const codexMarketplacePath = path.join(publishCliDir, ".agents/plugins/marketplace.json");
+  if (fs.existsSync(codexMarketplacePath)) {
+    const codexMarketplaceData = JSON.parse(fs.readFileSync(codexMarketplacePath, 'utf8'));
+    if (codexMarketplaceData.plugins?.[0]) {
+      codexMarketplaceData.plugins[0].version = newVersion;
+    }
+    fs.writeFileSync(codexMarketplacePath, JSON.stringify(codexMarketplaceData, null, 2) + '\n');
+  }
 }
 
 export function processSkills(publishRoot: string) {

--- a/serving/skills-cli/generate-release-notes.test.ts
+++ b/serving/skills-cli/generate-release-notes.test.ts
@@ -211,6 +211,7 @@ test('getUniqueGuideNames deduplicates guide paths, includes SKILL.md, and filte
 
 test('isPluginFile correctly identifies plugin and manifest files', () => {
   assert.strictEqual(isPluginFile('.claude-plugin/plugin.json'), true);
+  assert.strictEqual(isPluginFile('.codex-plugin/plugin.json'), true);
   assert.strictEqual(isPluginFile('.grok-plugin/marketplace.json'), true);
   assert.strictEqual(isPluginFile('gemini-extension.json'), true);
   assert.strictEqual(isPluginFile('skills/modern-web-guidance/SKILL.md'), false);

--- a/serving/skills-cli/template/.agents/plugins/marketplace.json
+++ b/serving/skills-cli/template/.agents/plugins/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "name": "googlechrome",
+  "interface": {
+    "displayName": "Google Chrome"
+  },
+  "plugins": [
+    {
+      "name": "modern-web-guidance",
+      "source": {
+        "source": "local",
+        "path": "./"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Development",
+      "version": "0.0.26"
+    }
+  ]
+}

--- a/serving/skills-cli/template/.codex-plugin/plugin.json
+++ b/serving/skills-cli/template/.codex-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "modern-web-guidance",
+  "description": "Keep your coding agent up to date with the latest web best practices",
+  "version": "0.0.26",
+  "skills": "./skills/",
+  "author": {
+    "name": "Google Chrome"
+  }
+}

--- a/serving/skills-cli/template/.codex-plugin/plugin.json
+++ b/serving/skills-cli/template/.codex-plugin/plugin.json
@@ -1,9 +1,35 @@
 {
   "name": "modern-web-guidance",
-  "description": "Keep your coding agent up to date with the latest web best practices",
   "version": "0.0.26",
-  "skills": "./skills/",
+  "description": "Keep your coding agent up to date with the latest web best practices",
   "author": {
-    "name": "Google Chrome"
+    "name": "Google Chrome",
+    "url": "https://developer.chrome.com"
+  },
+  "homepage": "https://developer.chrome.com/docs/modern-web-guidance",
+  "repository": "https://github.com/GoogleChrome/modern-web-guidance",
+  "license": "Apache-2.0",
+  "keywords": [
+    "web",
+    "html",
+    "css",
+    "javascript",
+    "best-practices"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Modern Web Guidance",
+    "shortDescription": "Keep your coding agent up to date with modern web platform best practices",
+    "longDescription": "Modern Web Guidance is an agent skill and CLI tool designed to help AI coding agents build web applications using modern, secure, and high-performance APIs rather than outdated workarounds. Supported by the Google Chrome team, it injects expert-curated web platform best practices directly into an agent's context window to prevent the generation of bloated, legacy code.",
+    "developerName": "Google Chrome",
+    "category": "Development",
+    "capabilities": [
+      "Read"
+    ],
+    "websiteURL": "https://developer.chrome.com/docs/modern-web-guidance",
+    "defaultPrompt": [
+      "Audit this project for modern web best practices and modernization opportunities",
+      "What is the recommended modern way to implement responsive dialogs and popovers?"
+    ]
   }
 }

--- a/serving/skills-cli/template/README.md
+++ b/serving/skills-cli/template/README.md
@@ -163,6 +163,14 @@ grok plugin install https://github.com/GoogleChrome/modern-web-guidance --trust
 ```
 </details>
 
+<details>
+<summary><b>OpenAI Codex</b></summary>
+
+```shell
+codex plugin marketplace add GoogleChrome/modern-web-guidance
+```
+</details>
+
 ## <img src="https://github.com/GoogleChrome/modern-web-guidance/raw/main/.github/img/refresh-cw.svg" width="24" height="24" style="vertical-align: middle; margin-right: 4px;"> Updating
 
 If you installed the skill using `npx modern-web-guidance@latest install`, you can update with: `npx modern-web-guidance@latest update`.

--- a/serving/skills-cli/test-dist.test.ts
+++ b/serving/skills-cli/test-dist.test.ts
@@ -70,6 +70,16 @@ test('Codex Plugin Config in Dist', async () => {
   await assert.doesNotReject(fs.access(resolvedSkillsDir), `Codex skills path ${pluginJson.skills} must resolve to a valid directory`);
   const skillMdPath = path.join(resolvedSkillsDir, 'modern-web-guidance/SKILL.md');
   await assert.doesNotReject(fs.access(skillMdPath), `Codex skills directory must contain modern-web-guidance/SKILL.md`);
+
+  // Codex Marketplace config validation
+  const marketplaceJsonRaw = await fs.readFile(path.join(STAGING_DIR, '.agents/plugins/marketplace.json'), 'utf8');
+  const marketplaceJson = JSON.parse(marketplaceJsonRaw);
+  assert.strictEqual(marketplaceJson.name, 'googlechrome', 'marketplace.json name should be googlechrome');
+  assert.strictEqual(marketplaceJson.interface.displayName, 'Google Chrome', 'marketplace.json displayName should match');
+  assert.ok(Array.isArray(marketplaceJson.plugins) && marketplaceJson.plugins.length > 0, 'marketplace must declare plugins');
+  assert.strictEqual(marketplaceJson.plugins[0].name, 'modern-web-guidance');
+  assert.strictEqual(marketplaceJson.plugins[0].category, 'Development');
+  assert.strictEqual(marketplaceJson.plugins[0].version, pkgJson.version);
 });
 
 test('Gemini and VS Code manifests', async () => {

--- a/serving/skills-cli/test-dist.test.ts
+++ b/serving/skills-cli/test-dist.test.ts
@@ -53,6 +53,25 @@ test('Grok Plugin Config in Dist', async () => {
   assert.strictEqual(marketplaceJson.plugins[0].source, './');
 });
 
+test('Codex Plugin Config in Dist', async () => {
+  const pluginJsonRaw = await fs.readFile(path.join(STAGING_DIR, '.codex-plugin/plugin.json'), 'utf8');
+  const pluginJson = JSON.parse(pluginJsonRaw);
+  assert.strictEqual(pluginJson.name, 'modern-web-guidance', 'plugin.json name should match');
+  assert.strictEqual(pluginJson.author.name, 'Google Chrome', 'plugin.json author should be Google Chrome');
+  assert.strictEqual(pluginJson.skills, './skills/', 'plugin.json skills should point to ./skills/');
+
+  // updateVersionsInDir must keep the manifest version in sync with the rest of the distribution
+  const pkgJson = JSON.parse(await fs.readFile(path.join(STAGING_DIR, 'package.json'), 'utf8'));
+  assert.strictEqual(pluginJson.version, pkgJson.version, 'plugin.json version should match package.json version');
+
+  // Codex resolves skills directory relative to the plugin root (the dist dir)
+  assert.ok(pluginJson.skills.startsWith('./'), `Codex skills path ${pluginJson.skills} must start with './'`);
+  const resolvedSkillsDir = path.join(STAGING_DIR, pluginJson.skills);
+  await assert.doesNotReject(fs.access(resolvedSkillsDir), `Codex skills path ${pluginJson.skills} must resolve to a valid directory`);
+  const skillMdPath = path.join(resolvedSkillsDir, 'modern-web-guidance/SKILL.md');
+  await assert.doesNotReject(fs.access(skillMdPath), `Codex skills directory must contain modern-web-guidance/SKILL.md`);
+});
+
 test('Gemini and VS Code manifests', async () => {
   const geminiJson = JSON.parse(await fs.readFile(path.join(STAGING_DIR, 'gemini-extension.json'), 'utf8'));
   assert.strictEqual(geminiJson.name, 'modern-web-guidance');


### PR DESCRIPTION
Codex is running MWG in a sandbox and it's unable to call out to `npx`:
<img width="2156" height="1272" alt="image" src="https://github.com/user-attachments/assets/0d3a4368-a793-472c-b1b6-301e7947de34" />

<details>
<summary>Codex CLI response</summary>

# Codex conversation

## User

@Modern-Web-Guidance what's the fallback if interest invokers doesn't meet my baseline target

## Assistant

I’m checking the current platform guidance because Invoker Commands are still evolving and your Chrome-only baseline changes the practical fallback.

## Activity

    $ /bin/bash -lc "sed -n '1,240p' /Users/rviscomi/.codex/plugins/cache/googlechrome/modern-web-guidance/0.0.185/skills/modern-web-guidance/SKILL.md"
    status: Completed · exit 0
      ---
      name: modern-web-guidance
      description: |
        Search tool for modern web development best practices. MANDATORY: Execute FIRST for all HTML/CSS and clientside JS tasks. Do NOT skip — web APIs evolve rapidly and training weights contain obsolete patterns.
      
        Trigger immediately for:
        - UI/Layout: Modals, dialogs, popovers, Glassmorphism/backdrop-filters, anchor positioning, container queries, `:has()`, `:user-valid`.
        - Scroll/Motion: View Transitions, Scroll-driven animations, scroll parallax/reveals.
        - Performance: CWV (LCP, INP), content-visibility, Fetch Priority, image optimization.
        - System/APIs: Local filesystem access, WebUSB, WebSockets sync, WebAssembly widgets.
        - Frameworks: Adapting layout/styles in React, Vue, Angular.
        - General Frontend: Forms, autofill, advanced inputs, custom scrollbars, modern component states, etc.
      
        DO NOT trigger for:
        - Backend: Database SQL, ORMs, Express API routes.
        - Pipelines: CI/CD deployment, Docker, Actions.
        - Generic: Local scripts (Python/Go tools), ESLint, Git.
      ---
      
      # Modern Web Guidance
      
      A skill to search for specific web development use cases and retrieve their corresponding best practice guides.
      
      ## When to use
      
      Must use this skill:
      - At the **start** of implementing any web feature.
      - Before creating a new component, to check if a standardized pattern already exists.
      - To avoid implementing ad-hoc solutions or loading large dependencies unnecessarily.
      
      ## Usage Instructions
      
      ### Step 1. Search Use Cases
      
      Search with an action-oriented query summarizing what you want to achieve using the `search` command. Run `modern-web-guidance` directly with `npx`.
      
      ```sh
      npx -y modern-web-guidance@latest search "<query>" --skill-version 2026_08_28-acbcfdb0
      ```
      
      **Example Output**:
      ```json
      [
        {
          "id": "optimize-image-priority",
          "description": "Optimize the loading priority of Largest Contentful Paint (LCP) candidate images.",
          "category": "performance",
          "featuresUsed": [ "Fetch priority" ],
          "tokenCount": 985,
          "similarity": 0.7289
        },
        {
          "id": "defer-rendering-heavy-content",
          "description": "Reduce rendering times in content-heavy web pages by deferring rendering for offscreen content.",
          "category": "performance",
          "featuresUsed": [ "content-visibility", "hidden=\"until-found\"" ],
          "tokenCount": 1250,
          "similarity": 0.6961
        }
      ]
      ```
      
      > **Note**: If search results are vague, return no matches, or show low similarity scores, run the `list` command to browse all guides:
      > ```sh
      > npx -y modern-web-guidance@latest list
      > ```
      
      ---
      
      ### Step 2. Retrieve Best Practices
      
      Once you have a relevant `id` from the search results, call this script using the `retrieve` command to get the full guide. You can pass multiple IDs separated by commas.
      
      ```sh
      npx -y modern-web-guidance@latest retrieve "<id>"
      ```
      
      **Example Output**:
      `The markdown content of the guide describing implementation steps...`
      
      ---
      
      ### Step 3. Verify Guidance Compliance
      
      When generating or modifying code, cross-check the implementation against the retrieved guide before concluding:
      - **Applicable Guidance & Fallbacks**: Ensure the relevant modern patterns and necessary fallback strategies from the guide are correctly applied, without forcing unrequested features.
      - **Task Fulfillment**: Confirm that the implementation fully satisfies the user's request.
      
      ## Using npx
      
      -   IMPORTANT: on Windows, using `npx` may fail. Use `npx.cmd ...` instead.
      -   Network access is required for fetching npm packages needed by the task.
      -   If the `npx -y modern-web-guidance…` command hangs, you may be offline. Try running again in offline
          mode: `npx --offline …`.
      -   The `--skill-version` flag is used to determine if this SKILL.md is out of date. If it is, a warning
          message is logged to stderr.
      
      ## Guidelines
      
      -   Always search **first** to find the most relevant guides.
      -   These guides are usually framework-agnostic; adapt them correctly to your setup.
      -   Do not hallucinate guides or ignore them; they represent the preferred local standard for the user's project.
      
      ## Interpreting Browser Support & Fallbacks
      
      * **Default Behavior**: All guides assume **Baseline Widely available** features are safe to use without fallbacks. For features that are not Baseline widely available, you **MUST** follow the fallback recommendations in the guide, unless the user has specified a custom browser support policy.
      * **Custom Policies**: If the user has already defined explicit browser support requirements, use the browser compatibility data in the guide to determine if a fallback can be safely ignored.
        - For Baseline YYYY targets, a feature satisfies this target if its "Baseline since" date is <= YYYY.
        - **Policy Examples**:
          - _"Do not implement feature fallbacks."_ (for exploratory prototypes of the cutting-edge web)
          - _"Safari 17.4+"_ (for internal tools targeting macOS or Tauri-based desktop apps)
          - _"Never recommend or implement polyfills; if a Baseline Newly Available feature is required for core functionality, provide a lightweight custom fallback or redesign the approach."_ (to minimize bundle size and avoid technical debt)
          - _"Assume a modern execution environment where Baseline Newly Available features can be used natively, provided they are strictly feature-detected and degrade gracefully."_ (for progressive enhancement strategies)
      * **Reactive Policy Discovery**: Watch for environmental cues to suggest documenting a policy in CLAUDE.md or AGENTS.md. Suggest this if the developer:
        - Mentions building for a restricted runtime (e.g., Electron or Tauri).
        - Explicitly excludes specific targets (e.g., "we don't support Desktop Chrome").
        - Expresses hesitation about polyfill complexity, bundle size, or performance cost.
        - Questions if a feature is safe to use without fallbacks.
      
        No defined policy format. This is an example: `**Browser Support:** Allow Newly Available features, but only adopt custom fallback code that adds <= 20 lines and does not require external dependencies.`

## Activity

    web search: Invoker Commands interestfor invoketarget official Chrome documentation fallback interest invokers ...

## Activity

    $ /bin/bash -lc 'npx -y modern-web-guidance@latest search "provide accessible fallback for invoker commands interest invokers hover preview" --skill-version 2026_08_28-acbcfdb0'
    status: Failed · exit 1
      npm error code ENOTFOUND
      npm error syscall getaddrinfo
      npm error errno ENOTFOUND
      npm error network request to https://registry.npmjs.org/modern-web-guidance failed, reason: getaddrinfo ENOTFOUND registry.npmjs.org
      npm error network This is a problem related to network connectivity.
      npm error network In most cases you are behind a proxy or have bad network settings.
      npm error network
      npm error network If you are behind a proxy, please make sure that the
      npm error network 'proxy' config is set properly.  See: 'npm help config'
      npm error Log files were not written due to an error writing to the directory: /Users/rviscomi/.npm/_logs
      npm error You can rerun the command with `--loglevel=verbose` to see the logs in your terminal

## Activity

    web search: Invoker Commands interestfor invoketarget official Chrome documentation fallback interest invokers ...

## Assistant

For your Chrome-only target, interest invokers are acceptable if you require Chrome 142+. They’re still “Limited availability” globally because Firefox and Safari don’t support them, but that does not conflict with your stated baseline. [Support data](https://caniuse.com/wf-interest-invokers)

If you need to support older Chrome too, progressively enhance:

```js
const supportsInterestInvokers = Object.hasOwn(
  HTMLButtonElement.prototype,
  "interestForElement",
);

if (!supportsInterestInvokers) {
  // Attach pointer/focus listeners to show and hide the preview yourself.
}
```

The fallback should be a small JS hover-and-focus preview: show on `pointerenter` / `focusin`, hide on `pointerleave` / `focusout`, and allow `Escape` to dismiss. Keep the invoker a real link or button and make the preview’s information available through the normal destination/action—don’t make hover-only content essential.

For interactive preview cards, use click-to-toggle (`popover` where supported) as the fallback instead of auto-hiding on pointer leave. MDN recommends feature detection via `interestForElement` specifically. [MDN guidance](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API/Using_interest_invokers)

## Activity

    $ /bin/bash -lc 'npx -y modern-web-guidance@latest search "invoker commands" --skill-version 2026_08_28-acbcfdb0'
    status: Failed · exit 1
      npm error code ENOTFOUND
      npm error syscall getaddrinfo
      npm error errno ENOTFOUND
      npm error network request to https://registry.npmjs.org/modern-web-guidance failed, reason: getaddrinfo ENOTFOUND registry.npmjs.org
      npm error network This is a problem related to network connectivity.
      npm error network In most cases you are behind a proxy or have bad network settings.
      npm error network
      npm error network If you are behind a proxy, please make sure that the
      npm error network 'proxy' config is set properly.  See: 'npm help config'
      npm error Log files were not written due to an error writing to the directory: /Users/rviscomi/.npm/_logs
      npm error You can rerun the command with `--loglevel=verbose` to see the logs in your terminal

## User

it looks like you're unable to use the MWG CLI. find a way to make it work

## Assistant

I’ll fix the CLI path rather than treating the silent result as a valid search. I’m using the Modern Web Guidance skill again to validate its required invocation and then isolate whether this is an `npx`, network, or CLI-output issue.

## Activity

    $ /bin/bash -lc 'node --versionnpm --versionnpx --versionnpx --yes --offline modern-web-guidance@latest --helpnpm cache ls modern-web-guidance'
    status: Completed · exit 0
      10.9.4
      10.9.4
      npm error code ENOTCACHED
      npm error request to https://registry.npmjs.org/modern-web-guidance failed: cache mode is 'only-if-cached' but no cached response is available.
      npm error Log files were not written due to an error writing to the directory: /Users/rviscomi/.npm/_logs
      npm error You can rerun the command with `--loglevel=verbose` to see the logs in your terminal
      make-fetch-happen:request-cache:https://registry.npmjs.org/modern-web-guidance
      make-fetch-happen:request-cache:https://registry.npmjs.org/modern-web-guidance/-/modern-web-guidance-0.0.177.tgz
      make-fetch-happen:request-cache:https://registry.npmjs.org/modern-web-guidance/-/modern-web-guidance-0.0.179.tgz
      make-fetch-happen:request-cache:https://registry.npmjs.org/modern-web-guidance/-/modern-web-guidance-0.0.180.tgz
      make-fetch-happen:request-cache:https://registry.npmjs.org/modern-web-guidance/-/modern-web-guidance-0.0.183.tgz
      make-fetch-happen:request-cache:https://registry.npmjs.org/modern-web-guidance/-/modern-web-guidance-0.0.184.tgz
      make-fetch-happen:request-cache:https://registry.npmjs.org/modern-web-guidance/-/modern-web-guidance-0.0.185.tgz

## Activity

    $ /bin/bash -lc 'npm exec --yes --package=modern-web-guidance@latest -- modern-web-guidance search "interest invokers" --skill-version 2026_08_28-acbcfdb0'
    status: Completed · exit 0
      [{"id":"interest-triggered-action-previews","description":"Show a live preview of a button's effect when a user signals interest (e.g. hovering, focusing, or long-pressing) but before they commit to clicking.","category":"ui-behaviors","featuresUsed":["Interest invokers"],"tokenCount":1123,"similarity":0.4542},
      {"id":"interest-triggered-tooltips","description":"Show a tooltip or supplemental information when a user hovers over, focuses on, or long-presses an interactive element, without requiring a click.","category":"ui-behaviors","featuresUsed":["Interest invokers","Popover","popover=\"hint\"","Anchor positioning"],"tokenCount":2330,"similarity":0.3437},
      {"id":"custom-button-actions","description":"Declaratively connect a button to any element to trigger custom, application-specific actions using declarative button commands, invoker commands, button commands, custom commands, or declarative toggle actions.","category":"ui-behaviors","featuresUsed":["Invoker commands"],"tokenCount":2090,"similarity":0.3083}]

## Activity

    $ /bin/bash -lc 'npx -y modern-web-guidance@latest retrieve "interest-triggered-tooltips"'
    status: Completed · exit 0
      
      --- Guide for interest-triggered-tooltips ---
      # Show a tooltip when hovering
      
      Users expect to see additional related information without completely changing their context. Showing a tooltip when a user is interested in more information can be useful to provide definitions for a term, clarifying the action an icon-only button will take, or provide additional form field guidance.
      
      ## Creating the tooltip
      
      You can create a popover with the required behavior by adding the `popover="hint"` attribute to a `<div>` or other semantically appropriate element. When the user opens the tooltip, this hides other `popover="hint"` tooltips, but doesn't hide `auto` or `manual` tooltips. It also handles dismissing nested tooltips.
      
      It also provides light dismiss behavior, so when a user clicks or otherwise focuses outside of the popover, the popover is dismissed.
      
      The tooltip element must have an `id` attribute with a unique value:
      
      ```html
      <!-- MANDATORY: The tooltip container `<div>` must have a `popover` attribute.
           the value of `"hint"` ensures it can be "light dismissed". -->
      <div popover="hint" id="tooltip">Tooltip content</div>
      ```
      
      A user expresses interest in the additional information by hovering or focusing on an `<a>` or `<button>` element. The element must have an `interestfor` attribute that matches the `id` attribute of the tooltip.
      
      ```html
      <!-- The `interestfor` attribute can be applied to a `<button>` element: -->
      <button interestfor="tooltip">Tooltip trigger</button>
      
      <!-- The `interestfor` attribute can also be applied to an `<a>` element: -->
      <a interestfor="tooltip" href="">Tooltip trigger</a>
      ```
      
      The trigger must have a visual indicator to indicate that there is additional information available by interacting with the trigger.
      
      ### Accessibility built in to `interestfor`
      
      `interestfor` handles the assistive-technology wiring for you, so you generally do not need to add ARIA attributes manually:
      
      - A target with `popover="hint"` gains an implicit minimum role of `tooltip`. **DO NOT** set `role="tooltip"` yourself.
      - The browser implicitly associates the source element with the target via `aria-describedby` when the target is plaintext, or via `aria-details` when the target contains interactive content. **DO NOT** add `aria-describedby` or `aria-details` to the trigger.
      - Because the association switches to `aria-details` when needed, the target IS allowed to contain interactive content (e.g. a link inside an "interest card").
      
      ### Accessibility Constraints (WCAG 1.4.13)
      
      Even with `interestfor` handling the semantics above, your implementation MUST still satisfy WCAG 1.4.13 (Content on Hover or Focus):
      - **Dismissible:** Users must be able to dismiss the tooltip without moving pointer hover or keyboard focus (e.g., by pressing the `Escape` key). The native `popover` attribute manages this binding automatically.
      - **Hoverable:** The pointer must be able to move over the tooltip content itself without the tooltip disappearing. This allows users with magnification tools to read the tooltip text safely.
      - **Persistent:** The tooltip must remain visible until the hover or focus trigger is removed, the user explicitly dismisses it, or its content is no longer valid.
      
      ### Positioning the tooltip
      
      The tooltip can be positioned using anchor positioning. When the tooltip is opened using `interestfor`, the trigger becomes an implicit anchor for the tooltip, meaning you don't have to add `anchor-name` or `position-anchor` CSS properties. However, to support browsers without anchor positioning you must use the anchor positioning polyfill, which has several limitations for popovers. **MANDATORY:** Implicit anchors are NOT supported by the polyfill, so YOU MUST explicitly set an `anchor-name` on the trigger and `position-anchor` on the popover.
      
      
      ```css
      /* MANDATORY: use explicit anchor names for compatibility with the polyfill */
      button[interestfor="tooltip-dom"] {
        anchor-name: --tooltip-dom;
      }
      #tooltip-dom {
        position-anchor: --tooltip-dom;
      }
      ```
      
      Also, the polyfill does not support `position-area` on popovers, so **MANDATORY:** DO position using `anchor()` functions, and **YOU MUST** include a `position-try` fallback (e.g. `flip-block` or `flip-inline`).
      
      ```css
      [popover]{
        /* MANDATORY: use anchor functions and a position-try fallback for the polyfill */
        top: anchor(bottom);
        left: anchor(center);
        position-try: flip-block;
        margin: unset;
      }
      ```
      
      
      ### Fallback strategies
      
      Interest invokers has limited availability.
      Supported by: Chrome 142 (Oct 2025) and Edge 142 (Oct 2025).
      Unsupported in: Firefox and Safari.
      
      Interest invokers must be conditionally polyfilled using the `interestfor` polyfill package from NPM. Do prefer bundling the polyfill over using the CDN.
      
      ```html
      <script type="module">
        if(!HTMLButtonElement.prototype.hasOwnProperty("interestForElement")){
          // CDN link only used for example, prefer bundling.
          await import("https://unpkg.com/interestfor@latest");
        }
      </script>
      ```
      
      ### Fallbacks & browser support for Popover
      
      Baseline status for Popover: Newly available. It's been Baseline since 2025-01-27.
      Supported by: Chrome 116 (Aug 2023), Edge 116 (Aug 2023), Firefox 125 (Apr 2024), Safari 17 (Sep 2023), and Safari iOS 18.3 (Jan 2025).
      
      The Popover API is mostly **progressive enhancement**, but its defining behaviors — top-layer promotion, light-dismiss, and `popovertarget` invocation — have no CSS-only equivalent. Older browsers need a polyfill, or a manual fallback if you would rather not ship one.
      
      **Polyfill:** To support the `popover` attribute in older browsers, conditionally load [`@oddbird/popover-polyfill`](https://github.com/oddbird/popover-polyfill). **MANDATORY:** Feature detect by checking for the `popover` property on `HTMLElement.prototype`, and load the polyfill **only** when native support is missing — do NOT load it unconditionally.
      
      With a bundler or import map:
      
      ```js
      // MANDATORY: Feature detect 'popover' on HTMLElement.prototype.
      if (!("popover" in HTMLElement.prototype)) {
        import("@oddbird/popover-polyfill");
      }
      ```
      
      Without a bundler, import from a CDN inside a `<script type="module">`:
      
      ```html
      <script type="module">
        if (!("popover" in HTMLElement.prototype)) {
          import("https://unpkg.com/@oddbird/popover-polyfill@latest/dist/popover.min.js");
        }
      </script>
      ```
      
      **Styling caveat:** The polyfill cannot define the real `:popover-open` pseudo-class, so it applies a `.\:popover-open` class instead. **MANDATORY:** Combine the two with `:is()` or `:where()`, otherwise browsers that lack `:popover-open` discard the entire rule:
      
      ```css
      [popover]:is(:popover-open, .\:popover-open) {
        display: block;
      }
      ```
      
      Alternatively, for a legacy fallback without a polyfill, use `position: fixed` and manually calculate coordinates via `getBoundingClientRect()` or rely on default positioning with `inset: auto` if that's acceptable for the use case.
      
      popover="hint" has limited availability.
      Supported by: Chrome 151, Edge 151, and Firefox 153 (Jul 2026).
      Unsupported in: Safari.
      
      The `popover-polyfill` does not polyfill the hint behavior in browsers that support `popover` but not `popover="hint"`. For those browsers, a tooltip opened via focus may stay open when a second tooltip opened via hover.
      
      Anchor positioning is not natively supported by any major browser yet.
      
      **MANDATORY:** To support browsers without anchor positioning, you MUST use the `@oddbird/css-anchor-positioning` polyfill. It does not support implicit anchors, so you MUST add anchor names to the trigger. Additionally, `position-area` is not supported on popovers by the polyfill, so you MUST use `anchor()` on the desired insets.
      
      ```html
      <!-- MANDATORY: Conditionally install the anchor positioning polyfill -->
      <script type="module">
        if (!("anchorName" in document.documentElement.style)) {
          await import("https://unpkg.com/@oddbird/css-anchor-positioning");
        }
      </script>
      ```
      
      ```css
      button[interestfor="tooltip-attrs"] {
        /* MANDATORY: Each trigger and popover pair must have a unique anchor name, referenced by `anchor-name` on the trigger and `position-anchor` on the popover. */
        anchor-name: --tooltip-attrs;
      }
      #tooltip-attrs {
        position-anchor: --tooltip-attrs;
        /* If using the anchor positioning polyfill with a popover, DO use `anchor()` functions, and not `position-area. */
        top: anchor(bottom);
        left: anchor(right);
        margin: unset;
      }
      ```

## Assistant

The registry-enabled run succeeded, and the actual failure mode was package resolution under the restricted network—not the MWG command itself. I’m doing one offline repeat now so subsequent searches can work without another registry fetch.

## Activity

    $ /bin/bash -lc 'npx -y --offline modern-web-guidance@0.0.185 search "interest invokers" --skill-version 2026_08_28-acbcfdb0'
    status: Failed · exit 1
      npm error code ENOTCACHED
      npm error request to https://registry.npmjs.org/modern-web-guidance failed: cache mode is 'only-if-cached' but no cached response is available.
      npm error Log files were not written due to an error writing to the directory: /Users/rviscomi/.npm/_logs
      npm error You can rerun the command with `--loglevel=verbose` to see the logs in your terminal

## Activity

    $ /bin/bash -lc 'test -d /private/tmp/modern-web-guidance-cli && find /private/tmp/modern-web-guidance-cli -maxdepth 2 -type f -print | head -20 || true'
    status: Completed · exit 0

## Activity

    $ /bin/bash -lc 'npm install --prefix /private/tmp/modern-web-guidance-cli --no-save modern-web-guidance@0.0.185'
    status: Completed · exit 0
      
      added 1 package in 606ms

## Assistant

I’m installing an isolated temporary copy rather than changing the repository or global npm state; once it finishes, I’ll verify the binary directly.

## Activity

    $ /bin/bash -lc '/private/tmp/modern-web-guidance-cli/node_modules/.bin/modern-web-guidance search "interest invokers" --skill-version 2026_08_28-acbcfdb0'
    status: Completed · exit 0
      [{"id":"interest-triggered-action-previews","description":"Show a live preview of a button's effect when a user signals interest (e.g. hovering, focusing, or long-pressing) but before they commit to clicking.","category":"ui-behaviors","featuresUsed":["Interest invokers"],"tokenCount":1123,"similarity":0.4542},
      {"id":"interest-triggered-tooltips","description":"Show a tooltip or supplemental information when a user hovers over, focuses on, or long-presses an interactive element, without requiring a click.","category":"ui-behaviors","featuresUsed":["Interest invokers","Popover","popover=\"hint\"","Anchor positioning"],"tokenCount":2330,"similarity":0.3437},
      {"id":"custom-button-actions","description":"Declaratively connect a button to any element to trigger custom, application-specific actions using declarative button commands, invoker commands, button commands, custom commands, or declarative toggle actions.","category":"ui-behaviors","featuresUsed":["Invoker commands"],"tokenCount":2090,"similarity":0.3083}]

## Assistant

Fixed. MWG is now installed in an isolated temporary directory and runs successfully without registry access:

```sh
/private/tmp/modern-web-guidance-cli/node_modules/.bin/modern-web-guidance search "interest invokers" --skill-version 2026_08_28-acbcfdb0
```

The earlier silent runs were caused by restricted npm registry resolution, not an invalid query. I’ll use this local binary for MWG lookups during this session; no repository files were changed.
</details>
 
Codex recommends that we add this to the MWG SKILL.md:

>   If the `npx -y modern-web-guidance…` command reports a registry or network error, hangs, or produces no result, retry the same command with the environment's normal network approval. Do not treat empty output as a successful search.

After the user gives approval, Codex will persist it to a local config file and future MWG calls will work as expected:

```sh
# /Users/rviscomi/.codex/rules/default.rules
prefix_rule(pattern=["npx", "-y", "modern-web-guidance@latest"], decision="allow")
```