### PR TITLE
skills: recommend pnpx runner and scoped permission rules

### DIFF
--- a/eval-view/utils.js
+++ b/eval-view/utils.js
@@ -170,7 +170,7 @@ export function formatTestName(name) {
 
 // Google Identity Services (OAuth) Integration
 const GOOGLE_CLIENT_ID = '169412140096-fk4rtf6iqk982d43385s1ilucrda91g2.apps.googleusercontent.com';
-let accessToken = typeof localStorage !== 'undefined' ? localStorage.getItem('gcs_access_token') : null;
+let accessToken = typeof localStorage !== 'undefined' && typeof localStorage.getItem === 'function' ? localStorage.getItem('gcs_access_token') : null;
 
 export function getAccessToken() {
     return accessToken;

--- a/guides/modern-web-guidance/SKILL.md
+++ b/guides/modern-web-guidance/SKILL.md
@@ -86,8 +86,10 @@ When generating or modifying code, cross-check the implementation against the re
 - **Applicable Guidance & Fallbacks**: Ensure the relevant modern patterns and necessary fallback strategies from the guide are correctly applied, without forcing unrequested features.
 - **Task Fulfillment**: Confirm that the implementation fully satisfies the user's request.
 
-## Using npx
+## Using npx / pnx
 
+-   Prefer `pnx` over `npx` if `pnpm` is available.
+-   When requesting tool permissions, allowlist `npx -y modern-web-guidance@latest *` specifically (or the `pnx` equivalent), never bare `npx *`.
 -   IMPORTANT: on Windows, using `npx` may fail. Use `npx.cmd ...` instead.
 -   Network access is required for fetching npm packages needed by the task.
 -   If the `npx -y modern-web-guidance…` command hangs, you may be offline. Try running again in offline

--- a/guides/modern-web-guidance/SKILL.md
+++ b/guides/modern-web-guidance/SKILL.md
@@ -86,10 +86,10 @@ When generating or modifying code, cross-check the implementation against the re
 - **Applicable Guidance & Fallbacks**: Ensure the relevant modern patterns and necessary fallback strategies from the guide are correctly applied, without forcing unrequested features.
 - **Task Fulfillment**: Confirm that the implementation fully satisfies the user's request.
 
-## Using npx / pnx
+## Using npx / pnpx
 
--   Prefer `pnx` over `npx` if `pnpm` is available.
--   When requesting tool permissions, allowlist `npx -y modern-web-guidance@latest *` specifically (or the `pnx` equivalent), never bare `npx *`.
+-   Prefer `pnpx` over `npx` if `pnpm` is available (note: `pnpx` does not use the `-y` flag).
+-   When requesting tool permissions, allowlist `npx -y modern-web-guidance@latest *` specifically (or `pnpx modern-web-guidance@latest *`), never bare `npx *` or `pnpx *`.
 -   IMPORTANT: on Windows, using `npx` may fail. Use `npx.cmd ...` instead.
 -   Network access is required for fetching npm packages needed by the task.
 -   If the `npx -y modern-web-guidance…` command hangs, you may be offline. Try running again in offline


### PR DESCRIPTION
### Summary

- **Runner preference**: Advises agents to prefer `pnpx` over `npx` when `pnpm` is available for faster execution and better local caching (noting that `pnpx` does not use `-y`).
- **Permission scoping**: Instructs agents to scope command approval rules specifically to `npx -y modern-web-guidance@latest *` or `pnpx modern-web-guidance@latest *` rather than over-permissive bare `npx *` / `pnpx *`.
- **Node test resilience**: Safely checks `typeof localStorage.getItem === 'function'` in `eval-view/utils.js` for test runs under Node.