### PR TITLE
harness: preserve pi agent sessions by default and clean up boolean env parsing

### DIFF
--- a/eval-view/server.js
+++ b/eval-view/server.js
@@ -8,9 +8,10 @@ import os from 'os';
 import { exec, spawn } from 'child_process';
 import { runAllManifests } from './generate-manifests.js';
 import { extractSuiteSummary } from './summary-extractor.js';
+import { parseBooleanEnv } from '../lib/env.ts';
 
 const PORT = process.env.PORT || 8081;
-const STATIC = process.env.STATIC === 'true';
+const STATIC = parseBooleanEnv(process.env.STATIC, false);
 
 if (STATIC) {
   console.log('🌐 Running in STATIC mode via statikk. Dynamic APIs will be unavailable.');
@@ -58,7 +59,7 @@ if (STATIC) {
   const url = `http://localhost:${PORT}/?source=static`;
   console.log(`Server running at ${url}`);
 
-  if (process.env.NO_OPEN !== 'true') {
+  if (!parseBooleanEnv(process.env.NO_OPEN, false)) {
     const startCommand = process.platform === 'darwin' ? 'open' :
       process.platform === 'win32' ? 'start' : 'xdg-open';
 
@@ -581,12 +582,12 @@ const server = http.createServer(async (req, res) => {
 });
 
 server.listen(PORT, () => {
-  const isLaunchUi = process.env.LAUNCH_UI === 'true';
+  const isLaunchUi = parseBooleanEnv(process.env.LAUNCH_UI, false);
   const url = isLaunchUi ? `http://localhost:${PORT}/eval-ui.html` : `http://localhost:${PORT}/`;
   console.log(`Server running at ${url}`);
 
   // Try to open the browser if not disabled
-  if (process.env.NO_OPEN !== 'true') {
+  if (!parseBooleanEnv(process.env.NO_OPEN, false)) {
     const startCommand = process.platform === 'darwin' ? 'open' :
       process.platform === 'win32' ? 'start' : 'xdg-open';
 

--- a/guides/sync-use-cases.ts
+++ b/guides/sync-use-cases.ts
@@ -4,6 +4,7 @@ import { Octokit } from '@octokit/rest';
 import { fileURLToPath } from 'url';
 import { ProjectStatus, processGuideInventory, scanAllGuides, type GuideInventory } from '../lib/guide-validation.ts';
 import { extractFeatureIds } from '../lib/feature-parser.ts';
+import { parseBooleanEnv } from '../lib/env.ts';
 
 // --- Types ---
 
@@ -70,8 +71,10 @@ const PROJECT_GITHUB_TOKEN = process.env.PROJECT_GITHUB_TOKEN || GITHUB_TOKEN;
 const ORG = 'GoogleChrome';
 const REPO = 'modern-web-guidance-src';
 const PROJECT_NUMBER = 30;
-// Default to dry run mode unless explicitly disabled.
-const IS_DRY_RUN = process.env.DRY_RUN !== 'false';
+// Default to dry run mode unless explicitly disabled via --write, --live, or DRY_RUN=false/0/no.
+const hasWriteFlag = process.argv.includes('--write') || process.argv.includes('--live');
+const isDryRunEnv = parseBooleanEnv(process.env.DRY_RUN, true);
+const IS_DRY_RUN = hasWriteFlag ? false : isDryRunEnv;
 
 if (IS_DRY_RUN) {
   console.log('🏃 Dry run mode enabled. No changes will be made to GitHub.');

--- a/harness/README.md
+++ b/harness/README.md
@@ -105,7 +105,7 @@ Each agent harness passes the model to the CLI binary:
 // harness/agents/pi-agent.ts
 const piModel = process.env.PI_MODEL || process.env.PROMPT_MODEL;
 const modelArg = piModel ? ['--model', piModel] : [];
-const commandArgs = ['-p', '--no-session', '--offline', ...modelArg, userPrompt];
+const commandArgs = ['-p', '--offline', ...modelArg, userPrompt];
 
 // harness/agents/codex-cli-agent.ts
 const model = process.env.CODEX_MODEL;
@@ -657,8 +657,8 @@ node --experimental-strip-types quick-smoke.ts pi unguided
 To inspect actual Pi trajectories from a run:
 
 ```bash
-# Run with sessions enabled (not ephemeral)
-PI_NO_SESSION=false GD_SUITE_CONFIG='{"agent":"pi","serving":"skills_cli"}' \
+# Run full eval suite with Pi (sessions enabled by default)
+GD_SUITE_CONFIG='{"agent":"pi","serving":"skills_cli"}' \
   node --experimental-strip-types harness/run_suite.ts <task>
 
 # Sessions are saved to the isolated HOME, then exported to results dir

--- a/harness/agents/pi-agent.ts
+++ b/harness/agents/pi-agent.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 
 import config, { Agents } from '../config.ts';
+import { parseBooleanEnv } from '../../lib/env.ts';
 import {
   cleanupIsolatedHome,
   copyFileIfExists,
@@ -59,8 +60,8 @@ export function getPiCommandAndArgs(prompt: string, extraArgs: string[] = []): {
   const modelArg = piModel ? ['--model', piModel] : [];
 
   // By default, sessions should be preserved so trajectories can be captured and graded.
-  // Allow running in ephemeral mode only if explicitly enabled via PI_NO_SESSION=true.
-  const noSession = process.env.PI_NO_SESSION === 'true';
+  // Allow running in ephemeral mode only if explicitly enabled via PI_NO_SESSION=true/1/yes.
+  const noSession = parseBooleanEnv(process.env.PI_NO_SESSION, false);
   const sessionArgs = noSession ? ['--no-session'] : [];
 
   const commandArgs = [

--- a/harness/agents/pi-agent.ts
+++ b/harness/agents/pi-agent.ts
@@ -9,7 +9,6 @@ import {
   copyFileIfExists,
   parseAgentArgs,
   watchLogFile,
-  exportTrajectories,
   runCliAgentCommand,
   parseJsonlFile,
   setupIsolatedWorkDir,
@@ -59,13 +58,14 @@ export function getPiCommandAndArgs(prompt: string, extraArgs: string[] = []): {
   const piModel = process.env.PI_MODEL || process.env.PROMPT_MODEL;
   const modelArg = piModel ? ['--model', piModel] : [];
 
-  // Allow overriding --no-session via env var for trajectory testing
-  const noSession = process.env.PI_NO_SESSION !== 'false';
+  // By default, sessions should be preserved so trajectories can be captured and graded.
+  // Allow running in ephemeral mode only if explicitly enabled via PI_NO_SESSION=true.
+  const noSession = process.env.PI_NO_SESSION === 'true';
   const sessionArgs = noSession ? ['--no-session'] : [];
 
   const commandArgs = [
     '-p', // print mode: non-interactive, process and exit
-    ...sessionArgs, // ephemeral mode: don't save session (unless disabled)
+    ...sessionArgs, // ephemeral mode: only if explicitly requested
     '--offline', // disable network operations for update checks
     ...modelArg,
     ...extraArgs,
@@ -74,9 +74,20 @@ export function getPiCommandAndArgs(prompt: string, extraArgs: string[] = []): {
   return { command, commandArgs };
 }
 
-function exportPiTrajectories(workDir: string, targetDir: string): void {
+export function exportPiTrajectories(workDir: string, targetDir: string): void {
   const sessionsDir = path.join(path.dirname(workDir), '.pi', 'agent', 'sessions');
-  exportTrajectories(sessionsDir, '*.jsonl', targetDir);
+  if (!fs.existsSync(sessionsDir)) return;
+
+  const files = fs.globSync('**/*.jsonl', { cwd: sessionsDir });
+  for (const relativePath of files) {
+    const src = path.join(sessionsDir, relativePath);
+    const baseName = relativePath.replace(/[\\/]/g, '-').replace(/\.jsonl$/, '');
+    const isSubagent = relativePath.includes('subagent');
+    const destName = isSubagent
+      ? (baseName.startsWith('subagent-') ? `${baseName}.jsonl` : `subagent-${baseName}.jsonl`)
+      : (baseName.startsWith('session-') ? `${baseName}.jsonl` : `session-${baseName}.jsonl`);
+    fs.copyFileSync(src, path.join(targetDir, destName));
+  }
 }
 
 /**

--- a/harness/tests/pi-parsing.test.ts
+++ b/harness/tests/pi-parsing.test.ts
@@ -10,6 +10,7 @@ import {
   extractPiModel,
   extractPiTokenUsage
 } from '../lib/trajectory-normalizer.ts';
+import { getPiCommandAndArgs, exportPiTrajectories } from '../agents/pi-agent.ts';
 import { Agents } from '../config.ts';
 
 function createTempDir(): string {
@@ -369,3 +370,52 @@ test('collectPi metrics and token extraction from trajectory files', async () =>
     removeTempDir(tempDir);
   }
 });
+
+test('getPiCommandAndArgs does not include --no-session by default', () => {
+  const oldEnv = process.env.PI_NO_SESSION;
+  delete process.env.PI_NO_SESSION;
+  try {
+    const { commandArgs } = getPiCommandAndArgs('test prompt');
+    assert.ok(!commandArgs.includes('--no-session'), 'Should not use --no-session by default');
+  } finally {
+    if (oldEnv !== undefined) {
+      process.env.PI_NO_SESSION = oldEnv;
+    }
+  }
+});
+
+test('getPiCommandAndArgs includes --no-session when PI_NO_SESSION is true', () => {
+  const oldEnv = process.env.PI_NO_SESSION;
+  process.env.PI_NO_SESSION = 'true';
+  try {
+    const { commandArgs } = getPiCommandAndArgs('test prompt');
+    assert.ok(commandArgs.includes('--no-session'), 'Should use --no-session when PI_NO_SESSION=true');
+  } finally {
+    if (oldEnv !== undefined) {
+      process.env.PI_NO_SESSION = oldEnv;
+    } else {
+      delete process.env.PI_NO_SESSION;
+    }
+  }
+});
+
+test('exportPiTrajectories exports nested Pi session files with session- prefix', () => {
+  const tempHome = createTempDir();
+  const targetDir = createTempDir();
+  try {
+    const workDir = path.join(tempHome, 'work');
+    const sessionsDir = path.join(tempHome, '.pi', 'agent', 'sessions', '--path--');
+    fs.mkdirSync(sessionsDir, { recursive: true });
+    fs.writeFileSync(path.join(sessionsDir, '2026-08-30_abc.jsonl'), '{"type":"session"}');
+
+    exportPiTrajectories(workDir, targetDir);
+
+    const exportedFiles = fs.readdirSync(targetDir);
+    assert.strictEqual(exportedFiles.length, 1);
+    assert.strictEqual(exportedFiles[0], 'session---path---2026-08-30_abc.jsonl');
+  } finally {
+    removeTempDir(tempHome);
+    removeTempDir(targetDir);
+  }
+});
+

--- a/harness/tests/pi-parsing.test.ts
+++ b/harness/tests/pi-parsing.test.ts
@@ -399,6 +399,26 @@ test('getPiCommandAndArgs includes --no-session when PI_NO_SESSION is true', () 
   }
 });
 
+test('getPiCommandAndArgs handles PI_NO_SESSION=1, 0, and false', () => {
+  const oldEnv = process.env.PI_NO_SESSION;
+  try {
+    process.env.PI_NO_SESSION = '1';
+    assert.ok(getPiCommandAndArgs('test').commandArgs.includes('--no-session'));
+
+    process.env.PI_NO_SESSION = 'false';
+    assert.ok(!getPiCommandAndArgs('test').commandArgs.includes('--no-session'));
+
+    process.env.PI_NO_SESSION = '0';
+    assert.ok(!getPiCommandAndArgs('test').commandArgs.includes('--no-session'));
+  } finally {
+    if (oldEnv !== undefined) {
+      process.env.PI_NO_SESSION = oldEnv;
+    } else {
+      delete process.env.PI_NO_SESSION;
+    }
+  }
+});
+
 test('exportPiTrajectories exports nested Pi session files with session- prefix', () => {
   const tempHome = createTempDir();
   const targetDir = createTempDir();

--- a/lib/env.test.ts
+++ b/lib/env.test.ts
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { parseBooleanEnv } from './env.ts';
+
+test('parseBooleanEnv returns defaultValue when value is undefined', () => {
+  assert.strictEqual(parseBooleanEnv(undefined, false), false);
+  assert.strictEqual(parseBooleanEnv(undefined, true), true);
+  assert.strictEqual(parseBooleanEnv(undefined), false);
+});
+
+test('parseBooleanEnv recognizes truthy strings', () => {
+  for (const truthy of ['1', 'true', 'TRUE', 'True', 'yes', 'YES', 'on', 'ON']) {
+    assert.strictEqual(parseBooleanEnv(truthy, false), true, `Expected ${truthy} to be true`);
+  }
+});
+
+test('parseBooleanEnv recognizes falsy strings', () => {
+  for (const falsy of ['0', 'false', 'FALSE', 'False', 'no', 'NO', 'off', 'OFF', '', '   ']) {
+    assert.strictEqual(parseBooleanEnv(falsy, true), false, `Expected ${falsy} to be false`);
+  }
+});
+
+test('parseBooleanEnv returns defaultValue for unrecognized strings', () => {
+  assert.strictEqual(parseBooleanEnv('maybe', false), false);
+  assert.strictEqual(parseBooleanEnv('maybe', true), true);
+  assert.strictEqual(parseBooleanEnv('random_string', false), false);
+});

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,0 +1,13 @@
+/**
+ * Parses a boolean value from an environment variable string with support for common
+ * shell conventions (1/0, true/false, yes/no, on/off).
+ *
+ * If the value is undefined or not recognized as a boolean representation, returns `defaultValue`.
+ */
+export function parseBooleanEnv(value: string | undefined, defaultValue = false): boolean {
+  if (value === undefined) return defaultValue;
+  const normalized = value.trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'off', ''].includes(normalized)) return false;
+  return defaultValue;
+}


### PR DESCRIPTION
Fixes an issue where Pi ran with `--no-session` by default during evals (due to `PI_NO_SESSION !== 'false'`), so no session files were ever written or exported to results. Also cleans up related env var boolean checks across the repo.

- **Pi session persistence**: Pi now keeps sessions by default so trajectories actually get captured and graded. Only runs ephemeral if `PI_NO_SESSION=true|1`.
- **Nested session export**: `exportPiTrajectories()` now searches recursively and adds the `session-` prefix so trajectory normalizers pick them up.
- **Boolean env parsing**: Added a small `parseBooleanEnv()` helper (`1`/`0`, `true`/`false`, `yes`/`no`) to replace brittle string checks for `PI_NO_SESSION`, `NO_OPEN`, and `DRY_RUN`.
- **`sync-use-cases`**: Added `--write` / `--live` flags while keeping dry-run as default.
- **Codex parsing**: Safely stringifies non-string function call outputs to avoid crashes during normalization.