### PR TITLE
fix(gd): update PR title format in gd pr to 'grader updates: [guide-name]'

### DIFF
--- a/guides/dev-pr.test.ts
+++ b/guides/dev-pr.test.ts
@@ -196,7 +196,7 @@ describe('runDevPr', () => {
       const success = await runDevPr(tempDir);
       assert.equal(success, true);
       assert.equal(prCreated, true);
-      assert.equal(prTitleArg, `gd dev output for ${path.basename(tempDir)}`);
+      assert.equal(prTitleArg, `grader updates: ${path.basename(tempDir)}`);
       assert.deepEqual(prLabelsArg, ['gd-dev-content']);
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true });

--- a/guides/lib/dev-pr.ts
+++ b/guides/lib/dev-pr.ts
@@ -181,7 +181,7 @@ export async function runDevPr(guideDir: string): Promise<boolean> {
       return false;
     }
   } else {
-    const prTitle = `gd dev output for ${guideName}`;
+    const prTitle = `grader updates: ${guideName}`;
     try {
       const prUrl = devPrCli.createPr(prTitle, reportPath, labels);
       console.log(`\n${cGreen('📄 Pull Request:')} ${prUrl}`);


### PR DESCRIPTION
Updates the default PR title generated by `gd pr` to `grader updates: [guide-name]` instead of `gd dev output for [guide-name]`.