### PR TITLE
fix(navigation-drawer): guard the viewport width used for the observer threshold

### DIFF
--- a/guides/ui-components/navigation-drawer/demo.html
+++ b/guides/ui-components/navigation-drawer/demo.html
@@ -230,7 +230,12 @@
     }
 
     function observeOpenAndClosedState() {
-      const visibleThreshold = 1 / window.innerWidth; // At least 1px on screen.
+      // At least 1px on screen. The width is guarded because
+      // `window.innerWidth` is 0 before first layout, and a non-finite
+      // threshold makes the IntersectionObserver constructor throw.
+      const viewportWidth =
+        window.innerWidth || document.documentElement.clientWidth || 360;
+      const visibleThreshold = 1 / viewportWidth;
       const observer = new IntersectionObserver(
         (entries) => {
           const entry = entries.at(-1); // Only the last entry is relevant.

--- a/guides/ui-components/navigation-drawer/guide.md
+++ b/guides/ui-components/navigation-drawer/guide.md
@@ -260,7 +260,14 @@ function onDrawerClosed() {
 // Treat "any pixel of the sheet visible inside the popover root" as
 // "open enough to count as not closed". This threshold is intentionally
 // tiny so the closed callback only fires once the sheet is truly gone.
-const visibleThreshold = 1 / window.innerWidth;
+//
+// Guard the width: `window.innerWidth` is 0 in a page that has not been
+// laid out yet, and `1 / 0` is Infinity, which makes the
+// IntersectionObserver constructor throw. That would take the rest of
+// this script with it, leaving a drawer that opens and can never close.
+const viewportWidth =
+  window.innerWidth || document.documentElement.clientWidth || 360;
+const visibleThreshold = 1 / viewportWidth;
 
 const observer = new IntersectionObserver(
   (entries) => {


### PR DESCRIPTION
Fixes #1409.

## The bug

`navigation-drawer` derives the IntersectionObserver threshold from the viewport width:

```js
const visibleThreshold = 1 / window.innerWidth;
```

When `window.innerWidth` is `0` — a page that has not been laid out yet — this is `Infinity`, and `IntersectionObserver` throws from the constructor rather than clamping:

```
Failed to construct 'IntersectionObserver': Failed to read the 'threshold' property
from 'IntersectionObserverInit': The provided double value is non-finite.
```

Because step 4 builds the observer *before* step 5 attaches the trigger and dismissal handlers, the exception takes the rest of the script with it. The drawer is not inert, though: `popover="manual"` still promotes the panel to the top layer, so **the menu opens and then cannot be closed** — not by the close button, not by tapping the scrim, not with Escape.

## Reproduced on this repo's own demo

Same browser, same page, `window.innerWidth === 0`:

| File | Console |
| --- | --- |
| `demo.html` at `7de9677` (unchanged) | `Uncaught TypeError: ...non-finite` at line 272 |
| `demo.html` with this patch | clean |

## The change

```js
const viewportWidth =
  window.innerWidth || document.documentElement.clientWidth || 360;
const visibleThreshold = 1 / viewportWidth;
```

The width only exists to express "one pixel", so any sane fallback preserves the intent. With a real viewport the value is unchanged — `375` → `0.00267`, `1280` → `0.00078` — so this is purely defensive and does not alter behaviour anywhere it already worked.

Applied to both `guide.md` and `demo.html`, with a short comment explaining why the guard is there so it does not get simplified away later.

## Note on the CLA

I have not signed the Google CLA yet. Happy to do so — flagging it up front so this is not blocked silently.
