### PR TITLE
harness: fix trajectory normalizers and remove demo.html check

### DIFF
--- a/harness/agents/codex-cli-agent.ts
+++ b/harness/agents/codex-cli-agent.ts
@@ -308,12 +308,18 @@ export function parseCodexTrajectory(logData: CodexRolloutLine[] | any[], subage
       if (entry.type === 'response_item' && (entry.payload?.type === 'function_call_output' || entry.payload?.type === 'custom_tool_call_output')) {
         const p = entry.payload;
         const callId = p.call_id;
-        const out = p.output || '';
+        const rawOut = p.output ?? '';
+        const outStr = typeof rawOut === 'string'
+          ? rawOut
+          : Array.isArray(rawOut)
+            ? rawOut.map((item: any) => (typeof item === 'string' ? item : item?.text || JSON.stringify(item))).join('\n')
+            : JSON.stringify(rawOut);
         const step = callId ? callMap.get(callId) : undefined;
         if (step) {
+          const isError = p.is_error === true || outStr.toLowerCase().includes('error:');
           step.outcome = {
-            status: out.toLowerCase().includes('error:') ? 'error' : 'success',
-            message: truncateMessage(out)
+            status: isError ? 'error' : 'success',
+            message: truncateMessage(outStr)
           };
         }
       }

--- a/harness/agents/codex.d.ts
+++ b/harness/agents/codex.d.ts
@@ -120,7 +120,7 @@ export interface CodexResponseFunctionCallOutputItem {
   type: "function_call_output";
   id?: string;
   call_id: string;
-  output: string | Record<string, unknown>;
+  output: string | Record<string, unknown> | Array<unknown>;
   is_error?: boolean;
 }
 
@@ -137,7 +137,7 @@ export interface CodexResponseCustomToolCallOutputItem {
   type: "custom_tool_call_output";
   id?: string;
   call_id: string;
-  output: string | Record<string, unknown>;
+  output: string | Record<string, unknown> | Array<unknown>;
   is_error?: boolean;
 }
 

--- a/harness/agents/jetski-cli-agent.ts
+++ b/harness/agents/jetski-cli-agent.ts
@@ -77,9 +77,8 @@ export function getJetskiCliCommandAndArgs(prompt: string): { command: string; c
 }
 
 function exportJetskiTrajectories(workDir: string, targetDir: string): void {
-  const jetskiLogDir = path.join(path.dirname(workDir), '.gemini', 'jetski', 'brain');
-  exportTrajectories(jetskiLogDir, '**/*.db', targetDir);
-  exportTrajectories(jetskiLogDir, '**/modern-web.log', targetDir);
+  const conversationsDir = path.join(path.dirname(workDir), '.gemini', 'jetski', 'conversations');
+  exportTrajectories(conversationsDir, '**/*.db', targetDir);
 }
 
 async function run() {

--- a/harness/tests/codex-cli-parsing.test.ts
+++ b/harness/tests/codex-cli-parsing.test.ts
@@ -11,6 +11,7 @@ import {
   extractCodexCliTokenUsage
 } from '../lib/trajectory-normalizer.ts';
 import { extractCommandsFromCodexItem } from '../agents/codex-cli-agent.ts';
+import { extractModelFromResults } from '../lib/collection.ts';
 import { Agents } from '../config.ts';
 
 function createTempDir(): string {
@@ -380,3 +381,69 @@ test('collectCodex metrics from modern custom_tool_call trajectory file', async 
     removeTempDir(tempDir);
   }
 });
+
+test('Codex CLI normalization handles Responses API array output and extracts model', async () => {
+  const tempDir = createTempDir();
+  try {
+    const lines = [
+      JSON.stringify({
+        type: 'turn_context',
+        payload: { model: 'gpt-5.6-sol' }
+      }),
+      JSON.stringify({
+        type: 'response_item',
+        payload: {
+          type: 'custom_tool_call',
+          call_id: 'call_array_1',
+          name: 'exec',
+          input: 'const r = await tools.exec_command({"cmd":"cat index.html"}); text(r.output);'
+        }
+      }),
+      JSON.stringify({
+        type: 'response_item',
+        payload: {
+          type: 'custom_tool_call_output',
+          call_id: 'call_array_1',
+          output: [
+            {
+              type: 'input_text',
+              text: 'Script completed\nWall time 0.1 seconds\nOutput:\n<html><body>Hello</body></html>'
+            }
+          ]
+        }
+      }),
+      JSON.stringify({
+        type: 'event_msg',
+        payload: {
+          type: 'token_count',
+          info: {
+            total_token_usage: {
+              total_tokens: 2500,
+              cached_input_tokens: 1000
+            }
+          }
+        }
+      })
+    ];
+
+    fs.writeFileSync(path.join(tempDir, 'session-responses-api.jsonl'), lines.join('\n'));
+
+    await generateNormalizedTrajectory(tempDir, Agents.CODEX_CLI, 'Check index.html');
+
+    const summaryPath = path.join(tempDir, 'trajectory_summary.json');
+    assert.ok(fs.existsSync(summaryPath), 'trajectory_summary.json must be generated');
+
+    const summary = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+    assert.strictEqual(summary.model, 'gpt-5.6-sol');
+    assert.strictEqual(summary.steps.length, 1);
+    assert.strictEqual(summary.steps[0].outcome?.status, 'success');
+    assert.ok(summary.steps[0].outcome?.message?.includes('Script completed'));
+
+    // Verify extractModelFromResults from collection.ts
+    const extractedModel = extractModelFromResults(tempDir);
+    assert.strictEqual(extractedModel, 'gpt-5.6-sol');
+  } finally {
+    removeTempDir(tempDir);
+  }
+});
+

--- a/lib/guide-validation.ts
+++ b/lib/guide-validation.ts
@@ -187,22 +187,9 @@ export function processGuideInventory(guides: GuideInventory[]): GuideInventoryR
 
   for (const inv of guides) {
     const subdir = inv.dir;
-    const { hasGuide, hasDemo, hasGrader, hasTask, isDisciplineSkill, targets } = inv;
-    const hasTargets = !!targets && targets.length > 0;
+    const { hasGuide, hasGrader, hasTask, isDisciplineSkill } = inv;
     const relativeSubdir = path.relative(REPO_ROOT, subdir);
-    const guideExists = hasGuide || inv.isStub;
     const isDisciplineGuide = inv.name === inv.category || ['css-layout', 'passkeys'].includes(inv.name);
-
-    // Discipline skills don't need demo.html; a frontmatter-only stub
-    // (a proposed use case) doesn't need one either
-    // Guides with multi-app targets don't need a top-level demo.html
-    if (!isDisciplineSkill && !isDisciplineGuide && !hasTargets && ((hasGuide && !hasDemo) || (hasDemo && !guideExists))) {
-      const missingFile = guideExists ? DEMO_FILE : GUIDE_FILE;
-      const msg = `❌ Error in ${relativeSubdir}: Missing ${missingFile}. Must have BOTH ${GUIDE_FILE} and ${DEMO_FILE}.`;
-      console.error(msg);
-      errors.push(msg);
-      hasError = true;
-    }
 
     if (hasGrader !== hasTask) {
       const missingFile = hasGrader ? TASK_FILE : GRADER_FILE;
@@ -241,7 +228,7 @@ export function processGuideInventory(guides: GuideInventory[]): GuideInventoryR
       }
     }
 
-    const isIncomplete = (!hasGuide && !inv.isStub) || (hasGuide && !hasDemo);
+    const isIncomplete = !hasGuide && !inv.isStub;
     const featureIds = isIncomplete ? inv.featureIds : (guideData['web-feature-ids'] || []) as string[];
     const statusName = !isIncomplete && guideErrors.length === 0 ? getStatusName(guideBody, hasGrader, hasTask) : null;
     const isActive = isIncomplete || guideErrors.length > 0 || statusName !== null;


### PR DESCRIPTION
Noticed the latest evals had missing data for Codex and Jetski CLI, here are the fixes. Also remove validation for `demo.html`, which we don't enforce anymore.

## Summary

- **Codex CLI Model Extraction**: Safely handle array outputs in Responses API tool results (`p.output`), preventing `TypeError: out.toLowerCase is not a function` from crashing `trajectory_summary.json` generation and leaving `model: "unknown"`.
- **Jetski CLI Trajectory Export**: Correct the trajectory export search path from `.gemini/jetski/brain` to `.gemini/jetski/conversations` (fixing a path regression introduced in #1186 that caused `.db` files to be missed during cleanup).
- **Remove `demo.html` Requirement**: Remove the paired `demo.html` check from `processGuideInventory` so use case guides with full guidance content sync cleanly without requiring a `demo.html` (e.g. #1411).
- **Unit Test**: Added regression test in `harness/tests/codex-cli-parsing.test.ts` for Codex Responses API normalization.

## Verification
- Passed `pnpm run preflight` (build, typecheck, lint, and all workspace unit tests passed).