### PR TITLE
Release notes escaping and other cleanup fixes

### DIFF
--- a/serving/skills-cli/generate-release-notes.test.ts
+++ b/serving/skills-cli/generate-release-notes.test.ts
@@ -9,7 +9,7 @@ import {
   buildBaselineBullets,
   parseBaselineUpdateFromPatch,
   parseBaselineUpdatesFromPatch,
-  isPatchOnlyBaselineUpdate,
+  isPatchOnlyNonSubstantive,
   stripBaselineLinesFromPatch,
   classifyChanges,
   getGuideDescription,
@@ -55,7 +55,7 @@ test('isPatchOnlyVersionBump correctly detects rote version bumps', () => {
   assert.strictEqual(isPatchOnlyVersionBump(realChangePatch), false);
 });
 
-test('isPatchOnlyBaselineUpdate correctly identifies baseline-only patches', () => {
+test('isPatchOnlyNonSubstantive correctly identifies baseline-only and non-substantive patches', () => {
   const baselinePatch = `
 @@ -54,7 +54,7 @@
  ### Fallback strategies
@@ -63,7 +63,7 @@ test('isPatchOnlyBaselineUpdate correctly identifies baseline-only patches', () 
 +Baseline status for Masks: Widely available. It's been Baseline since 2023-12-07.
  Supported by: Chrome 120 (Dec 2023), Edge 120 (Dec 2023), Firefox 53 (Apr 2017), and Safari 15.4 (Mar 2022).
 `;
-  assert.strictEqual(isPatchOnlyBaselineUpdate(baselinePatch), true);
+  assert.strictEqual(isPatchOnlyNonSubstantive(baselinePatch), true);
 
   const limitedBaselinePatch = `
 @@ -54,4 +54,4 @@
@@ -73,7 +73,7 @@ test('isPatchOnlyBaselineUpdate correctly identifies baseline-only patches', () 
 +Supported by: Chrome 151, Edge 151, and Firefox 153 (Jul 2026).
   Unsupported in: Safari.
 `;
-  assert.strictEqual(isPatchOnlyBaselineUpdate(limitedBaselinePatch), true);
+  assert.strictEqual(isPatchOnlyNonSubstantive(limitedBaselinePatch), true);
 
   const substantivePatch = `
 @@ -10,6 +10,8 @@
@@ -81,7 +81,7 @@ test('isPatchOnlyBaselineUpdate correctly identifies baseline-only patches', () 
 +Here is some new important guidance about using mask-image safely.
 +Always specify a fallback.
 `;
-  assert.strictEqual(isPatchOnlyBaselineUpdate(substantivePatch), false);
+  assert.strictEqual(isPatchOnlyNonSubstantive(substantivePatch), false);
 });
 
 test('stripBaselineLinesFromPatch filters out baseline status lines while retaining substantive diffs', () => {
@@ -574,6 +574,16 @@ test('formatGuideBoldLink and formatGuideCodeLink format links when guide exists
     '[`translator`](https://github.com/GoogleChrome/modern-web-guidance/blob/v0.0.185/skills/modern-web-guidance/guides/built-in-ai/translator.md)'
   );
 
+  // Standalone skill (ends with -skill) formats as "**[name](url)** skill"
+  assert.strictEqual(
+    formatGuideBoldLink('modern-web-guidance-skill', 'v0.0.186'),
+    '**[modern-web-guidance](https://github.com/GoogleChrome/modern-web-guidance/blob/v0.0.186/skills/modern-web-guidance/SKILL.md)** skill'
+  );
+  assert.strictEqual(
+    formatGuideCodeLink('modern-web-guidance-skill', 'v0.0.186'),
+    '[`modern-web-guidance`](https://github.com/GoogleChrome/modern-web-guidance/blob/v0.0.186/skills/modern-web-guidance/SKILL.md)'
+  );
+
   // Non-existent guide
   assert.strictEqual(formatGuideBoldLink('unknown-guide'), '**unknown-guide**');
   assert.strictEqual(formatGuideCodeLink('unknown-guide'), '`unknown-guide`');
@@ -741,4 +751,106 @@ test('parseBaselineUpdatesFromPatch extracts multiple feature updates from multi
   assert.strictEqual(parseBaselineUpdateFromPatch('unrelated-guide', unidentifiablePatch), null);
   assert.deepStrictEqual(parseBaselineUpdatesFromPatch('unrelated-guide', unidentifiablePatch), []);
 });
+
+test('parseBaselineUpdateFromHunk strips leading + from feature name in diff lines', () => {
+  const patchWithPlus = `
+@@ -114,6 +114,8 @@
+-Speculative loading is a new feature, and as such, is not supported in all modern browsers (Baseline limited availability).
++Speculation rules has limited availability.
++Supported by: Chrome 109 (Jan 2023) and Edge 109 (Jan 2023).
++Unsupported in: Firefox and Safari.
+`;
+  const info = parseBaselineUpdateFromPatch('improve-next-page-load-performance', patchWithPlus);
+  assert.ok(info);
+  assert.strictEqual(info.featureName, 'Speculation rules');
+  assert.strictEqual(info.featureId, 'speculation-rules');
+  assert.strictEqual(info.statusDescription, 'Added **Chrome 109 and Edge 109** support');
+  assert.strictEqual(
+    formatWebFeatureBoldLink(info.featureName, info.featureId),
+    '**[Speculation rules](https://webstatus.dev/features/speculation-rules)**'
+  );
+});
+
+test('formatWebFeatureBoldLink escapes HTML tags to prevent broken markdown rendering', () => {
+  assert.strictEqual(
+    formatWebFeatureBoldLink('<details>', 'details'),
+    '**[&lt;details&gt;](https://webstatus.dev/features/details)**'
+  );
+  assert.strictEqual(
+    formatWebFeatureBoldLink('<select>', 'select'),
+    '**[&lt;select&gt;](https://webstatus.dev/features/select)**'
+  );
+  assert.strictEqual(
+    formatWebFeatureBoldLink('<dialog>'),
+    '**[&lt;dialog&gt;](https://webstatus.dev/features/dialog)**'
+  );
+  assert.strictEqual(
+    formatWebFeatureBoldLink('<a>'),
+    '**[&lt;a&gt;](https://webstatus.dev/features/a)**'
+  );
+  assert.strictEqual(
+    formatWebFeatureBoldLink('<custom-unregistered>'),
+    '**&lt;custom-unregistered&gt;**'
+  );
+});
+
+test('hasSubstantiveGuideChanges and isPatchOnlyNonSubstantive filter out heading additions and legacy baseline text', () => {
+  // 1. Guide with only auto-generated H1 title added at the top
+  const titleOnlyPatch = `
+@@ -1,3 +1,5 @@
++# Complex Shapes
++
+ ## Overview
+`;
+  assert.strictEqual(isPatchOnlyNonSubstantive(titleOnlyPatch), true);
+  assert.strictEqual(stripBaselineLinesFromPatch(titleOnlyPatch).trim(), '@@ -1,3 +1,5 @@\n ## Overview');
+
+  // 2. Guide with legacy handwritten baseline line removed and replaced by macro
+  const legacyBaselineReplacementPatch = `
+@@ -97,7 +97,8 @@
+-The \`:user-invalid\` pseudo-class is widely supported (Baseline 2023), but older browsers need a fallback.
++Baseline status for :user-valid and :user-invalid: Widely available. It's been Baseline since 2023-11-02.
++Supported by: Chrome 119 (Oct 2023), Edge 119 (Nov 2023), Firefox 88 (Apr 2021), and Safari 16.5 (May 2023).
+`;
+  assert.strictEqual(isPatchOnlyNonSubstantive(legacyBaselineReplacementPatch), true);
+
+  // 3. Guide with fallback boilerplate change
+  const fallbackBoilerplatePatch = `
+@@ -603,7 +603,7 @@
+-Most of the features used in this guide are Baseline Widely available, and do not require any fallback. The only features not widely available that may require fallbacks are scroll-snap-events and scroll-driven-animations, both of which have robust fallback or progressive enhancement stories, and are safe to use for this use case:
++The features that may require fallbacks are scroll-snap-events and scroll-driven-animations, both of which have robust fallback or progressive enhancement stories, and are safe to use for this use case:
+`;
+  assert.strictEqual(isPatchOnlyNonSubstantive(fallbackBoilerplatePatch), true);
+
+  // 4. Truly substantive guide change
+  const substantivePatch = `
+@@ -50,6 +50,10 @@
++When handling Enter key press, always check \`KeyboardEvent.isComposing\`.
++Otherwise IME conversion will be broken for multilingual users.
+`;
+  assert.strictEqual(isPatchOnlyNonSubstantive(substantivePatch), false);
+});
+
+test('linkifyGuideBullets correctly links bold and code guide names', () => {
+  const bullets = [
+    '* Updated the **modern-web-guidance** skill with redirection instructions.',
+    '* Enhanced **forms** with IME handling guidance.',
+    '* Updated the **modern-web-guidance-skill** directly.',
+  ];
+  const linked = linkifyGuideBullets(bullets, ['modern-web-guidance-skill', 'forms'], 'v0.0.186');
+
+  assert.strictEqual(
+    linked[0],
+    '* Updated the **[modern-web-guidance](https://github.com/GoogleChrome/modern-web-guidance/blob/v0.0.186/skills/modern-web-guidance/SKILL.md)** skill with redirection instructions.'
+  );
+  assert.strictEqual(
+    linked[1],
+    '* Enhanced **[forms](https://github.com/GoogleChrome/modern-web-guidance/blob/v0.0.186/skills/modern-web-guidance/guides/forms/forms.md)** with IME handling guidance.'
+  );
+  assert.strictEqual(
+    linked[2],
+    '* Updated the **[modern-web-guidance-skill](https://github.com/GoogleChrome/modern-web-guidance/blob/v0.0.186/skills/modern-web-guidance/SKILL.md)** directly.'
+  );
+});
+
 

--- a/serving/skills-cli/generate-release-notes.ts
+++ b/serving/skills-cli/generate-release-notes.ts
@@ -23,7 +23,6 @@ import {
   buildReleaseNotesMarkdown,
   generateFallbackReleaseNotes,
   linkifyGuideBullets,
-  escapeRegExp,
 } from './release-notes-markdown.ts';
 import {
   generateNewGuideSummariesWithGemini,

--- a/serving/skills-cli/generate-release-notes.ts
+++ b/serving/skills-cli/generate-release-notes.ts
@@ -23,6 +23,7 @@ import {
   buildReleaseNotesMarkdown,
   generateFallbackReleaseNotes,
   linkifyGuideBullets,
+  escapeRegExp,
 } from './release-notes-markdown.ts';
 import {
   generateNewGuideSummariesWithGemini,

--- a/serving/skills-cli/release-notes-diff.ts
+++ b/serving/skills-cli/release-notes-diff.ts
@@ -60,14 +60,21 @@ const GH_PUBLISH_PATTERNS = [
 ];
 
 // Canonical lines produced by formatStatusMessage() in serving/lib/baseline.ts and baseline macros
-const BASELINE_OUTPUT_PATTERNS = [
+export const BASELINE_OUTPUT_PATTERNS = [
   /^Baseline status for /i,
-  /has limited availability\./i,
-  /is not natively supported by any major browser yet\./i,
+  /has limited availability/i,
+  /is not natively supported by any major browser yet/i,
   /^Supported by:\s*(Chrome|Firefox|Safari|Edge|iOS)/i,
   /^Unsupported in:\s*(Chrome|Firefox|Safari|Edge|iOS)/i,
   /^<!--\s*(?:baseline:|MACRO:(?:BASELINE_STATUS|FEATURE_FALLBACKS))/i,
   /^>\s*Baseline:\s*\[/i,
+];
+
+export const NON_SUBSTANTIVE_PATTERNS = [
+  ...BASELINE_OUTPUT_PATTERNS,
+  /Baseline\s*(?:\d{4}|widely|newly|limited)/i,
+  /(?:core mechanics|features used in this guide|is widely supported|are all Baseline|are Baseline Widely available|safe to use for this use case)/i,
+  /^#+\s+/, // Markdown headings (# H1 through ###### H6)
 ];
 
 export function getPreviousTag(targetTag: string): string {
@@ -149,9 +156,10 @@ export function hasBaselineUpdateInPatch(patch?: string): boolean {
 }
 
 /**
- * Checks if a git diff patch represents only Baseline status or browser support updates.
+ * Checks if a git diff patch represents only non-substantive changes
+ * (Baseline status updates, macro expansions, heading structure, or boilerplate).
  */
-export function isPatchOnlyBaselineUpdate(patch?: string): boolean {
+export function isPatchOnlyNonSubstantive(patch?: string): boolean {
   if (!patch) return false;
   const changedLines = patch
     .split('\n')
@@ -162,12 +170,12 @@ export function isPatchOnlyBaselineUpdate(patch?: string): boolean {
 
   return changedLines.every(line => {
     if (!line) return true;
-    return BASELINE_OUTPUT_PATTERNS.some(pattern => pattern.test(line));
+    return NON_SUBSTANTIVE_PATTERNS.some(pattern => pattern.test(line));
   });
 }
 
 /**
- * Strips out Baseline status and browser support lines from a diff patch,
+ * Strips out Baseline status, browser support, and non-substantive lines from a diff patch,
  * leaving only substantive code and documentation changes.
  */
 export function stripBaselineLinesFromPatch(patch?: string): string {
@@ -176,11 +184,26 @@ export function stripBaselineLinesFromPatch(patch?: string): string {
   const filtered = lines.filter(line => {
     if ((line.startsWith('+') || line.startsWith('-')) && !line.startsWith('+++') && !line.startsWith('---')) {
       const content = line.slice(1).trim();
-      return !BASELINE_OUTPUT_PATTERNS.some(pattern => pattern.test(content));
+      if (!content) return false;
+      return !NON_SUBSTANTIVE_PATTERNS.some(pattern => pattern.test(content));
     }
     return true;
   });
   return filtered.join('\n');
+}
+
+/**
+ * Determines whether a patch contains substantive guide modifications.
+ */
+export function hasSubstantiveGuideChanges(patch?: string): boolean {
+  if (!patch) return false;
+  const substantive = stripBaselineLinesFromPatch(patch);
+  const changedLines = substantive
+    .split('\n')
+    .filter(l => (l.startsWith('+') || l.startsWith('-')) && !l.startsWith('+++') && !l.startsWith('---'))
+    .map(l => l.slice(1).trim())
+    .filter(Boolean);
+  return changedLines.length > 0;
 }
 
 function formatList(items: string[]): string {
@@ -215,6 +238,10 @@ export function parseBaselineUpdateFromHunk(guideName: string, hunk: string): Ba
     .filter(l => l.startsWith('-') && !l.startsWith('---'))
     .map(l => l.slice(1).trim());
 
+  const allStrippedLines = hunk
+    .split('\n')
+    .map(l => l.replace(/^[+-]/, '').trim());
+
   let featureName = '';
   let statusRank = 3;
   let statusDescription = 'Updated browser engine support';
@@ -236,11 +263,15 @@ export function parseBaselineUpdateFromHunk(guideName: string, hunk: string): Ba
     }
   }
 
-  // 2. If status line didn't change (e.g. engine update in Limited status), extract featureName from hunk context
+  // 2. If status line didn't change (e.g. engine update in Limited status), extract featureName from context lines
   if (!featureName) {
-    const match = hunk.match(/(?:Baseline status for\s+(.+?):|(.+?)\s+has limited availability)/i);
-    if (match) {
-      featureName = (match[1] || match[2]).trim();
+    const candidateLine = addedLines.find(l => /has limited availability/i.test(l) || /Baseline status for/i.test(l))
+      || allStrippedLines.find(l => /has limited availability/i.test(l) || /Baseline status for/i.test(l));
+    if (candidateLine) {
+      const match = candidateLine.match(/(?:Baseline status for\s+(.+?):|(.+?)\s+has limited availability)/i);
+      if (match) {
+        featureName = (match[1] || match[2]).trim();
+      }
     }
   }
 
@@ -248,6 +279,9 @@ export function parseBaselineUpdateFromHunk(guideName: string, hunk: string): Ba
   if (!featureName) {
     return null;
   }
+
+  // Clean up any remaining leading/trailing diff symbols or backticks
+  featureName = featureName.replace(/^[+-]\s*/, '').replace(/^`|`$/g, '').trim();
 
   if (statusRank === 3) {
     const addedSupported = addedLines.find(l => l.includes('Supported by:'));
@@ -464,9 +498,14 @@ export function getGuideGithubUrl(guideName: string, ref = 'main'): string | und
 
 /**
  * Formats a guide name as a markdown bold link if a URL is resolved, or plain bold if not.
+ * Formats standalone skills (ending in -skill) as `**[name](url)** skill`.
  */
 export function formatGuideBoldLink(guideName: string, ref = 'main'): string {
   const url = getGuideGithubUrl(guideName, ref);
+  if (guideName.endsWith('-skill')) {
+    const displayName = guideName.slice(0, -'-skill'.length);
+    return url ? `**[${displayName}](${url})** skill` : `**${displayName}** skill`;
+  }
   return url ? `**[${guideName}](${url})**` : `**${guideName}**`;
 }
 
@@ -475,7 +514,16 @@ const featureNameToIdMap = new Map<string, string>();
 for (const [id, f] of Object.entries(features)) {
   if (f.kind === 'feature') {
     featureNameToIdMap.set(f.name, id);
+    featureNameToIdMap.set(id, id);
   }
+}
+
+/**
+ * Escapes special HTML characters so feature names like <select> or <details>
+ * don't get interpreted as HTML tags in Markdown.
+ */
+export function escapeHtml(str: string): string {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
 /**
@@ -495,12 +543,14 @@ export function getWebStatusUrl(featureName: string): string | undefined {
 
 /**
  * Formats a web feature name as a markdown bold link to webstatus.dev if resolved, or plain bold if not.
+ * Escapes HTML characters (e.g. <details>, <select>) to ensure valid Markdown rendering.
  */
 export function formatWebFeatureBoldLink(featureName: string, featureId?: string): string {
   const resolvedId = featureId || resolveWebFeatureId(featureName);
+  const escapedName = escapeHtml(featureName);
   return resolvedId
-    ? `**[${featureName}](https://webstatus.dev/features/${resolvedId})**`
-    : `**${featureName}**`;
+    ? `**[${escapedName}](https://webstatus.dev/features/${resolvedId})**`
+    : `**${escapedName}**`;
 }
 
 /**
@@ -508,7 +558,8 @@ export function formatWebFeatureBoldLink(featureName: string, featureId?: string
  */
 export function formatGuideCodeLink(guideName: string, ref = 'main'): string {
   const url = getGuideGithubUrl(guideName, ref);
-  return url ? `[\`${guideName}\`](${url})` : `\`${guideName}\``;
+  const displayName = guideName.endsWith('-skill') ? guideName.slice(0, -'-skill'.length) : guideName;
+  return url ? `[\`${displayName}\`](${url})` : `\`${displayName}\``;
 }
 
 /**
@@ -553,7 +604,7 @@ export function classifyChanges(records: RawChangeRecord[]): ClassifiedChanges {
           if (hasBaselineUpdateInPatch(patch)) {
             baselineUpdates.push(...parseBaselineUpdatesFromPatch(guideName, patch));
           }
-          if (!isPatchOnlyBaselineUpdate(patch)) {
+          if (hasSubstantiveGuideChanges(patch)) {
             const renameNote = oldGuideName !== guideName
               ? ` (Renamed from ${oldPath || oldGuideName})`
               : '';
@@ -575,7 +626,7 @@ export function classifyChanges(records: RawChangeRecord[]): ClassifiedChanges {
         if (hasBaselineUpdateInPatch(patch)) {
           baselineUpdates.push(...parseBaselineUpdatesFromPatch(guideName, patch));
         }
-        if (!isPatchOnlyBaselineUpdate(patch)) {
+        if (hasSubstantiveGuideChanges(patch)) {
           const substantivePatch = stripBaselineLinesFromPatch(patch);
           modifiedGuidePatches.push(`--- ${relPath} (${status}) ---\n${substantivePatch}`);
           modifiedGuideNamesSet.add(guideName);

--- a/serving/skills-cli/release-notes-gemini.ts
+++ b/serving/skills-cli/release-notes-gemini.ts
@@ -128,7 +128,7 @@ function buildGuideSummaryPrompt({ type, guideNames, guideDiff }: BuildGuideSumm
   return `You are writing concise release note bullet points for ${label} in GoogleChrome/modern-web-guidance.
 
 ### ${sectionHeader} (${guideNames.length} total):
-${guideNames.map(g => `- ${g}`).join('\n')}
+${guideNames.map(g => `- ${g.endsWith('-skill') ? `${g.slice(0, -'-skill'.length)} skill` : g}`).join('\n')}
 
 ### Content Diff:
 ${guideDiff}
@@ -137,7 +137,7 @@ ${guideDiff}
 1. Output exactly ${guideNames.length} Markdown bullet points (starting with '* ' or '- '), one for each ${targetDesc}.
 2. Each bullet must describe ${contentDesc} in a single concise sentence or short paragraph.
 3. Keep each bullet point on a single line without manual line breaks.
-4. Bold the guide identifier in each bullet using Markdown bold syntax (e.g., "${boldExample}").
+4. Bold the guide identifier or skill name in each bullet using Markdown bold syntax (e.g., "* Updated the **modern-web-guidance** skill to..." or "${boldExample}").
 5. NEVER use nested sub-bullets or multiple bullet points for a single guide.
 6. Do NOT mention Baseline status or browser compatibility updates (these are tracked separately in the Browser Support section). Focus on substantive ${focusDesc}.
 7. Do NOT include headings, sections, benchmark tables, code blocks, or preamble. Output ONLY the ${guideNames.length} bullet points.`;

--- a/serving/skills-cli/release-notes-markdown.ts
+++ b/serving/skills-cli/release-notes-markdown.ts
@@ -10,7 +10,7 @@ import {
   type EvalSummaryItem,
 } from './release-notes-diff.ts';
 
-function escapeRegExp(string: string): string {
+export function escapeRegExp(string: string): string {
   return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
@@ -31,23 +31,36 @@ export function linkifyGuideBullets(bullets: string[], guideNames: string[], ref
       // Skip if this URL is already linked in the bullet
       if (result.includes(`](${url})`)) continue;
 
-      // Replace bold markdown: **guideName**
-      const exactBoldRegex = new RegExp(`(?<!\\[)\\*\\*${escapeRegExp(guideName)}\\*\\*(?!\\]\\()`, 'gi');
-      if (exactBoldRegex.test(result)) {
-        result = result.replace(exactBoldRegex, (match) => {
-          const inner = match.slice(2, -2);
-          return `**[${inner}](${url})**`;
-        });
-        continue;
+      const candidates = [guideName];
+      if (guideName.endsWith('-skill')) {
+        candidates.push(guideName.slice(0, -'-skill'.length));
       }
 
-      // Replace code markdown: `guideName` (case-sensitive to avoid false positives on API symbols)
-      const codeRegex = new RegExp(`(?<!\\[)\`${escapeRegExp(guideName)}\`(?!\\]\\()`, 'g');
-      if (codeRegex.test(result)) {
-        result = result.replace(codeRegex, (match) => {
-          return `[${match}](${url})`;
-        });
+      let matched = false;
+      for (const nameToMatch of candidates) {
+        // Replace bold markdown: **nameToMatch**
+        const exactBoldRegex = new RegExp(`(?<!\\[)\\*\\*${escapeRegExp(nameToMatch)}\\*\\*(?!\\]\\()`, 'gi');
+        if (exactBoldRegex.test(result)) {
+          result = result.replace(exactBoldRegex, (match) => {
+            const inner = match.slice(2, -2);
+            return `**[${inner}](${url})**`;
+          });
+          matched = true;
+          break;
+        }
+
+        // Replace code markdown: `nameToMatch` (case-sensitive to avoid false positives on API symbols)
+        const codeRegex = new RegExp(`(?<!\\[)\`${escapeRegExp(nameToMatch)}\`(?!\\]\\()`, 'g');
+        if (codeRegex.test(result)) {
+          result = result.replace(codeRegex, (match) => {
+            return `[${match}](${url})`;
+          });
+          matched = true;
+          break;
+        }
       }
+
+      if (matched) continue;
     }
     return result;
   });


### PR DESCRIPTION
This fixes an earlier version of the [v0.0.186](https://github.com/GoogleChrome/modern-web-guidance/releases/tag/v0.0.186) release notes published today

- #1369 added headings to dozens of guides, all of which were listed as updated even though there weren't any substantive changes. Updated to ignore these kinds of changes.
- #1369 also replaced handwritten browser support text with the Baseline status macro. This was detected as a browser support change even though nothing substantively changed. I manually dropped these from the notes.
- Feature names weren't escaped, so things like `<select>` were rendered as HTML. Added escaping.
- There was a parsing bug where the feature name was displayed as "+Speculation rules". Fixed the parsing.
- Reformatted the way the MWG skill gets displayed, from "modern-web-guidance-skill" to "modern-web-guidance skill".