### PR TITLE
Use projectOctokit in updateProjectItemStatus

### DIFF
--- a/guides/sync-use-cases.ts
+++ b/guides/sync-use-cases.ts
@@ -398,7 +398,7 @@ async function updateProjectItemStatus(issueNumber: number, projectId: string, f
         }
       }
     `;
-    const addResult = await octokit.graphql(addItemMutation, { projectId, contentId: issueNodeId }) as any;
+    const addResult = await projectOctokit.graphql(addItemMutation, { projectId, contentId: issueNodeId }) as any;
     const itemId = addResult.addProjectV2ItemById.item.id;
 
     const updateFieldMutation = `
@@ -417,7 +417,7 @@ async function updateProjectItemStatus(issueNumber: number, projectId: string, f
         }
       }
     `;
-    await octokit.graphql(updateFieldMutation, { projectId, itemId, fieldId, optionId });
+    await projectOctokit.graphql(updateFieldMutation, { projectId, itemId, fieldId, optionId });
   } catch (err: any) {
     console.error(`Error updating project for issue #${issueNumber}:`, err.message);
   }


### PR DESCRIPTION
`projectOctokit` has the necessary auth permissions to change project statuses, but `octokit` doesn't

This behavior is a weird edge case with the way GitHub projects are always at the org-level, which requires a different set of permissions